### PR TITLE
fix: Incorrect to_schema generation for dataclass using ResultConverter

### DIFF
--- a/sqlspec/mixins.py
+++ b/sqlspec/mixins.py
@@ -1,3 +1,4 @@
+import dataclasses
 import datetime
 from abc import abstractmethod
 from collections.abc import Sequence
@@ -257,10 +258,10 @@ class ResultConverter:
             if not isinstance(data, Sequence):
                 return cast("ModelT", data)
             return cast("Sequence[ModelT]", data)
-        if is_dataclass(schema_type):
+        if dataclasses.is_dataclass(schema_type):
             if not isinstance(data, Sequence):
                 # data is assumed to be dict[str, Any] as per the method's overloads
-                return cast("ModelDTOT", schema_type(**data))  # type: ignore[operator]
+                return cast("ModelDTOT", schema_type(data))  # type: ignore[operator]
             # data is assumed to be Sequence[dict[str, Any]]
             return cast("Sequence[ModelDTOT]", [schema_type(**item) for item in data])  # type: ignore[operator]
         if is_msgspec_struct(schema_type):

--- a/sqlspec/typing.py
+++ b/sqlspec/typing.py
@@ -117,7 +117,7 @@ def is_dataclass_instance(obj: Any) -> "TypeGuard[DataclassProtocol]":
     Returns:
         True if the object is a dataclass instance.
     """
-    return hasattr(type(obj), "__dataclass_fields__")  # pyright: ignore[reportUnknownArgumentType]
+    return hasattr(obj, "__dataclass_fields__")  # pyright: ignore[reportUnknownArgumentType]
 
 
 @lru_cache(typed=True)

--- a/sqlspec/typing.py
+++ b/sqlspec/typing.py
@@ -117,7 +117,7 @@ def is_dataclass_instance(obj: Any) -> "TypeGuard[DataclassProtocol]":
     Returns:
         True if the object is a dataclass instance.
     """
-    return hasattr(obj, "__dataclass_fields__")  # pyright: ignore[reportUnknownArgumentType]
+    return hasattr(type(obj), "__dataclass_fields__")  # pyright: ignore[reportUnknownArgumentType]
 
 
 @lru_cache(typed=True)

--- a/tests/unit/test_mixins.py
+++ b/tests/unit/test_mixins.py
@@ -1,0 +1,72 @@
+"""Tests for mixins utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, ClassVar
+
+import pytest
+from msgspec import Struct
+from pydantic import BaseModel
+
+from sqlspec.mixins import (
+    ResultConverter
+)
+from sqlspec.typing import (
+    Empty,
+    is_dataclass_instance,
+)
+
+
+@dataclass
+class SampleDataclass:
+    """Sample dataclass for testing."""
+
+    name: str
+    value: int | None = None
+    empty_field: Any = Empty
+    meta: ClassVar[str] = "test"
+
+
+class SamplePydanticModel(BaseModel):
+    """Sample Pydantic model for testing."""
+
+    name: str
+    value: int | None = None
+
+
+class SampleMsgspecModel(Struct):
+    """Sample Msgspec model for testing."""
+
+    name: str
+    value: int | None = None
+
+
+@pytest.fixture(scope="session")
+def sample_dataclass() -> SampleDataclass:
+    """Create a sample dataclass instance."""
+    return SampleDataclass(name="test", value=42)
+
+
+@pytest.fixture(scope="session")
+def sample_pydantic() -> SamplePydanticModel:
+    """Create a sample Pydantic model instance."""
+    return SamplePydanticModel(name="test", value=42)
+
+
+@pytest.fixture(scope="session")
+def sample_msgspec() -> SampleMsgspecModel:
+    """Create a sample Msgspec model instance."""
+    return SampleMsgspecModel(name="test", value=42)
+
+
+@pytest.fixture(scope="session")
+def sample_dict() -> dict[str, Any]:
+    """Create a sample dictionary."""
+    return {"name": "test", "value": 42}
+
+
+def test_is_result_converter_dataclass(sample_dataclass: SampleDataclass) -> None:
+    """Test dataclass type checking."""
+    assert is_dataclass_instance(ResultConverter.to_schema(data=SampleDataclass(name="test", value=42), schema_type=SampleDataclass))
+


### PR DESCRIPTION
Not sure that is the best way to fix the issue.

## Description

The following code was not working and returned ``SQLSpecError: `schema_type` should be a valid Dataclass, Pydantic model or Msgspec struct``


```python
#Import there

@dataclass
class SampleDataclass:
    """Sample dataclass for testing."""

    name: str
    value: int | None = None
    empty_field: Any = Empty
    meta: ClassVar[str] = "test"

data = ResultConverter.to_schema(data=SampleDataclass(name="test", value=42), schema_type=SampleDataclass)
```
I tried to replace the ``is_dataclass`` by the built in ``is_dataclass`` from ``dataclasses``, it correctly  identify whether the passed argument is a dataclass type (if it's a class) or an instance of a dataclass. Where the method in ``typing`` was working only when it was an instance of the class.

There was a fail also right after when trying to cast the dictionary into the dataclass.