### PR TITLE
refactor: refactor cursor exit

### DIFF
--- a/sqlspec/adapters/adbc/driver.py
+++ b/sqlspec/adapters/adbc/driver.py
@@ -335,8 +335,7 @@ class AdbcCursor:
         self.cursor = self.connection.cursor()
         return self.cursor
 
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        _ = (exc_type, exc_val, exc_tb)
+    def __exit__(self, *_: Any) -> None:
         if self.cursor is not None:
             with contextlib.suppress(Exception):
                 self.cursor.close()  # type: ignore[no-untyped-call]

--- a/sqlspec/adapters/aiosqlite/driver.py
+++ b/sqlspec/adapters/aiosqlite/driver.py
@@ -66,8 +66,7 @@ class AiosqliteCursor:
         self.cursor = await self.connection.cursor()
         return self.cursor
 
-    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        _ = (exc_type, exc_val, exc_tb)
+    async def __aexit__(self, *_: Any) -> None:
         if self.cursor is not None:
             with contextlib.suppress(Exception):
                 await self.cursor.close()

--- a/sqlspec/adapters/asyncmy/driver.py
+++ b/sqlspec/adapters/asyncmy/driver.py
@@ -66,8 +66,7 @@ class AsyncmyCursor:
         self.cursor = self.connection.cursor()
         return self.cursor
 
-    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        _ = (exc_type, exc_val, exc_tb)
+    async def __aexit__(self, *_: Any) -> None:
         if self.cursor is not None:
             await self.cursor.close()
 

--- a/sqlspec/adapters/asyncpg/driver.py
+++ b/sqlspec/adapters/asyncpg/driver.py
@@ -63,8 +63,7 @@ class AsyncpgCursor:
     async def __aenter__(self) -> "AsyncpgConnection":
         return self.connection
 
-    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        _ = (exc_type, exc_val, exc_tb)
+    async def __aexit__(self, *_: Any) -> None: ...
 
 
 class AsyncpgExceptionHandler:

--- a/sqlspec/adapters/bigquery/driver.py
+++ b/sqlspec/adapters/bigquery/driver.py
@@ -177,7 +177,7 @@ class BigQueryCursor:
     def __enter__(self) -> "BigQueryConnection":
         return self.connection
 
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+    def __exit__(self, *_: Any) -> None:
         """Clean up cursor resources including active QueryJobs."""
         if self.job is not None:
             try:

--- a/sqlspec/adapters/duckdb/driver.py
+++ b/sqlspec/adapters/duckdb/driver.py
@@ -60,8 +60,7 @@ class DuckDBCursor:
         self.cursor = self.connection.cursor()
         return self.cursor
 
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        _ = (exc_type, exc_val, exc_tb)
+    def __exit__(self, *_: Any) -> None:
         if self.cursor is not None:
             self.cursor.close()
 

--- a/sqlspec/adapters/oracledb/driver.py
+++ b/sqlspec/adapters/oracledb/driver.py
@@ -63,8 +63,7 @@ class OracleSyncCursor:
         self.cursor = self.connection.cursor()
         return self.cursor
 
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        _ = (exc_type, exc_val, exc_tb)  # Mark as intentionally unused
+    def __exit__(self, *_: Any) -> None:
         if self.cursor is not None:
             self.cursor.close()
 

--- a/sqlspec/adapters/psqlpy/driver.py
+++ b/sqlspec/adapters/psqlpy/driver.py
@@ -238,7 +238,7 @@ class PsqlpyCursor:
         self._in_use = True
         return self.connection
 
-    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+    async def __aexit__(self, *_: Any) -> None:
         """Exit cursor context.
 
         Args:
@@ -246,7 +246,6 @@ class PsqlpyCursor:
             exc_val: Exception value
             exc_tb: Exception traceback
         """
-        _ = (exc_type, exc_val, exc_tb)
         self._in_use = False
 
     def is_in_use(self) -> bool:

--- a/sqlspec/adapters/psycopg/driver.py
+++ b/sqlspec/adapters/psycopg/driver.py
@@ -125,8 +125,7 @@ class PsycopgSyncCursor:
         self.cursor = self.connection.cursor()
         return self.cursor
 
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        _ = (exc_type, exc_val, exc_tb)
+    def __exit__(self, *_: Any) -> None:
         if self.cursor is not None:
             self.cursor.close()
 

--- a/sqlspec/adapters/sqlite/driver.py
+++ b/sqlspec/adapters/sqlite/driver.py
@@ -75,7 +75,7 @@ class SqliteCursor:
         self.cursor = self.connection.cursor()
         return self.cursor
 
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+    def __exit__(self, *_: Any) -> None:
         """Clean up cursor resources.
 
         Args:
@@ -83,7 +83,6 @@ class SqliteCursor:
             exc_val: Exception value if an exception occurred
             exc_tb: Exception traceback if an exception occurred
         """
-        _ = (exc_type, exc_val, exc_tb)
         if self.cursor is not None:
             with contextlib.suppress(Exception):
                 self.cursor.close()


### PR DESCRIPTION
<!--
By submitting this pull request, you agree to:
- follow [Litestar's Code of Conduct](https://github.com/litestar-org/.github/blob/main/CODE_OF_CONDUCT.md)
- follow [Litestar's contribution guidelines](https://github.com/litestar-org/.github/blob/main/CONTRIBUTING.md)
- follow the [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)
-->
## Description
This PR refactors the `exit` and `aexit` methods for db cursor classes.
-

<!--
Please add in issue numbers this pull request will close, if applicable
Examples: Fixes #4321 or Closes #1234

Ensure you are using a supported keyword to properly link an issue:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
## Closes
