### PR TITLE
fix: Imrpove builder type hints and enhance SQL operations

### DIFF
--- a/sqlspec/_sql.py
+++ b/sqlspec/_sql.py
@@ -178,7 +178,9 @@ class SQLFactory:
     # ===================
     # Statement Builders
     # ===================
-    def select(self, *columns_or_sql: Union[str, exp.Expression, Column], dialect: DialectType = None) -> "Select":
+    def select(
+        self, *columns_or_sql: Union[str, exp.Expression, Column, "SQL"], dialect: DialectType = None
+    ) -> "Select":
         builder_dialect = dialect or self.dialect
         if len(columns_or_sql) == 1 and isinstance(columns_or_sql[0], str):
             sql_candidate = columns_or_sql[0].strip()

--- a/sqlspec/_sql.py
+++ b/sqlspec/_sql.py
@@ -1531,7 +1531,7 @@ class WindowFunctionBuilder:
                 self._order_by_cols.append(exp.Ordered(this=col, desc=False))
         return self
 
-    def as_(self, alias: str) -> exp.Expression:
+    def as_(self, alias: str) -> exp.Alias:
         """Complete the window function with an alias.
 
         Args:
@@ -1755,11 +1755,11 @@ class JoinBuilder:
         if isinstance(self._table, str):
             table_expr = exp.to_table(self._table)
             if self._alias:
-                table_expr = cast("exp.Expression", exp.alias_(table_expr, self._alias))
+                table_expr = exp.alias_(table_expr, self._alias)
         else:
             table_expr = self._table
             if self._alias:
-                table_expr = cast("exp.Expression", exp.alias_(table_expr, self._alias))
+                table_expr = exp.alias_(table_expr, self._alias)
 
         # Create the appropriate join type using same pattern as existing JoinClauseMixin
         if self._join_type == "INNER JOIN":

--- a/sqlspec/builder/mixins/_select_operations.py
+++ b/sqlspec/builder/mixins/_select_operations.py
@@ -13,6 +13,7 @@ from sqlspec.utils.type_guards import has_query_builder_parameters, is_expressio
 
 if TYPE_CHECKING:
     from sqlspec.builder._column import Column, FunctionColumn
+    from sqlspec.core.statement import SQL
     from sqlspec.protocols import SelectBuilderProtocol, SQLBuilderProtocol
 
 __all__ = ("CaseBuilder", "SelectClauseMixin")
@@ -27,7 +28,7 @@ class SelectClauseMixin:
     # Type annotation for PyRight - this will be provided by the base class
     _expression: Optional[exp.Expression]
 
-    def select(self, *columns: Union[str, exp.Expression, "Column", "FunctionColumn"]) -> Self:
+    def select(self, *columns: Union[str, exp.Expression, "Column", "FunctionColumn", "SQL"]) -> Self:
         """Add columns to SELECT clause.
 
         Raises:
@@ -43,7 +44,7 @@ class SelectClauseMixin:
             msg = "Cannot add select columns to a non-SELECT expression."
             raise SQLBuilderError(msg)
         for column in columns:
-            builder._expression = builder._expression.select(parse_column_expression(column), copy=False)
+            builder._expression = builder._expression.select(parse_column_expression(column, builder), copy=False)
         return cast("Self", builder)
 
     def distinct(self, *columns: Union[str, exp.Expression, "Column", "FunctionColumn"]) -> Self:
@@ -67,7 +68,7 @@ class SelectClauseMixin:
         if not columns:
             builder._expression.set("distinct", exp.Distinct())
         else:
-            distinct_columns = [parse_column_expression(column) for column in columns]
+            distinct_columns = [parse_column_expression(column, builder) for column in columns]
             builder._expression.set("distinct", exp.Distinct(expressions=distinct_columns))
         return cast("Self", builder)
 

--- a/sqlspec/builder/mixins/_select_operations.py
+++ b/sqlspec/builder/mixins/_select_operations.py
@@ -47,7 +47,7 @@ class SelectClauseMixin:
             builder._expression = builder._expression.select(parse_column_expression(column, builder), copy=False)
         return cast("Self", builder)
 
-    def distinct(self, *columns: Union[str, exp.Expression, "Column", "FunctionColumn"]) -> Self:
+    def distinct(self, *columns: Union[str, exp.Expression, "Column", "FunctionColumn", "SQL"]) -> Self:
         """Add DISTINCT clause to SELECT.
 
         Args:

--- a/sqlspec/builder/mixins/_update_operations.py
+++ b/sqlspec/builder/mixins/_update_operations.py
@@ -99,6 +99,25 @@ class UpdateSetClauseMixin:
                 if has_query_builder_parameters(val):
                     for p_name, p_value in val.parameters.items():
                         self.add_parameter(p_value, name=p_name)
+            elif hasattr(val, "expression") and hasattr(val, "sql"):
+                # Handle SQL objects (from sql.raw with parameters)
+                expression = getattr(val, "expression", None)
+                if expression is not None and isinstance(expression, exp.Expression):
+                    # Merge parameters from SQL object into builder
+                    if hasattr(val, "parameters"):
+                        sql_parameters = getattr(val, "parameters", {})
+                        for param_name, param_value in sql_parameters.items():
+                            self.add_parameter(param_value, name=param_name)
+                    value_expr = expression
+                else:
+                    # If expression is None, fall back to parsing the raw SQL
+                    sql_text = getattr(val, "sql", "")
+                    # Merge parameters even when parsing raw SQL
+                    if hasattr(val, "parameters"):
+                        sql_parameters = getattr(val, "parameters", {})
+                        for param_name, param_value in sql_parameters.items():
+                            self.add_parameter(param_value, name=param_name)
+                    value_expr = exp.maybe_parse(sql_text) or exp.convert(str(sql_text))
             else:
                 column_name = col if isinstance(col, str) else str(col)
                 if "." in column_name:
@@ -119,6 +138,25 @@ class UpdateSetClauseMixin:
                     if has_query_builder_parameters(val):
                         for p_name, p_value in val.parameters.items():
                             self.add_parameter(p_value, name=p_name)
+                elif hasattr(val, "expression") and hasattr(val, "sql"):
+                    # Handle SQL objects (from sql.raw with parameters)
+                    expression = getattr(val, "expression", None)
+                    if expression is not None and isinstance(expression, exp.Expression):
+                        # Merge parameters from SQL object into builder
+                        if hasattr(val, "parameters"):
+                            sql_parameters = getattr(val, "parameters", {})
+                            for param_name, param_value in sql_parameters.items():
+                                self.add_parameter(param_value, name=param_name)
+                        value_expr = expression
+                    else:
+                        # If expression is None, fall back to parsing the raw SQL
+                        sql_text = getattr(val, "sql", "")
+                        # Merge parameters even when parsing raw SQL
+                        if hasattr(val, "parameters"):
+                            sql_parameters = getattr(val, "parameters", {})
+                            for param_name, param_value in sql_parameters.items():
+                                self.add_parameter(param_value, name=param_name)
+                        value_expr = exp.maybe_parse(sql_text) or exp.convert(str(sql_text))
                 else:
                     column_name = col if isinstance(col, str) else str(col)
                     if "." in column_name:

--- a/sqlspec/builder/mixins/_update_operations.py
+++ b/sqlspec/builder/mixins/_update_operations.py
@@ -1,7 +1,7 @@
 """Update operation mixins for SQL builders."""
 
 from collections.abc import Mapping
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, cast
 
 from mypy_extensions import trait
 from sqlglot import exp
@@ -61,6 +61,52 @@ class UpdateSetClauseMixin:
         msg = "Method must be provided by QueryBuilder subclass"
         raise NotImplementedError(msg)
 
+    def _process_update_value(self, val: Any, col: Any) -> exp.Expression:
+        """Process a value for UPDATE assignment, handling SQL objects and parameters.
+
+        Args:
+            val: The value to process
+            col: The column name for parameter naming
+
+        Returns:
+            The processed expression for the value
+        """
+        if isinstance(val, exp.Expression):
+            return val
+        if has_query_builder_parameters(val):
+            subquery = val.build()
+            sql_str = subquery.sql if hasattr(subquery, "sql") and not callable(subquery.sql) else str(subquery)
+            value_expr = exp.paren(exp.maybe_parse(sql_str, dialect=getattr(self, "dialect", None)))
+            if has_query_builder_parameters(val):
+                for p_name, p_value in val.parameters.items():
+                    self.add_parameter(p_value, name=p_name)
+            return value_expr
+        if hasattr(val, "expression") and hasattr(val, "sql"):
+            # Handle SQL objects (from sql.raw with parameters)
+            expression = getattr(val, "expression", None)
+            if expression is not None and isinstance(expression, exp.Expression):
+                # Merge parameters from SQL object into builder
+                if hasattr(val, "parameters"):
+                    sql_parameters = getattr(val, "parameters", {})
+                    for param_name, param_value in sql_parameters.items():
+                        self.add_parameter(param_value, name=param_name)
+                return cast("exp.Expression", expression)
+            # If expression is None, fall back to parsing the raw SQL
+            sql_text = getattr(val, "sql", "")
+            # Merge parameters even when parsing raw SQL
+            if hasattr(val, "parameters"):
+                sql_parameters = getattr(val, "parameters", {})
+                for param_name, param_value in sql_parameters.items():
+                    self.add_parameter(param_value, name=param_name)
+            parsed_expr = exp.maybe_parse(sql_text)
+            return parsed_expr if parsed_expr is not None else exp.convert(str(sql_text))
+        column_name = col if isinstance(col, str) else str(col)
+        if "." in column_name:
+            column_name = column_name.split(".")[-1]
+        param_name = self._generate_unique_parameter_name(column_name)
+        param_name = self.add_parameter(val, name=param_name)[1]
+        return exp.Placeholder(this=param_name)
+
     def set(self, *args: Any, **kwargs: Any) -> Self:
         """Set columns and values for the UPDATE statement.
 
@@ -80,7 +126,6 @@ class UpdateSetClauseMixin:
         Returns:
             The current builder instance for method chaining.
         """
-
         if self._expression is None:
             self._expression = exp.Update()
         if not isinstance(self._expression, exp.Update):
@@ -90,80 +135,12 @@ class UpdateSetClauseMixin:
         if len(args) == MIN_SET_ARGS and not kwargs:
             col, val = args
             col_expr = col if isinstance(col, exp.Column) else exp.column(col)
-            if isinstance(val, exp.Expression):
-                value_expr = val
-            elif has_query_builder_parameters(val):
-                subquery = val.build()
-                sql_str = subquery.sql if hasattr(subquery, "sql") and not callable(subquery.sql) else str(subquery)
-                value_expr = exp.paren(exp.maybe_parse(sql_str, dialect=getattr(self, "dialect", None)))
-                if has_query_builder_parameters(val):
-                    for p_name, p_value in val.parameters.items():
-                        self.add_parameter(p_value, name=p_name)
-            elif hasattr(val, "expression") and hasattr(val, "sql"):
-                # Handle SQL objects (from sql.raw with parameters)
-                expression = getattr(val, "expression", None)
-                if expression is not None and isinstance(expression, exp.Expression):
-                    # Merge parameters from SQL object into builder
-                    if hasattr(val, "parameters"):
-                        sql_parameters = getattr(val, "parameters", {})
-                        for param_name, param_value in sql_parameters.items():
-                            self.add_parameter(param_value, name=param_name)
-                    value_expr = expression
-                else:
-                    # If expression is None, fall back to parsing the raw SQL
-                    sql_text = getattr(val, "sql", "")
-                    # Merge parameters even when parsing raw SQL
-                    if hasattr(val, "parameters"):
-                        sql_parameters = getattr(val, "parameters", {})
-                        for param_name, param_value in sql_parameters.items():
-                            self.add_parameter(param_value, name=param_name)
-                    value_expr = exp.maybe_parse(sql_text) or exp.convert(str(sql_text))
-            else:
-                column_name = col if isinstance(col, str) else str(col)
-                if "." in column_name:
-                    column_name = column_name.split(".")[-1]
-                param_name = self._generate_unique_parameter_name(column_name)
-                param_name = self.add_parameter(val, name=param_name)[1]
-                value_expr = exp.Placeholder(this=param_name)
+            value_expr = self._process_update_value(val, col)
             assignments.append(exp.EQ(this=col_expr, expression=value_expr))
         elif (len(args) == 1 and isinstance(args[0], Mapping)) or kwargs:
             all_values = dict(args[0] if args else {}, **kwargs)
             for col, val in all_values.items():
-                if isinstance(val, exp.Expression):
-                    value_expr = val
-                elif has_query_builder_parameters(val):
-                    subquery = val.build()
-                    sql_str = subquery.sql if hasattr(subquery, "sql") and not callable(subquery.sql) else str(subquery)
-                    value_expr = exp.paren(exp.maybe_parse(sql_str, dialect=getattr(self, "dialect", None)))
-                    if has_query_builder_parameters(val):
-                        for p_name, p_value in val.parameters.items():
-                            self.add_parameter(p_value, name=p_name)
-                elif hasattr(val, "expression") and hasattr(val, "sql"):
-                    # Handle SQL objects (from sql.raw with parameters)
-                    expression = getattr(val, "expression", None)
-                    if expression is not None and isinstance(expression, exp.Expression):
-                        # Merge parameters from SQL object into builder
-                        if hasattr(val, "parameters"):
-                            sql_parameters = getattr(val, "parameters", {})
-                            for param_name, param_value in sql_parameters.items():
-                                self.add_parameter(param_value, name=param_name)
-                        value_expr = expression
-                    else:
-                        # If expression is None, fall back to parsing the raw SQL
-                        sql_text = getattr(val, "sql", "")
-                        # Merge parameters even when parsing raw SQL
-                        if hasattr(val, "parameters"):
-                            sql_parameters = getattr(val, "parameters", {})
-                            for param_name, param_value in sql_parameters.items():
-                                self.add_parameter(param_value, name=param_name)
-                        value_expr = exp.maybe_parse(sql_text) or exp.convert(str(sql_text))
-                else:
-                    column_name = col if isinstance(col, str) else str(col)
-                    if "." in column_name:
-                        column_name = column_name.split(".")[-1]
-                    param_name = self._generate_unique_parameter_name(column_name)
-                    param_name = self.add_parameter(val, name=param_name)[1]
-                    value_expr = exp.Placeholder(this=param_name)
+                value_expr = self._process_update_value(val, col)
                 assignments.append(exp.EQ(this=exp.column(col), expression=value_expr))
         else:
             msg = "Invalid arguments for set(): use (column, value), mapping, or kwargs."

--- a/sqlspec/builder/mixins/_where_clause.py
+++ b/sqlspec/builder/mixins/_where_clause.py
@@ -3,6 +3,9 @@
 
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
+if TYPE_CHECKING:
+    from sqlspec.core.statement import SQL
+
 from mypy_extensions import trait
 from sqlglot import exp
 from typing_extensions import Self
@@ -208,7 +211,9 @@ class WhereClauseMixin:
 
     def where(
         self,
-        condition: Union[str, exp.Expression, exp.Condition, tuple[str, Any], tuple[str, str, Any], "ColumnExpression"],
+        condition: Union[
+            str, exp.Expression, exp.Condition, tuple[str, Any], tuple[str, str, Any], "ColumnExpression", "SQL"
+        ],
         value: Optional[Any] = None,
         operator: Optional[str] = None,
     ) -> Self:

--- a/tests/unit/test_builder/test_insert_builder.py
+++ b/tests/unit/test_builder/test_insert_builder.py
@@ -1,0 +1,338 @@
+"""Unit tests for INSERT builder functionality including ON CONFLICT operations."""
+
+import pytest
+
+from sqlspec import sql
+from sqlspec.exceptions import SQLBuilderError
+
+
+def test_insert_basic_functionality() -> None:
+    """Test basic INSERT builder functionality."""
+    query = sql.insert("users").columns("name", "email").values("John", "john@test.com")
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert '"users"' in stmt.sql or "users" in stmt.sql
+    assert "name" in stmt.parameters
+    assert "email" in stmt.parameters
+    assert stmt.parameters["name"] == "John"
+    assert stmt.parameters["email"] == "john@test.com"
+
+
+def test_insert_with_table_in_constructor() -> None:
+    """Test INSERT with table specified in constructor."""
+    query = sql.insert("products").values(name="Widget", price=29.99)
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "products" in stmt.sql
+    assert "name" in stmt.parameters
+    assert "price" in stmt.parameters
+
+
+def test_insert_values_from_dict() -> None:
+    """Test INSERT using values_from_dict method."""
+    data = {"id": 1, "name": "John", "status": "active"}
+    query = sql.insert("users").values_from_dict(data)
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert len(stmt.parameters) == 3
+    assert stmt.parameters["id"] == 1
+    assert stmt.parameters["name"] == "John"
+    assert stmt.parameters["status"] == "active"
+
+
+def test_insert_values_from_dicts_multiple_rows() -> None:
+    """Test INSERT using values_from_dicts for multiple rows."""
+    data = [
+        {"id": 1, "name": "John"},
+        {"id": 2, "name": "Jane"},
+        {"id": 3, "name": "Bob"}
+    ]
+    query = sql.insert("users").values_from_dicts(data)
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    # Should have parameters for all rows
+    assert "id" in stmt.parameters
+    assert "name" in stmt.parameters
+    assert "id_1" in stmt.parameters
+    assert "name_1" in stmt.parameters
+    assert "id_2" in stmt.parameters
+    assert "name_2" in stmt.parameters
+
+
+def test_insert_with_kwargs() -> None:
+    """Test INSERT using kwargs in values method."""
+    query = sql.insert("products").values(name="Widget", price=29.99, in_stock=True)
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "name" in stmt.parameters
+    assert "price" in stmt.parameters
+    assert "in_stock" in stmt.parameters
+    assert stmt.parameters["name"] == "Widget"
+    assert stmt.parameters["price"] == 29.99
+    assert stmt.parameters["in_stock"] is True
+
+
+def test_insert_mixed_args_kwargs_error() -> None:
+    """Test that mixing positional and keyword arguments raises error."""
+    with pytest.raises(SQLBuilderError, match="Cannot mix positional values with keyword values"):
+        sql.insert("users").values("John", email="john@test.com")
+
+
+def test_insert_multiple_values_calls() -> None:
+    """Test multiple calls to values() method for multi-row insert."""
+    query = (
+        sql.insert("users")
+        .columns("name", "email")
+        .values("John", "john@test.com")
+        .values("Jane", "jane@test.com")
+    )
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    # Should have parameters for both rows
+    assert "name" in stmt.parameters
+    assert "email" in stmt.parameters
+    assert "name_1" in stmt.parameters
+    assert "email_1" in stmt.parameters
+
+
+def test_insert_with_returning() -> None:
+    """Test INSERT with RETURNING clause."""
+    query = sql.insert("users").values(name="John").returning("id", "created_at")
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "RETURNING" in stmt.sql
+    assert "id" in stmt.sql
+    assert "created_at" in stmt.sql
+
+
+def test_insert_without_table_error() -> None:
+    """Test that values() without table raises error."""
+    with pytest.raises(SQLBuilderError, match="The target table must be set"):
+        sql.insert().values(name="John")
+
+
+def test_insert_values_columns_mismatch_error() -> None:
+    """Test that mismatched columns and values raises error."""
+    with pytest.raises(SQLBuilderError, match="Number of values"):
+        sql.insert("users").columns("name", "email").values("John")  # Missing email value
+
+
+def test_insert_columns_and_values_consistency() -> None:
+    """Test that columns and values are consistent."""
+    query = sql.insert("users").columns("name", "email", "age").values("John", "john@test.com", 25)
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert len(stmt.parameters) == 3
+    assert stmt.parameters["name"] == "John"
+    assert stmt.parameters["email"] == "john@test.com"
+    assert stmt.parameters["age"] == 25
+
+
+def test_insert_inconsistent_dict_keys_error() -> None:
+    """Test that inconsistent dictionary keys in values_from_dicts raises error."""
+    data = [
+        {"id": 1, "name": "John"},
+        {"id": 2, "email": "jane@test.com"}  # Missing name, has email instead
+    ]
+    with pytest.raises(SQLBuilderError, match="do not match expected keys"):
+        sql.insert("users").values_from_dicts(data).build()
+
+
+def test_insert_with_sql_raw_expressions() -> None:
+    """Test INSERT with sql.raw expressions."""
+    query = sql.insert("logs").values(
+        message="Test message",
+        created_at=sql.raw("NOW()"),
+        uuid=sql.raw("UUID()")
+    )
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "NOW()" in stmt.sql
+    assert "UUID()" in stmt.sql
+    assert "message" in stmt.parameters
+    assert stmt.parameters["message"] == "Test message"
+
+
+def test_insert_with_sql_raw_parameters() -> None:
+    """Test INSERT with sql.raw that has parameters."""
+    query = sql.insert("users").values(
+        name="John",
+        computed_field=sql.raw("COALESCE(:fallback, 'default')", fallback="custom")
+    )
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "COALESCE" in stmt.sql
+    assert "name" in stmt.parameters
+    assert "fallback" in stmt.parameters
+    assert stmt.parameters["name"] == "John"
+    assert stmt.parameters["fallback"] == "custom"
+
+
+# ON CONFLICT functionality tests
+def test_on_conflict_do_nothing_basic() -> None:
+    """Test basic ON CONFLICT DO NOTHING."""
+    query = sql.insert("users").values(id=1, name="John").on_conflict("id").do_nothing()
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO NOTHING" in stmt.sql
+    assert "id" in stmt.parameters
+
+
+def test_on_conflict_do_update_basic() -> None:
+    """Test basic ON CONFLICT DO UPDATE."""
+    query = sql.insert("users").values(id=1, name="John").on_conflict("id").do_update(name="Updated")
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO UPDATE" in stmt.sql
+    assert "SET" in stmt.sql
+    assert "name_1" in stmt.parameters
+    assert stmt.parameters["name_1"] == "Updated"
+
+
+def test_on_conflict_multiple_columns() -> None:
+    """Test ON CONFLICT with multiple columns."""
+    query = (
+        sql.insert("users")
+        .values(email="john@test.com", username="john", name="John")
+        .on_conflict("email", "username")
+        .do_nothing()
+    )
+    stmt = query.build()
+
+    assert "ON CONFLICT" in stmt.sql
+    assert "email" in stmt.sql
+    assert "username" in stmt.sql
+
+
+def test_on_conflict_no_columns() -> None:
+    """Test ON CONFLICT without specific columns."""
+    query = sql.insert("users").values(id=1, name="John").on_conflict().do_nothing()
+    stmt = query.build()
+
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO NOTHING" in stmt.sql
+    # Should not specify columns
+    assert "ON CONFLICT(" not in stmt.sql
+
+
+def test_on_conflict_do_update_with_sql_raw() -> None:
+    """Test ON CONFLICT DO UPDATE with sql.raw expressions."""
+    query = (
+        sql.insert("users")
+        .values(id=1, name="John")
+        .on_conflict("id")
+        .do_update(updated_at=sql.raw("NOW()"), name="Updated")
+    )
+    stmt = query.build()
+
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO UPDATE" in stmt.sql
+    assert "NOW()" in stmt.sql
+    assert "name_1" in stmt.parameters
+
+
+def test_on_conflict_convenience_method() -> None:
+    """Test on_conflict_do_nothing convenience method."""
+    query = sql.insert("users").values(id=1, name="John").on_conflict_do_nothing("id")
+    stmt = query.build()
+
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO NOTHING" in stmt.sql
+
+
+def test_legacy_on_duplicate_key_update() -> None:
+    """Test legacy on_duplicate_key_update method."""
+    query = (
+        sql.insert("users")
+        .values(id=1, name="John")
+        .on_duplicate_key_update(name="Updated", updated_at=sql.raw("NOW()"))
+    )
+    stmt = query.build()
+
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO UPDATE" in stmt.sql
+    assert "NOW()" in stmt.sql
+
+
+def test_on_conflict_chaining() -> None:
+    """Test ON CONFLICT method chaining."""
+    query = (
+        sql.insert("users")
+        .values(id=1, name="John")
+        .on_conflict("id")
+        .do_update(name="Updated")
+        .returning("id", "name")
+    )
+    stmt = query.build()
+
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO UPDATE" in stmt.sql
+    assert "RETURNING" in stmt.sql
+
+
+def test_on_conflict_type_safety() -> None:
+    """Test ON CONFLICT method return types for chaining."""
+    insert_builder = sql.insert("users").values(id=1, name="John")
+
+    # on_conflict should return ConflictBuilder
+    conflict_builder = insert_builder.on_conflict("id")
+    assert hasattr(conflict_builder, "do_nothing")
+    assert hasattr(conflict_builder, "do_update")
+
+    # do_nothing should return Insert for further chaining
+    final_builder = conflict_builder.do_nothing()
+    assert hasattr(final_builder, "returning")
+    assert hasattr(final_builder, "build")
+
+
+def test_on_conflict_empty_do_update() -> None:
+    """Test ON CONFLICT DO UPDATE with no arguments."""
+    query = sql.insert("users").values(id=1, name="John").on_conflict("id").do_update()
+    stmt = query.build()
+
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO UPDATE" in stmt.sql
+
+
+def test_on_conflict_parameter_merging() -> None:
+    """Test that ON CONFLICT properly merges parameters from SQL objects."""
+    query = (
+        sql.insert("users")
+        .values(id=1, name="John")
+        .on_conflict("id")
+        .do_update(
+            name=sql.raw("COALESCE(:new_name, name)", new_name="Updated"),
+            updated_at=sql.raw("NOW()")
+        )
+    )
+    stmt = query.build()
+
+    assert "new_name" in stmt.parameters
+    assert stmt.parameters["new_name"] == "Updated"
+    assert "NOW()" in stmt.sql
+
+
+def test_on_conflict_with_values_from_dict() -> None:
+    """Test ON CONFLICT with values_from_dict."""
+    data = {"id": 1, "name": "John", "email": "john@test.com"}
+    query = sql.insert("users").values_from_dict(data).on_conflict("id").do_update(name="Updated")
+    stmt = query.build()
+
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO UPDATE" in stmt.sql
+    assert "name_1" in stmt.parameters
+    assert stmt.parameters["name_1"] == "Updated"

--- a/tests/unit/test_sql_factory.py
+++ b/tests/unit/test_sql_factory.py
@@ -1007,19 +1007,19 @@ def test_sql_raw_parameter_name_conflicts_handled() -> None:
     # Create two SQL objects with different parameter names (should work fine)
     raw_expr1 = sql.raw("COALESCE(name, :value)", value="default1")
     raw_expr2 = sql.raw("COALESCE(email, :other_value)", other_value="default2")
-    
+
     query = sql.select("id", raw_expr1, raw_expr2).from_("users")
     stmt = query.build()
-    
+
     assert "value" in stmt.parameters
     assert "other_value" in stmt.parameters
     assert stmt.parameters["value"] == "default1"
     assert stmt.parameters["other_value"] == "default2"
-    
+
     # Test that actual conflicts are detected
     raw_conflict1 = sql.raw("COALESCE(name, :conflict)", conflict="first")
     raw_conflict2 = sql.raw("COALESCE(email, :conflict)", conflict="second")
-    
+
     with pytest.raises(SQLBuilderError, match="Parameter name 'conflict' already exists"):
         sql.select("id", raw_conflict1, raw_conflict2).from_("users").build()
 
@@ -1077,16 +1077,14 @@ def test_update_set_method_with_sql_objects() -> None:
     """Test that UPDATE.set() method properly handles SQL objects with kwargs."""
     raw_timestamp = sql.raw("NOW()")
     raw_computed = sql.raw("UPPER(:value)", value="test")
-    
+
     # Test using kwargs with SQL objects
-    query = sql.update("users").set(
-        name="John",
-        last_updated=raw_timestamp,
-        computed_field=raw_computed
-    ).where_eq("id", 1)
-    
+    query = (
+        sql.update("users").set(name="John", last_updated=raw_timestamp, computed_field=raw_computed).where_eq("id", 1)
+    )
+
     stmt = query.build()
-    
+
     assert "UPDATE" in stmt.sql
     assert "NOW()" in stmt.sql
     assert "UPPER" in stmt.sql
@@ -1101,20 +1099,425 @@ def test_update_set_method_with_sql_objects() -> None:
 def test_update_set_method_backward_compatibility() -> None:
     """Test that UPDATE.set() method maintains backward compatibility with dict."""
     raw_timestamp = sql.raw("NOW()")
-    
+
     # Test using dict (original API)
     query1 = sql.update("users").set({"name": "John", "updated_at": raw_timestamp})
     stmt1 = query1.build()
-    
+
     assert "UPDATE" in stmt1.sql
     assert "NOW()" in stmt1.sql
     assert "name" in stmt1.parameters
     assert stmt1.parameters["name"] == "John"
-    
+
     # Test using positional args (column, value)
     query2 = sql.update("users").set("status", "active")
     stmt2 = query2.build()
-    
+
     assert "UPDATE" in stmt2.sql
     assert "status" in stmt2.parameters
     assert stmt2.parameters["status"] == "active"
+
+
+# Tests for ON CONFLICT functionality
+def test_on_conflict_do_nothing_basic() -> None:
+    """Test basic ON CONFLICT DO NOTHING functionality."""
+    query = sql.insert("users").columns("id", "name").values(1, "John").on_conflict("id").do_nothing()
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO NOTHING" in stmt.sql
+    assert '"id"' in stmt.sql or "id" in stmt.sql
+    assert "id" in stmt.parameters
+    assert "name" in stmt.parameters
+    assert stmt.parameters["id"] == 1
+    assert stmt.parameters["name"] == "John"
+
+
+def test_on_conflict_do_nothing_multiple_columns() -> None:
+    """Test ON CONFLICT DO NOTHING with multiple conflict columns."""
+    query = (
+        sql.insert("users")
+        .columns("email", "username", "name")
+        .values("john@test.com", "john", "John")
+        .on_conflict("email", "username")
+        .do_nothing()
+    )
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO NOTHING" in stmt.sql
+    assert "email" in stmt.sql and "username" in stmt.sql
+    assert "email" in stmt.parameters
+    assert "username" in stmt.parameters
+    assert "name" in stmt.parameters
+
+
+def test_on_conflict_do_nothing_no_columns() -> None:
+    """Test ON CONFLICT DO NOTHING without specific columns (catches all conflicts)."""
+    query = sql.insert("users").columns("id", "name").values(1, "John").on_conflict().do_nothing()
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO NOTHING" in stmt.sql
+    # Should not have specific columns in conflict clause
+    assert "ON CONFLICT(" not in stmt.sql
+
+
+def test_on_conflict_do_update_basic() -> None:
+    """Test basic ON CONFLICT DO UPDATE functionality."""
+    query = sql.insert("users").columns("id", "name").values(1, "John").on_conflict("id").do_update(name="Updated John")
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO UPDATE" in stmt.sql
+    assert "SET" in stmt.sql
+    assert "id" in stmt.parameters
+    assert "name" in stmt.parameters
+    assert "name_1" in stmt.parameters  # The update parameter
+    assert stmt.parameters["id"] == 1
+    assert stmt.parameters["name"] == "John"
+    assert stmt.parameters["name_1"] == "Updated John"
+
+
+def test_on_conflict_do_update_multiple_values() -> None:
+    """Test ON CONFLICT DO UPDATE with multiple update values."""
+    query = (
+        sql.insert("users")
+        .columns("id", "name", "email")
+        .values(1, "John", "john@test.com")
+        .on_conflict("id")
+        .do_update(name="Updated John", email="updated@test.com")
+    )
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO UPDATE" in stmt.sql
+    assert "SET" in stmt.sql
+    assert "name_1" in stmt.parameters
+    assert "email_1" in stmt.parameters
+    assert stmt.parameters["name_1"] == "Updated John"
+    assert stmt.parameters["email_1"] == "updated@test.com"
+
+
+def test_on_conflict_do_update_with_sql_raw() -> None:
+    """Test ON CONFLICT DO UPDATE with sql.raw expressions."""
+    query = (
+        sql.insert("users")
+        .columns("id", "name")
+        .values(1, "John")
+        .on_conflict("id")
+        .do_update(updated_at=sql.raw("NOW()"), name="Updated")
+    )
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO UPDATE" in stmt.sql
+    assert "SET" in stmt.sql
+    assert "NOW()" in stmt.sql
+    assert "name_1" in stmt.parameters
+    assert stmt.parameters["name_1"] == "Updated"
+
+
+def test_on_conflict_do_update_with_sql_raw_parameters() -> None:
+    """Test ON CONFLICT DO UPDATE with sql.raw that has parameters."""
+    query = (
+        sql.insert("users")
+        .columns("id", "name")
+        .values(1, "John")
+        .on_conflict("id")
+        .do_update(
+            updated_at=sql.raw("NOW()"), status=sql.raw("COALESCE(:new_status, 'active')", new_status="verified")
+        )
+    )
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO UPDATE" in stmt.sql
+    assert "NOW()" in stmt.sql
+    assert "COALESCE" in stmt.sql
+    assert "new_status" in stmt.parameters
+    assert stmt.parameters["new_status"] == "verified"
+
+
+def test_on_conflict_convenience_method() -> None:
+    """Test the convenience method on_conflict_do_nothing."""
+    query = sql.insert("users").columns("id", "name").values(1, "John").on_conflict_do_nothing("id")
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO NOTHING" in stmt.sql
+    assert "id" in stmt.parameters
+    assert stmt.parameters["id"] == 1
+
+
+def test_legacy_on_duplicate_key_update_method() -> None:
+    """Test that the legacy on_duplicate_key_update method uses the new ON CONFLICT API."""
+    query = (
+        sql.insert("users")
+        .columns("id", "name")
+        .values(1, "John")
+        .on_duplicate_key_update(name="Updated", updated_at=sql.raw("NOW()"))
+    )
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO UPDATE" in stmt.sql
+    assert "SET" in stmt.sql
+    assert "NOW()" in stmt.sql
+    assert "name_1" in stmt.parameters
+    assert stmt.parameters["name_1"] == "Updated"
+
+
+def test_on_conflict_with_insert_from_dict() -> None:
+    """Test ON CONFLICT with insert using from_dict methods."""
+    data = {"id": 1, "name": "John", "email": "john@test.com"}
+    query = sql.insert("users").values_from_dict(data).on_conflict("id").do_update(name="Updated John")
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO UPDATE" in stmt.sql
+    assert "id" in stmt.parameters
+    assert "name" in stmt.parameters
+    assert "email" in stmt.parameters
+    assert "name_1" in stmt.parameters  # The update parameter
+    assert stmt.parameters["name_1"] == "Updated John"
+
+
+def test_on_conflict_with_multiple_rows() -> None:
+    """Test ON CONFLICT with multiple value rows."""
+    query = sql.insert("users").columns("id", "name").values(1, "John").values(2, "Jane").on_conflict("id").do_nothing()
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO NOTHING" in stmt.sql
+    # Check that both rows are included
+    assert "id" in stmt.parameters
+    assert "name" in stmt.parameters
+    assert "id_1" in stmt.parameters
+    assert "name_1" in stmt.parameters
+
+
+def test_on_conflict_chaining_with_returning() -> None:
+    """Test ON CONFLICT chaining with RETURNING clause."""
+    query = (
+        sql.insert("users")
+        .columns("id", "name")
+        .values(1, "John")
+        .on_conflict("id")
+        .do_update(name="Updated John")
+        .returning("id", "name", "updated_at")
+    )
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO UPDATE" in stmt.sql
+    assert "RETURNING" in stmt.sql
+    assert "id" in stmt.sql and "name" in stmt.sql and "updated_at" in stmt.sql
+
+
+def test_on_conflict_empty_do_update() -> None:
+    """Test ON CONFLICT DO UPDATE with no arguments (should work but do nothing)."""
+    query = sql.insert("users").columns("id", "name").values(1, "John").on_conflict("id").do_update()
+    stmt = query.build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "ON CONFLICT" in stmt.sql
+    assert "DO UPDATE" in stmt.sql
+
+
+def test_on_conflict_sql_generation_postgres_style() -> None:
+    """Test that ON CONFLICT generates PostgreSQL-style syntax that SQLGlot can transpile."""
+    query = sql.insert("users").columns("id", "name").values(1, "John").on_conflict("id").do_update(name="Updated")
+    stmt = query.build()
+
+    # Should generate proper PostgreSQL ON CONFLICT syntax
+    assert "ON CONFLICT(" in stmt.sql or "ON CONFLICT (" in stmt.sql
+    assert "DO UPDATE SET" in stmt.sql
+    assert '"id"' in stmt.sql or "id" in stmt.sql
+
+
+def test_on_conflict_type_safety() -> None:
+    """Test that ON CONFLICT methods return proper types for method chaining."""
+    # This test ensures the ConflictBuilder properly returns Insert builder
+    query_builder = sql.insert("users").columns("id", "name").values(1, "John")
+
+    # on_conflict should return ConflictBuilder
+    conflict_builder = query_builder.on_conflict("id")
+    assert hasattr(conflict_builder, "do_nothing")
+    assert hasattr(conflict_builder, "do_update")
+
+    # do_nothing should return Insert builder for further chaining
+    final_builder = conflict_builder.do_nothing()
+    assert hasattr(final_builder, "returning")
+    assert hasattr(final_builder, "build")
+
+    # Should be able to continue chaining
+    final_query = final_builder.returning("id")
+    stmt = final_query.build()
+    assert "RETURNING" in stmt.sql
+
+
+# Tests for MERGE kwargs functionality
+def test_merge_when_matched_then_update_with_kwargs() -> None:
+    """Test MERGE when_matched_then_update with kwargs support."""
+    query = (
+        sql.merge("users")
+        .using("new_users")
+        .on("users.id = new_users.id")
+        .when_matched_then_update(name="Updated John", email="updated@test.com")
+    )
+    stmt = query.build()
+
+    assert "MERGE INTO" in stmt.sql
+    assert "WHEN MATCHED THEN UPDATE" in stmt.sql
+    assert "name" in stmt.parameters
+    assert "email" in stmt.parameters
+    assert stmt.parameters["name"] == "Updated John"
+    assert stmt.parameters["email"] == "updated@test.com"
+
+
+def test_merge_when_matched_then_update_mixed_dict_kwargs() -> None:
+    """Test MERGE when_matched_then_update with mixed dict and kwargs."""
+    query = (
+        sql.merge("users")
+        .using("new_users")
+        .on("users.id = new_users.id")
+        .when_matched_then_update({"name": "Dict Name"}, email="Kwargs Email", status="active")
+    )
+    stmt = query.build()
+
+    assert "MERGE INTO" in stmt.sql
+    assert "WHEN MATCHED THEN UPDATE" in stmt.sql
+    assert "name" in stmt.parameters
+    assert "email" in stmt.parameters
+    assert "status" in stmt.parameters
+    assert stmt.parameters["name"] == "Dict Name"
+    assert stmt.parameters["email"] == "Kwargs Email"
+    assert stmt.parameters["status"] == "active"
+
+
+def test_merge_when_matched_then_update_with_sql_raw() -> None:
+    """Test MERGE when_matched_then_update with sql.raw expressions."""
+    query = (
+        sql.merge("users")
+        .using("new_users")
+        .on("users.id = new_users.id")
+        .when_matched_then_update(
+            name="Updated John",
+            updated_at=sql.raw("NOW()"),
+            status=sql.raw("COALESCE(:new_status, 'active')", new_status="verified"),
+        )
+    )
+    stmt = query.build()
+
+    assert "MERGE INTO" in stmt.sql
+    assert "WHEN MATCHED THEN UPDATE" in stmt.sql
+    assert "NOW()" in stmt.sql
+    assert "COALESCE" in stmt.sql
+    assert "name" in stmt.parameters
+    assert "new_status" in stmt.parameters
+    assert stmt.parameters["name"] == "Updated John"
+    assert stmt.parameters["new_status"] == "verified"
+
+
+def test_merge_when_not_matched_by_source_then_update_with_kwargs() -> None:
+    """Test MERGE when_not_matched_by_source_then_update with kwargs support."""
+    query = (
+        sql.merge("users")
+        .using("new_users")
+        .on("users.id = new_users.id")
+        .when_not_matched_by_source_then_update(status="inactive", last_seen=sql.raw("NOW()"))
+    )
+    stmt = query.build()
+
+    assert "MERGE INTO" in stmt.sql
+    assert "WHEN NOT MATCHED BY SOURCE THEN UPDATE" in stmt.sql
+    assert "NOW()" in stmt.sql
+    assert "status" in stmt.parameters
+    assert stmt.parameters["status"] == "inactive"
+
+
+def test_merge_when_not_matched_by_source_then_update_mixed() -> None:
+    """Test MERGE when_not_matched_by_source_then_update with mixed dict and kwargs."""
+    query = (
+        sql.merge("users")
+        .using("new_users")
+        .on("users.id = new_users.id")
+        .when_not_matched_by_source_then_update(
+            {"status": "Dict Status"}, last_seen=sql.raw("NOW()"), notes="Kwargs Notes"
+        )
+    )
+    stmt = query.build()
+
+    assert "MERGE INTO" in stmt.sql
+    assert "WHEN NOT MATCHED BY SOURCE THEN UPDATE" in stmt.sql
+    assert "NOW()" in stmt.sql
+    assert "status" in stmt.parameters
+    assert "notes" in stmt.parameters
+    assert stmt.parameters["status"] == "Dict Status"
+    assert stmt.parameters["notes"] == "Kwargs Notes"
+
+
+def test_merge_empty_update_values_error() -> None:
+    """Test that MERGE update methods raise error when no values provided."""
+    merge_builder = sql.merge("users").using("new_users").on("users.id = new_users.id")
+
+    with pytest.raises(SQLBuilderError, match="No update values provided"):
+        merge_builder.when_matched_then_update()
+
+    with pytest.raises(SQLBuilderError, match="No update values provided"):
+        merge_builder.when_not_matched_by_source_then_update()
+
+
+def test_merge_backward_compatibility() -> None:
+    """Test that MERGE methods maintain backward compatibility with dict-only usage."""
+    query = (
+        sql.merge("users")
+        .using("new_users")
+        .on("users.id = new_users.id")
+        .when_matched_then_update({"name": "Updated", "email": "updated@test.com"})
+        .when_not_matched_by_source_then_update({"status": "inactive"})
+    )
+    stmt = query.build()
+
+    assert "MERGE INTO" in stmt.sql
+    assert "WHEN MATCHED THEN UPDATE" in stmt.sql
+    assert "WHEN NOT MATCHED BY SOURCE THEN UPDATE" in stmt.sql
+    assert "name" in stmt.parameters
+    assert "email" in stmt.parameters
+    assert "status" in stmt.parameters
+
+
+def test_merge_comprehensive_example() -> None:
+    """Test comprehensive MERGE example with all features."""
+    query = (
+        sql.merge("users")
+        .using("new_users")
+        .on("users.id = new_users.id")
+        .when_matched_then_update(name="new_users.name", email="new_users.email", updated_at=sql.raw("NOW()"))
+        .when_not_matched_then_insert(
+            ["id", "name", "email", "created_at"],
+            ["new_users.id", "new_users.name", "new_users.email", sql.raw("NOW()")],
+        )
+        .when_not_matched_by_source_then_update(status="archived", archived_at=sql.raw("NOW()"))
+    )
+    stmt = query.build()
+
+    assert "MERGE INTO" in stmt.sql
+    assert "WHEN MATCHED THEN UPDATE" in stmt.sql
+    assert "WHEN NOT MATCHED THEN INSERT" in stmt.sql
+    assert "WHEN NOT MATCHED BY SOURCE THEN UPDATE" in stmt.sql
+    assert "NOW()" in stmt.sql
+    assert len(stmt.parameters) >= 6  # Should have multiple parameters


### PR DESCRIPTION
Improve type hints for `as_` and `select` methods, and ensure correct handling of `upsert` and `merge` operations with SQL objects. This enhances type safety and functionality in SQL operations.