### PR TITLE
feat: register CLI with litestar extension

### DIFF
--- a/sqlspec/extensions/litestar/cli.py
+++ b/sqlspec/extensions/litestar/cli.py
@@ -39,7 +39,7 @@ def get_database_migration_plugin(app: "Litestar") -> "SQLSpec":
     raise ImproperConfigurationError(msg)
 
 
-@click.group(cls=LitestarGroup, name="database")
+@click.group(cls=LitestarGroup, name="db")
 def database_group(ctx: "click.Context") -> None:
     """Manage SQLSpec database components."""
     ctx.obj = {"app": ctx.obj, "configs": get_database_migration_plugin(ctx.obj.app).config}

--- a/sqlspec/extensions/litestar/plugin.py
+++ b/sqlspec/extensions/litestar/plugin.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Any, Union
 
 from litestar.di import Provide
-from litestar.plugins import InitPluginProtocol
+from litestar.plugins import CLIPlugin, InitPluginProtocol
 
 from sqlspec.base import SQLSpec as SQLSpecBase
 from sqlspec.config import AsyncConfigT, DatabaseConfigProtocol, DriverT, SyncConfigT
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 logger = get_logger("extensions.litestar")
 
 
-class SQLSpec(InitPluginProtocol, SQLSpecBase):
+class SQLSpec(InitPluginProtocol, CLIPlugin, SQLSpecBase):
     """Litestar plugin for SQLSpec database integration."""
 
     __slots__ = ("_config", "_plugin_configs")


### PR DESCRIPTION
The Litestar extension will automatically register the CLI under the `db` command.