### PR TITLE
feat(litestar): add methods to get active request session

### DIFF
--- a/sqlspec/extensions/litestar/config.py
+++ b/sqlspec/extensions/litestar/config.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union, cast
 
 from sqlspec.exceptions import ImproperConfigurationError
+from sqlspec.extensions.litestar._utils import get_sqlspec_scope_state, set_sqlspec_scope_state
 from sqlspec.extensions.litestar.handlers import (
     autocommit_handler_maker,
     connection_provider_maker,
@@ -13,13 +14,14 @@ from sqlspec.extensions.litestar.handlers import (
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Awaitable
-    from contextlib import AbstractAsyncContextManager
+    from contextlib import AbstractAsyncContextManager, AbstractContextManager
 
     from litestar import Litestar
     from litestar.datastructures.state import State
     from litestar.types import BeforeMessageSendHookHandler, Scope
 
     from sqlspec.config import AsyncConfigT, DriverT, SyncConfigT
+    from sqlspec.driver import AsyncDriverAdapterBase, SyncDriverAdapterBase
     from sqlspec.typing import ConnectionT, PoolT
 
 
@@ -34,8 +36,10 @@ __all__ = (
     "DEFAULT_CONNECTION_KEY",
     "DEFAULT_POOL_KEY",
     "DEFAULT_SESSION_KEY",
+    "AsyncDatabaseConfig",
     "CommitMode",
     "DatabaseConfig",
+    "SyncDatabaseConfig",
 )
 
 
@@ -90,3 +94,183 @@ class DatabaseConfig:
         self.session_provider = session_provider_maker(
             config=self.config, connection_dependency_key=self.connection_key
         )
+
+    def get_request_session(
+        self, state: "State", scope: "Scope"
+    ) -> "Union[SyncDriverAdapterBase, AsyncDriverAdapterBase]":
+        """Get a session instance from the current request.
+
+        This method provides access to the database session that has been added to the request
+        scope, similar to Advanced Alchemy's provide_session method. It first looks for an
+        existing session in the request scope state, and if not found, creates a new one using
+        the connection from the scope.
+
+        Args:
+            state: The Litestar application State object.
+            scope: The ASGI scope containing the request context.
+
+        Returns:
+            A driver session instance.
+
+        Raises:
+            ImproperConfigurationError: If no connection is available in the scope.
+        """
+        # Create a unique scope key for sessions to avoid conflicts
+        session_scope_key = f"{self.session_key}_instance"
+
+        # Try to get existing session from scope
+        session = get_sqlspec_scope_state(scope, session_scope_key)
+        if session is not None:
+            return cast("Union[SyncDriverAdapterBase, AsyncDriverAdapterBase]", session)
+
+        # Get connection from scope state
+        connection = get_sqlspec_scope_state(scope, self.connection_key)
+        if connection is None:
+            msg = f"No database connection found in scope for key '{self.connection_key}'. "
+            msg += "Ensure the connection dependency is properly configured and available."
+            raise ImproperConfigurationError(detail=msg)
+
+        # Create new session using the connection
+        # Access driver_type which is available on all config types
+        session = self.config.driver_type(connection=connection)  # type: ignore[union-attr]
+
+        # Store session in scope for future use
+        set_sqlspec_scope_state(scope, session_scope_key, session)
+
+        return cast("Union[SyncDriverAdapterBase, AsyncDriverAdapterBase]", session)
+
+    def get_request_connection(self, state: "State", scope: "Scope") -> "Any":
+        """Get a connection instance from the current request.
+
+        This method provides access to the database connection that has been added to the request
+        scope. This is useful in guards, middleware, or other contexts where you need direct
+        access to the connection that's been established for the current request.
+
+        Args:
+            state: The Litestar application State object.
+            scope: The ASGI scope containing the request context.
+
+        Returns:
+            A database connection instance.
+
+        Raises:
+            ImproperConfigurationError: If no connection is available in the scope.
+        """
+        connection = get_sqlspec_scope_state(scope, self.connection_key)
+        if connection is None:
+            msg = f"No database connection found in scope for key '{self.connection_key}'. "
+            msg += "Ensure the connection dependency is properly configured and available."
+            raise ImproperConfigurationError(detail=msg)
+
+        return cast("Any", connection)
+
+
+# Add passthrough methods to both specialized classes for convenience
+class SyncDatabaseConfig(DatabaseConfig):
+    """Sync-specific DatabaseConfig with better typing for get_request_session."""
+
+    def get_request_session(self, state: "State", scope: "Scope") -> "SyncDriverAdapterBase":
+        """Get a sync session instance from the current request.
+
+        This method provides access to the database session that has been added to the request
+        scope, similar to Advanced Alchemy's provide_session method. It first looks for an
+        existing session in the request scope state, and if not found, creates a new one using
+        the connection from the scope.
+
+        Args:
+            state: The Litestar application State object.
+            scope: The ASGI scope containing the request context.
+
+        Returns:
+            A sync driver session instance.
+        """
+        session = super().get_request_session(state, scope)
+        return cast("SyncDriverAdapterBase", session)
+
+    def provide_session(self) -> "AbstractContextManager[SyncDriverAdapterBase]":
+        """Provide a database session context manager.
+
+        This is a passthrough to the underlying config's provide_session method
+        for convenient access to database sessions.
+
+        Returns:
+            Context manager that yields a sync driver session.
+        """
+        return self.config.provide_session()  # type: ignore[union-attr,no-any-return]
+
+    def provide_connection(self) -> "AbstractContextManager[Any]":
+        """Provide a database connection context manager.
+
+        This is a passthrough to the underlying config's provide_connection method
+        for convenient access to database connections.
+
+        Returns:
+            Context manager that yields a sync database connection.
+        """
+        return self.config.provide_connection()  # type: ignore[union-attr,no-any-return]
+
+    def create_connection(self) -> "Any":
+        """Create and return a new database connection.
+
+        This is a passthrough to the underlying config's create_connection method
+        for direct connection creation without context management.
+
+        Returns:
+            A new sync database connection.
+        """
+        return self.config.create_connection()  # type: ignore[union-attr]
+
+
+class AsyncDatabaseConfig(DatabaseConfig):
+    """Async-specific DatabaseConfig with better typing for get_request_session."""
+
+    def get_request_session(self, state: "State", scope: "Scope") -> "AsyncDriverAdapterBase":
+        """Get an async session instance from the current request.
+
+        This method provides access to the database session that has been added to the request
+        scope, similar to Advanced Alchemy's provide_session method. It first looks for an
+        existing session in the request scope state, and if not found, creates a new one using
+        the connection from the scope.
+
+        Args:
+            state: The Litestar application State object.
+            scope: The ASGI scope containing the request context.
+
+        Returns:
+            An async driver session instance.
+        """
+        session = super().get_request_session(state, scope)
+        return cast("AsyncDriverAdapterBase", session)
+
+    def provide_session(self) -> "AbstractAsyncContextManager[AsyncDriverAdapterBase]":
+        """Provide a database session context manager.
+
+        This is a passthrough to the underlying config's provide_session method
+        for convenient access to database sessions.
+
+        Returns:
+            Context manager that yields an async driver session.
+        """
+        return self.config.provide_session()  # type: ignore[union-attr,no-any-return]
+
+    def provide_connection(self) -> "AbstractAsyncContextManager[Any]":
+        """Provide a database connection context manager.
+
+        This is a passthrough to the underlying config's provide_connection method
+        for convenient access to database connections.
+
+        Returns:
+            Context manager that yields an async database connection.
+        """
+        return self.config.provide_connection()  # type: ignore[union-attr,no-any-return]
+
+    async def create_connection(self) -> "Any":
+        """Create and return a new database connection.
+
+        This is a passthrough to the underlying config's create_connection method
+        for direct connection creation without context management.
+
+        Returns:
+            A new async database connection.
+        """
+        return await self.config.create_connection()  # type: ignore[union-attr]

--- a/sqlspec/extensions/litestar/plugin.py
+++ b/sqlspec/extensions/litestar/plugin.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union, cast, overload
 
 from litestar.di import Provide
 from litestar.plugins import CLIPlugin, InitPluginProtocol
@@ -6,14 +6,17 @@ from litestar.plugins import CLIPlugin, InitPluginProtocol
 from sqlspec.base import SQLSpec as SQLSpecBase
 from sqlspec.config import AsyncConfigT, DatabaseConfigProtocol, DriverT, SyncConfigT
 from sqlspec.exceptions import ImproperConfigurationError
-from sqlspec.extensions.litestar.config import DatabaseConfig
+from sqlspec.extensions.litestar.config import AsyncDatabaseConfig, DatabaseConfig, SyncDatabaseConfig
 from sqlspec.typing import ConnectionT, PoolT
 from sqlspec.utils.logging import get_logger
 
 if TYPE_CHECKING:
     from click import Group
     from litestar.config.app import AppConfig
+    from litestar.datastructures.state import State
+    from litestar.types import Scope
 
+    from sqlspec.driver import AsyncDriverAdapterBase, SyncDriverAdapterBase
     from sqlspec.loader import SQLFileLoader
 
 logger = get_logger("extensions.litestar")
@@ -131,10 +134,241 @@ class SQLSpec(SQLSpecBase, InitPluginProtocol, CLIPlugin):
             The annotation for the configuration.
         """
         for c in self.config:
-            if key == c.config or key in {c.annotation, c.connection_key, c.pool_key}:
+            # Check annotation only if it's been set (during on_app_init)
+            annotation_match = hasattr(c, "annotation") and key == c.annotation
+            if key == c.config or annotation_match or key in {c.connection_key, c.pool_key}:
+                if not hasattr(c, "annotation"):
+                    msg = (
+                        "Annotation not set for configuration. Ensure the plugin has been initialized with on_app_init."
+                    )
+                    raise AttributeError(msg)
                 return c.annotation
         msg = f"No configuration found for {key}"
         raise KeyError(msg)
+
+    @overload
+    def get_config(self, name: "type[SyncConfigT]") -> "SyncConfigT": ...
+
+    @overload
+    def get_config(self, name: "type[AsyncConfigT]") -> "AsyncConfigT": ...
+
+    @overload
+    def get_config(self, name: str) -> "DatabaseConfig": ...
+
+    @overload
+    def get_config(self, name: "type[SyncDatabaseConfig]") -> "SyncDatabaseConfig": ...
+
+    @overload
+    def get_config(self, name: "type[AsyncDatabaseConfig]") -> "AsyncDatabaseConfig": ...
+
+    def get_config(
+        self, name: "Union[type[DatabaseConfigProtocol[ConnectionT, PoolT, DriverT]], str, Any]"
+    ) -> "Union[DatabaseConfigProtocol[ConnectionT, PoolT, DriverT], DatabaseConfig, SyncDatabaseConfig, AsyncDatabaseConfig]":
+        """Get a configuration instance by name, supporting both base behavior and Litestar extensions.
+
+        This method extends the base get_config to support Litestar-specific lookup patterns
+        while maintaining compatibility with the base class signature. It supports lookup by
+        connection key, pool key, session key, config instance, or annotation type.
+
+        Args:
+            name: The configuration identifier - can be:
+                - Type annotation (base class behavior)
+                - connection_key (e.g., "auth_db_connection")
+                - pool_key (e.g., "analytics_db_pool")
+                - session_key (e.g., "reporting_db_session")
+                - config instance
+                - annotation type
+
+        Raises:
+            KeyError: If no configuration is found for the given name.
+
+        Returns:
+            The configuration instance for the specified name.
+        """
+        # First try base class behavior for type-based lookup
+        # Only call super() if name matches the expected base class types
+        if not isinstance(name, str):
+            try:
+                return super().get_config(name)  # type: ignore[no-any-return]
+            except (KeyError, AttributeError):
+                # Fall back to Litestar-specific lookup patterns
+                pass
+
+        # Litestar-specific lookups by string keys
+        if isinstance(name, str):
+            for c in self.config:
+                if name in {c.connection_key, c.pool_key, c.session_key}:
+                    return c  # Return the DatabaseConfig wrapper for string lookups
+
+        # Lookup by config instance or annotation
+        for c in self.config:
+            annotation_match = hasattr(c, "annotation") and name == c.annotation
+            if name == c.config or annotation_match:
+                return c.config  # Return the underlying config for type-based lookups
+
+        msg = f"No database configuration found for name '{name}'. Available keys: {self._get_available_keys()}"
+        raise KeyError(msg)
+
+    def provide_request_session(
+        self,
+        key: "Union[str, SyncConfigT, AsyncConfigT, type[Union[SyncConfigT, AsyncConfigT]]]",
+        state: "State",
+        scope: "Scope",
+    ) -> "Union[SyncDriverAdapterBase, AsyncDriverAdapterBase]":
+        """Provide a database session for the specified configuration key from request scope.
+
+        This is a convenience method that combines get_config and get_request_session
+        into a single call, similar to Advanced Alchemy's provide_session pattern.
+
+        Args:
+            key: The configuration identifier (same as get_config)
+            state: The Litestar application State object
+            scope: The ASGI scope containing the request context
+
+        Returns:
+            A driver session instance for the specified database configuration
+
+        Example:
+            >>> sqlspec_plugin = connection.app.state.sqlspec
+            >>> # Direct session access by key
+            >>> auth_session = sqlspec_plugin.provide_request_session(
+            ...     "auth_db", state, scope
+            ... )
+            >>> analytics_session = sqlspec_plugin.provide_request_session(
+            ...     "analytics_db", state, scope
+            ... )
+        """
+        # Get DatabaseConfig wrapper for Litestar methods
+        db_config = self._get_database_config(key)
+        return db_config.get_request_session(state, scope)
+
+    def provide_sync_request_session(
+        self, key: "Union[str, SyncConfigT, type[SyncConfigT]]", state: "State", scope: "Scope"
+    ) -> "SyncDriverAdapterBase":
+        """Provide a sync database session for the specified configuration key from request scope.
+
+        This method provides better type hints for sync database sessions, ensuring the returned
+        session is properly typed as SyncDriverAdapterBase for better IDE support and type safety.
+
+        Args:
+            key: The sync configuration identifier
+            state: The Litestar application State object
+            scope: The ASGI scope containing the request context
+
+        Returns:
+            A sync driver session instance for the specified database configuration
+
+        Example:
+            >>> sqlspec_plugin = connection.app.state.sqlspec
+            >>> auth_session = sqlspec_plugin.provide_sync_request_session(
+            ...     "auth_db", state, scope
+            ... )
+            >>> # auth_session is now correctly typed as SyncDriverAdapterBase
+        """
+        # Get DatabaseConfig wrapper for Litestar methods
+        db_config = self._get_database_config(key)
+        session = db_config.get_request_session(state, scope)
+        return cast("SyncDriverAdapterBase", session)
+
+    def provide_async_request_session(
+        self, key: "Union[str, AsyncConfigT, type[AsyncConfigT]]", state: "State", scope: "Scope"
+    ) -> "AsyncDriverAdapterBase":
+        """Provide an async database session for the specified configuration key from request scope.
+
+        This method provides better type hints for async database sessions, ensuring the returned
+        session is properly typed as AsyncDriverAdapterBase for better IDE support and type safety.
+
+        Args:
+            key: The async configuration identifier
+            state: The Litestar application State object
+            scope: The ASGI scope containing the request context
+
+        Returns:
+            An async driver session instance for the specified database configuration
+
+        Example:
+            >>> sqlspec_plugin = connection.app.state.sqlspec
+            >>> auth_session = sqlspec_plugin.provide_async_request_session(
+            ...     "auth_db", state, scope
+            ... )
+            >>> # auth_session is now correctly typed as AsyncDriverAdapterBase
+        """
+        # Get DatabaseConfig wrapper for Litestar methods
+        db_config = self._get_database_config(key)
+        session = db_config.get_request_session(state, scope)
+        return cast("AsyncDriverAdapterBase", session)
+
+    def provide_request_connection(
+        self,
+        key: "Union[str, SyncConfigT, AsyncConfigT, type[Union[SyncConfigT, AsyncConfigT]]]",
+        state: "State",
+        scope: "Scope",
+    ) -> Any:
+        """Provide a database connection for the specified configuration key from request scope.
+
+        This is a convenience method that combines get_config and get_request_connection
+        into a single call.
+
+        Args:
+            key: The configuration identifier (same as get_config)
+            state: The Litestar application State object
+            scope: The ASGI scope containing the request context
+
+        Returns:
+            A database connection instance for the specified database configuration
+
+        Example:
+            >>> sqlspec_plugin = connection.app.state.sqlspec
+            >>> # Direct connection access by key
+            >>> auth_conn = sqlspec_plugin.provide_request_connection(
+            ...     "auth_db", state, scope
+            ... )
+            >>> analytics_conn = sqlspec_plugin.provide_request_connection(
+            ...     "analytics_db", state, scope
+            ... )
+        """
+        # Get DatabaseConfig wrapper for Litestar methods
+        db_config = self._get_database_config(key)
+        return db_config.get_request_connection(state, scope)
+
+    def _get_database_config(
+        self, key: "Union[str, SyncConfigT, AsyncConfigT, type[Union[SyncConfigT, AsyncConfigT]]]"
+    ) -> DatabaseConfig:
+        """Get a DatabaseConfig wrapper instance by name.
+
+        This is used internally by provide_request_session and provide_request_connection
+        to get the DatabaseConfig wrapper that has the request session methods.
+
+        Args:
+            key: The configuration identifier
+
+        Returns:
+            The DatabaseConfig wrapper instance
+
+        Raises:
+            KeyError: If no configuration is found for the given key
+        """
+        # For string keys, lookup by connection/pool/session keys
+        if isinstance(key, str):
+            for c in self.config:
+                if key in {c.connection_key, c.pool_key, c.session_key}:
+                    return c
+
+        # For other keys, lookup by config instance or annotation
+        for c in self.config:
+            annotation_match = hasattr(c, "annotation") and key == c.annotation
+            if key == c.config or annotation_match:
+                return c
+
+        msg = f"No database configuration found for name '{key}'. Available keys: {self._get_available_keys()}"
+        raise KeyError(msg)
+
+    def _get_available_keys(self) -> "list[str]":
+        """Get a list of all available configuration keys for error messages."""
+        keys = []
+        for c in self.config:
+            keys.extend([c.connection_key, c.pool_key, c.session_key])
+        return keys
 
     def _validate_dependency_keys(self) -> None:
         """Validate that connection and pool keys are unique across configurations.

--- a/tests/unit/test_extensions/__init__.py
+++ b/tests/unit/test_extensions/__init__.py
@@ -1,0 +1,1 @@
+"""Extension unit tests."""

--- a/tests/unit/test_extensions/test_litestar/__init__.py
+++ b/tests/unit/test_extensions/test_litestar/__init__.py
@@ -1,0 +1,1 @@
+"""Litestar extension unit tests."""

--- a/tests/unit/test_extensions/test_litestar/test_config.py
+++ b/tests/unit/test_extensions/test_litestar/test_config.py
@@ -1,0 +1,482 @@
+"""Test SQLSpec Litestar configuration extensions."""
+
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from sqlspec.adapters.sqlite.config import SqliteConfig
+
+if TYPE_CHECKING:
+    from litestar.types import Scope
+from sqlspec.exceptions import ImproperConfigurationError
+from sqlspec.extensions.litestar._utils import set_sqlspec_scope_state
+from sqlspec.extensions.litestar.config import AsyncDatabaseConfig, DatabaseConfig, SyncDatabaseConfig
+from sqlspec.extensions.litestar.plugin import SQLSpec
+
+
+def test_get_request_session_with_existing_session() -> None:
+    """Test get_request_session returns existing session from scope."""
+    # Arrange
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    db_config = DatabaseConfig(config=sqlite_config)
+
+    state = MagicMock()
+    scope = cast("Scope", {})
+
+    # Mock existing session in scope
+    session_scope_key = f"{db_config.session_key}_instance"
+    expected_session = MagicMock()
+    set_sqlspec_scope_state(scope, session_scope_key, expected_session)
+
+    # Act
+    result = db_config.get_request_session(state, scope)
+
+    # Assert
+    assert result is expected_session
+
+
+def test_get_request_session_creates_new_session() -> None:
+    """Test get_request_session creates new session when none exists."""
+    # Arrange
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    db_config = DatabaseConfig(config=sqlite_config)
+
+    state = MagicMock()
+    scope = cast("Scope", {})
+
+    # Mock connection in scope
+    mock_connection = MagicMock()
+    set_sqlspec_scope_state(scope, db_config.connection_key, mock_connection)
+
+    # Act
+    result = db_config.get_request_session(state, scope)
+
+    # Assert
+    assert result is not None
+    # Verify the session was created with the connection
+    assert hasattr(result, "connection")
+
+
+def test_get_request_session_raises_when_no_connection() -> None:
+    """Test get_request_session raises error when no connection in scope."""
+    # Arrange
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    db_config = DatabaseConfig(config=sqlite_config)
+
+    state = MagicMock()
+    scope = cast("Scope", {})  # No connection in scope
+
+    # Act & Assert
+    with pytest.raises(ImproperConfigurationError) as exc_info:
+        db_config.get_request_session(state, scope)
+
+    assert "No database connection found in scope" in str(exc_info.value)
+    assert db_config.connection_key in str(exc_info.value)
+
+
+def test_get_request_connection_returns_connection() -> None:
+    """Test get_request_connection returns connection from scope."""
+    # Arrange
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    db_config = DatabaseConfig(config=sqlite_config)
+
+    state = MagicMock()
+    scope = cast("Scope", {})
+
+    # Mock connection in scope
+    expected_connection = MagicMock()
+    set_sqlspec_scope_state(scope, db_config.connection_key, expected_connection)
+
+    # Act
+    result = db_config.get_request_connection(state, scope)
+
+    # Assert
+    assert result is expected_connection
+
+
+def test_get_request_connection_raises_when_no_connection() -> None:
+    """Test get_request_connection raises error when no connection in scope."""
+    # Arrange
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    db_config = DatabaseConfig(config=sqlite_config)
+
+    state = MagicMock()
+    scope = cast("Scope", {})  # No connection in scope
+
+    # Act & Assert
+    with pytest.raises(ImproperConfigurationError) as exc_info:
+        db_config.get_request_connection(state, scope)
+
+    assert "No database connection found in scope" in str(exc_info.value)
+    assert db_config.connection_key in str(exc_info.value)
+
+
+def test_get_request_session_caches_session_in_scope() -> None:
+    """Test get_request_session stores created session in scope for reuse."""
+    # Arrange
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    db_config = DatabaseConfig(config=sqlite_config)
+
+    state = MagicMock()
+    scope = cast("Scope", {})
+
+    # Mock connection in scope
+    mock_connection = MagicMock()
+    set_sqlspec_scope_state(scope, db_config.connection_key, mock_connection)
+
+    # Act - call twice
+    result1 = db_config.get_request_session(state, scope)
+    result2 = db_config.get_request_session(state, scope)
+
+    # Assert - should return the same cached session
+    assert result1 is result2
+
+
+def test_database_config_provides_both_methods() -> None:
+    """Test DatabaseConfig exposes both get_request_session and get_request_connection methods."""
+    # Arrange
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    db_config = DatabaseConfig(config=sqlite_config)
+
+    # Assert
+    assert hasattr(db_config, "get_request_session")
+    assert callable(db_config.get_request_session)
+    assert hasattr(db_config, "get_request_connection")
+    assert callable(db_config.get_request_connection)
+
+
+def test_sqlspec_plugin_get_config_by_connection_key() -> None:
+    """Test SQLSpec plugin get_config method with connection key."""
+    # Arrange
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    auth_db_config = DatabaseConfig(config=sqlite_config, connection_key="auth_db_connection")
+
+    plugin = SQLSpec(config=auth_db_config)
+
+    # Act
+    result = plugin.get_config("auth_db_connection")
+
+    # Assert
+    assert result is auth_db_config
+
+
+def test_sqlspec_plugin_get_config_by_pool_key() -> None:
+    """Test SQLSpec plugin get_config method with pool key."""
+    # Arrange
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    analytics_db_config = DatabaseConfig(config=sqlite_config, pool_key="analytics_db_pool")
+
+    plugin = SQLSpec(config=analytics_db_config)
+
+    # Act
+    result = plugin.get_config("analytics_db_pool")
+
+    # Assert
+    assert result is analytics_db_config
+
+
+def test_sqlspec_plugin_get_config_by_session_key() -> None:
+    """Test SQLSpec plugin get_config method with session key."""
+    # Arrange
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    reporting_db_config = DatabaseConfig(config=sqlite_config, session_key="reporting_db_session")
+
+    plugin = SQLSpec(config=reporting_db_config)
+
+    # Act
+    result = plugin.get_config("reporting_db_session")
+
+    # Assert
+    assert result is reporting_db_config
+
+
+def test_sqlspec_plugin_get_config_with_multiple_configs() -> None:
+    """Test SQLSpec plugin get_config method with multiple database configurations."""
+    # Arrange
+    auth_sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    auth_db_config = DatabaseConfig(config=auth_sqlite_config, connection_key="auth_db_connection")
+
+    analytics_sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    analytics_db_config = DatabaseConfig(config=analytics_sqlite_config, connection_key="analytics_db_connection")
+
+    plugin = SQLSpec(config=[auth_db_config, analytics_db_config])
+
+    # Act & Assert
+    auth_result = plugin.get_config("auth_db_connection")
+    analytics_result = plugin.get_config("analytics_db_connection")
+
+    assert auth_result is auth_db_config
+    assert analytics_result is analytics_db_config
+
+
+def test_sqlspec_plugin_get_config_raises_keyerror_for_unknown_key() -> None:
+    """Test SQLSpec plugin get_config raises KeyError for unknown key."""
+    # Arrange
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    db_config = DatabaseConfig(config=sqlite_config)
+
+    plugin = SQLSpec(config=db_config)
+
+    # Act & Assert
+    with pytest.raises(KeyError) as exc_info:
+        plugin.get_config("nonexistent_key")
+
+    assert "No database configuration found for name 'nonexistent_key'" in str(exc_info.value)
+    assert "Available keys:" in str(exc_info.value)
+
+
+def test_sqlspec_plugin_provide_request_session() -> None:
+    """Test SQLSpec plugin provide_request_session method."""
+    # Arrange
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    db_config = DatabaseConfig(config=sqlite_config, connection_key="test_db_connection")
+
+    plugin = SQLSpec(config=db_config)
+
+    state = MagicMock()
+    scope = cast("Scope", {})
+
+    # Mock connection in scope
+    mock_connection = MagicMock()
+    set_sqlspec_scope_state(scope, db_config.connection_key, mock_connection)
+
+    # Act
+    result: Any = plugin.provide_request_session("test_db_connection", state, scope)
+
+    # Assert
+    assert result is not None
+    assert hasattr(result, "connection")
+
+
+def test_sqlspec_plugin_provide_request_connection() -> None:
+    """Test SQLSpec plugin provide_request_connection method."""
+    # Arrange
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    db_config = DatabaseConfig(config=sqlite_config, connection_key="test_db_connection")
+
+    plugin = SQLSpec(config=db_config)
+
+    state = MagicMock()
+    scope = cast("Scope", {})
+
+    # Mock connection in scope
+    expected_connection = MagicMock()
+    set_sqlspec_scope_state(scope, db_config.connection_key, expected_connection)
+
+    # Act
+    result: Any = plugin.provide_request_connection("test_db_connection", state, scope)
+
+    # Assert
+    assert result is expected_connection
+
+
+def test_sqlspec_plugin_provide_request_session_raises_keyerror_for_unknown_key() -> None:
+    """Test SQLSpec plugin provide_request_session raises KeyError for unknown key."""
+    # Arrange
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    db_config = DatabaseConfig(config=sqlite_config)
+
+    plugin = SQLSpec(config=db_config)
+
+    state = MagicMock()
+    scope = cast("Scope", {})
+
+    # Act & Assert
+    with pytest.raises(KeyError):
+        plugin.provide_request_session("nonexistent_key", state, scope)
+
+
+def test_sqlspec_plugin_provide_request_connection_raises_keyerror_for_unknown_key() -> None:
+    """Test SQLSpec plugin provide_request_connection raises KeyError for unknown key."""
+    # Arrange
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    db_config = DatabaseConfig(config=sqlite_config)
+
+    plugin = SQLSpec(config=db_config)
+
+    state = MagicMock()
+    scope = cast("Scope", {})
+
+    # Act & Assert
+    with pytest.raises(KeyError):
+        plugin.provide_request_connection("nonexistent_key", state, scope)
+
+
+def test_sync_database_config_returns_sync_driver_type() -> None:
+    """Test SyncDatabaseConfig.get_request_session returns SyncDriverAdapterBase type."""
+    # Arrange
+
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    sync_db_config = SyncDatabaseConfig(config=sqlite_config)
+
+    state = MagicMock()
+    scope = cast("Scope", {})
+
+    # Mock connection in scope
+    mock_connection = MagicMock()
+    set_sqlspec_scope_state(scope, sync_db_config.connection_key, mock_connection)
+
+    # Act
+    result = sync_db_config.get_request_session(state, scope)
+
+    # Assert
+    assert result is not None
+    # The type checker should now know this is SyncDriverAdapterBase
+    assert hasattr(result, "execute")  # Basic driver interface check
+
+
+def test_async_database_config_returns_async_driver_type() -> None:
+    """Test AsyncDatabaseConfig.get_request_session returns AsyncDriverAdapterBase type."""
+    # Arrange - using aiosqlite for async example
+    from sqlspec.adapters.aiosqlite.config import AiosqliteConfig
+
+    aiosqlite_config = AiosqliteConfig(pool_config={"database": ":memory:"})
+    async_db_config = AsyncDatabaseConfig(config=aiosqlite_config)
+
+    state = MagicMock()
+    scope = cast("Scope", {})
+
+    # Mock connection in scope
+    mock_connection = MagicMock()
+    set_sqlspec_scope_state(scope, async_db_config.connection_key, mock_connection)
+
+    # Act
+    result = async_db_config.get_request_session(state, scope)
+
+    # Assert
+    assert result is not None
+    # The type checker should now know this is AsyncDriverAdapterBase
+    assert hasattr(result, "execute")  # Basic driver interface check
+
+
+def test_specialized_configs_inherit_from_base_config() -> None:
+    """Test that specialized configs inherit all functionality from DatabaseConfig."""
+    # Arrange
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    sync_config = SyncDatabaseConfig(config=sqlite_config)
+
+    from sqlspec.adapters.aiosqlite.config import AiosqliteConfig
+
+    aiosqlite_config = AiosqliteConfig(pool_config={"database": ":memory:"})
+    async_config = AsyncDatabaseConfig(config=aiosqlite_config)
+
+    # Assert - Should have all the same attributes as base DatabaseConfig
+    base_attrs = [
+        "connection_key",
+        "pool_key",
+        "session_key",
+        "commit_mode",
+        "get_request_session",
+        "get_request_connection",
+    ]
+
+    for attr in base_attrs:
+        assert hasattr(sync_config, attr), f"SyncDatabaseConfig missing {attr}"
+        assert hasattr(async_config, attr), f"AsyncDatabaseConfig missing {attr}"
+
+
+def test_specialized_configs_work_with_plugin() -> None:
+    """Test that SQLSpec plugin works with specialized database configs."""
+    # Arrange
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    sync_db_config = SyncDatabaseConfig(config=sqlite_config, connection_key="sync_db")
+
+    from sqlspec.adapters.aiosqlite.config import AiosqliteConfig
+
+    aiosqlite_config = AiosqliteConfig(pool_config={"database": ":memory:"})
+    async_db_config = AsyncDatabaseConfig(config=aiosqlite_config, connection_key="async_db")
+
+    plugin = SQLSpec(config=[sync_db_config, async_db_config])
+
+    # Act & Assert
+    sync_config = plugin.get_config("sync_db")
+    async_config = plugin.get_config("async_db")
+
+    assert isinstance(sync_config, SyncDatabaseConfig)
+    assert isinstance(async_config, AsyncDatabaseConfig)
+    assert sync_config is sync_db_config
+    assert async_config is async_db_config
+
+
+def test_sqlspec_plugin_provide_sync_request_session() -> None:
+    """Test SQLSpec plugin provide_sync_request_session method returns properly typed session."""
+    # Arrange
+    sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    db_config = DatabaseConfig(config=sqlite_config, connection_key="sync_db_connection")
+
+    plugin = SQLSpec(config=db_config)
+
+    state = MagicMock()
+    scope = cast("Scope", {})
+
+    # Mock connection in scope
+    mock_connection = MagicMock()
+    set_sqlspec_scope_state(scope, db_config.connection_key, mock_connection)
+
+    # Act
+    result: Any = plugin.provide_sync_request_session("sync_db_connection", state, scope)
+
+    # Assert
+    assert result is not None
+    assert hasattr(result, "connection")
+    # The returned type should be SyncDriverAdapterBase according to type hints
+
+
+def test_sqlspec_plugin_provide_async_request_session() -> None:
+    """Test SQLSpec plugin provide_async_request_session method returns properly typed session."""
+    # Arrange
+    from sqlspec.adapters.aiosqlite.config import AiosqliteConfig
+
+    aiosqlite_config = AiosqliteConfig(pool_config={"database": ":memory:"})
+    db_config = DatabaseConfig(config=aiosqlite_config, connection_key="async_db_connection")
+
+    plugin = SQLSpec(config=db_config)
+
+    state = MagicMock()
+    scope = cast("Scope", {})
+
+    # Mock connection in scope
+    mock_connection = MagicMock()
+    set_sqlspec_scope_state(scope, db_config.connection_key, mock_connection)
+
+    # Act
+    result: Any = plugin.provide_async_request_session("async_db_connection", state, scope)
+
+    # Assert
+    assert result is not None
+    assert hasattr(result, "connection")
+    # The returned type should be AsyncDriverAdapterBase according to type hints
+
+
+def test_sqlspec_plugin_provide_typed_session_methods_with_multiple_configs() -> None:
+    """Test typed session methods work with multiple database configurations."""
+    # Arrange
+    sync_sqlite_config = SqliteConfig(pool_config={"database": ":memory:"})
+    sync_db_config = DatabaseConfig(config=sync_sqlite_config, connection_key="sync_db")
+
+    from sqlspec.adapters.aiosqlite.config import AiosqliteConfig
+
+    async_sqlite_config = AiosqliteConfig(pool_config={"database": ":memory:"})
+    async_db_config = DatabaseConfig(config=async_sqlite_config, connection_key="async_db")
+
+    plugin = SQLSpec(config=[sync_db_config, async_db_config])
+
+    state = MagicMock()
+    scope = cast("Scope", {})
+
+    # Mock connections in scope
+    mock_sync_connection = MagicMock()
+    mock_async_connection = MagicMock()
+    set_sqlspec_scope_state(scope, sync_db_config.connection_key, mock_sync_connection)
+    set_sqlspec_scope_state(scope, async_db_config.connection_key, mock_async_connection)
+
+    # Act & Assert - sync session
+    sync_result: Any = plugin.provide_sync_request_session("sync_db", state, scope)
+    assert sync_result is not None
+    assert hasattr(sync_result, "connection")
+
+    # Act & Assert - async session
+    async_result: Any = plugin.provide_async_request_session("async_db", state, scope)
+    assert async_result is not None
+    assert hasattr(async_result, "connection")


### PR DESCRIPTION
Introduce methods to access the active database session and connection from the current request context, enhancing the integration with Litestar's request handling. This improves session management and provides better typing for synchronous and asynchronous database configurations.