### PR TITLE
fix: correctly handle named paramter values

### DIFF
--- a/sqlspec/_sql.py
+++ b/sqlspec/_sql.py
@@ -4,17 +4,65 @@ Provides both statement builders (select, insert, update, etc.) and column expre
 """
 
 import logging
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import sqlglot
 from sqlglot import exp
 from sqlglot.dialects.dialect import DialectType
 from sqlglot.errors import ParseError as SQLGlotParseError
 
-from sqlspec.builder import Column, Delete, Insert, Merge, Select, Truncate, Update
+from sqlspec.builder import (
+    AlterTable,
+    Column,
+    CommentOn,
+    CreateIndex,
+    CreateMaterializedView,
+    CreateSchema,
+    CreateTable,
+    CreateTableAsSelect,
+    CreateView,
+    Delete,
+    DropIndex,
+    DropSchema,
+    DropTable,
+    DropView,
+    Insert,
+    Merge,
+    RenameTable,
+    Select,
+    Truncate,
+    Update,
+)
 from sqlspec.exceptions import SQLBuilderError
 
-__all__ = ("Case", "Column", "Delete", "Insert", "Merge", "SQLFactory", "Select", "Truncate", "Update", "sql")
+if TYPE_CHECKING:
+    from sqlspec.core.statement import SQL
+
+__all__ = (
+    "AlterTable",
+    "Case",
+    "Column",
+    "CommentOn",
+    "CreateIndex",
+    "CreateMaterializedView",
+    "CreateSchema",
+    "CreateTable",
+    "CreateTableAsSelect",
+    "CreateView",
+    "Delete",
+    "DropIndex",
+    "DropSchema",
+    "DropTable",
+    "DropView",
+    "Insert",
+    "Merge",
+    "RenameTable",
+    "SQLFactory",
+    "Select",
+    "Truncate",
+    "Update",
+    "sql",
+)
 
 logger = logging.getLogger("sqlspec")
 
@@ -213,6 +261,174 @@ class SQLFactory:
         return builder
 
     # ===================
+    # DDL Statement Builders
+    # ===================
+
+    def create_table(self, table_name: str, dialect: DialectType = None) -> "CreateTable":
+        """Create a CREATE TABLE builder.
+
+        Args:
+            table_name: Name of the table to create
+            dialect: Optional SQL dialect
+
+        Returns:
+            CreateTable builder instance
+        """
+        builder = CreateTable(table_name)
+        builder.dialect = dialect or self.dialect
+        return builder
+
+    def create_table_as_select(self, dialect: DialectType = None) -> "CreateTableAsSelect":
+        """Create a CREATE TABLE AS SELECT builder.
+
+        Args:
+            dialect: Optional SQL dialect
+
+        Returns:
+            CreateTableAsSelect builder instance
+        """
+        builder = CreateTableAsSelect()
+        builder.dialect = dialect or self.dialect
+        return builder
+
+    def create_view(self, dialect: DialectType = None) -> "CreateView":
+        """Create a CREATE VIEW builder.
+
+        Args:
+            dialect: Optional SQL dialect
+
+        Returns:
+            CreateView builder instance
+        """
+        builder = CreateView()
+        builder.dialect = dialect or self.dialect
+        return builder
+
+    def create_materialized_view(self, dialect: DialectType = None) -> "CreateMaterializedView":
+        """Create a CREATE MATERIALIZED VIEW builder.
+
+        Args:
+            dialect: Optional SQL dialect
+
+        Returns:
+            CreateMaterializedView builder instance
+        """
+        builder = CreateMaterializedView()
+        builder.dialect = dialect or self.dialect
+        return builder
+
+    def create_index(self, index_name: str, dialect: DialectType = None) -> "CreateIndex":
+        """Create a CREATE INDEX builder.
+
+        Args:
+            index_name: Name of the index to create
+            dialect: Optional SQL dialect
+
+        Returns:
+            CreateIndex builder instance
+        """
+        return CreateIndex(index_name, dialect=dialect or self.dialect)
+
+    def create_schema(self, dialect: DialectType = None) -> "CreateSchema":
+        """Create a CREATE SCHEMA builder.
+
+        Args:
+            dialect: Optional SQL dialect
+
+        Returns:
+            CreateSchema builder instance
+        """
+        builder = CreateSchema()
+        builder.dialect = dialect or self.dialect
+        return builder
+
+    def drop_table(self, table_name: str, dialect: DialectType = None) -> "DropTable":
+        """Create a DROP TABLE builder.
+
+        Args:
+            table_name: Name of the table to drop
+            dialect: Optional SQL dialect
+
+        Returns:
+            DropTable builder instance
+        """
+        return DropTable(table_name, dialect=dialect or self.dialect)
+
+    def drop_view(self, dialect: DialectType = None) -> "DropView":
+        """Create a DROP VIEW builder.
+
+        Args:
+            dialect: Optional SQL dialect
+
+        Returns:
+            DropView builder instance
+        """
+        return DropView(dialect=dialect or self.dialect)
+
+    def drop_index(self, index_name: str, dialect: DialectType = None) -> "DropIndex":
+        """Create a DROP INDEX builder.
+
+        Args:
+            index_name: Name of the index to drop
+            dialect: Optional SQL dialect
+
+        Returns:
+            DropIndex builder instance
+        """
+        return DropIndex(index_name, dialect=dialect or self.dialect)
+
+    def drop_schema(self, dialect: DialectType = None) -> "DropSchema":
+        """Create a DROP SCHEMA builder.
+
+        Args:
+            dialect: Optional SQL dialect
+
+        Returns:
+            DropSchema builder instance
+        """
+        return DropSchema(dialect=dialect or self.dialect)
+
+    def alter_table(self, table_name: str, dialect: DialectType = None) -> "AlterTable":
+        """Create an ALTER TABLE builder.
+
+        Args:
+            table_name: Name of the table to alter
+            dialect: Optional SQL dialect
+
+        Returns:
+            AlterTable builder instance
+        """
+        builder = AlterTable(table_name)
+        builder.dialect = dialect or self.dialect
+        return builder
+
+    def rename_table(self, dialect: DialectType = None) -> "RenameTable":
+        """Create a RENAME TABLE builder.
+
+        Args:
+            dialect: Optional SQL dialect
+
+        Returns:
+            RenameTable builder instance
+        """
+        builder = RenameTable()
+        builder.dialect = dialect or self.dialect
+        return builder
+
+    def comment_on(self, dialect: DialectType = None) -> "CommentOn":
+        """Create a COMMENT ON builder.
+
+        Args:
+            dialect: Optional SQL dialect
+
+        Returns:
+            CommentOn builder instance
+        """
+        builder = CommentOn()
+        builder.dialect = dialect or self.dialect
+        return builder
+
+    # ===================
     # SQL Analysis Helpers
     # ===================
 
@@ -363,8 +579,8 @@ class SQLFactory:
     # ===================
 
     @staticmethod
-    def raw(sql_fragment: str) -> exp.Expression:
-        """Create a raw SQL expression from a string fragment.
+    def raw(sql_fragment: str, **parameters: Any) -> "Union[exp.Expression, SQL]":
+        """Create a raw SQL expression from a string fragment with optional parameters.
 
         This method makes it explicit that you are passing raw SQL that should
         be parsed and included directly in the query. Useful for complex expressions,
@@ -372,30 +588,30 @@ class SQLFactory:
 
         Args:
             sql_fragment: Raw SQL string to parse into an expression.
+            **parameters: Named parameters for parameter binding.
 
         Returns:
-            SQLGlot expression from the parsed SQL fragment.
+            SQLGlot expression from the parsed SQL fragment (if no parameters).
+            SQL statement object (if parameters provided).
 
         Raises:
             SQLBuilderError: If the SQL fragment cannot be parsed.
 
         Example:
             ```python
-            # Raw column expression with alias
-            query = sql.select(
-                sql.raw("user.id AS u_id"), "name"
-            ).from_("users")
+            # Raw expression without parameters (current behavior)
+            expr = sql.raw("COALESCE(name, 'Unknown')")
 
-            # Raw function call
-            query = sql.select(
-                sql.raw("COALESCE(name, 'Unknown')")
-            ).from_("users")
+            # Raw SQL with named parameters (new functionality)
+            stmt = sql.raw(
+                "LOWER(name) LIKE LOWER(:pattern)", pattern=f"%{query}%"
+            )
 
-            # Raw complex expression
-            query = (
-                sql.select("*")
-                .from_("orders")
-                .where(sql.raw("DATE(created_at) = CURRENT_DATE"))
+            # Raw complex expression with parameters
+            expr = sql.raw(
+                "price BETWEEN :min_price AND :max_price",
+                min_price=100,
+                max_price=500,
             )
 
             # Raw window function
@@ -407,16 +623,23 @@ class SQLFactory:
             ).from_("employees")
             ```
         """
-        try:
-            parsed: Optional[exp.Expression] = exp.maybe_parse(sql_fragment)
-            if parsed is not None:
-                return parsed
-            if sql_fragment.strip().replace("_", "").replace(".", "").isalnum():
-                return exp.to_identifier(sql_fragment)
-            return exp.Literal.string(sql_fragment)
-        except Exception as e:
-            msg = f"Failed to parse raw SQL fragment '{sql_fragment}': {e}"
-            raise SQLBuilderError(msg) from e
+        if not parameters:
+            # Original behavior - return pure expression
+            try:
+                parsed: Optional[exp.Expression] = exp.maybe_parse(sql_fragment)
+                if parsed is not None:
+                    return parsed
+                if sql_fragment.strip().replace("_", "").replace(".", "").isalnum():
+                    return exp.to_identifier(sql_fragment)
+                return exp.Literal.string(sql_fragment)
+            except Exception as e:
+                msg = f"Failed to parse raw SQL fragment '{sql_fragment}': {e}"
+                raise SQLBuilderError(msg) from e
+
+        # New behavior - return SQL statement with parameters
+        from sqlspec.core.statement import SQL
+
+        return SQL(sql_fragment, parameters)
 
     # ===================
     # Aggregate Functions

--- a/sqlspec/builder/_parsing_utils.py
+++ b/sqlspec/builder/_parsing_utils.py
@@ -109,7 +109,11 @@ def parse_condition_expression(
         if value is None:
             return exp.Is(this=column_expr, expression=exp.null())
         if builder and has_parameter_builder(builder):
-            _, param_name = builder.add_parameter(value)
+            from sqlspec.builder.mixins._where_clause import _extract_column_name
+
+            column_name = _extract_column_name(column)
+            param_name = builder._generate_unique_parameter_name(column_name)
+            _, param_name = builder.add_parameter(value, name=param_name)
             return exp.EQ(this=column_expr, expression=exp.Placeholder(this=param_name))
         if isinstance(value, str):
             return exp.EQ(this=column_expr, expression=exp.convert(value))

--- a/sqlspec/builder/mixins/_merge_operations.py
+++ b/sqlspec/builder/mixins/_merge_operations.py
@@ -172,7 +172,11 @@ class MergeMatchedClauseMixin:
         """
         update_expressions: list[exp.EQ] = []
         for col, val in set_values.items():
-            param_name = self.add_parameter(val)[1]  # type: ignore[attr-defined]
+            column_name = col if isinstance(col, str) else str(col)
+            if "." in column_name:
+                column_name = column_name.split(".")[-1]
+            param_name = self._generate_unique_parameter_name(column_name)  # type: ignore[attr-defined]
+            param_name = self.add_parameter(val, name=param_name)[1]  # type: ignore[attr-defined]
             update_expressions.append(exp.EQ(this=exp.column(col), expression=exp.var(param_name)))
 
         when_args: dict[str, Any] = {"matched": True, "then": exp.Update(expressions=update_expressions)}
@@ -270,8 +274,12 @@ class MergeNotMatchedClauseMixin:
                 raise SQLBuilderError(msg)
 
             parameterized_values: list[exp.Expression] = []
-            for val in values:
-                param_name = self.add_parameter(val)[1]  # type: ignore[attr-defined]
+            for i, val in enumerate(values):
+                column_name = columns[i] if isinstance(columns[i], str) else str(columns[i])
+                if "." in column_name:
+                    column_name = column_name.split(".")[-1]
+                param_name = self._generate_unique_parameter_name(column_name)  # type: ignore[attr-defined]
+                param_name = self.add_parameter(val, name=param_name)[1]  # type: ignore[attr-defined]
                 parameterized_values.append(exp.var(param_name))
 
             insert_args["this"] = exp.Tuple(expressions=[exp.column(c) for c in columns])
@@ -336,7 +344,11 @@ class MergeNotMatchedBySourceClauseMixin:
         """
         update_expressions: list[exp.EQ] = []
         for col, val in set_values.items():
-            param_name = self.add_parameter(val)[1]  # type: ignore[attr-defined]
+            column_name = col if isinstance(col, str) else str(col)
+            if "." in column_name:
+                column_name = column_name.split(".")[-1]
+            param_name = self._generate_unique_parameter_name(column_name)  # type: ignore[attr-defined]
+            param_name = self.add_parameter(val, name=param_name)[1]  # type: ignore[attr-defined]
             update_expressions.append(exp.EQ(this=exp.column(col), expression=exp.var(param_name)))
 
         when_args: dict[str, Any] = {

--- a/sqlspec/builder/mixins/_select_operations.py
+++ b/sqlspec/builder/mixins/_select_operations.py
@@ -563,7 +563,8 @@ class CaseBuilder:
             CaseBuilder: The current builder instance for method chaining.
         """
         cond_expr = exp.condition(condition) if isinstance(condition, str) else condition
-        param_name = self._parent.add_parameter(value)[1]
+        param_name = self._parent._generate_unique_parameter_name("case_when_value")
+        param_name = self._parent.add_parameter(value, name=param_name)[1]
         value_expr = exp.Placeholder(this=param_name)
 
         when_clause = exp.When(this=cond_expr, then=value_expr)
@@ -582,7 +583,8 @@ class CaseBuilder:
         Returns:
             CaseBuilder: The current builder instance for method chaining.
         """
-        param_name = self._parent.add_parameter(value)[1]
+        param_name = self._parent._generate_unique_parameter_name("case_else_value")
+        param_name = self._parent.add_parameter(value, name=param_name)[1]
         value_expr = exp.Placeholder(this=param_name)
         self._case_expr.set("default", value_expr)
         return self

--- a/sqlspec/builder/mixins/_update_operations.py
+++ b/sqlspec/builder/mixins/_update_operations.py
@@ -81,7 +81,12 @@ class UpdateSetClauseMixin:
                     for p_name, p_value in val.parameters.items():
                         self.add_parameter(p_value, name=p_name)  # type: ignore[attr-defined]
             else:
-                param_name = self.add_parameter(val)[1]  # type: ignore[attr-defined]
+                column_name = col if isinstance(col, str) else str(col)
+                # Extract just the column part if table.column format
+                if "." in column_name:
+                    column_name = column_name.split(".")[-1]
+                param_name = self._generate_unique_parameter_name(column_name)  # type: ignore[attr-defined]
+                param_name = self.add_parameter(val, name=param_name)[1]  # type: ignore[attr-defined]
                 value_expr = exp.Placeholder(this=param_name)
             assignments.append(exp.EQ(this=col_expr, expression=value_expr))
         elif (len(args) == 1 and isinstance(args[0], Mapping)) or kwargs:
@@ -97,7 +102,12 @@ class UpdateSetClauseMixin:
                         for p_name, p_value in val.parameters.items():
                             self.add_parameter(p_value, name=p_name)  # type: ignore[attr-defined]
                 else:
-                    param_name = self.add_parameter(val)[1]  # type: ignore[attr-defined]
+                    # Extract column name for parameter naming
+                    column_name = col if isinstance(col, str) else str(col)
+                    if "." in column_name:
+                        column_name = column_name.split(".")[-1]
+                    param_name = self._generate_unique_parameter_name(column_name)  # type: ignore[attr-defined]
+                    param_name = self.add_parameter(val, name=param_name)[1]  # type: ignore[attr-defined]
                     value_expr = exp.Placeholder(this=param_name)
                 assignments.append(exp.EQ(this=exp.column(col), expression=value_expr))
         else:

--- a/sqlspec/driver/mixins/_result_tools.py
+++ b/sqlspec/driver/mixins/_result_tools.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from enum import Enum
 from functools import partial
 from pathlib import Path, PurePath
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union, overload
+from typing import Any, Callable, Optional, overload
 from uuid import UUID
 
 from mypy_extensions import trait
@@ -13,8 +13,6 @@ from mypy_extensions import trait
 from sqlspec.exceptions import SQLSpecError, wrap_exceptions
 from sqlspec.typing import (
     CATTRS_INSTALLED,
-    DataclassProtocol,
-    DictLike,
     ModelDTOT,
     ModelT,
     attrs_asdict,
@@ -24,9 +22,6 @@ from sqlspec.typing import (
     get_type_adapter,
 )
 from sqlspec.utils.type_guards import is_attrs_schema, is_dataclass, is_msgspec_struct, is_pydantic_model
-
-if TYPE_CHECKING:
-    from sqlspec._typing import AttrsInstanceStub, BaseModelStub, StructStub
 
 __all__ = ("_DEFAULT_TYPE_DECODERS", "_default_msgspec_deserializer")
 
@@ -74,10 +69,16 @@ class ToSchemaMixin:
     # Schema conversion overloads - handle common cases first
     @overload
     @staticmethod
+    def to_schema(data: "list[dict[str, Any]]") -> "list[dict[str, Any]]": ...
+    @overload
+    @staticmethod
     def to_schema(data: "list[dict[str, Any]]", *, schema_type: "type[ModelDTOT]") -> "list[ModelDTOT]": ...
     @overload
     @staticmethod
     def to_schema(data: "list[dict[str, Any]]", *, schema_type: None = None) -> "list[dict[str, Any]]": ...
+    @overload
+    @staticmethod
+    def to_schema(data: "dict[str, Any]") -> "dict[str, Any]": ...
     @overload
     @staticmethod
     def to_schema(data: "dict[str, Any]", *, schema_type: "type[ModelDTOT]") -> "ModelDTOT": ...
@@ -86,24 +87,19 @@ class ToSchemaMixin:
     def to_schema(data: "dict[str, Any]", *, schema_type: None = None) -> "dict[str, Any]": ...
     @overload
     @staticmethod
+    def to_schema(data: "list[ModelT]") -> "list[ModelT]": ...
+    @overload
+    @staticmethod
     def to_schema(data: "list[ModelT]", *, schema_type: "type[ModelDTOT]") -> "list[ModelDTOT]": ...
     @overload
     @staticmethod
     def to_schema(data: "list[ModelT]", *, schema_type: None = None) -> "list[ModelT]": ...
     @overload
     @staticmethod
-    def to_schema(
-        data: "Union[DictLike, StructStub, BaseModelStub, DataclassProtocol, AttrsInstanceStub]",
-        *,
-        schema_type: "type[ModelDTOT]",
-    ) -> "ModelDTOT": ...
+    def to_schema(data: "ModelT") -> "ModelT": ...
     @overload
     @staticmethod
-    def to_schema(
-        data: "Union[DictLike, StructStub, BaseModelStub, DataclassProtocol, AttrsInstanceStub]",
-        *,
-        schema_type: None = None,
-    ) -> "Union[DictLike, StructStub, BaseModelStub, DataclassProtocol, AttrsInstanceStub]": ...
+    def to_schema(data: Any, *, schema_type: None = None) -> Any: ...
 
     @staticmethod
     def to_schema(data: Any, *, schema_type: "Optional[type[ModelDTOT]]" = None) -> Any:

--- a/tests/unit/test_builder/__init__.py
+++ b/tests/unit/test_builder/__init__.py
@@ -1,0 +1,1 @@
+"""Builder tests package."""

--- a/tests/unit/test_builder/test_parameter_naming.py
+++ b/tests/unit/test_builder/test_parameter_naming.py
@@ -13,7 +13,6 @@ Tests cover:
 - Edge cases and error conditions
 """
 
-
 from sqlspec import sql
 
 
@@ -64,11 +63,13 @@ def test_where_any_uses_column_name_with_any_suffix() -> None:
 
 def test_multiple_where_conditions_preserve_column_names() -> None:
     """Test that multiple WHERE conditions preserve individual column names."""
-    query = (sql.select("*")
-             .from_("orders")
-             .where_eq("status", "pending")
-             .where_gt("total", 100.0)
-             .where_like("customer_email", "%@company.com"))
+    query = (
+        sql.select("*")
+        .from_("orders")
+        .where_eq("status", "pending")
+        .where_gt("total", 100.0)
+        .where_like("customer_email", "%@company.com")
+    )
     stmt = query.build()
 
     assert "status" in stmt.parameters
@@ -81,10 +82,7 @@ def test_multiple_where_conditions_preserve_column_names() -> None:
 
 def test_parameter_collision_handling() -> None:
     """Test that parameter name collisions are resolved with numbering."""
-    query = (sql.select("*")
-             .from_("products")
-             .where_gt("price", 10)
-             .where_lt("price", 100))
+    query = sql.select("*").from_("products").where_gt("price", 10).where_lt("price", 100)
     stmt = query.build()
 
     # Should have both price parameters with collision resolution
@@ -100,11 +98,13 @@ def test_parameter_collision_handling() -> None:
 
 def test_table_prefixed_columns_extract_column_name() -> None:
     """Test that table-prefixed columns extract just the column name."""
-    query = (sql.select("*")
-             .from_("users u")
-             .join("profiles p", "u.id = p.user_id")
-             .where_eq("u.email", "test@example.com")
-             .where_eq("p.status", "active"))
+    query = (
+        sql.select("*")
+        .from_("users u")
+        .join("profiles p", "u.id = p.user_id")
+        .where_eq("u.email", "test@example.com")
+        .where_eq("p.status", "active")
+    )
     stmt = query.build()
 
     # Should extract column names without table prefix
@@ -126,10 +126,7 @@ def test_update_set_single_column_uses_column_name() -> None:
 
 def test_update_set_multiple_columns_preserve_names() -> None:
     """Test that UPDATE SET with multiple columns preserves all names."""
-    query = (sql.update("products")
-             .set("name", "Updated Product")
-             .set("price", 49.99)
-             .set("in_stock", True))
+    query = sql.update("products").set("name", "Updated Product").set("price", 49.99).set("in_stock", True)
     stmt = query.build()
 
     assert "name" in stmt.parameters
@@ -142,11 +139,7 @@ def test_update_set_multiple_columns_preserve_names() -> None:
 
 def test_update_set_with_dict_uses_column_names() -> None:
     """Test that UPDATE SET with dictionary uses column names."""
-    query = sql.update("accounts").set({
-        "balance": 1500.75,
-        "last_transaction": "2023-01-15",
-        "is_verified": True
-    })
+    query = sql.update("accounts").set({"balance": 1500.75, "last_transaction": "2023-01-15", "is_verified": True})
     stmt = query.build()
 
     # Should use dictionary keys as parameter names
@@ -163,9 +156,9 @@ def test_update_set_with_dict_uses_column_names() -> None:
 
 def test_insert_with_columns_uses_column_names() -> None:
     """Test that INSERT with specified columns uses column names."""
-    query = (sql.insert("employees")
-             .columns("first_name", "last_name", "department")
-             .values("John", "Smith", "Engineering"))
+    query = (
+        sql.insert("employees").columns("first_name", "last_name", "department").values("John", "Smith", "Engineering")
+    )
     stmt = query.build()
 
     # Should use column names for parameters
@@ -179,31 +172,29 @@ def test_insert_with_columns_uses_column_names() -> None:
 
 def test_insert_values_from_dict_preserves_keys() -> None:
     """Test that INSERT values_from_dict preserves dictionary keys."""
-    query = sql.insert("orders").values_from_dict({
-        "customer_id": 12345,
-        "product_name": "Widget",
-        "quantity": 3,
-        "order_date": "2023-01-01"
-    })
+    query = sql.insert("orders").values_from_dict(
+        {"customer_id": 12345, "product_name": "Widget", "quantity": 3, "order_date": "2023-01-01"}
+    )
     stmt = query.build()
 
     # Should preserve dictionary keys in parameter names
     expected_keys = ["customer_id", "product_name", "quantity", "order_date"]
     for key in expected_keys:
         # Check if key exists directly or as part of parameter name
-        assert (key in stmt.parameters or
-                any(key in param_key for param_key in stmt.parameters.keys()))
+        assert key in stmt.parameters or any(key in param_key for param_key in stmt.parameters.keys())
 
 
 def test_complex_query_preserves_all_column_names() -> None:
     """Test that complex queries preserve column names across all operations."""
-    query = (sql.select("u.username", "p.title")
-             .from_("users u")
-             .join("posts p", "u.id = p.author_id")
-             .where_eq("u.status", "active")
-             .where_in("p.category", ["tech", "science"])
-             .where_between("p.views", 100, 10000)
-             .where_like("p.title", "%python%"))
+    query = (
+        sql.select("u.username", "p.title")
+        .from_("users u")
+        .join("posts p", "u.id = p.author_id")
+        .where_eq("u.status", "active")
+        .where_in("p.category", ["tech", "science"])
+        .where_between("p.views", 100, 10000)
+        .where_like("p.title", "%python%")
+    )
     stmt = query.build()
 
     params = stmt.parameters
@@ -233,9 +224,7 @@ def test_subquery_parameters_are_preserved() -> None:
     """Test that subquery parameters maintain their names."""
     subquery = sql.select("user_id").from_("subscriptions").where_eq("plan_type", "premium")
 
-    query = (sql.select("name", "email")
-             .from_("users")
-             .where_in("id", subquery))
+    query = sql.select("name", "email").from_("users").where_in("id", subquery)
     stmt = query.build()
 
     # Subquery parameter should be preserved
@@ -245,15 +234,19 @@ def test_subquery_parameters_are_preserved() -> None:
 
 def test_mixed_parameter_types_preserve_names() -> None:
     """Test that mixed parameter types preserve proper column names."""
-    query = (sql.update("user_profiles")
-             .set({
-                 "username": "john_doe",           # string
-                 "age": 28,                       # int
-                 "salary": 75000.50,              # float
-                 "is_active": True,               # bool
-                 "last_seen": None                # None
-             })
-             .where_eq("user_id", 12345))
+    query = (
+        sql.update("user_profiles")
+        .set(
+            {
+                "username": "john_doe",  # string
+                "age": 28,  # int
+                "salary": 75000.50,  # float
+                "is_active": True,  # bool
+                "last_seen": None,  # None
+            }
+        )
+        .where_eq("user_id", 12345)
+    )
     stmt = query.build()
 
     params = stmt.parameters
@@ -323,10 +316,9 @@ def test_no_generic_param_names_in_insert_operations() -> None:
 
 def test_parameter_names_are_sql_safe() -> None:
     """Test that generated parameter names are safe for SQL usage."""
-    query = (sql.select("*")
-             .from_("test_table")
-             .where_eq("column_name", "value")
-             .where_in("other_column", ["a", "b", "c"]))
+    query = (
+        sql.select("*").from_("test_table").where_eq("column_name", "value").where_in("other_column", ["a", "b", "c"])
+    )
     stmt = query.build()
 
     for param_name in stmt.parameters.keys():
@@ -342,13 +334,17 @@ def test_parameter_names_are_sql_safe() -> None:
 
 def test_empty_and_null_values_preserve_column_names() -> None:
     """Test that empty and null values still preserve column names."""
-    query = (sql.update("users")
-             .set({
-                 "middle_name": "",           # empty string
-                 "phone": None,               # null
-                 "notes": "   ",              # whitespace
-             })
-             .where_eq("id", 1))
+    query = (
+        sql.update("users")
+        .set(
+            {
+                "middle_name": "",  # empty string
+                "phone": None,  # null
+                "notes": "   ",  # whitespace
+            }
+        )
+        .where_eq("id", 1)
+    )
     stmt = query.build()
 
     params = stmt.parameters
@@ -367,9 +363,7 @@ def test_empty_and_null_values_preserve_column_names() -> None:
 
 def test_original_user_example_works_correctly() -> None:
     """Test the exact user example that was originally failing."""
-    query = (sql.select("id", "name", "slug")
-             .from_("test_table")
-             .where_eq("slug", "test-item"))
+    query = sql.select("id", "name", "slug").from_("test_table").where_eq("slug", "test-item")
     stmt = query.build()
 
     # Should use :slug parameter, not :param_1
@@ -383,10 +377,12 @@ def test_original_user_example_works_correctly() -> None:
 
 def test_parameter_naming_with_special_characters_in_values() -> None:
     """Test that parameter naming works with special characters in values."""
-    query = (sql.select("*")
-             .from_("logs")
-             .where_eq("message", "Error: Connection failed!")
-             .where_like("details", "%SQL injection attempt: DROP TABLE%"))
+    query = (
+        sql.select("*")
+        .from_("logs")
+        .where_eq("message", "Error: Connection failed!")
+        .where_like("details", "%SQL injection attempt: DROP TABLE%")
+    )
     stmt = query.build()
 
     # Should preserve column names despite special characters in values

--- a/tests/unit/test_builder/test_parameter_naming.py
+++ b/tests/unit/test_builder/test_parameter_naming.py
@@ -1,0 +1,396 @@
+"""Unit tests for SQL builder parameter naming.
+
+This module tests that all SQL builder operations use descriptive, column-based
+parameter names instead of generic param_1, param_2, etc.
+
+Tests cover:
+- WHERE clause methods with column name preservation
+- UPDATE operations with SET clauses
+- INSERT operations with values and columns
+- MERGE operations
+- Complex queries with multiple parameter types
+- Parameter collision handling
+- Edge cases and error conditions
+"""
+
+
+from sqlspec import sql
+
+
+def test_where_eq_uses_column_name_as_parameter() -> None:
+    """Test that where_eq uses column name as parameter name."""
+    query = sql.select("*").from_("users").where_eq("email", "test@example.com")
+    stmt = query.build()
+
+    assert "email" in stmt.parameters
+    assert stmt.parameters["email"] == "test@example.com"
+    assert ":email" in stmt.sql
+
+
+def test_where_in_uses_column_name_with_numbering() -> None:
+    """Test that where_in uses column name with numbering for multiple values."""
+    query = sql.select("*").from_("posts").where_in("category", ["tech", "science", "business"])
+    stmt = query.build()
+
+    assert "category_1" in stmt.parameters
+    assert "category_2" in stmt.parameters
+    assert "category_3" in stmt.parameters
+    assert stmt.parameters["category_1"] == "tech"
+    assert stmt.parameters["category_2"] == "science"
+    assert stmt.parameters["category_3"] == "business"
+
+
+def test_where_between_uses_descriptive_suffixes() -> None:
+    """Test that where_between uses descriptive low/high suffixes."""
+    query = sql.select("*").from_("events").where_between("date", "2023-01-01", "2023-12-31")
+    stmt = query.build()
+
+    assert "date_low" in stmt.parameters
+    assert "date_high" in stmt.parameters
+    assert stmt.parameters["date_low"] == "2023-01-01"
+    assert stmt.parameters["date_high"] == "2023-12-31"
+
+
+def test_where_any_uses_column_name_with_any_suffix() -> None:
+    """Test that where_any uses column name with any suffix."""
+    query = sql.select("*").from_("users").where_any("role", ["admin", "moderator"])
+    stmt = query.build()
+
+    assert "role_any_1" in stmt.parameters
+    assert "role_any_2" in stmt.parameters
+    assert stmt.parameters["role_any_1"] == "admin"
+    assert stmt.parameters["role_any_2"] == "moderator"
+
+
+def test_multiple_where_conditions_preserve_column_names() -> None:
+    """Test that multiple WHERE conditions preserve individual column names."""
+    query = (sql.select("*")
+             .from_("orders")
+             .where_eq("status", "pending")
+             .where_gt("total", 100.0)
+             .where_like("customer_email", "%@company.com"))
+    stmt = query.build()
+
+    assert "status" in stmt.parameters
+    assert "total" in stmt.parameters
+    assert "customer_email" in stmt.parameters
+    assert stmt.parameters["status"] == "pending"
+    assert stmt.parameters["total"] == 100.0
+    assert stmt.parameters["customer_email"] == "%@company.com"
+
+
+def test_parameter_collision_handling() -> None:
+    """Test that parameter name collisions are resolved with numbering."""
+    query = (sql.select("*")
+             .from_("products")
+             .where_gt("price", 10)
+             .where_lt("price", 100))
+    stmt = query.build()
+
+    # Should have both price parameters with collision resolution
+    price_params = [key for key in stmt.parameters.keys() if "price" in key]
+    assert len(price_params) == 2
+
+    # One should be "price", the other "price_1"
+    assert "price" in stmt.parameters
+    assert "price_1" in stmt.parameters
+    assert 10 in stmt.parameters.values()
+    assert 100 in stmt.parameters.values()
+
+
+def test_table_prefixed_columns_extract_column_name() -> None:
+    """Test that table-prefixed columns extract just the column name."""
+    query = (sql.select("*")
+             .from_("users u")
+             .join("profiles p", "u.id = p.user_id")
+             .where_eq("u.email", "test@example.com")
+             .where_eq("p.status", "active"))
+    stmt = query.build()
+
+    # Should extract column names without table prefix
+    assert "email" in stmt.parameters
+    assert "status" in stmt.parameters
+    assert stmt.parameters["email"] == "test@example.com"
+    assert stmt.parameters["status"] == "active"
+
+
+def test_update_set_single_column_uses_column_name() -> None:
+    """Test that UPDATE SET with single column uses column name."""
+    query = sql.update("users").set("last_login", "2023-01-01 10:00:00")
+    stmt = query.build()
+
+    assert "last_login" in stmt.parameters
+    assert stmt.parameters["last_login"] == "2023-01-01 10:00:00"
+    assert ":last_login" in stmt.sql
+
+
+def test_update_set_multiple_columns_preserve_names() -> None:
+    """Test that UPDATE SET with multiple columns preserves all names."""
+    query = (sql.update("products")
+             .set("name", "Updated Product")
+             .set("price", 49.99)
+             .set("in_stock", True))
+    stmt = query.build()
+
+    assert "name" in stmt.parameters
+    assert "price" in stmt.parameters
+    assert "in_stock" in stmt.parameters
+    assert stmt.parameters["name"] == "Updated Product"
+    assert stmt.parameters["price"] == 49.99
+    assert stmt.parameters["in_stock"] is True
+
+
+def test_update_set_with_dict_uses_column_names() -> None:
+    """Test that UPDATE SET with dictionary uses column names."""
+    query = sql.update("accounts").set({
+        "balance": 1500.75,
+        "last_transaction": "2023-01-15",
+        "is_verified": True
+    })
+    stmt = query.build()
+
+    # Should use dictionary keys as parameter names
+    expected_keys = ["balance", "last_transaction", "is_verified"]
+    for key in expected_keys:
+        # Parameter might have collision suffix, so check if base name exists
+        assert any(key in param_key for param_key in stmt.parameters.keys())
+
+    # Should preserve values
+    assert 1500.75 in stmt.parameters.values()
+    assert "2023-01-15" in stmt.parameters.values()
+    assert True in stmt.parameters.values()
+
+
+def test_insert_with_columns_uses_column_names() -> None:
+    """Test that INSERT with specified columns uses column names."""
+    query = (sql.insert("employees")
+             .columns("first_name", "last_name", "department")
+             .values("John", "Smith", "Engineering"))
+    stmt = query.build()
+
+    # Should use column names for parameters
+    assert "first_name" in stmt.parameters
+    assert "last_name" in stmt.parameters
+    assert "department" in stmt.parameters
+    assert stmt.parameters["first_name"] == "John"
+    assert stmt.parameters["last_name"] == "Smith"
+    assert stmt.parameters["department"] == "Engineering"
+
+
+def test_insert_values_from_dict_preserves_keys() -> None:
+    """Test that INSERT values_from_dict preserves dictionary keys."""
+    query = sql.insert("orders").values_from_dict({
+        "customer_id": 12345,
+        "product_name": "Widget",
+        "quantity": 3,
+        "order_date": "2023-01-01"
+    })
+    stmt = query.build()
+
+    # Should preserve dictionary keys in parameter names
+    expected_keys = ["customer_id", "product_name", "quantity", "order_date"]
+    for key in expected_keys:
+        # Check if key exists directly or as part of parameter name
+        assert (key in stmt.parameters or
+                any(key in param_key for param_key in stmt.parameters.keys()))
+
+
+def test_complex_query_preserves_all_column_names() -> None:
+    """Test that complex queries preserve column names across all operations."""
+    query = (sql.select("u.username", "p.title")
+             .from_("users u")
+             .join("posts p", "u.id = p.author_id")
+             .where_eq("u.status", "active")
+             .where_in("p.category", ["tech", "science"])
+             .where_between("p.views", 100, 10000)
+             .where_like("p.title", "%python%"))
+    stmt = query.build()
+
+    params = stmt.parameters
+
+    # Should preserve all column names
+    assert "status" in params
+    assert params["status"] == "active"
+
+    # Category parameters with numbering
+    category_params = [key for key in params.keys() if "category" in key]
+    assert len(category_params) == 2
+    assert "tech" in params.values()
+    assert "science" in params.values()
+
+    # Views parameters with descriptive suffixes
+    views_params = [key for key in params.keys() if "views" in key]
+    assert len(views_params) == 2
+    assert 100 in params.values()
+    assert 10000 in params.values()
+
+    # Title parameter
+    assert "title" in params
+    assert params["title"] == "%python%"
+
+
+def test_subquery_parameters_are_preserved() -> None:
+    """Test that subquery parameters maintain their names."""
+    subquery = sql.select("user_id").from_("subscriptions").where_eq("plan_type", "premium")
+
+    query = (sql.select("name", "email")
+             .from_("users")
+             .where_in("id", subquery))
+    stmt = query.build()
+
+    # Subquery parameter should be preserved
+    assert "plan_type" in stmt.parameters
+    assert stmt.parameters["plan_type"] == "premium"
+
+
+def test_mixed_parameter_types_preserve_names() -> None:
+    """Test that mixed parameter types preserve proper column names."""
+    query = (sql.update("user_profiles")
+             .set({
+                 "username": "john_doe",           # string
+                 "age": 28,                       # int
+                 "salary": 75000.50,              # float
+                 "is_active": True,               # bool
+                 "last_seen": None                # None
+             })
+             .where_eq("user_id", 12345))
+    stmt = query.build()
+
+    params = stmt.parameters
+
+    # Should preserve all column names regardless of value type
+    expected_columns = ["username", "age", "salary", "is_active", "last_seen", "user_id"]
+    for col in expected_columns:
+        assert any(col in param_key for param_key in params.keys())
+
+    # Should preserve value types
+    assert "john_doe" in params.values()
+    assert 28 in params.values()
+    assert 75000.50 in params.values()
+    assert True in params.values()
+    assert None in params.values()
+    assert 12345 in params.values()
+
+
+def test_no_generic_param_names_in_where_clauses() -> None:
+    """Test that WHERE clauses never use generic param_1, param_2 names."""
+    test_cases = [
+        sql.select("*").from_("users").where_eq("name", "John"),
+        sql.select("*").from_("posts").where_in("status", ["draft", "published"]),
+        sql.select("*").from_("events").where_between("date", "2023-01-01", "2023-12-31"),
+        sql.select("*").from_("products").where_like("name", "%widget%"),
+        sql.select("*").from_("orders").where_gt("total", 100),
+    ]
+
+    for query in test_cases:
+        stmt = query.build()
+
+        # Should not contain any generic parameter names
+        generic_params = [key for key in stmt.parameters.keys() if key.startswith("param_")]
+        assert len(generic_params) == 0, f"Found generic parameters {generic_params} in: {stmt.sql}"
+
+
+def test_no_generic_param_names_in_update_operations() -> None:
+    """Test that UPDATE operations never use generic parameter names."""
+    test_cases = [
+        sql.update("users").set("email", "new@email.com"),
+        sql.update("posts").set({"title": "New Title", "content": "New content"}),
+        sql.update("products").set("price", 29.99).where_eq("id", 123),
+    ]
+
+    for query in test_cases:
+        stmt = query.build()
+
+        # Should not contain any generic parameter names
+        generic_params = [key for key in stmt.parameters.keys() if key.startswith("param_")]
+        assert len(generic_params) == 0, f"Found generic parameters {generic_params} in: {stmt.sql}"
+
+
+def test_no_generic_param_names_in_insert_operations() -> None:
+    """Test that INSERT operations use descriptive parameter names."""
+    test_cases = [
+        sql.insert("users").values_from_dict({"name": "John", "email": "john@test.com"}),
+        sql.insert("posts").columns("title", "content").values("Hello", "World"),
+    ]
+
+    for query in test_cases:
+        stmt = query.build()
+
+        # Should not contain any generic parameter names
+        generic_params = [key for key in stmt.parameters.keys() if key.startswith("param_")]
+        assert len(generic_params) == 0, f"Found generic parameters {generic_params} in: {stmt.sql}"
+
+
+def test_parameter_names_are_sql_safe() -> None:
+    """Test that generated parameter names are safe for SQL usage."""
+    query = (sql.select("*")
+             .from_("test_table")
+             .where_eq("column_name", "value")
+             .where_in("other_column", ["a", "b", "c"]))
+    stmt = query.build()
+
+    for param_name in stmt.parameters.keys():
+        # Should not contain SQL injection characters
+        assert "'" not in param_name
+        assert '"' not in param_name
+        assert ";" not in param_name
+        assert "--" not in param_name
+
+        # Should be valid identifier-like
+        assert param_name.replace("_", "").replace("0123456789", "").isalpha() or "_" in param_name
+
+
+def test_empty_and_null_values_preserve_column_names() -> None:
+    """Test that empty and null values still preserve column names."""
+    query = (sql.update("users")
+             .set({
+                 "middle_name": "",           # empty string
+                 "phone": None,               # null
+                 "notes": "   ",              # whitespace
+             })
+             .where_eq("id", 1))
+    stmt = query.build()
+
+    params = stmt.parameters
+
+    # Should preserve column names even for empty/null values
+    expected_columns = ["middle_name", "phone", "notes", "id"]
+    for col in expected_columns:
+        assert any(col in param_key for param_key in params.keys())
+
+    # Should preserve actual values
+    assert "" in params.values()
+    assert None in params.values()
+    assert "   " in params.values()
+    assert 1 in params.values()
+
+
+def test_original_user_example_works_correctly() -> None:
+    """Test the exact user example that was originally failing."""
+    query = (sql.select("id", "name", "slug")
+             .from_("test_table")
+             .where_eq("slug", "test-item"))
+    stmt = query.build()
+
+    # Should use :slug parameter, not :param_1
+    assert "slug" in stmt.parameters
+    assert stmt.parameters["slug"] == "test-item"
+    assert ":slug" in stmt.sql
+
+    # Should not contain any generic parameters
+    assert not any(key.startswith("param_") for key in stmt.parameters.keys())
+
+
+def test_parameter_naming_with_special_characters_in_values() -> None:
+    """Test that parameter naming works with special characters in values."""
+    query = (sql.select("*")
+             .from_("logs")
+             .where_eq("message", "Error: Connection failed!")
+             .where_like("details", "%SQL injection attempt: DROP TABLE%"))
+    stmt = query.build()
+
+    # Should preserve column names despite special characters in values
+    assert "message" in stmt.parameters
+    assert "details" in stmt.parameters
+    assert stmt.parameters["message"] == "Error: Connection failed!"
+    assert stmt.parameters["details"] == "%SQL injection attempt: DROP TABLE%"

--- a/tests/unit/test_builder_parameter_naming.py
+++ b/tests/unit/test_builder_parameter_naming.py
@@ -22,11 +22,7 @@ def test_update_set_uses_column_names() -> None:
 
 def test_update_set_with_dict_uses_column_names() -> None:
     """Test that UPDATE SET with dictionary uses column names for parameters."""
-    query = sql.update("products").set({
-        "name": "Widget",
-        "price": 29.99,
-        "category": "Tools"
-    })
+    query = sql.update("products").set({"name": "Widget", "price": 29.99, "category": "Tools"})
     stmt = query.build()
 
     assert "name" in stmt.parameters
@@ -39,9 +35,7 @@ def test_update_set_with_dict_uses_column_names() -> None:
 
 def test_insert_with_columns_uses_column_names() -> None:
     """Test that INSERT with specified columns uses column names for parameters."""
-    query = (sql.insert("users")
-             .columns("name", "email", "age")
-             .values("Alice Smith", "alice@test.com", 28))
+    query = sql.insert("users").columns("name", "email", "age").values("Alice Smith", "alice@test.com", 28)
     stmt = query.build()
 
     assert "name" in stmt.parameters
@@ -54,12 +48,9 @@ def test_insert_with_columns_uses_column_names() -> None:
 
 def test_insert_values_from_dict_uses_column_names() -> None:
     """Test that INSERT values_from_dict uses column names for parameters."""
-    query = sql.insert("orders").values_from_dict({
-        "customer_id": 123,
-        "product_name": "Laptop",
-        "quantity": 2,
-        "total": 1999.98
-    })
+    query = sql.insert("orders").values_from_dict(
+        {"customer_id": 123, "product_name": "Laptop", "quantity": 2, "total": 1999.98}
+    )
     stmt = query.build()
 
     # Should preserve the dictionary key names as parameter names
@@ -82,13 +73,15 @@ def test_insert_without_columns_uses_positional_names() -> None:
 
 def test_case_when_uses_descriptive_names() -> None:
     """Test that CASE WHEN expressions use descriptive parameter names."""
-    query = (sql.select("name")
-             .from_("users")
-             .case_()
-             .when("age > 65", "Senior")
-             .when("age > 18", "Adult")
-             .else_("Minor")
-             .end())
+    query = (
+        sql.select("name")
+        .from_("users")
+        .case_()
+        .when("age > 65", "Senior")
+        .when("age > 18", "Adult")
+        .else_("Minor")
+        .end()
+    )
     stmt = query.build()
 
     # Should use descriptive names for CASE values
@@ -105,12 +98,14 @@ def test_case_when_uses_descriptive_names() -> None:
 
 def test_complex_query_preserves_column_names() -> None:
     """Test that complex queries with multiple operations preserve column names."""
-    query = (sql.select("u.name", "p.title")
-             .from_("users u")
-             .join("posts p", "u.id = p.user_id")
-             .where_eq("u.status", "active")
-             .where_in("p.category", ["tech", "science"])
-             .where_between("p.created_at", "2023-01-01", "2023-12-31"))
+    query = (
+        sql.select("u.name", "p.title")
+        .from_("users u")
+        .join("posts p", "u.id = p.user_id")
+        .where_eq("u.status", "active")
+        .where_in("p.category", ["tech", "science"])
+        .where_between("p.created_at", "2023-01-01", "2023-12-31")
+    )
     stmt = query.build()
 
     # Should use descriptive parameter names
@@ -135,11 +130,9 @@ def test_complex_query_preserves_column_names() -> None:
 
 def test_parameter_collision_handling() -> None:
     """Test that parameter name collisions are handled gracefully."""
-    query = (sql.select("*")
-             .from_("events")
-             .where_gt("priority", 1)
-             .where_lt("priority", 10)
-             .where_eq("status", "active"))
+    query = (
+        sql.select("*").from_("events").where_gt("priority", 1).where_lt("priority", 10).where_eq("status", "active")
+    )
     stmt = query.build()
 
     params = stmt.parameters
@@ -162,9 +155,7 @@ def test_subquery_parameter_preservation() -> None:
     """Test that parameters in subqueries are properly preserved."""
     subquery = sql.select("id").from_("active_users").where_eq("status", "verified")
 
-    query = (sql.select("name")
-             .from_("posts")
-             .where_in("author_id", subquery))
+    query = sql.select("name").from_("posts").where_in("author_id", subquery)
     stmt = query.build()
 
     # Should preserve the subquery parameter name
@@ -174,10 +165,7 @@ def test_subquery_parameter_preservation() -> None:
 
 def test_table_prefixed_columns_extract_column_name() -> None:
     """Test that table-prefixed columns extract just the column name for parameters."""
-    query = (sql.select("*")
-             .from_("users u")
-             .where_eq("u.email", "test@example.com")
-             .where_gt("u.age", 21))
+    query = sql.select("*").from_("users u").where_eq("u.email", "test@example.com").where_gt("u.age", 21)
     stmt = query.build()
 
     # Should extract column names without table prefix
@@ -189,14 +177,11 @@ def test_table_prefixed_columns_extract_column_name() -> None:
 
 def test_mixed_parameter_types_preserve_names() -> None:
     """Test that mixed parameter types (strings, numbers, booleans) preserve proper names."""
-    query = (sql.update("accounts")
-             .set({
-                 "username": "john_doe",
-                 "balance": 1500.75,
-                 "is_active": True,
-                 "last_login": None
-             })
-             .where_eq("account_id", 12345))
+    query = (
+        sql.update("accounts")
+        .set({"username": "john_doe", "balance": 1500.75, "is_active": True, "last_login": None})
+        .where_eq("account_id", 12345)
+    )
     stmt = query.build()
 
     params = stmt.parameters

--- a/tests/unit/test_builder_parameter_naming.py
+++ b/tests/unit/test_builder_parameter_naming.py
@@ -1,0 +1,237 @@
+"""Unit tests for comprehensive parameter naming across all SQL builder operations.
+
+This module tests that all SQL builder operations use descriptive, column-based
+parameter names instead of generic param_1, param_2, etc.
+"""
+
+from sqlspec import sql
+
+
+def test_update_set_uses_column_names() -> None:
+    """Test that UPDATE SET operations use column names for parameters."""
+    query = sql.update("users").set("name", "John Doe").set("email", "john@example.com")
+    stmt = query.build()
+
+    assert "name" in stmt.parameters
+    assert "email" in stmt.parameters
+    assert stmt.parameters["name"] == "John Doe"
+    assert stmt.parameters["email"] == "john@example.com"
+    assert ":name" in stmt.sql
+    assert ":email" in stmt.sql
+
+
+def test_update_set_with_dict_uses_column_names() -> None:
+    """Test that UPDATE SET with dictionary uses column names for parameters."""
+    query = sql.update("products").set({
+        "name": "Widget",
+        "price": 29.99,
+        "category": "Tools"
+    })
+    stmt = query.build()
+
+    assert "name" in stmt.parameters
+    assert "price" in stmt.parameters
+    assert "category" in stmt.parameters
+    assert stmt.parameters["name"] == "Widget"
+    assert stmt.parameters["price"] == 29.99
+    assert stmt.parameters["category"] == "Tools"
+
+
+def test_insert_with_columns_uses_column_names() -> None:
+    """Test that INSERT with specified columns uses column names for parameters."""
+    query = (sql.insert("users")
+             .columns("name", "email", "age")
+             .values("Alice Smith", "alice@test.com", 28))
+    stmt = query.build()
+
+    assert "name" in stmt.parameters
+    assert "email" in stmt.parameters
+    assert "age" in stmt.parameters
+    assert stmt.parameters["name"] == "Alice Smith"
+    assert stmt.parameters["email"] == "alice@test.com"
+    assert stmt.parameters["age"] == 28
+
+
+def test_insert_values_from_dict_uses_column_names() -> None:
+    """Test that INSERT values_from_dict uses column names for parameters."""
+    query = sql.insert("orders").values_from_dict({
+        "customer_id": 123,
+        "product_name": "Laptop",
+        "quantity": 2,
+        "total": 1999.98
+    })
+    stmt = query.build()
+
+    # Should preserve the dictionary key names as parameter names
+    assert "customer_id" in stmt.parameters or any("customer_id" in key for key in stmt.parameters.keys())
+    assert "product_name" in stmt.parameters or any("product_name" in key for key in stmt.parameters.keys())
+    assert "quantity" in stmt.parameters or any("quantity" in key for key in stmt.parameters.keys())
+    assert "total" in stmt.parameters or any("total" in key for key in stmt.parameters.keys())
+
+
+def test_insert_without_columns_uses_positional_names() -> None:
+    """Test that INSERT without specified columns uses descriptive positional names."""
+    query = sql.insert("logs").values("INFO", "User login", "2023-01-01")
+    stmt = query.build()
+
+    # Without column info, should use value_1, value_2, etc.
+    param_keys = list(stmt.parameters.keys())
+    assert len(param_keys) == 3
+    assert any("value" in key for key in param_keys)
+
+
+def test_case_when_uses_descriptive_names() -> None:
+    """Test that CASE WHEN expressions use descriptive parameter names."""
+    query = (sql.select("name")
+             .from_("users")
+             .case_()
+             .when("age > 65", "Senior")
+             .when("age > 18", "Adult")
+             .else_("Minor")
+             .end())
+    stmt = query.build()
+
+    # Should use descriptive names for CASE values
+    param_keys = list(stmt.parameters.keys())
+    case_params = [key for key in param_keys if "case" in key]
+    assert len(case_params) >= 2  # At least when and else values
+
+    # Should contain the actual values
+    param_values = list(stmt.parameters.values())
+    assert "Senior" in param_values
+    assert "Adult" in param_values
+    assert "Minor" in param_values
+
+
+def test_complex_query_preserves_column_names() -> None:
+    """Test that complex queries with multiple operations preserve column names."""
+    query = (sql.select("u.name", "p.title")
+             .from_("users u")
+             .join("posts p", "u.id = p.user_id")
+             .where_eq("u.status", "active")
+             .where_in("p.category", ["tech", "science"])
+             .where_between("p.created_at", "2023-01-01", "2023-12-31"))
+    stmt = query.build()
+
+    # Should use descriptive parameter names
+    params = stmt.parameters
+
+    # Status parameter
+    assert "status" in params
+    assert params["status"] == "active"
+
+    # IN clause parameters
+    category_params = [key for key in params.keys() if "category" in key]
+    assert len(category_params) == 2
+    assert "tech" in params.values()
+    assert "science" in params.values()
+
+    # BETWEEN clause parameters
+    created_at_params = [key for key in params.keys() if "created_at" in key]
+    assert len(created_at_params) == 2
+    assert "2023-01-01" in params.values()
+    assert "2023-12-31" in params.values()
+
+
+def test_parameter_collision_handling() -> None:
+    """Test that parameter name collisions are handled gracefully."""
+    query = (sql.select("*")
+             .from_("events")
+             .where_gt("priority", 1)
+             .where_lt("priority", 10)
+             .where_eq("status", "active"))
+    stmt = query.build()
+
+    params = stmt.parameters
+
+    # Should have status parameter
+    assert "status" in params
+    assert params["status"] == "active"
+
+    # Should have priority parameters with collision resolution
+    priority_params = [key for key in params.keys() if "priority" in key]
+    assert len(priority_params) == 2
+
+    # One should be "priority", the other "priority_1"
+    assert "priority" in params or "priority_1" in params
+    assert 1 in params.values()
+    assert 10 in params.values()
+
+
+def test_subquery_parameter_preservation() -> None:
+    """Test that parameters in subqueries are properly preserved."""
+    subquery = sql.select("id").from_("active_users").where_eq("status", "verified")
+
+    query = (sql.select("name")
+             .from_("posts")
+             .where_in("author_id", subquery))
+    stmt = query.build()
+
+    # Should preserve the subquery parameter name
+    assert "status" in stmt.parameters
+    assert stmt.parameters["status"] == "verified"
+
+
+def test_table_prefixed_columns_extract_column_name() -> None:
+    """Test that table-prefixed columns extract just the column name for parameters."""
+    query = (sql.select("*")
+             .from_("users u")
+             .where_eq("u.email", "test@example.com")
+             .where_gt("u.age", 21))
+    stmt = query.build()
+
+    # Should extract column names without table prefix
+    assert "email" in stmt.parameters
+    assert "age" in stmt.parameters
+    assert stmt.parameters["email"] == "test@example.com"
+    assert stmt.parameters["age"] == 21
+
+
+def test_mixed_parameter_types_preserve_names() -> None:
+    """Test that mixed parameter types (strings, numbers, booleans) preserve proper names."""
+    query = (sql.update("accounts")
+             .set({
+                 "username": "john_doe",
+                 "balance": 1500.75,
+                 "is_active": True,
+                 "last_login": None
+             })
+             .where_eq("account_id", 12345))
+    stmt = query.build()
+
+    params = stmt.parameters
+
+    # Should preserve all column names
+    expected_keys = ["username", "balance", "is_active", "last_login", "account_id"]
+    for key in expected_keys:
+        assert key in params or any(key in param_key for param_key in params.keys())
+
+    # Should preserve values with correct types
+    assert "john_doe" in params.values()
+    assert 1500.75 in params.values()
+    assert True in params.values()
+    assert None in params.values()
+    assert 12345 in params.values()
+
+
+def test_no_generic_param_names_in_common_operations() -> None:
+    """Test that common operations do not generate generic param_1, param_2 names."""
+    # Test various common query patterns
+    queries = [
+        sql.select("*").from_("users").where_eq("name", "John"),
+        sql.update("users").set("email", "new@email.com").where_eq("id", 1),
+        sql.insert("users").values_from_dict({"name": "Jane", "age": 25}),
+        sql.select("*").from_("posts").where_in("category", ["tech", "news"]),
+        sql.select("*").from_("events").where_between("date", "2023-01-01", "2023-12-31"),
+    ]
+
+    for query in queries:
+        stmt = query.build()
+
+        # Should not contain any generic parameter names
+        generic_params = [key for key in stmt.parameters.keys() if key.startswith("param_")]
+        assert len(generic_params) == 0, f"Found generic parameters {generic_params} in query: {stmt.sql}"
+
+        # All parameter names should be descriptive
+        for param_name in stmt.parameters.keys():
+            assert not param_name.startswith("param_"), f"Parameter name '{param_name}' is generic"

--- a/tests/unit/test_core/test_filters.py
+++ b/tests/unit/test_core/test_filters.py
@@ -1,0 +1,257 @@
+"""Unit tests for SQL statement filters.
+
+This module tests the filter system that provides dynamic WHERE clauses,
+ORDER BY, LIMIT/OFFSET, and other SQL modifications with proper parameter naming.
+"""
+
+from datetime import datetime
+
+from sqlspec.core.filters import (
+    AnyCollectionFilter,
+    BeforeAfterFilter,
+    InCollectionFilter,
+    LimitOffsetFilter,
+    NotInCollectionFilter,
+    OrderByFilter,
+    SearchFilter,
+    apply_filter,
+)
+from sqlspec.core.statement import SQL
+
+
+def test_before_after_filter_uses_column_based_parameters() -> None:
+    """Test that BeforeAfterFilter uses column-based parameter names."""
+    before_date = datetime(2023, 12, 31)
+    after_date = datetime(2023, 1, 1)
+
+    filter_obj = BeforeAfterFilter("created_at", before=before_date, after=after_date)
+
+    positional, named = filter_obj.extract_parameters()
+
+    assert positional == []
+    assert "created_at_before" in named
+    assert "created_at_after" in named
+    assert named["created_at_before"] == before_date
+    assert named["created_at_after"] == after_date
+
+
+def test_in_collection_filter_uses_column_based_parameters() -> None:
+    """Test that InCollectionFilter uses column-based parameter names."""
+    values = ["active", "pending", "completed"]
+
+    filter_obj = InCollectionFilter("status", values)
+
+    positional, named = filter_obj.extract_parameters()
+
+    assert positional == []
+    assert "status_in_0" in named
+    assert "status_in_1" in named
+    assert "status_in_2" in named
+    assert named["status_in_0"] == "active"
+    assert named["status_in_1"] == "pending"
+    assert named["status_in_2"] == "completed"
+
+
+def test_search_filter_uses_column_based_parameters() -> None:
+    """Test that SearchFilter uses column-based parameter names."""
+    filter_obj = SearchFilter("name", "john")
+
+    positional, named = filter_obj.extract_parameters()
+
+    assert positional == []
+    assert "name_search" in named
+    assert named["name_search"] == "%john%"
+
+
+def test_any_collection_filter_uses_column_based_parameters() -> None:
+    """Test that AnyCollectionFilter uses column-based parameter names."""
+    values = [1, 2, 3]
+
+    filter_obj = AnyCollectionFilter("user_id", values)
+
+    positional, named = filter_obj.extract_parameters()
+
+    assert positional == []
+    assert "user_id_any_0" in named
+    assert "user_id_any_1" in named
+    assert "user_id_any_2" in named
+    assert named["user_id_any_0"] == 1
+    assert named["user_id_any_1"] == 2
+    assert named["user_id_any_2"] == 3
+
+
+def test_not_in_collection_filter_uses_column_based_parameters() -> None:
+    """Test that NotInCollectionFilter uses column-based parameter names."""
+    values = ["deleted", "archived"]
+
+    filter_obj = NotInCollectionFilter("status", values)
+
+    positional, named = filter_obj.extract_parameters()
+
+    assert positional == []
+    # NotInCollectionFilter includes object id for uniqueness
+    param_names = list(named.keys())
+    assert len(param_names) == 2
+    assert all("status_notin_" in name for name in param_names)
+    assert "deleted" in named.values()
+    assert "archived" in named.values()
+
+
+def test_limit_offset_filter_uses_descriptive_parameters() -> None:
+    """Test that LimitOffsetFilter uses descriptive parameter names."""
+    filter_obj = LimitOffsetFilter(limit=25, offset=50)
+
+    positional, named = filter_obj.extract_parameters()
+
+    assert positional == []
+    assert "limit" in named
+    assert "offset" in named
+    assert named["limit"] == 25
+    assert named["offset"] == 50
+
+
+def test_order_by_filter_no_parameters() -> None:
+    """Test that OrderByFilter doesn't use parameters."""
+    filter_obj = OrderByFilter("created_at", "desc")
+
+    positional, named = filter_obj.extract_parameters()
+
+    assert positional == []
+    assert named == {}
+
+
+def test_filter_parameter_conflict_resolution() -> None:
+    """Test that filters resolve parameter name conflicts."""
+    sql_stmt = SQL("SELECT * FROM users WHERE name = :name_search", {"name_search": "existing"})
+
+    # This should create a conflict with the existing name_search parameter
+    filter_obj = SearchFilter("name", "new_value")
+
+    result = apply_filter(sql_stmt, filter_obj)
+
+    # Should have the original parameter plus a new unique one
+    assert "name_search" in result.parameters
+    assert result.parameters["name_search"] == "existing"
+
+    # Find the new parameter (it will have a UUID suffix)
+    new_param_keys = [k for k in result.parameters.keys() if k.startswith("name_search_") and k != "name_search"]
+    assert len(new_param_keys) == 1
+    assert result.parameters[new_param_keys[0]] == "%new_value%"
+
+
+def test_multiple_filters_preserve_column_names() -> None:
+    """Test that multiple filters maintain column-based parameter naming and merge properly."""
+    sql_stmt = SQL("SELECT * FROM users")
+
+    # Apply multiple filters in sequence
+    status_filter = InCollectionFilter("status", ["active", "pending"])
+    search_filter = SearchFilter("name", "john")
+    limit_filter = LimitOffsetFilter(10, 0)
+
+    result = sql_stmt
+    result = apply_filter(result, status_filter)
+    result = apply_filter(result, search_filter)
+    result = apply_filter(result, limit_filter)
+
+    # Check that all parameters use descriptive names and are preserved
+    params = result.parameters
+
+    # Status filter parameters
+    assert "status_in_0" in params
+    assert "status_in_1" in params
+    assert params["status_in_0"] == "active"
+    assert params["status_in_1"] == "pending"
+
+    # Search filter parameter
+    assert "name_search" in params
+    assert params["name_search"] == "%john%"
+
+    # Pagination filter parameters
+    assert "limit" in params
+    assert "offset" in params
+    assert params["limit"] == 10
+    assert params["offset"] == 0
+
+    # Verify final SQL contains all components
+    sql_text = result.sql.upper()
+    assert "SELECT" in sql_text
+    assert "FROM" in sql_text
+    assert "WHERE" in sql_text
+    assert "STATUS IN" in sql_text
+    assert "NAME LIKE" in sql_text
+    assert "LIMIT" in sql_text
+    assert "OFFSET" in sql_text
+
+
+def test_filter_with_empty_values() -> None:
+    """Test filters handle empty values correctly."""
+    # Empty IN filter
+    empty_in_filter: InCollectionFilter[str] = InCollectionFilter("status", [])
+    positional, named = empty_in_filter.extract_parameters()
+    assert positional == []
+    assert named == {}
+
+    # None values
+    none_in_filter: InCollectionFilter[str] = InCollectionFilter("status", None)
+    positional, named = none_in_filter.extract_parameters()
+    assert positional == []
+    assert named == {}
+
+
+def test_search_filter_multiple_fields() -> None:
+    """Test SearchFilter with multiple field names."""
+    fields = {"first_name", "last_name", "email"}
+    filter_obj = SearchFilter(fields, "john")
+
+    positional, named = filter_obj.extract_parameters()
+
+    assert positional == []
+    assert "search_value" in named  # Uses generic name for multiple fields
+    assert named["search_value"] == "%john%"
+
+
+def test_cache_key_generation() -> None:
+    """Test that filters generate proper cache keys."""
+    # BeforeAfterFilter
+    before_date = datetime(2023, 12, 31)
+    after_date = datetime(2023, 1, 1)
+    ba_filter = BeforeAfterFilter("created_at", before=before_date, after=after_date)
+
+    cache_key = ba_filter.get_cache_key()
+    assert cache_key[0] == "BeforeAfterFilter"
+    assert cache_key[1] == "created_at"
+    assert before_date in cache_key
+    assert after_date in cache_key
+
+    # InCollectionFilter
+    in_filter = InCollectionFilter("status", ["active", "pending"])
+    cache_key = in_filter.get_cache_key()
+    assert cache_key[0] == "InCollectionFilter"
+    assert cache_key[1] == "status"
+    assert cache_key[2] == ("active", "pending")
+
+
+def test_filter_sql_generation_preserves_parameter_names() -> None:
+    """Test that applying filters to SQL generates proper parameter placeholders."""
+    sql_stmt = SQL("SELECT * FROM users")
+
+    # Apply a search filter
+    search_filter = SearchFilter("name", "john")
+    result = apply_filter(sql_stmt, search_filter)
+
+    # Check that SQL contains the named parameter
+    assert ":name_search" in result.sql
+    assert "name_search" in result.parameters
+    assert result.parameters["name_search"] == "%john%"
+
+    # Apply an IN filter
+    in_filter = InCollectionFilter("status", ["active", "pending"])
+    result = apply_filter(result, in_filter)
+
+    # Check both filters' parameters are preserved
+    assert ":status_in_0" in result.sql
+    assert ":status_in_1" in result.sql
+    assert "status_in_0" in result.parameters
+    assert "status_in_1" in result.parameters
+    assert result.parameters["status_in_0"] == "active"
+    assert result.parameters["status_in_1"] == "pending"

--- a/tests/unit/test_sql_factory.py
+++ b/tests/unit/test_sql_factory.py
@@ -154,11 +154,7 @@ def test_where_not_any_with_values_uses_placeholders() -> None:
 def test_multiple_where_conditions_sequential_parameters() -> None:
     """Test that multiple WHERE conditions create descriptive parameters."""
     query = (
-        sql.select("*")
-        .from_("users")
-        .where_eq("name", "John")
-        .where_gt("age", 21)
-        .where_like("email", "%@gmail.com")
+        sql.select("*").from_("users").where_eq("name", "John").where_gt("age", 21).where_like("email", "%@gmail.com")
     )
     stmt = query.build()
 
@@ -174,11 +170,7 @@ def test_multiple_where_conditions_sequential_parameters() -> None:
 
 def test_user_reproducible_example_fixed() -> None:
     """Test the exact user example that was failing before the fix."""
-    query = (
-        sql.select("id", "name", "slug")
-        .from_("test_table")
-        .where_eq("slug", "test-item")
-    )
+    query = sql.select("id", "name", "slug").from_("test_table").where_eq("slug", "test-item")
 
     stmt = query.build()
 
@@ -210,11 +202,7 @@ def test_raw_with_named_parameters_returns_sql_object() -> None:
 
 def test_raw_with_multiple_named_parameters() -> None:
     """Test raw SQL with multiple named parameters."""
-    stmt = sql.raw(
-        "price BETWEEN :min_price AND :max_price",
-        min_price=100,
-        max_price=500
-    )
+    stmt = sql.raw("price BETWEEN :min_price AND :max_price", min_price=100, max_price=500)
 
     assert isinstance(stmt, SQL)
     assert stmt.sql == "price BETWEEN :min_price AND :max_price"
@@ -224,11 +212,7 @@ def test_raw_with_multiple_named_parameters() -> None:
 
 def test_raw_with_complex_sql_and_parameters() -> None:
     """Test raw SQL with complex query and named parameters."""
-    stmt = sql.raw(
-        "LOWER(name) LIKE LOWER(:pattern) AND status = :status",
-        pattern="%test%",
-        status="active"
-    )
+    stmt = sql.raw("LOWER(name) LIKE LOWER(:pattern) AND status = :status", pattern="%test%", status="active")
 
     assert isinstance(stmt, SQL)
     assert "LOWER(name) LIKE LOWER(:pattern)" in stmt.sql
@@ -240,10 +224,7 @@ def test_raw_with_complex_sql_and_parameters() -> None:
 def test_raw_with_various_parameter_types() -> None:
     """Test raw SQL with different parameter value types."""
     stmt = sql.raw(
-        "id = :user_id AND active = :is_active AND score >= :min_score",
-        user_id=123,
-        is_active=True,
-        min_score=4.5
+        "id = :user_id AND active = :is_active AND score >= :min_score", user_id=123, is_active=True, min_score=4.5
     )
 
     assert isinstance(stmt, SQL)
@@ -270,10 +251,7 @@ def test_raw_none_values_in_parameters() -> None:
 
 def test_raw_parameter_overwrite_behavior() -> None:
     """Test behavior when same parameter name used multiple times."""
-    stmt = sql.raw(
-        "field1 = :value AND field2 = :value",
-        value="test"
-    )
+    stmt = sql.raw("field1 = :value AND field2 = :value", value="test")
 
     assert isinstance(stmt, SQL)
     assert stmt.parameters["value"] == "test"
@@ -360,10 +338,19 @@ def test_alter_table_method_exists() -> None:
 def test_all_ddl_methods_exist() -> None:
     """Test that all expected DDL methods exist on the sql factory."""
     ddl_methods = [
-        "create_table", "create_view", "create_index", "create_schema",
-        "create_materialized_view", "create_table_as_select",
-        "drop_table", "drop_view", "drop_index", "drop_schema",
-        "alter_table", "rename_table", "comment_on"
+        "create_table",
+        "create_view",
+        "create_index",
+        "create_schema",
+        "create_materialized_view",
+        "create_table_as_select",
+        "drop_table",
+        "drop_view",
+        "drop_index",
+        "drop_schema",
+        "alter_table",
+        "rename_table",
+        "comment_on",
     ]
 
     for method_name in ddl_methods:
@@ -445,12 +432,7 @@ def test_empty_raw_sql() -> None:
 
 def test_parameter_names_use_column_names() -> None:
     """Test that parameters use column names when possible."""
-    query = (
-        sql.select("*")
-        .from_("users")
-        .where_eq("name", "John")
-        .where_eq("status", "active")
-    )
+    query = sql.select("*").from_("users").where_eq("name", "John").where_eq("status", "active")
     stmt = query.build()
 
     assert "name" in stmt.parameters
@@ -461,12 +443,7 @@ def test_parameter_names_use_column_names() -> None:
 
 def test_parameter_values_preserved_correctly() -> None:
     """Test that parameter values are preserved exactly."""
-    test_values = [
-        ("string_val", "test"),
-        ("int_val", 42),
-        ("float_val", 3.14159),
-        ("bool_val", True),
-    ]
+    test_values = [("string_val", "test"), ("int_val", 42), ("float_val", 3.14159), ("bool_val", True)]
 
     query = sql.select("*").from_("test")
     for column_name, value in test_values:

--- a/tests/unit/test_sql_factory.py
+++ b/tests/unit/test_sql_factory.py
@@ -1,0 +1,485 @@
+"""Unit tests for SQL factory functionality including parameter binding fixes and new features."""
+
+import pytest
+from sqlglot import exp
+
+from sqlspec import sql
+from sqlspec._sql import SQLFactory
+from sqlspec.core.statement import SQL
+from sqlspec.exceptions import SQLBuilderError
+
+
+def test_sql_factory_instance() -> None:
+    """Test that sql is an instance of SQLFactory."""
+    assert isinstance(sql, SQLFactory)
+
+
+def test_sql_factory_default_dialect() -> None:
+    """Test SQL factory default dialect behavior."""
+    factory = SQLFactory()
+    assert factory.dialect is None
+
+    factory_with_dialect = SQLFactory(dialect="postgres")
+    assert factory_with_dialect.dialect == "postgres"
+
+
+def test_where_eq_uses_placeholder_not_var() -> None:
+    """Test that where_eq uses Placeholder instead of var for parameters."""
+    query = sql.select("*").from_("users").where_eq("name", "John")
+    stmt = query.build()
+
+    assert ":name" in stmt.sql
+    assert "name" in stmt.parameters
+    assert stmt.parameters["name"] == "John"
+
+
+def test_where_neq_uses_placeholder() -> None:
+    """Test that where_neq uses proper parameter binding."""
+    query = sql.select("*").from_("users").where_neq("status", "inactive")
+    stmt = query.build()
+
+    assert ":status" in stmt.sql
+    assert stmt.parameters["status"] == "inactive"
+
+
+def test_where_comparison_operators_use_placeholders() -> None:
+    """Test all comparison WHERE methods use proper parameter binding."""
+    test_cases = [
+        ("where_lt", lambda q: q.where_lt("age", 18), "age"),
+        ("where_lte", lambda q: q.where_lte("score", 100), "score"),
+        ("where_gt", lambda q: q.where_gt("price", 50.0), "price"),
+        ("where_gte", lambda q: q.where_gte("rating", 3.5), "rating"),
+    ]
+
+    for method_name, query_builder, column_name in test_cases:
+        query = query_builder(sql.select("*").from_("test_table"))  # type: ignore[no-untyped-call]
+        stmt = query.build()
+
+        assert f":{column_name}" in stmt.sql, f"{method_name} should use :{column_name} placeholder"
+        assert column_name in stmt.parameters, f"{method_name} should have {column_name} in parameters"
+
+        sql_upper = stmt.sql.upper()
+        bare_param_exists = column_name.upper() in sql_upper and f":{column_name.upper()}" not in sql_upper
+        assert not bare_param_exists, f"{method_name} should not have bare {column_name} reference"
+
+
+def test_where_between_uses_placeholders() -> None:
+    """Test that where_between uses proper parameter binding for both values."""
+    query = sql.select("*").from_("products").where_between("price", 10, 100)
+    stmt = query.build()
+
+    assert "price_low" in stmt.parameters
+    assert "price_high" in stmt.parameters
+    assert stmt.parameters["price_low"] == 10
+    assert stmt.parameters["price_high"] == 100
+
+    assert ":price_low" in stmt.sql
+    assert ":price_high" in stmt.sql
+
+
+def test_where_like_uses_placeholder() -> None:
+    """Test that where_like uses proper parameter binding."""
+    query = sql.select("*").from_("users").where_like("name", "%John%")
+    stmt = query.build()
+
+    assert ":name" in stmt.sql
+    assert stmt.parameters["name"] == "%John%"
+
+
+def test_where_not_like_uses_placeholder() -> None:
+    """Test that where_not_like uses proper parameter binding."""
+    query = sql.select("*").from_("users").where_not_like("name", "%spam%")
+    stmt = query.build()
+
+    assert ":name" in stmt.sql
+    assert stmt.parameters["name"] == "%spam%"
+
+
+def test_where_ilike_uses_placeholder() -> None:
+    """Test that where_ilike uses proper parameter binding."""
+    query = sql.select("*").from_("users").where_ilike("email", "%@example.com")
+    stmt = query.build()
+
+    assert ":email" in stmt.sql
+    assert stmt.parameters["email"] == "%@example.com"
+
+
+def test_where_in_uses_placeholders() -> None:
+    """Test that where_in uses proper parameter binding for multiple values."""
+    query = sql.select("*").from_("users").where_in("status", ["active", "pending"])
+    stmt = query.build()
+
+    assert "status_1" in stmt.parameters
+    assert "status_2" in stmt.parameters
+    assert stmt.parameters["status_1"] == "active"
+    assert stmt.parameters["status_2"] == "pending"
+
+    assert ":status_1" in stmt.sql
+    assert ":status_2" in stmt.sql
+
+
+def test_where_not_in_uses_placeholders() -> None:
+    """Test that where_not_in uses proper parameter binding."""
+    query = sql.select("*").from_("users").where_not_in("role", ["admin", "superuser"])
+    stmt = query.build()
+
+    assert "role_1" in stmt.parameters
+    assert "role_2" in stmt.parameters
+    assert stmt.parameters["role_1"] == "admin"
+    assert stmt.parameters["role_2"] == "superuser"
+
+
+def test_where_any_with_values_uses_placeholders() -> None:
+    """Test that where_any with value list uses proper parameter binding."""
+    query = sql.select("*").from_("users").where_any("status", ["active", "verified"])
+    stmt = query.build()
+
+    assert "status_any_1" in stmt.parameters
+    assert "status_any_2" in stmt.parameters
+    assert stmt.parameters["status_any_1"] == "active"
+    assert stmt.parameters["status_any_2"] == "verified"
+
+
+def test_where_not_any_with_values_uses_placeholders() -> None:
+    """Test that where_not_any with value list uses proper parameter binding."""
+    query = sql.select("*").from_("users").where_not_any("status", ["banned", "suspended"])
+    stmt = query.build()
+
+    assert "status_not_any_1" in stmt.parameters
+    assert "status_not_any_2" in stmt.parameters
+    assert stmt.parameters["status_not_any_1"] == "banned"
+    assert stmt.parameters["status_not_any_2"] == "suspended"
+
+
+def test_multiple_where_conditions_sequential_parameters() -> None:
+    """Test that multiple WHERE conditions create descriptive parameters."""
+    query = (
+        sql.select("*")
+        .from_("users")
+        .where_eq("name", "John")
+        .where_gt("age", 21)
+        .where_like("email", "%@gmail.com")
+    )
+    stmt = query.build()
+
+    assert len(stmt.parameters) == 3
+    assert stmt.parameters["name"] == "John"
+    assert stmt.parameters["age"] == 21
+    assert stmt.parameters["email"] == "%@gmail.com"
+
+    assert ":name" in stmt.sql
+    assert ":age" in stmt.sql
+    assert ":email" in stmt.sql
+
+
+def test_user_reproducible_example_fixed() -> None:
+    """Test the exact user example that was failing before the fix."""
+    query = (
+        sql.select("id", "name", "slug")
+        .from_("test_table")
+        .where_eq("slug", "test-item")
+    )
+
+    stmt = query.build()
+
+    assert "WHERE" in stmt.sql
+    assert ":slug" in stmt.sql
+    assert stmt.parameters["slug"] == "test-item"
+
+    sql_upper = stmt.sql.upper()
+    bare_param_exists = "SLUG" in sql_upper and ":SLUG" not in sql_upper
+    assert not bare_param_exists, "Should not contain bare slug reference"
+
+
+def test_raw_without_parameters_backward_compatibility() -> None:
+    """Test that raw() without parameters maintains backward compatibility."""
+    expr = sql.raw("COALESCE(name, 'Unknown')")
+
+    assert isinstance(expr, exp.Expression)
+    assert not isinstance(expr, SQL)
+
+
+def test_raw_with_named_parameters_returns_sql_object() -> None:
+    """Test that raw() with parameters returns SQL statement object."""
+    stmt = sql.raw("name = :name_param", name_param="John")
+
+    assert isinstance(stmt, SQL)
+    assert stmt.sql == "name = :name_param"
+    assert stmt.parameters["name_param"] == "John"
+
+
+def test_raw_with_multiple_named_parameters() -> None:
+    """Test raw SQL with multiple named parameters."""
+    stmt = sql.raw(
+        "price BETWEEN :min_price AND :max_price",
+        min_price=100,
+        max_price=500
+    )
+
+    assert isinstance(stmt, SQL)
+    assert stmt.sql == "price BETWEEN :min_price AND :max_price"
+    assert stmt.parameters["min_price"] == 100
+    assert stmt.parameters["max_price"] == 500
+
+
+def test_raw_with_complex_sql_and_parameters() -> None:
+    """Test raw SQL with complex query and named parameters."""
+    stmt = sql.raw(
+        "LOWER(name) LIKE LOWER(:pattern) AND status = :status",
+        pattern="%test%",
+        status="active"
+    )
+
+    assert isinstance(stmt, SQL)
+    assert "LOWER(name) LIKE LOWER(:pattern)" in stmt.sql
+    assert "status = :status" in stmt.sql
+    assert stmt.parameters["pattern"] == "%test%"
+    assert stmt.parameters["status"] == "active"
+
+
+def test_raw_with_various_parameter_types() -> None:
+    """Test raw SQL with different parameter value types."""
+    stmt = sql.raw(
+        "id = :user_id AND active = :is_active AND score >= :min_score",
+        user_id=123,
+        is_active=True,
+        min_score=4.5
+    )
+
+    assert isinstance(stmt, SQL)
+    assert stmt.parameters["user_id"] == 123
+    assert stmt.parameters["is_active"] is True
+    assert stmt.parameters["min_score"] == 4.5
+
+
+def test_raw_empty_parameters_returns_expression() -> None:
+    """Test that raw() with empty kwargs returns expression."""
+    expr = sql.raw("SELECT 1")
+
+    assert isinstance(expr, exp.Expression)
+    assert not isinstance(expr, SQL)
+
+
+def test_raw_none_values_in_parameters() -> None:
+    """Test raw SQL with None values in parameters."""
+    stmt = sql.raw("description = :desc", desc=None)
+
+    assert isinstance(stmt, SQL)
+    assert stmt.parameters["desc"] is None
+
+
+def test_raw_parameter_overwrite_behavior() -> None:
+    """Test behavior when same parameter name used multiple times."""
+    stmt = sql.raw(
+        "field1 = :value AND field2 = :value",
+        value="test"
+    )
+
+    assert isinstance(stmt, SQL)
+    assert stmt.parameters["value"] == "test"
+    assert stmt.sql.count(":value") == 2
+    assert len(stmt.parameters) == 1
+
+
+def test_select_method() -> None:
+    """Test sql.select() method."""
+    query = sql.select("name", "email").from_("users")
+    stmt = query.build()
+
+    assert "SELECT" in stmt.sql
+    assert "name" in stmt.sql
+    assert "email" in stmt.sql
+    assert "FROM" in stmt.sql
+    assert "users" in stmt.sql
+
+
+def test_insert_method() -> None:
+    """Test sql.insert() method."""
+    query = sql.insert("users").values_from_dict({"name": "John", "email": "john@test.com"})
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "users" in stmt.sql
+    assert "name" in stmt.parameters
+    assert "email" in stmt.parameters
+
+
+def test_update_method() -> None:
+    """Test sql.update() method."""
+    query = sql.update("users").set({"name": "Jane"}).where_eq("id", 1)
+    stmt = query.build()
+
+    assert "UPDATE" in stmt.sql
+    assert "users" in stmt.sql
+    assert "SET" in stmt.sql
+    assert "WHERE" in stmt.sql
+
+
+def test_delete_method() -> None:
+    """Test sql.delete() method."""
+    query = sql.delete().from_("users").where_eq("inactive", True)
+    stmt = query.build()
+
+    assert "DELETE FROM" in stmt.sql
+    assert "users" in stmt.sql
+    assert "WHERE" in stmt.sql
+
+
+def test_create_table_method_exists() -> None:
+    """Test that create_table method exists and works."""
+    builder = sql.create_table("test_table")
+
+    assert builder is not None
+    assert hasattr(builder, "column")
+
+
+def test_create_index_method_exists() -> None:
+    """Test that create_index method exists and works."""
+    builder = sql.create_index("idx_test")
+
+    assert builder is not None
+    assert hasattr(builder, "on_table")
+
+
+def test_drop_table_method_exists() -> None:
+    """Test that drop_table method exists and works."""
+    builder = sql.drop_table("test_table")
+
+    assert builder is not None
+    assert hasattr(builder, "if_exists")
+
+
+def test_alter_table_method_exists() -> None:
+    """Test that alter_table method exists and works."""
+    builder = sql.alter_table("test_table")
+
+    assert builder is not None
+    assert hasattr(builder, "add_column")
+
+
+def test_all_ddl_methods_exist() -> None:
+    """Test that all expected DDL methods exist on the sql factory."""
+    ddl_methods = [
+        "create_table", "create_view", "create_index", "create_schema",
+        "create_materialized_view", "create_table_as_select",
+        "drop_table", "drop_view", "drop_index", "drop_schema",
+        "alter_table", "rename_table", "comment_on"
+    ]
+
+    for method_name in ddl_methods:
+        assert hasattr(sql, method_name), f"sql.{method_name}() should exist"
+        method = getattr(sql, method_name)
+        assert callable(method), f"sql.{method_name} should be callable"
+
+
+def test_count_function() -> None:
+    """Test sql.count() function."""
+    expr = sql.count()
+    assert isinstance(expr, exp.Expression)
+
+    count_column = sql.count("user_id")
+    assert isinstance(count_column, exp.Expression)
+
+
+def test_sum_function() -> None:
+    """Test sql.sum() function."""
+    expr = sql.sum("amount")
+    assert isinstance(expr, exp.Expression)
+
+
+def test_avg_function() -> None:
+    """Test sql.avg() function."""
+    expr = sql.avg("score")
+    assert isinstance(expr, exp.Expression)
+
+
+def test_max_function() -> None:
+    """Test sql.max() function."""
+    expr = sql.max("created_at")
+    assert isinstance(expr, exp.Expression)
+
+
+def test_min_function() -> None:
+    """Test sql.min() function."""
+    expr = sql.min("price")
+    assert isinstance(expr, exp.Expression)
+
+
+def test_column_method() -> None:
+    """Test sql.column() method."""
+    col = sql.column("name")
+    assert col is not None
+    assert hasattr(col, "like")
+    assert hasattr(col, "in_")
+
+    col_with_table = sql.column("name", "users")
+    assert col_with_table is not None
+
+
+def test_dynamic_column_access() -> None:
+    """Test dynamic column access via __getattr__."""
+    col = sql.name
+    assert col is not None
+    assert hasattr(col, "like")
+    assert hasattr(col, "in_")
+
+    test_col = sql.some_column_name
+    assert test_col is not None
+
+
+def test_raw_sql_parsing_error() -> None:
+    """Test that raw SQL parsing errors raise appropriate exceptions."""
+    with pytest.raises(SQLBuilderError) as exc_info:
+        sql.raw("INVALID SQL SYNTAX ((())")
+
+    assert "Failed to parse raw SQL fragment" in str(exc_info.value)
+
+
+def test_empty_raw_sql() -> None:
+    """Test raw SQL with empty string raises error."""
+    with pytest.raises(SQLBuilderError) as exc_info:
+        sql.raw("")
+
+    assert "Failed to parse raw SQL fragment" in str(exc_info.value)
+
+
+def test_parameter_names_use_column_names() -> None:
+    """Test that parameters use column names when possible."""
+    query = (
+        sql.select("*")
+        .from_("users")
+        .where_eq("name", "John")
+        .where_eq("status", "active")
+    )
+    stmt = query.build()
+
+    assert "name" in stmt.parameters
+    assert "status" in stmt.parameters
+    assert stmt.parameters["name"] == "John"
+    assert stmt.parameters["status"] == "active"
+
+
+def test_parameter_values_preserved_correctly() -> None:
+    """Test that parameter values are preserved exactly."""
+    test_values = [
+        ("string_val", "test"),
+        ("int_val", 42),
+        ("float_val", 3.14159),
+        ("bool_val", True),
+    ]
+
+    query = sql.select("*").from_("test")
+    for column_name, value in test_values:
+        query = query.where_eq(column_name, value)
+
+    stmt = query.build()
+
+    for column_name, expected_value in test_values:
+        assert column_name in stmt.parameters
+        assert stmt.parameters[column_name] == expected_value
+
+    # Test None value separately - it creates a parameter with None value
+    none_query = sql.select("*").from_("test").where_eq("none_col", None)
+    none_stmt = none_query.build()
+    assert "none_col" in none_stmt.parameters
+    assert none_stmt.parameters["none_col"] is None


### PR DESCRIPTION
Enhance the parameter naming strategy in the builder to ensure unique names based on column names or positional indices, improving clarity and preventing conflicts.