### PR TITLE
fix: repair Linux wheels to use `manylinux` platform tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,6 +91,15 @@ jobs:
           MYPYC_DEBUG_LEVEL: "0"
           MYPYC_MULTI_FILE: "1"
 
+      - name: Repair Linux wheels with auditwheel
+        if: runner.os == 'Linux'
+        run: |
+          for wheel in dist/*.whl; do
+            echo "Repairing $wheel"
+            uv tool run auditwheel repair "$wheel" -w dist/ --plat manylinux_2_17_x86_64
+            rm "$wheel"
+          done
+
       - name: Upload mypyc wheel artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -103,6 +103,15 @@ jobs:
           MYPYC_MULTI_FILE: "1"
         shell: bash
 
+      - name: Repair Linux wheels with auditwheel
+        if: runner.os == 'Linux'
+        run: |
+          for wheel in dist/*.whl; do
+            echo "Repairing $wheel"
+            uv tool run auditwheel repair "$wheel" -w dist/ --plat manylinux_2_17_x86_64
+            rm "$wheel"
+          done
+
       - name: Upload mypyc wheel artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Implement a process to repair Linux wheels using `auditwheel`, ensuring compatibility with the `manylinux_2_17_x86_64` platform tag.