### PR TITLE
fix: `get_next` in sync tools properly raises `StopIteration`

### DIFF
--- a/sqlspec/utils/sync_tools.py
+++ b/sqlspec/utils/sync_tools.py
@@ -29,6 +29,13 @@ ParamSpecT = ParamSpec("ParamSpecT")
 T = TypeVar("T")
 
 
+class NoValue:
+    """Sentinel class for missing values."""
+
+
+NO_VALUE = NoValue()
+
+
 class CapacityLimiter:
     """Limits the number of concurrent operations using a semaphore."""
 
@@ -240,11 +247,7 @@ def with_ensure_async_(
     return obj
 
 
-class NoValue:
-    """Sentinel class for missing values."""
-
-
-async def get_next(iterable: Any, default: Any = NoValue, *args: Any) -> Any:  # pragma: no cover
+async def get_next(iterable: Any, default: Any = NO_VALUE, *args: Any) -> Any:  # pragma: no cover
     """Return the next item from an async iterator.
 
     Args:

--- a/tests/unit/test_utils/test_sync_tools.py
+++ b/tests/unit/test_utils/test_sync_tools.py
@@ -320,6 +320,9 @@ async def test_get_next_with_default() -> None:
     """Test get_next with default value when iterator is exhausted."""
 
     class EmptyAsyncIterator:
+        def __aiter__(self) -> "EmptyAsyncIterator":
+            return self
+
         async def __anext__(self) -> int:
             raise StopAsyncIteration
 
@@ -334,17 +337,17 @@ async def test_get_next_no_default_behavior() -> None:
     """Test get_next behavior when iterator is exhausted without default."""
 
     class EmptyAsyncIterator:
+        def __aiter__(self) -> "EmptyAsyncIterator":
+            return self
+
         async def __anext__(self) -> int:
             raise StopAsyncIteration
 
     iterator = EmptyAsyncIterator()
 
-    try:
-        result = await get_next(iterator)
-
-        assert isinstance(result, type(NoValue))
-    except StopAsyncIteration:
-        pass
+    # Should raise StopAsyncIteration when no default is provided
+    with pytest.raises(StopAsyncIteration):
+        await get_next(iterator)
 
 
 def test_no_value_class() -> None:


### PR DESCRIPTION
Raise `StopAsyncIteration` when the async iterator is exhausted and no default value is provided. Introduce a sentinel class for missing values to improve clarity in the code.