### PR TITLE
chore: `sqlspec.driver` cleanup

### DIFF
--- a/sqlspec/core/result.py
+++ b/sqlspec/core/result.py
@@ -123,9 +123,7 @@ class StatementResult(ABC):
         Returns:
             The type of SQL operation that produced this result.
         """
-        if hasattr(self.statement, "operation_type"):
-            return cast("OperationType", self.statement.operation_type)
-        return "SELECT"
+        return self.statement.operation_type
 
 
 @mypyc_attr(allow_interpreted_subclasses=True)

--- a/sqlspec/core/statement.py
+++ b/sqlspec/core/statement.py
@@ -24,7 +24,7 @@ from sqlglot import exp
 from sqlglot.errors import ParseError
 from typing_extensions import TypeAlias
 
-from sqlspec.core.compiler import SQLProcessor
+from sqlspec.core.compiler import OperationType, SQLProcessor
 from sqlspec.core.parameters import ParameterConverter, ParameterStyle, ParameterStyleConfig, ParameterValidator
 from sqlspec.typing import Empty, EmptyEnum
 from sqlspec.utils.logging import get_logger
@@ -84,13 +84,14 @@ class ProcessedState:
     """
 
     __slots__ = PROCESSED_STATE_SLOTS
+    operation_type: "OperationType"
 
     def __init__(
         self,
         compiled_sql: str,
         execution_parameters: Any,
         parsed_expression: "Optional[exp.Expression]" = None,
-        operation_type: str = "UNKNOWN",
+        operation_type: "OperationType" = "UNKNOWN",
         validation_errors: "Optional[list[str]]" = None,
         is_many: bool = False,
     ) -> None:
@@ -263,7 +264,7 @@ class SQL:
         return self._positional_parameters or []
 
     @property
-    def operation_type(self) -> str:
+    def operation_type(self) -> "OperationType":
         """SQL operation type - requires explicit compilation."""
         if self._processed_state is Empty:
             return "UNKNOWN"

--- a/sqlspec/driver/_async.py
+++ b/sqlspec/driver/_async.py
@@ -1,8 +1,4 @@
-"""Asynchronous driver protocol implementation.
-
-This module provides the async driver infrastructure for database adapters,
-including connection management, transaction support, and result processing.
-"""
+"""Asynchronous driver protocol implementation."""
 
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, Final, NoReturn, Optional, Union, cast, overload
@@ -32,21 +28,12 @@ EMPTY_FILTERS: Final["list[StatementFilter]"] = []
 
 
 class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToSchemaMixin):
-    """Base class for asynchronous database drivers.
-
-    Provides the foundation for async database adapters, including connection management,
-    transaction support, and SQL execution methods. All database operations are performed
-    asynchronously and support context manager patterns for proper resource cleanup.
-    """
+    """Base class for asynchronous database drivers."""
 
     __slots__ = ()
 
     async def dispatch_statement_execution(self, statement: "SQL", connection: "Any") -> "SQLResult":
         """Central execution dispatcher using the Template Method Pattern.
-
-        Orchestrates the common execution flow, delegating database-specific steps
-        to abstract methods that concrete adapters must implement.
-        All database operations are wrapped in exception handling.
 
         Args:
             statement: The SQL statement to execute

--- a/sqlspec/driver/_sync.py
+++ b/sqlspec/driver/_sync.py
@@ -1,8 +1,4 @@
-"""Synchronous driver protocol implementation.
-
-This module provides the sync driver infrastructure for database adapters,
-including connection management, transaction support, and result processing.
-"""
+"""Synchronous driver protocol implementation."""
 
 from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, Final, NoReturn, Optional, Union, cast, overload
@@ -32,21 +28,12 @@ EMPTY_FILTERS: Final["list[StatementFilter]"] = []
 
 
 class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToSchemaMixin):
-    """Base class for synchronous database drivers.
-
-    Provides the foundation for sync database adapters, including connection management,
-    transaction support, and SQL execution methods. All database operations are performed
-    synchronously and support context manager patterns for proper resource cleanup.
-    """
+    """Base class for synchronous database drivers."""
 
     __slots__ = ()
 
     def dispatch_statement_execution(self, statement: "SQL", connection: "Any") -> "SQLResult":
         """Central execution dispatcher using the Template Method Pattern.
-
-        Orchestrates the common execution flow, delegating database-specific steps
-        to abstract methods that concrete adapters must implement.
-        All database operations are wrapped in exception handling.
 
         Args:
             statement: The SQL statement to execute

--- a/sqlspec/driver/mixins/_sql_translator.py
+++ b/sqlspec/driver/mixins/_sql_translator.py
@@ -9,7 +9,7 @@ from sqlspec.exceptions import SQLConversionError
 
 __all__ = ("SQLTranslatorMixin",)
 
-# Constants for better performance
+
 _DEFAULT_PRETTY: Final[bool] = True
 
 
@@ -35,7 +35,7 @@ class SQLTranslatorMixin:
         Raises:
             SQLConversionError: If parsing or conversion fails
         """
-        # Fast path: get the parsed expression with minimal allocations
+
         parsed_expression: Optional[exp.Expression] = None
 
         if statement is not None and isinstance(statement, SQL):
@@ -47,19 +47,16 @@ class SQLTranslatorMixin:
         else:
             parsed_expression = self._parse_statement_safely(statement)
 
-        # Get target dialect with fallback
-        target_dialect = to_dialect or self.dialect  # type: ignore[attr-defined]
+        target_dialect = to_dialect or self.dialect
 
-        # Generate SQL with error handling
         return self._generate_sql_safely(parsed_expression, target_dialect, pretty)
 
     def _parse_statement_safely(self, statement: "Statement") -> "exp.Expression":
         """Parse statement with copy=False optimization and proper error handling."""
         try:
-            # Convert statement to string if needed
             sql_string = str(statement)
-            # Use copy=False for better performance
-            return parse_one(sql_string, dialect=self.dialect, copy=False)  # type: ignore[attr-defined]
+
+            return parse_one(sql_string, dialect=self.dialect, copy=False)
         except Exception as e:
             self._raise_parse_error(e)
 

--- a/tests/unit/test_core/test_compiler.py
+++ b/tests/unit/test_core/test_compiler.py
@@ -28,7 +28,7 @@ import sqlglot
 from sqlglot import expressions as exp
 from sqlglot.errors import ParseError
 
-from sqlspec.core.compiler import CompiledSQL, SQLProcessor
+from sqlspec.core.compiler import CompiledSQL, OperationType, SQLProcessor
 from sqlspec.core.parameters import ParameterProcessor, ParameterStyle, ParameterStyleConfig
 from sqlspec.core.statement import StatementConfig
 
@@ -141,7 +141,7 @@ def test_compiled_sql_creation() -> None:
     """Test CompiledSQL object creation and basic properties."""
     compiled_sql = "SELECT * FROM users WHERE id = ?"
     execution_parameters = [123]
-    operation_type = "SELECT"
+    operation_type: OperationType = "SELECT"
     expression = Mock(spec=exp.Select)
 
     result = CompiledSQL(


### PR DESCRIPTION
Refactor docstrings and typing annotations across various modules to enhance code clarity and maintainability. This includes standardizing operation type definitions and improving type hints.