### PR TITLE
feat: async migrations and callable config support

### DIFF
--- a/sqlspec/adapters/asyncmy/_types.py
+++ b/sqlspec/adapters/asyncmy/_types.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-from asyncmy import Connection
+from asyncmy import Connection  # pyright: ignore
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias

--- a/sqlspec/adapters/asyncmy/config.py
+++ b/sqlspec/adapters/asyncmy/config.py
@@ -6,8 +6,8 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypedDict, Union
 
 import asyncmy
-from asyncmy.cursors import Cursor, DictCursor
-from asyncmy.pool import Pool as AsyncmyPool
+from asyncmy.cursors import Cursor, DictCursor  # pyright: ignore
+from asyncmy.pool import Pool as AsyncmyPool  # pyright: ignore
 from typing_extensions import NotRequired
 
 from sqlspec.adapters.asyncmy._types import AsyncmyConnection
@@ -15,8 +15,8 @@ from sqlspec.adapters.asyncmy.driver import AsyncmyCursor, AsyncmyDriver, asyncm
 from sqlspec.config import AsyncDatabaseConfig
 
 if TYPE_CHECKING:
-    from asyncmy.cursors import Cursor, DictCursor
-    from asyncmy.pool import Pool
+    from asyncmy.cursors import Cursor, DictCursor  # pyright: ignore
+    from asyncmy.pool import Pool  # pyright: ignore
 
     from sqlspec.core.statement import StatementConfig
 
@@ -57,7 +57,7 @@ class AsyncmyPoolParams(AsyncmyConnectionParams, total=False):
     pool_recycle: NotRequired[int]
 
 
-class AsyncmyConfig(AsyncDatabaseConfig[AsyncmyConnection, "Pool", AsyncmyDriver]):  # pyright: ignore
+class AsyncmyConfig(AsyncDatabaseConfig[AsyncmyConnection, "AsyncmyPool", AsyncmyDriver]):  # pyright: ignore
     """Configuration for Asyncmy database connections."""
 
     driver_type: ClassVar[type[AsyncmyDriver]] = AsyncmyDriver
@@ -67,7 +67,7 @@ class AsyncmyConfig(AsyncDatabaseConfig[AsyncmyConnection, "Pool", AsyncmyDriver
         self,
         *,
         pool_config: "Optional[Union[AsyncmyPoolParams, dict[str, Any]]]" = None,
-        pool_instance: "Optional[Pool]" = None,
+        pool_instance: "Optional[AsyncmyPool]" = None,
         migration_config: Optional[dict[str, Any]] = None,
         statement_config: "Optional[StatementConfig]" = None,
         driver_features: "Optional[dict[str, Any]]" = None,
@@ -102,9 +102,9 @@ class AsyncmyConfig(AsyncDatabaseConfig[AsyncmyConnection, "Pool", AsyncmyDriver
             driver_features=driver_features or {},
         )
 
-    async def _create_pool(self) -> "Pool":  # pyright: ignore
+    async def _create_pool(self) -> "AsyncmyPool":  # pyright: ignore
         """Create the actual async connection pool."""
-        return await asyncmy.create_pool(**dict(self.pool_config))
+        return await asyncmy.create_pool(**dict(self.pool_config))  # pyright: ignore
 
     async def _close_pool(self) -> None:
         """Close the actual async connection pool."""

--- a/sqlspec/adapters/sqlite/pool.py
+++ b/sqlspec/adapters/sqlite/pool.py
@@ -40,7 +40,7 @@ class SqliteConnectionPool:
     __slots__ = ("_connection_parameters", "_enable_optimizations", "_thread_local")
 
     def __init__(
-        self, connection_parameters: "dict[str, Any]", enable_optimizations: bool = True, **kwargs: Any
+        self, connection_parameters: "dict[str, Any]", enable_optimizations: bool = True, **_kwargs: Any
     ) -> None:
         """Initialize the thread-local connection manager.
 
@@ -49,6 +49,10 @@ class SqliteConnectionPool:
             enable_optimizations: Whether to apply performance PRAGMAs
             **kwargs: Ignored pool parameters for compatibility
         """
+        # Default check_same_thread to False if not specified to support async operations
+        # This is safe because we use thread-local storage to prevent actual sharing
+        if "check_same_thread" not in connection_parameters:
+            connection_parameters = {**connection_parameters, "check_same_thread": False}
         self._connection_parameters = connection_parameters
         self._thread_local = threading.local()
         self._enable_optimizations = enable_optimizations

--- a/sqlspec/cli.py
+++ b/sqlspec/cli.py
@@ -4,8 +4,6 @@ import sys
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
-from sqlspec.utils.sync_tools import run_
-
 if TYPE_CHECKING:
     from click import Group
 
@@ -289,6 +287,7 @@ def add_migration_commands(database_group: Optional["Group"] = None) -> "Group":
     ) -> None:
         """Show current database revision."""
         from sqlspec.migrations.commands import create_migration_commands
+        from sqlspec.utils.sync_tools import run_
 
         ctx = click.get_current_context()
 
@@ -317,7 +316,6 @@ def add_migration_commands(database_group: Optional["Group"] = None) -> "Group":
                     except Exception as e:
                         console.print(f"[red]✗ Failed to get current revision for {config_name}: {e}[/]")
             else:
-                # Single config operation
                 console.rule("[yellow]Listing current revision[/]", align="left")
                 sqlspec_config = get_config_by_bind_key(cast("click.Context", ctx), bind_key)
                 migration_commands = create_migration_commands(config=sqlspec_config)
@@ -344,6 +342,7 @@ def add_migration_commands(database_group: Optional["Group"] = None) -> "Group":
         from rich.prompt import Confirm
 
         from sqlspec.migrations.commands import create_migration_commands
+        from sqlspec.utils.sync_tools import run_
 
         ctx = click.get_current_context()
 
@@ -414,6 +413,7 @@ def add_migration_commands(database_group: Optional["Group"] = None) -> "Group":
         from rich.prompt import Confirm
 
         from sqlspec.migrations.commands import create_migration_commands
+        from sqlspec.utils.sync_tools import run_
 
         ctx = click.get_current_context()
 
@@ -470,6 +470,7 @@ def add_migration_commands(database_group: Optional["Group"] = None) -> "Group":
     def stamp(bind_key: Optional[str], revision: str) -> None:  # pyright: ignore[reportUnusedFunction]
         """Stamp the revision table with the given revision."""
         from sqlspec.migrations.commands import create_migration_commands
+        from sqlspec.utils.sync_tools import run_
 
         ctx = click.get_current_context()
 
@@ -492,6 +493,7 @@ def add_migration_commands(database_group: Optional["Group"] = None) -> "Group":
         from rich.prompt import Confirm
 
         from sqlspec.migrations.commands import create_migration_commands
+        from sqlspec.utils.sync_tools import run_
 
         ctx = click.get_current_context()
 
@@ -533,6 +535,7 @@ def add_migration_commands(database_group: Optional["Group"] = None) -> "Group":
         from rich.prompt import Prompt
 
         from sqlspec.migrations.commands import create_migration_commands
+        from sqlspec.utils.sync_tools import run_
 
         ctx = click.get_current_context()
 

--- a/sqlspec/config.py
+++ b/sqlspec/config.py
@@ -244,25 +244,25 @@ class DatabaseConfigProtocol(ABC, Generic[ConnectionT, PoolT, DriverT]):
         """
         return self._ensure_migration_commands()
 
-    def migrate_up(self, revision: str = "head") -> None:
+    async def migrate_up(self, revision: str = "head") -> None:
         """Apply migrations up to the specified revision.
 
         Args:
             revision: Target revision or "head" for latest. Defaults to "head".
         """
         commands = self._ensure_migration_commands()
-        commands.upgrade(revision)
+        await commands.upgrade(revision)
 
-    def migrate_down(self, revision: str = "-1") -> None:
+    async def migrate_down(self, revision: str = "-1") -> None:
         """Apply migrations down to the specified revision.
 
         Args:
             revision: Target revision, "-1" for one step back, or "base" for all migrations. Defaults to "-1".
         """
         commands = self._ensure_migration_commands()
-        commands.downgrade(revision)
+        await commands.downgrade(revision)
 
-    def get_current_migration(self, verbose: bool = False) -> "Optional[str]":
+    async def get_current_migration(self, verbose: bool = False) -> "Optional[str]":
         """Get the current migration version.
 
         Args:
@@ -272,9 +272,9 @@ class DatabaseConfigProtocol(ABC, Generic[ConnectionT, PoolT, DriverT]):
             Current migration version or None if no migrations applied.
         """
         commands = self._ensure_migration_commands()
-        return commands.current(verbose=verbose)
+        return await commands.current(verbose=verbose)
 
-    def create_migration(self, message: str, file_type: str = "sql") -> None:
+    async def create_migration(self, message: str, file_type: str = "sql") -> None:
         """Create a new migration file.
 
         Args:
@@ -282,9 +282,9 @@ class DatabaseConfigProtocol(ABC, Generic[ConnectionT, PoolT, DriverT]):
             file_type: Type of migration file to create ('sql' or 'py'). Defaults to 'sql'.
         """
         commands = self._ensure_migration_commands()
-        commands.revision(message, file_type)
+        await commands.revision(message, file_type)
 
-    def init_migrations(self, directory: "Optional[str]" = None, package: bool = True) -> None:
+    async def init_migrations(self, directory: "Optional[str]" = None, package: bool = True) -> None:
         """Initialize migration directory structure.
 
         Args:
@@ -297,7 +297,7 @@ class DatabaseConfigProtocol(ABC, Generic[ConnectionT, PoolT, DriverT]):
 
         commands = self._ensure_migration_commands()
         assert directory is not None
-        commands.init(directory, package)
+        await commands.init(directory, package)
 
 
 class NoPoolSyncConfig(DatabaseConfigProtocol[ConnectionT, None, DriverT]):

--- a/sqlspec/exceptions.py
+++ b/sqlspec/exceptions.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from typing import Any, Optional, Union
 
 __all__ = (
+    "ConfigResolverError",
     "FileNotFoundInStorageError",
     "ImproperConfigurationError",
     "IntegrityError",
@@ -67,6 +68,10 @@ class BackendNotRegisteredError(SQLSpecError):
 
     def __init__(self, backend_key: str) -> None:
         super().__init__(f"Storage backend '{backend_key}' is not registered. Please register it before use.")
+
+
+class ConfigResolverError(SQLSpecError):
+    """Exception raised when config resolution fails."""
 
 
 class SQLParsingError(SQLSpecError):

--- a/sqlspec/migrations/__init__.py
+++ b/sqlspec/migrations/__init__.py
@@ -12,21 +12,20 @@ from sqlspec.migrations.loaders import (
     SQLFileLoader,
     get_migration_loader,
 )
-from sqlspec.migrations.runner import AsyncMigrationRunner, SyncMigrationRunner
+from sqlspec.migrations.runner import MigrationRunner
 from sqlspec.migrations.tracker import AsyncMigrationTracker, SyncMigrationTracker
 from sqlspec.migrations.utils import create_migration_file, drop_all, get_author
 
 __all__ = (
     "AsyncMigrationCommands",
-    "AsyncMigrationRunner",
     "AsyncMigrationTracker",
     "BaseMigrationLoader",
     "MigrationCommands",
     "MigrationLoadError",
+    "MigrationRunner",
     "PythonFileLoader",
     "SQLFileLoader",
     "SyncMigrationCommands",
-    "SyncMigrationRunner",
     "SyncMigrationTracker",
     "create_migration_file",
     "drop_all",

--- a/sqlspec/migrations/__init__.py
+++ b/sqlspec/migrations/__init__.py
@@ -4,7 +4,7 @@ A native migration system for SQLSpec that leverages the SQLFileLoader
 and driver system for database versioning.
 """
 
-from sqlspec.migrations.commands import AsyncMigrationCommands, MigrationCommands, SyncMigrationCommands
+from sqlspec.migrations.commands import AsyncMigrationCommands, SyncMigrationCommands, create_migration_commands
 from sqlspec.migrations.loaders import (
     BaseMigrationLoader,
     MigrationLoadError,
@@ -12,22 +12,24 @@ from sqlspec.migrations.loaders import (
     SQLFileLoader,
     get_migration_loader,
 )
-from sqlspec.migrations.runner import MigrationRunner
+from sqlspec.migrations.runner import AsyncMigrationRunner, SyncMigrationRunner, create_migration_runner
 from sqlspec.migrations.tracker import AsyncMigrationTracker, SyncMigrationTracker
 from sqlspec.migrations.utils import create_migration_file, drop_all, get_author
 
 __all__ = (
     "AsyncMigrationCommands",
+    "AsyncMigrationRunner",
     "AsyncMigrationTracker",
     "BaseMigrationLoader",
-    "MigrationCommands",
     "MigrationLoadError",
-    "MigrationRunner",
     "PythonFileLoader",
     "SQLFileLoader",
     "SyncMigrationCommands",
+    "SyncMigrationRunner",
     "SyncMigrationTracker",
+    "create_migration_commands",
     "create_migration_file",
+    "create_migration_runner",
     "drop_all",
     "get_author",
     "get_migration_loader",

--- a/sqlspec/migrations/commands.py
+++ b/sqlspec/migrations/commands.py
@@ -284,7 +284,7 @@ class AsyncMigrationCommands(BaseMigrationCommands["AsyncConfigT", Any]):
             await self.tracker.ensure_tracking_table(driver)
 
             current = await self.tracker.get_current_version(driver)
-            all_migrations = self.runner.get_migration_files()
+            all_migrations = await self.runner.get_migration_files()
             pending = []
             for version, file_path in all_migrations:
                 if (current is None or version > current) and (revision == "head" or version <= revision):
@@ -333,7 +333,7 @@ class AsyncMigrationCommands(BaseMigrationCommands["AsyncConfigT", Any]):
                 return
 
             console.print(f"[yellow]Reverting {len(to_revert)} migrations[/]")
-            all_files = dict(self.runner.get_migration_files())
+            all_files = dict(await self.runner.get_migration_files())
             for migration_record in to_revert:
                 version = migration_record["version_num"]
                 if version not in all_files:
@@ -360,7 +360,7 @@ class AsyncMigrationCommands(BaseMigrationCommands["AsyncConfigT", Any]):
         async with self.config.provide_session() as driver:
             await self.tracker.ensure_tracking_table(driver)
 
-            all_migrations = dict(self.runner.get_migration_files())
+            all_migrations = dict(await self.runner.get_migration_files())
             if revision not in all_migrations:
                 console.print(f"[red]Unknown revision: {revision}[/]")
                 return
@@ -377,7 +377,7 @@ class AsyncMigrationCommands(BaseMigrationCommands["AsyncConfigT", Any]):
             message: Description for the migration.
             file_type: Type of migration file to create ('sql' or 'py').
         """
-        existing = self.runner.get_migration_files()
+        existing = await self.runner.get_migration_files()
         next_num = int(existing[-1][0]) + 1 if existing else 1
         next_version = str(next_num).zfill(4)
         file_path = create_migration_file(self.migrations_path, next_version, message, file_type)

--- a/sqlspec/migrations/runner.py
+++ b/sqlspec/migrations/runner.py
@@ -1,31 +1,41 @@
 """Migration execution engine for SQLSpec.
 
-This module handles migration file loading and execution using SQLFileLoader.
+This module provides a unified migration runner that handles both synchronous
+and asynchronous migration execution seamlessly.
 """
 
+import inspect
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 from sqlspec.core.statement import SQL
 from sqlspec.migrations.base import BaseMigrationRunner
 from sqlspec.migrations.loaders import get_migration_loader
 from sqlspec.utils.logging import get_logger
-from sqlspec.utils.sync_tools import await_
+from sqlspec.utils.sync_tools import async_, await_
 
 if TYPE_CHECKING:
     from sqlspec.driver import AsyncDriverAdapterBase, SyncDriverAdapterBase
 
-__all__ = ("AsyncMigrationRunner", "SyncMigrationRunner")
+__all__ = ("MigrationRunner",)
 
 logger = get_logger("migrations.runner")
 
 
-class SyncMigrationRunner(BaseMigrationRunner["SyncDriverAdapterBase"]):
-    """Synchronous migration executor."""
+class MigrationRunner(BaseMigrationRunner["Union[SyncDriverAdapterBase, AsyncDriverAdapterBase]"]):
+    """Unified migration executor that handles both sync and async operations seamlessly."""
 
     def get_migration_files(self) -> "list[tuple[str, Path]]":
         """Get all migration files sorted by version.
+
+        Returns:
+            List of (version, path) tuples sorted by version.
+        """
+        return self._get_migration_files_sync()
+
+    async def get_migration_files_async(self) -> "list[tuple[str, Path]]":
+        """Get all migration files sorted by version (async version).
 
         Returns:
             List of (version, path) tuples sorted by version.
@@ -43,99 +53,8 @@ class SyncMigrationRunner(BaseMigrationRunner["SyncDriverAdapterBase"]):
         """
         return self._load_migration_metadata(file_path)
 
-    def execute_upgrade(
-        self, driver: "SyncDriverAdapterBase", migration: "dict[str, Any]"
-    ) -> "tuple[Optional[str], int]":
-        """Execute an upgrade migration.
-
-        Args:
-            driver: The database driver to use.
-            migration: Migration metadata dictionary.
-
-        Returns:
-            Tuple of (sql_content, execution_time_ms).
-        """
-        upgrade_sql_list = self._get_migration_sql(migration, "up")
-        if upgrade_sql_list is None:
-            return None, 0
-
-        start_time = time.time()
-
-        for sql_statement in upgrade_sql_list:
-            if sql_statement.strip():
-                driver.execute_script(sql_statement)
-        execution_time = int((time.time() - start_time) * 1000)
-        return None, execution_time
-
-    def execute_downgrade(
-        self, driver: "SyncDriverAdapterBase", migration: "dict[str, Any]"
-    ) -> "tuple[Optional[str], int]":
-        """Execute a downgrade migration.
-
-        Args:
-            driver: The database driver to use.
-            migration: Migration metadata dictionary.
-
-        Returns:
-            Tuple of (sql_content, execution_time_ms).
-        """
-        downgrade_sql_list = self._get_migration_sql(migration, "down")
-        if downgrade_sql_list is None:
-            return None, 0
-
-        start_time = time.time()
-
-        for sql_statement in downgrade_sql_list:
-            if sql_statement.strip():
-                driver.execute_script(sql_statement)
-        execution_time = int((time.time() - start_time) * 1000)
-        return None, execution_time
-
-    def load_all_migrations(self) -> "dict[str, SQL]":
-        """Load all migrations into a single namespace for bulk operations.
-
-        Returns:
-            Dictionary mapping query names to SQL objects.
-        """
-        all_queries = {}
-        migrations = self.get_migration_files()
-
-        for version, file_path in migrations:
-            if file_path.suffix == ".sql":
-                self.loader.load_sql(file_path)
-                for query_name in self.loader.list_queries():
-                    all_queries[query_name] = self.loader.get_sql(query_name)
-            else:
-                loader = get_migration_loader(file_path, self.migrations_path, self.project_root, self.context)
-
-                try:
-                    up_sql = await_(loader.get_up_sql, raise_sync_error=False)(file_path)
-                    down_sql = await_(loader.get_down_sql, raise_sync_error=False)(file_path)
-
-                    if up_sql:
-                        all_queries[f"migrate-{version}-up"] = SQL(up_sql[0])
-                    if down_sql:
-                        all_queries[f"migrate-{version}-down"] = SQL(down_sql[0])
-
-                except Exception as e:
-                    logger.debug("Failed to load Python migration %s: %s", file_path, e)
-
-        return all_queries
-
-
-class AsyncMigrationRunner(BaseMigrationRunner["AsyncDriverAdapterBase"]):
-    """Asynchronous migration executor."""
-
-    async def get_migration_files(self) -> "list[tuple[str, Path]]":
-        """Get all migration files sorted by version.
-
-        Returns:
-            List of tuples containing (version, file_path).
-        """
-        return self._get_migration_files_sync()
-
-    async def load_migration(self, file_path: Path) -> "dict[str, Any]":
-        """Load a migration file and extract its components.
+    async def load_migration_async(self, file_path: Path) -> "dict[str, Any]":
+        """Load a migration file and extract its components (async version).
 
         Args:
             file_path: Path to the migration file.
@@ -154,19 +73,15 @@ class AsyncMigrationRunner(BaseMigrationRunner["AsyncDriverAdapterBase"]):
         Returns:
             Migration metadata dictionary.
         """
-        # Check if this is an extension migration and update context accordingly
         context_to_use = self.context
         if context_to_use and file_path.name.startswith("ext_"):
-            # Try to extract extension name from the version
             version = self._extract_version(file_path.name)
             if version and version.startswith("ext_"):
-                # Parse extension name from version like "ext_litestar_0001"
                 min_extension_version_parts = 3
                 parts = version.split("_", 2)
                 if len(parts) >= min_extension_version_parts:
                     ext_name = parts[1]
                     if ext_name in self.extension_configs:
-                        # Create a new context with the extension config
                         from sqlspec.migrations.context import MigrationContext
 
                         context_to_use = MigrationContext(
@@ -177,15 +92,14 @@ class AsyncMigrationRunner(BaseMigrationRunner["AsyncDriverAdapterBase"]):
                             extension_config=self.extension_configs[ext_name],
                         )
 
-        # For extension migrations, check by path
         for ext_name, ext_path in self.extension_migrations.items():
             if file_path.parent == ext_path:
                 if ext_name in self.extension_configs and self.context:
                     from sqlspec.migrations.context import MigrationContext
 
                     context_to_use = MigrationContext(
-                        dialect=self.context.dialect,
                         config=self.context.config,
+                        dialect=self.context.dialect,
                         driver=self.context.driver,
                         metadata=self.context.metadata.copy() if self.context.metadata else {},
                         extension_config=self.extension_configs[ext_name],
@@ -222,6 +136,170 @@ class AsyncMigrationRunner(BaseMigrationRunner["AsyncDriverAdapterBase"]):
             "loader": loader,
         }
 
+    def execute_upgrade(
+        self, driver: "Union[SyncDriverAdapterBase, AsyncDriverAdapterBase]", migration: "dict[str, Any]"
+    ) -> "tuple[Optional[str], int]":
+        """Execute an upgrade migration.
+
+        Args:
+            driver: The database driver to use.
+            migration: Migration metadata dictionary.
+
+        Returns:
+            Tuple of (sql_content, execution_time_ms).
+        """
+        if self._is_async_driver(driver):
+            return await_(self._execute_upgrade_async, raise_sync_error=False)(
+                cast("AsyncDriverAdapterBase", driver), migration
+            )
+        return self._execute_upgrade_sync(cast("SyncDriverAdapterBase", driver), migration)
+
+    async def execute_upgrade_async(
+        self, driver: "Union[SyncDriverAdapterBase, AsyncDriverAdapterBase]", migration: "dict[str, Any]"
+    ) -> "tuple[Optional[str], int]":
+        """Execute an upgrade migration (async version).
+
+        Args:
+            driver: The database driver to use.
+            migration: Migration metadata dictionary.
+
+        Returns:
+            Tuple of (sql_content, execution_time_ms).
+        """
+        if self._is_async_driver(driver):
+            return await self._execute_upgrade_async(cast("AsyncDriverAdapterBase", driver), migration)
+        return await async_(self._execute_upgrade_sync)(cast("SyncDriverAdapterBase", driver), migration)
+
+    def _execute_upgrade_sync(
+        self, driver: "SyncDriverAdapterBase", migration: "dict[str, Any]"
+    ) -> "tuple[Optional[str], int]":
+        """Execute an upgrade migration synchronously.
+
+        Args:
+            driver: The sync database driver to use.
+            migration: Migration metadata dictionary.
+
+        Returns:
+            Tuple of (sql_content, execution_time_ms).
+        """
+        upgrade_sql_list = self._get_migration_sql(migration, "up")
+        if upgrade_sql_list is None:
+            return None, 0
+
+        start_time = time.time()
+
+        for sql_statement in upgrade_sql_list:
+            if sql_statement.strip():
+                driver.execute_script(sql_statement)
+        execution_time = int((time.time() - start_time) * 1000)
+        return None, execution_time
+
+    async def _execute_upgrade_async(
+        self, driver: "AsyncDriverAdapterBase", migration: "dict[str, Any]"
+    ) -> "tuple[Optional[str], int]":
+        """Execute an upgrade migration asynchronously.
+
+        Args:
+            driver: The async database driver to use.
+            migration: Migration metadata dictionary.
+
+        Returns:
+            Tuple of (sql_content, execution_time_ms).
+        """
+        upgrade_sql_list = await self._get_migration_sql_async(migration, "up")
+        if upgrade_sql_list is None:
+            return None, 0
+
+        start_time = time.time()
+
+        for sql_statement in upgrade_sql_list:
+            if sql_statement.strip():
+                await driver.execute_script(sql_statement)
+        execution_time = int((time.time() - start_time) * 1000)
+        return None, execution_time
+
+    def execute_downgrade(
+        self, driver: "Union[SyncDriverAdapterBase, AsyncDriverAdapterBase]", migration: "dict[str, Any]"
+    ) -> "tuple[Optional[str], int]":
+        """Execute a downgrade migration.
+
+        Args:
+            driver: The database driver to use.
+            migration: Migration metadata dictionary.
+
+        Returns:
+            Tuple of (sql_content, execution_time_ms).
+        """
+        if self._is_async_driver(driver):
+            return await_(self._execute_downgrade_async, raise_sync_error=False)(
+                cast("AsyncDriverAdapterBase", driver), migration
+            )
+        return self._execute_downgrade_sync(cast("SyncDriverAdapterBase", driver), migration)
+
+    async def execute_downgrade_async(
+        self, driver: "Union[SyncDriverAdapterBase, AsyncDriverAdapterBase]", migration: "dict[str, Any]"
+    ) -> "tuple[Optional[str], int]":
+        """Execute a downgrade migration (async version).
+
+        Args:
+            driver: The database driver to use.
+            migration: Migration metadata dictionary.
+
+        Returns:
+            Tuple of (sql_content, execution_time_ms).
+        """
+        if self._is_async_driver(driver):
+            return await self._execute_downgrade_async(cast("AsyncDriverAdapterBase", driver), migration)
+        return await async_(self._execute_downgrade_sync)(cast("SyncDriverAdapterBase", driver), migration)
+
+    def _execute_downgrade_sync(
+        self, driver: "SyncDriverAdapterBase", migration: "dict[str, Any]"
+    ) -> "tuple[Optional[str], int]":
+        """Execute a downgrade migration synchronously.
+
+        Args:
+            driver: The sync database driver to use.
+            migration: Migration metadata dictionary.
+
+        Returns:
+            Tuple of (sql_content, execution_time_ms).
+        """
+        downgrade_sql_list = self._get_migration_sql(migration, "down")
+        if downgrade_sql_list is None:
+            return None, 0
+
+        start_time = time.time()
+
+        for sql_statement in downgrade_sql_list:
+            if sql_statement.strip():
+                driver.execute_script(sql_statement)
+        execution_time = int((time.time() - start_time) * 1000)
+        return None, execution_time
+
+    async def _execute_downgrade_async(
+        self, driver: "AsyncDriverAdapterBase", migration: "dict[str, Any]"
+    ) -> "tuple[Optional[str], int]":
+        """Execute a downgrade migration asynchronously.
+
+        Args:
+            driver: The async database driver to use.
+            migration: Migration metadata dictionary.
+
+        Returns:
+            Tuple of (sql_content, execution_time_ms).
+        """
+        downgrade_sql_list = await self._get_migration_sql_async(migration, "down")
+        if downgrade_sql_list is None:
+            return None, 0
+
+        start_time = time.time()
+
+        for sql_statement in downgrade_sql_list:
+            if sql_statement.strip():
+                await driver.execute_script(sql_statement)
+        execution_time = int((time.time() - start_time) * 1000)
+        return None, execution_time
+
     async def _get_migration_sql_async(self, migration: "dict[str, Any]", direction: str) -> "Optional[list[str]]":
         """Get migration SQL for given direction (async version).
 
@@ -256,62 +334,45 @@ class AsyncMigrationRunner(BaseMigrationRunner["AsyncDriverAdapterBase"]):
                 return cast("list[str]", sql_statements)
             return None
 
-    async def execute_upgrade(
-        self, driver: "AsyncDriverAdapterBase", migration: "dict[str, Any]"
-    ) -> "tuple[Optional[str], int]":
-        """Execute an upgrade migration.
-
-        Args:
-            driver: The async database driver to use.
-            migration: Migration metadata dictionary.
-
-        Returns:
-            Tuple of (sql_content, execution_time_ms).
-        """
-        upgrade_sql_list = await self._get_migration_sql_async(migration, "up")
-        if upgrade_sql_list is None:
-            return None, 0
-
-        start_time = time.time()
-
-        for sql_statement in upgrade_sql_list:
-            if sql_statement.strip():
-                await driver.execute_script(sql_statement)
-        execution_time = int((time.time() - start_time) * 1000)
-        return None, execution_time
-
-    async def execute_downgrade(
-        self, driver: "AsyncDriverAdapterBase", migration: "dict[str, Any]"
-    ) -> "tuple[Optional[str], int]":
-        """Execute a downgrade migration.
-
-        Args:
-            driver: The async database driver to use.
-            migration: Migration metadata dictionary.
-
-        Returns:
-            Tuple of (sql_content, execution_time_ms).
-        """
-        downgrade_sql_list = await self._get_migration_sql_async(migration, "down")
-        if downgrade_sql_list is None:
-            return None, 0
-
-        start_time = time.time()
-
-        for sql_statement in downgrade_sql_list:
-            if sql_statement.strip():
-                await driver.execute_script(sql_statement)
-        execution_time = int((time.time() - start_time) * 1000)
-        return None, execution_time
-
-    async def load_all_migrations(self) -> "dict[str, SQL]":
+    def load_all_migrations(self) -> "dict[str, SQL]":
         """Load all migrations into a single namespace for bulk operations.
 
         Returns:
             Dictionary mapping query names to SQL objects.
         """
         all_queries = {}
-        migrations = await self.get_migration_files()
+        migrations = self.get_migration_files()
+
+        for version, file_path in migrations:
+            if file_path.suffix == ".sql":
+                self.loader.load_sql(file_path)
+                for query_name in self.loader.list_queries():
+                    all_queries[query_name] = self.loader.get_sql(query_name)
+            else:
+                loader = get_migration_loader(file_path, self.migrations_path, self.project_root, self.context)
+
+                try:
+                    up_sql = await_(loader.get_up_sql, raise_sync_error=False)(file_path)
+                    down_sql = await_(loader.get_down_sql, raise_sync_error=False)(file_path)
+
+                    if up_sql:
+                        all_queries[f"migrate-{version}-up"] = SQL(up_sql[0])
+                    if down_sql:
+                        all_queries[f"migrate-{version}-down"] = SQL(down_sql[0])
+
+                except Exception as e:
+                    logger.debug("Failed to load Python migration %s: %s", file_path, e)
+
+        return all_queries
+
+    async def load_all_migrations_async(self) -> "dict[str, SQL]":
+        """Load all migrations into a single namespace for bulk operations (async version).
+
+        Returns:
+            Dictionary mapping query names to SQL objects.
+        """
+        all_queries = {}
+        migrations = await self.get_migration_files_async()
 
         for version, file_path in migrations:
             if file_path.suffix == ".sql":
@@ -334,3 +395,18 @@ class AsyncMigrationRunner(BaseMigrationRunner["AsyncDriverAdapterBase"]):
                     logger.debug("Failed to load Python migration %s: %s", file_path, e)
 
         return all_queries
+
+    def _is_async_driver(self, driver: "Union[SyncDriverAdapterBase, AsyncDriverAdapterBase]") -> bool:
+        """Check if the driver is async by examining its methods.
+
+        Args:
+            driver: The driver to check.
+
+        Returns:
+            True if driver is async, False otherwise.
+        """
+        execute_method = getattr(driver, "execute_script", None)
+        if execute_method is None:
+            return False
+
+        return inspect.iscoroutinefunction(execute_method)

--- a/sqlspec/utils/config_resolver.py
+++ b/sqlspec/utils/config_resolver.py
@@ -1,0 +1,108 @@
+"""Configuration resolver for SQLSpec CLI.
+
+This module provides utilities for resolving configuration objects from dotted paths,
+with support for both direct config instances and callable functions that return configs.
+Supports both synchronous and asynchronous callable functions.
+"""
+
+import inspect
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Union, cast
+
+from sqlspec.exceptions import SQLSpecError
+from sqlspec.utils.module_loader import import_string
+from sqlspec.utils.sync_tools import await_
+
+if TYPE_CHECKING:
+    from sqlspec.config import AsyncDatabaseConfig, SyncDatabaseConfig
+
+__all__ = ("ConfigResolverError", "resolve_config")
+
+
+class ConfigResolverError(SQLSpecError):
+    """Exception raised when config resolution fails."""
+
+
+def resolve_config(
+    config_path: str,
+) -> "Union[list[Union[AsyncDatabaseConfig, SyncDatabaseConfig]], Union[AsyncDatabaseConfig, SyncDatabaseConfig]]":
+    """Resolve config from dotted path, handling callables and direct instances.
+
+    Args:
+        config_path: Dotted path to config object or callable function.
+
+    Returns:
+        Resolved config instance or list of config instances.
+
+    Raises:
+        ConfigResolverError: If config resolution fails.
+    """
+    try:
+        config_obj = import_string(config_path)
+    except ImportError as e:
+        msg = f"Failed to import config from path '{config_path}': {e}"
+        raise ConfigResolverError(msg) from e
+
+    if not callable(config_obj):
+        return _validate_config_result(config_obj, config_path)
+
+    try:
+        if inspect.iscoroutinefunction(config_obj):
+            result = await_(config_obj, raise_sync_error=False)()
+        else:
+            result = config_obj()
+    except Exception as e:
+        msg = f"Failed to execute callable config '{config_path}': {e}"
+        raise ConfigResolverError(msg) from e
+
+    return _validate_config_result(result, config_path)
+
+
+def _validate_config_result(
+    config_result: Any, config_path: str
+) -> "Union[list[Union[AsyncDatabaseConfig, SyncDatabaseConfig]], Union[AsyncDatabaseConfig, SyncDatabaseConfig]]":
+    """Validate that the config result is a valid config or list of configs.
+
+    Args:
+        config_result: The result from config resolution.
+        config_path: Original config path for error messages.
+
+    Returns:
+        Validated config result.
+
+    Raises:
+        ConfigResolverError: If config result is invalid.
+    """
+    if config_result is None:
+        msg = f"Config '{config_path}' resolved to None. Expected config instance or list of configs."
+        raise ConfigResolverError(msg)
+
+    if isinstance(config_result, Sequence) and not isinstance(config_result, str):
+        if not config_result:
+            msg = f"Config '{config_path}' resolved to empty list. Expected at least one config."
+            raise ConfigResolverError(msg)
+
+        for i, config in enumerate(config_result):
+            if not _is_valid_config(config):
+                msg = f"Config '{config_path}' returned invalid config at index {i}. Expected database config instance."
+                raise ConfigResolverError(msg)
+
+        return cast("list[Union[AsyncDatabaseConfig, SyncDatabaseConfig]]", list(config_result))
+
+    if not _is_valid_config(config_result):
+        msg = f"Config '{config_path}' returned invalid type '{type(config_result).__name__}'. Expected database config instance or list."
+        raise ConfigResolverError(msg)
+
+    return cast("Union[AsyncDatabaseConfig, SyncDatabaseConfig]", config_result)
+
+
+def _is_valid_config(config: Any) -> bool:
+    """Check if an object is a valid SQLSpec database config.
+
+    Args:
+        config: Object to validate.
+
+    Returns:
+        True if object appears to be a valid config.
+    """
+    return hasattr(config, "database_url") and hasattr(config, "bind_key") and hasattr(config, "migration_config")

--- a/tests/integration/test_async_migrations.py
+++ b/tests/integration/test_async_migrations.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock
 import pytest
 
 from sqlspec.migrations.context import MigrationContext
-from sqlspec.migrations.runner import create_migration_runner
+from sqlspec.migrations.runner import SyncMigrationRunner, create_migration_runner
 from sqlspec.utils.config_resolver import resolve_config_async
 from sqlspec.utils.sync_tools import run_
 
@@ -99,7 +99,6 @@ class TestAsyncMigrationsIntegration:
 
     def test_sync_migration_runner_instantiation(self, temp_migration_dir: Any, mock_config: Any) -> None:
         """Test sync migration runner instantiation."""
-        from sqlspec.migrations.runner import SyncMigrationRunner
 
         context = MigrationContext.from_config(mock_config)
         runner = SyncMigrationRunner(temp_migration_dir, {}, context, {})

--- a/tests/integration/test_async_migrations.py
+++ b/tests/integration/test_async_migrations.py
@@ -11,6 +11,7 @@ import pytest
 from sqlspec.migrations.context import MigrationContext
 from sqlspec.migrations.runner import MigrationRunner
 from sqlspec.utils.config_resolver import resolve_config_async
+from sqlspec.utils.sync_tools import run_
 
 
 class TestAsyncMigrationsIntegration:
@@ -55,17 +56,20 @@ class TestAsyncMigrationsIntegration:
         def get_test_config() -> Mock:
             return mock_config
 
-        # Mock the import_string to return our function
-        import sqlspec.utils.config_resolver
+        async def _test() -> None:
+            # Mock the import_string to return our function
+            import sqlspec.utils.config_resolver
 
-        original_import = sqlspec.utils.config_resolver.import_string
+            original_import = sqlspec.utils.config_resolver.import_string
 
-        try:
-            sqlspec.utils.config_resolver.import_string = lambda path: get_test_config
-            result = resolve_config_async("test.config.get_database_config")
-            assert result is mock_config
-        finally:
-            sqlspec.utils.config_resolver.import_string = original_import
+            try:
+                sqlspec.utils.config_resolver.import_string = lambda path: get_test_config
+                result = await resolve_config_async("test.config.get_database_config")
+                assert result is mock_config
+            finally:
+                sqlspec.utils.config_resolver.import_string = original_import
+
+        run_(_test)()
 
     def test_async_callable_config_resolution(self) -> None:
         """Test resolving asynchronous callable config."""
@@ -78,17 +82,20 @@ class TestAsyncMigrationsIntegration:
         async def get_test_config() -> Mock:
             return mock_config
 
-        # Mock the import_string to return our async function
-        import sqlspec.utils.config_resolver
+        async def _test() -> None:
+            # Mock the import_string to return our async function
+            import sqlspec.utils.config_resolver
 
-        original_import = sqlspec.utils.config_resolver.import_string
+            original_import = sqlspec.utils.config_resolver.import_string
 
-        try:
-            sqlspec.utils.config_resolver.import_string = lambda path: get_test_config
-            result = resolve_config_async("test.config.async_get_database_config")
-            assert result is mock_config
-        finally:
-            sqlspec.utils.config_resolver.import_string = original_import
+            try:
+                sqlspec.utils.config_resolver.import_string = lambda path: get_test_config
+                result = await resolve_config_async("test.config.async_get_database_config")
+                assert result is mock_config
+            finally:
+                sqlspec.utils.config_resolver.import_string = original_import
+
+        run_(_test)()
 
     def test_unified_migration_runner_sync_driver_detection(self, temp_migration_dir: Any, mock_config: Any) -> None:
         """Test unified migration runner with sync driver detection."""
@@ -249,17 +256,20 @@ def down(context):
         def get_configs() -> list[Mock]:
             return [mock_config1, mock_config2]
 
-        # Mock the import_string to return our function
-        import sqlspec.utils.config_resolver
+        async def _test() -> None:
+            # Mock the import_string to return our function
+            import sqlspec.utils.config_resolver
 
-        original_import = sqlspec.utils.config_resolver.import_string
+            original_import = sqlspec.utils.config_resolver.import_string
 
-        try:
-            sqlspec.utils.config_resolver.import_string = lambda path: get_configs
-            result = resolve_config_async("test.config.get_database_configs")
-            assert isinstance(result, list)
-            assert len(result) == 2
-            assert result[0] is mock_config1
-            assert result[1] is mock_config2
-        finally:
-            sqlspec.utils.config_resolver.import_string = original_import
+            try:
+                sqlspec.utils.config_resolver.import_string = lambda path: get_configs
+                result = await resolve_config_async("test.config.get_database_configs")
+                assert isinstance(result, list)
+                assert len(result) == 2
+                assert result[0] is mock_config1
+                assert result[1] is mock_config2
+            finally:
+                sqlspec.utils.config_resolver.import_string = original_import
+
+        run_(_test)()

--- a/tests/integration/test_async_migrations.py
+++ b/tests/integration/test_async_migrations.py
@@ -1,0 +1,265 @@
+"""Integration tests for async migrations functionality."""
+
+import asyncio
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from sqlspec.migrations.context import MigrationContext
+from sqlspec.migrations.runner import MigrationRunner
+from sqlspec.utils.config_resolver import resolve_config
+
+
+class TestAsyncMigrationsIntegration:
+    """Integration tests for async migrations functionality."""
+
+    @pytest.fixture
+    def temp_migration_dir(self) -> Any:
+        """Create a temporary migration directory."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            migration_dir = Path(temp_dir) / "migrations"
+            migration_dir.mkdir()
+            yield migration_dir
+
+    @pytest.fixture
+    def mock_config(self) -> Any:
+        """Create a mock configuration."""
+        config = Mock()
+        config.database_url = "sqlite:///test.db"
+        config.bind_key = "test"
+        config.migration_config = {"script_location": "migrations", "version_table_name": "alembic_version"}
+        return config
+
+    def test_async_migration_context_properties(self) -> None:
+        """Test async migration context properties."""
+        context = MigrationContext(dialect="postgres")
+
+        # Test execution mode detection
+        assert context.execution_mode == "sync"
+
+        # Test metadata operations
+        context.set_execution_metadata("test_key", "test_value")
+        assert context.get_execution_metadata("test_key") == "test_value"
+
+    def test_sync_callable_config_resolution(self) -> None:
+        """Test resolving synchronous callable config."""
+        mock_config = Mock()
+        mock_config.database_url = "sqlite:///test.db"
+        mock_config.bind_key = "test"
+        mock_config.migration_config = {}
+
+        # Create a config factory function
+        def get_test_config() -> Mock:
+            return mock_config
+
+        # Mock the import_string to return our function
+        import sqlspec.utils.config_resolver
+
+        original_import = sqlspec.utils.config_resolver.import_string
+
+        try:
+            sqlspec.utils.config_resolver.import_string = lambda path: get_test_config
+            result = resolve_config("test.config.get_database_config")
+            assert result is mock_config
+        finally:
+            sqlspec.utils.config_resolver.import_string = original_import
+
+    def test_async_callable_config_resolution(self) -> None:
+        """Test resolving asynchronous callable config."""
+        mock_config = Mock()
+        mock_config.database_url = "sqlite:///test.db"
+        mock_config.bind_key = "test"
+        mock_config.migration_config = {}
+
+        # Create an async config factory function
+        async def get_test_config() -> Mock:
+            return mock_config
+
+        # Mock the import_string to return our async function
+        import sqlspec.utils.config_resolver
+
+        original_import = sqlspec.utils.config_resolver.import_string
+
+        try:
+            sqlspec.utils.config_resolver.import_string = lambda path: get_test_config
+            result = resolve_config("test.config.async_get_database_config")
+            assert result is mock_config
+        finally:
+            sqlspec.utils.config_resolver.import_string = original_import
+
+    def test_unified_migration_runner_sync_driver_detection(self, temp_migration_dir: Any, mock_config: Any) -> None:
+        """Test unified migration runner with sync driver detection."""
+        context = MigrationContext.from_config(mock_config)
+        runner = MigrationRunner(temp_migration_dir, {}, context, {})
+
+        # Mock sync driver
+        sync_driver = Mock()
+        sync_driver.execute_script = Mock()  # Regular function
+
+        assert not runner._is_async_driver(sync_driver)  # type: ignore[reportPrivateUsage]
+
+    def test_unified_migration_runner_async_driver_detection(self, temp_migration_dir: Any, mock_config: Any) -> None:
+        """Test unified migration runner with async driver detection."""
+        context = MigrationContext.from_config(mock_config)
+        runner = MigrationRunner(temp_migration_dir, {}, context, {})
+
+        # Mock async driver
+        async_driver = Mock()
+
+        async def mock_execute() -> None:
+            pass
+
+        async_driver.execute_script = mock_execute
+
+        assert runner._is_async_driver(async_driver)  # type: ignore[reportPrivateUsage]
+
+    def test_async_python_migration_execution(self, temp_migration_dir: Any) -> None:
+        """Test execution of async Python migration."""
+        # Create async Python migration file
+        migration_file = temp_migration_dir / "0001_create_users_async.py"
+        migration_content = '''"""Create users table with async validation."""
+
+async def up(context):
+    """Create users table."""
+    return [
+        """
+        CREATE TABLE users (
+            id SERIAL PRIMARY KEY,
+            email VARCHAR(255) UNIQUE NOT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        """
+    ]
+
+async def down(context):
+    """Drop users table."""
+    return ["DROP TABLE users;"]
+'''
+        migration_file.write_text(migration_content)
+
+        # Test loading the migration
+        from sqlspec.migrations.loaders import PythonFileLoader
+
+        context = MigrationContext(dialect="postgres")
+        loader = PythonFileLoader(temp_migration_dir, temp_migration_dir.parent, context)
+
+        # Test async execution
+        async def test_async_loading() -> None:
+            up_sql = await loader.get_up_sql(migration_file)
+            assert len(up_sql) == 1
+            assert "CREATE TABLE users" in up_sql[0]
+
+            down_sql = await loader.get_down_sql(migration_file)
+            assert len(down_sql) == 1
+            assert "DROP TABLE users" in down_sql[0]
+
+        asyncio.run(test_async_loading())
+
+    def test_mixed_sync_async_migration_loading(self, temp_migration_dir: Any) -> None:
+        """Test loading both sync and async migrations in the same directory."""
+        # Create sync migration
+        sync_migration = temp_migration_dir / "0001_sync_migration.py"
+        sync_migration.write_text("""
+def up(context):
+    return ["CREATE TABLE sync_test (id INT);"]
+
+def down(context):
+    return ["DROP TABLE sync_test;"]
+""")
+
+        # Create async migration
+        async_migration = temp_migration_dir / "0002_async_migration.py"
+        async_migration.write_text("""
+async def up(context):
+    return ["CREATE TABLE async_test (id INT);"]
+
+async def down(context):
+    return ["DROP TABLE async_test;"]
+""")
+
+        context = MigrationContext(dialect="postgres")
+        runner = MigrationRunner(temp_migration_dir, {}, context, {})
+
+        # Get migration files
+        migrations = runner.get_migration_files()
+        assert len(migrations) == 2
+
+        # Verify both migrations are loaded
+        versions = [version for version, _ in migrations]
+        assert "0001" in versions
+        assert "0002" in versions
+
+    def test_migration_context_validation(self) -> None:
+        """Test migration context async usage validation."""
+        context = MigrationContext()
+
+        # Test with sync function
+        def sync_migration() -> list[str]:
+            return ["CREATE TABLE test (id INT);"]
+
+        # Should not raise any exceptions
+        context.validate_async_usage(sync_migration)
+
+        # Test with async function
+        async def async_migration() -> list[str]:
+            return ["CREATE TABLE test (id INT);"]
+
+        # Should handle async function validation
+        context.validate_async_usage(async_migration)
+
+    def test_error_handling_in_async_migrations(self, temp_migration_dir: Any) -> None:
+        """Test error handling in async migration execution."""
+        # Create migration with error
+        error_migration = temp_migration_dir / "0001_error_migration.py"
+        error_migration.write_text("""
+async def up(context):
+    raise ValueError("Test error in migration")
+
+def down(context):
+    return ["DROP TABLE test;"]
+""")
+
+        from sqlspec.migrations.loaders import PythonFileLoader
+
+        context = MigrationContext(dialect="postgres")
+        loader = PythonFileLoader(temp_migration_dir, temp_migration_dir.parent, context)
+
+        # Test that error is properly raised
+        async def test_error_handling() -> None:
+            with pytest.raises(Exception):  # Should raise the ValueError from migration
+                await loader.get_up_sql(error_migration)
+
+        asyncio.run(test_error_handling())
+
+    def test_config_resolver_with_list_configs(self) -> None:
+        """Test config resolver with list of configurations."""
+        mock_config1 = Mock()
+        mock_config1.database_url = "sqlite:///test1.db"
+        mock_config1.bind_key = "test1"
+        mock_config1.migration_config = {}
+
+        mock_config2 = Mock()
+        mock_config2.database_url = "sqlite:///test2.db"
+        mock_config2.bind_key = "test2"
+        mock_config2.migration_config = {}
+
+        def get_configs() -> list[Mock]:
+            return [mock_config1, mock_config2]
+
+        # Mock the import_string to return our function
+        import sqlspec.utils.config_resolver
+
+        original_import = sqlspec.utils.config_resolver.import_string
+
+        try:
+            sqlspec.utils.config_resolver.import_string = lambda path: get_configs
+            result = resolve_config("test.config.get_database_configs")
+            assert isinstance(result, list)
+            assert len(result) == 2
+            assert result[0] is mock_config1
+            assert result[1] is mock_config2
+        finally:
+            sqlspec.utils.config_resolver.import_string = original_import

--- a/tests/integration/test_async_migrations.py
+++ b/tests/integration/test_async_migrations.py
@@ -10,7 +10,7 @@ import pytest
 
 from sqlspec.migrations.context import MigrationContext
 from sqlspec.migrations.runner import MigrationRunner
-from sqlspec.utils.config_resolver import resolve_config
+from sqlspec.utils.config_resolver import resolve_config_async
 
 
 class TestAsyncMigrationsIntegration:
@@ -62,7 +62,7 @@ class TestAsyncMigrationsIntegration:
 
         try:
             sqlspec.utils.config_resolver.import_string = lambda path: get_test_config
-            result = resolve_config("test.config.get_database_config")
+            result = resolve_config_async("test.config.get_database_config")
             assert result is mock_config
         finally:
             sqlspec.utils.config_resolver.import_string = original_import
@@ -85,7 +85,7 @@ class TestAsyncMigrationsIntegration:
 
         try:
             sqlspec.utils.config_resolver.import_string = lambda path: get_test_config
-            result = resolve_config("test.config.async_get_database_config")
+            result = resolve_config_async("test.config.async_get_database_config")
             assert result is mock_config
         finally:
             sqlspec.utils.config_resolver.import_string = original_import
@@ -256,7 +256,7 @@ def down(context):
 
         try:
             sqlspec.utils.config_resolver.import_string = lambda path: get_configs
-            result = resolve_config("test.config.get_database_configs")
+            result = resolve_config_async("test.config.get_database_configs")
             assert isinstance(result, list)
             assert len(result) == 2
             assert result[0] is mock_config1

--- a/tests/unit/test_config_resolver.py
+++ b/tests/unit/test_config_resolver.py
@@ -1,0 +1,164 @@
+"""Tests for configuration resolver functionality."""
+
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from sqlspec.utils.config_resolver import ConfigResolverError, resolve_config
+
+
+class TestConfigResolver:
+    """Test the config resolver utility."""
+
+    def test_resolve_direct_config_instance(self) -> None:
+        """Test resolving a direct config instance."""
+        mock_config = Mock()
+        mock_config.database_url = "sqlite:///test.db"
+        mock_config.bind_key = "test"
+        mock_config.migration_config = {}
+
+        with patch("sqlspec.utils.config_resolver.import_string", return_value=mock_config):
+            result = resolve_config("myapp.config.database_config")
+            # Check attributes instead of object identity since validation creates a copy
+            assert hasattr(result, "database_url")
+            assert hasattr(result, "bind_key")
+            assert hasattr(result, "migration_config")
+
+    def test_resolve_config_list(self) -> None:
+        """Test resolving a list of config instances."""
+        mock_config1 = Mock()
+        mock_config1.database_url = "sqlite:///test1.db"
+        mock_config1.bind_key = "test1"
+        mock_config1.migration_config = {}
+
+        mock_config2 = Mock()
+        mock_config2.database_url = "sqlite:///test2.db"
+        mock_config2.bind_key = "test2"
+        mock_config2.migration_config = {}
+
+        config_list = [mock_config1, mock_config2]
+
+        with patch("sqlspec.utils.config_resolver.import_string", return_value=config_list):
+            result = resolve_config("myapp.config.database_configs")
+            assert result == config_list
+            assert isinstance(result, list) and len(result) == 2
+
+    def test_resolve_sync_callable_config(self) -> None:
+        """Test resolving a synchronous callable that returns config."""
+        mock_config = Mock()
+        mock_config.database_url = "sqlite:///test.db"
+        mock_config.bind_key = "test"
+        mock_config.migration_config = {}
+
+        def get_config() -> Mock:
+            return mock_config
+
+        with patch("sqlspec.utils.config_resolver.import_string", return_value=get_config):
+            result = resolve_config("myapp.config.get_database_config")
+            assert result is mock_config
+
+    def test_resolve_async_callable_config(self) -> None:
+        """Test resolving an asynchronous callable that returns config."""
+        mock_config = Mock()
+        mock_config.database_url = "sqlite:///test.db"
+        mock_config.bind_key = "test"
+        mock_config.migration_config = {}
+
+        async def get_config() -> Mock:
+            return mock_config
+
+        with patch("sqlspec.utils.config_resolver.import_string", return_value=get_config):
+            result = resolve_config("myapp.config.async_get_database_config")
+            assert result is mock_config
+
+    def test_resolve_sync_callable_config_list(self) -> None:
+        """Test resolving a sync callable that returns config list."""
+        mock_config = Mock()
+        mock_config.database_url = "sqlite:///test.db"
+        mock_config.bind_key = "test"
+        mock_config.migration_config = {}
+
+        def get_configs() -> list[Mock]:
+            return [mock_config]
+
+        with patch("sqlspec.utils.config_resolver.import_string", return_value=get_configs):
+            result = resolve_config("myapp.config.get_database_configs")
+            assert isinstance(result, list)
+            assert len(result) == 1
+            assert result[0] is mock_config
+
+    def test_import_error_handling(self) -> None:
+        """Test proper handling of import errors."""
+        with patch("sqlspec.utils.config_resolver.import_string", side_effect=ImportError("Module not found")):
+            with pytest.raises(ConfigResolverError, match="Failed to import config from path"):
+                resolve_config("nonexistent.config")
+
+    def test_callable_execution_error(self) -> None:
+        """Test handling of errors during callable execution."""
+
+        def failing_config() -> None:
+            raise ValueError("Config generation failed")
+
+        with patch("sqlspec.utils.config_resolver.import_string", return_value=failing_config):
+            with pytest.raises(ConfigResolverError, match="Failed to execute callable config"):
+                resolve_config("myapp.config.failing_config")
+
+    def test_none_result_validation(self) -> None:
+        """Test validation when config resolves to None."""
+
+        def none_config() -> None:
+            return None
+
+        with patch("sqlspec.utils.config_resolver.import_string", return_value=none_config):
+            with pytest.raises(ConfigResolverError, match="resolved to None"):
+                resolve_config("myapp.config.none_config")
+
+    def test_empty_list_validation(self) -> None:
+        """Test validation when config resolves to empty list."""
+
+        def empty_list_config() -> list[Any]:
+            return []
+
+        with patch("sqlspec.utils.config_resolver.import_string", return_value=empty_list_config):
+            with pytest.raises(ConfigResolverError, match="resolved to empty list"):
+                resolve_config("myapp.config.empty_list_config")
+
+    def test_invalid_config_type_validation(self) -> None:
+        """Test validation when config is invalid type."""
+
+        def invalid_config() -> str:
+            return "not a config"
+
+        with patch("sqlspec.utils.config_resolver.import_string", return_value=invalid_config):
+            with pytest.raises(ConfigResolverError, match="returned invalid type"):
+                resolve_config("myapp.config.invalid_config")
+
+    def test_invalid_config_in_list_validation(self) -> None:
+        """Test validation when list contains invalid config."""
+        mock_valid_config = Mock()
+        mock_valid_config.database_url = "sqlite:///test.db"
+        mock_valid_config.bind_key = "test"
+        mock_valid_config.migration_config = {}
+
+        def mixed_config_list() -> list[Any]:
+            return [mock_valid_config, "invalid_config"]
+
+        with patch("sqlspec.utils.config_resolver.import_string", return_value=mixed_config_list):
+            with pytest.raises(ConfigResolverError, match="returned invalid config at index"):
+                resolve_config("myapp.config.mixed_configs")
+
+    def test_config_validation_attributes(self) -> None:
+        """Test that config validation checks for required attributes."""
+        # Test config missing database_url
+        mock_config = Mock()
+        mock_config.bind_key = "test"
+        mock_config.migration_config = {}
+        del mock_config.database_url  # Remove the attribute
+
+        def incomplete_config() -> Mock:
+            return mock_config
+
+        with patch("sqlspec.utils.config_resolver.import_string", return_value=incomplete_config):
+            with pytest.raises(ConfigResolverError, match="returned invalid type"):
+                resolve_config("myapp.config.incomplete_config")

--- a/tests/unit/test_migration_context.py
+++ b/tests/unit/test_migration_context.py
@@ -1,0 +1,172 @@
+"""Tests for enhanced migration context functionality."""
+
+import asyncio
+from unittest.mock import Mock
+
+from sqlspec.migrations.context import MigrationContext
+
+
+class TestMigrationContext:
+    """Test the enhanced migration context."""
+
+    def test_migration_context_initialization(self) -> None:
+        """Test basic migration context initialization."""
+        context = MigrationContext(dialect="postgres", config=Mock(), metadata={"test": "value"})
+
+        assert context.dialect == "postgres"
+        assert context.metadata is not None
+        assert context.metadata["test"] == "value"
+        assert context._execution_metadata == {}  # type: ignore[reportPrivateUsage]
+
+    def test_execution_metadata_operations(self) -> None:
+        """Test execution metadata set/get operations."""
+        context = MigrationContext()
+
+        context.set_execution_metadata("test_key", "test_value")
+        assert context.get_execution_metadata("test_key") == "test_value"
+        assert context.get_execution_metadata("nonexistent", "default") == "default"
+
+    def test_is_async_execution_detection(self) -> None:
+        """Test async execution context detection."""
+        context = MigrationContext()
+
+        # Should be False outside of async context
+        assert not context.is_async_execution
+
+        # Test inside async context
+        async def test_async() -> None:
+            assert context.is_async_execution
+
+        # Run the async test
+        asyncio.run(test_async())
+
+    def test_is_async_driver_detection(self) -> None:
+        """Test async driver detection."""
+        context = MigrationContext()
+
+        # No driver - should be False
+        assert not context.is_async_driver
+
+        # Mock sync driver
+        sync_driver = Mock()
+        sync_driver.execute_script = Mock()  # Regular function
+        context.driver = sync_driver
+        assert not context.is_async_driver
+
+        # Mock async driver
+        async_driver = Mock()
+
+        async def mock_execute() -> None:
+            pass
+
+        async_driver.execute_script = mock_execute
+        context.driver = async_driver
+        assert context.is_async_driver
+
+    def test_execution_mode_property(self) -> None:
+        """Test execution mode property."""
+        context = MigrationContext()
+
+        # Should be 'sync' outside async context
+        assert context.execution_mode == "sync"
+
+        # Test inside async context
+        async def test_async_mode() -> None:
+            assert context.execution_mode == "async"
+
+        asyncio.run(test_async_mode())
+
+    def test_validate_async_usage_with_async_function(self) -> None:
+        """Test async function validation."""
+        context = MigrationContext()
+
+        async def async_migration() -> list[str]:
+            return ["CREATE TABLE test (id INT);"]
+
+        # Should log warning when async function used in non-async context
+        # Since we're outside async context and no driver is set, both should be False
+        context.validate_async_usage(async_migration)
+
+    def test_validate_async_usage_with_sync_function(self) -> None:
+        """Test sync function validation in async context."""
+        context = MigrationContext()
+
+        def sync_migration() -> list[str]:
+            return ["CREATE TABLE test (id INT);"]
+
+        # Mock async driver by setting a mock driver
+        mock_async_driver = Mock()
+
+        async def mock_execute() -> None:
+            pass
+
+        mock_async_driver.execute_script = mock_execute
+        context.driver = mock_async_driver
+
+        context.validate_async_usage(sync_migration)
+        # Should set mixed execution metadata
+        assert context.get_execution_metadata("mixed_execution") is True
+
+    def test_from_config_class_method(self) -> None:
+        """Test creating context from config."""
+        mock_config = Mock()
+        mock_config.statement_config = Mock()
+        mock_config.statement_config.dialect = "postgres"
+
+        context = MigrationContext.from_config(mock_config)
+
+        assert context.config is mock_config
+        assert context.dialect == "postgres"
+
+    def test_from_config_with_callable_statement_config(self) -> None:
+        """Test creating context from config with callable statement config."""
+        mock_config = Mock()
+        mock_stmt_config = Mock()
+        mock_stmt_config.dialect = "mysql"
+        mock_config.statement_config = None
+        mock_config._create_statement_config = Mock(return_value=mock_stmt_config)
+
+        context = MigrationContext.from_config(mock_config)
+
+        assert context.config is mock_config
+        assert context.dialect == "mysql"
+
+    def test_from_config_no_dialect_available(self) -> None:
+        """Test creating context when no dialect is available."""
+        mock_config = Mock()
+        mock_config.statement_config = None
+        del mock_config._create_statement_config  # Remove the method
+
+        context = MigrationContext.from_config(mock_config)
+
+        assert context.config is mock_config
+        assert context.dialect is None
+
+    def test_from_config_exception_handling(self) -> None:
+        """Test exception handling in from_config method."""
+        mock_config = Mock()
+        mock_config.statement_config = None
+        mock_config._create_statement_config = Mock(side_effect=Exception("Test exception"))
+
+        # Should not raise exception, just log debug message
+        context = MigrationContext.from_config(mock_config)
+
+        assert context.config is mock_config
+        assert context.dialect is None
+
+    def test_post_init_metadata_initialization(self) -> None:
+        """Test __post_init__ metadata initialization."""
+        # Test with None values
+        context = MigrationContext(metadata=None, extension_config=None)
+
+        assert context.metadata == {}
+        assert context.extension_config == {}
+
+        # Test with existing values
+        existing_metadata = {"key": "value"}
+        existing_extension_config = {"ext": "config"}
+
+        context = MigrationContext(metadata=existing_metadata, extension_config=existing_extension_config)
+
+        assert context.metadata is existing_metadata
+        assert context.extension_config is existing_extension_config

--- a/tests/unit/test_migrations/test_migration_commands.py
+++ b/tests/unit/test_migrations/test_migration_commands.py
@@ -12,7 +12,8 @@ Tests focused on MigrationCommands class behavior including:
 
 import tempfile
 from pathlib import Path
-from unittest.mock import AsyncMock, Mock, patch
+from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -62,31 +63,18 @@ def test_migration_commands_sync_init_delegation(sync_config: SqliteConfig) -> N
             mock_init.assert_called_once_with(migration_dir, package=False)
 
 
-def test_migration_commands_async_init_delegation(async_config: AiosqliteConfig) -> None:
-    """Test that async config init uses await_ wrapper."""
-    with (
-        patch.object(AsyncMigrationCommands, "init", new_callable=AsyncMock) as mock_init,
-        patch("sqlspec.migrations.commands.await_") as mock_await,
-    ):
-        # Set up await_ to return a function that calls the async method
-        mock_func = Mock(return_value=None)
-        mock_await.return_value = mock_func
-
+async def test_migration_commands_async_init_delegation(async_config: AiosqliteConfig) -> None:
+    """Test that async config init calls async method directly."""
+    with patch.object(AsyncMigrationCommands, "init", new_callable=AsyncMock) as mock_init:
         commands = MigrationCommands(async_config)
 
         with tempfile.TemporaryDirectory() as temp_dir:
             migration_dir = str(Path(temp_dir) / "migrations")
 
-            commands.init(migration_dir, package=True)
+            await commands.init(migration_dir, package=True)
 
-            # Verify await_ was called with the async method
-            mock_await.assert_called_once()
-            # Check the first argument is the async method
-            assert mock_await.call_args[0][0] == mock_init
-            # Check raise_sync_error is False
-            assert mock_await.call_args[1]["raise_sync_error"] is False
-            # Verify the returned function was called with the correct args
-            mock_func.assert_called_once_with(migration_dir, package=True)
+            # Verify the async method was called directly
+            mock_init.assert_called_once_with(migration_dir, package=True)
 
 
 def test_migration_commands_sync_current_delegation(sync_config: SqliteConfig) -> None:
@@ -99,27 +87,18 @@ def test_migration_commands_sync_current_delegation(sync_config: SqliteConfig) -
         mock_current.assert_called_once_with(verbose=True)
 
 
-def test_migration_commands_async_current_delegation(async_config: AiosqliteConfig) -> None:
-    """Test that async config current uses await_ wrapper."""
-    with (
-        patch.object(AsyncMigrationCommands, "current", new_callable=AsyncMock) as mock_current,
-        patch("sqlspec.migrations.commands.await_") as mock_await,
-    ):
-        # Set up await_ to return a callable that returns the expected value
-        mock_func = Mock(return_value="test_version")
-        mock_await.return_value = mock_func
+async def test_migration_commands_async_current_delegation(async_config: AiosqliteConfig) -> None:
+    """Test that async config current calls async method directly."""
+    with patch.object(AsyncMigrationCommands, "current", new_callable=AsyncMock) as mock_current:
+        mock_current.return_value = "test_version"
 
         commands = MigrationCommands(async_config)
 
-        result = commands.current(verbose=False)
+        result = await commands.current(verbose=False)
 
-        # Verify await_ was called with the async method
-        mock_await.assert_called_once()
-        assert mock_await.call_args[0][0] == mock_current
-        assert mock_await.call_args[1]["raise_sync_error"] is False
+        # Verify the async method was called directly
+        mock_current.assert_called_once_with(verbose=False)
         assert result == "test_version"
-        # Verify the returned function was called with the correct args
-        mock_func.assert_called_once_with(verbose=False)
 
 
 def test_migration_commands_sync_upgrade_delegation(sync_config: SqliteConfig) -> None:
@@ -132,26 +111,15 @@ def test_migration_commands_sync_upgrade_delegation(sync_config: SqliteConfig) -
         mock_upgrade.assert_called_once_with(revision="001")
 
 
-def test_migration_commands_async_upgrade_delegation(async_config: AiosqliteConfig) -> None:
-    """Test that async config upgrade uses await_ wrapper."""
-    with (
-        patch.object(AsyncMigrationCommands, "upgrade", new_callable=AsyncMock) as mock_upgrade,
-        patch("sqlspec.migrations.commands.await_") as mock_await,
-    ):
-        # Set up await_ to return a callable that returns None
-        mock_func = Mock(return_value=None)
-        mock_await.return_value = mock_func
-
+async def test_migration_commands_async_upgrade_delegation(async_config: AiosqliteConfig) -> None:
+    """Test that async config upgrade calls async method directly."""
+    with patch.object(AsyncMigrationCommands, "upgrade", new_callable=AsyncMock) as mock_upgrade:
         commands = MigrationCommands(async_config)
 
-        commands.upgrade(revision="002")
+        await commands.upgrade(revision="002")
 
-        # Verify await_ was called with the async method
-        mock_await.assert_called_once()
-        assert mock_await.call_args[0][0] == mock_upgrade
-        assert mock_await.call_args[1]["raise_sync_error"] is False
-        # Verify the returned function was called with the correct args
-        mock_func.assert_called_once_with(revision="002")
+        # Verify the async method was called directly
+        mock_upgrade.assert_called_once_with(revision="002")
 
 
 def test_migration_commands_sync_downgrade_delegation(sync_config: SqliteConfig) -> None:
@@ -164,26 +132,15 @@ def test_migration_commands_sync_downgrade_delegation(sync_config: SqliteConfig)
         mock_downgrade.assert_called_once_with(revision="base")
 
 
-def test_migration_commands_async_downgrade_delegation(async_config: AiosqliteConfig) -> None:
-    """Test that async config downgrade uses await_ wrapper."""
-    with (
-        patch.object(AsyncMigrationCommands, "downgrade", new_callable=AsyncMock) as mock_downgrade,
-        patch("sqlspec.migrations.commands.await_") as mock_await,
-    ):
-        # Set up await_ to return a callable that returns None
-        mock_func = Mock(return_value=None)
-        mock_await.return_value = mock_func
-
+async def test_migration_commands_async_downgrade_delegation(async_config: AiosqliteConfig) -> None:
+    """Test that async config downgrade calls async method directly."""
+    with patch.object(AsyncMigrationCommands, "downgrade", new_callable=AsyncMock) as mock_downgrade:
         commands = MigrationCommands(async_config)
 
-        commands.downgrade(revision="001")
+        await commands.downgrade(revision="001")
 
-        # Verify await_ was called with the async method
-        mock_await.assert_called_once()
-        assert mock_await.call_args[0][0] == mock_downgrade
-        assert mock_await.call_args[1]["raise_sync_error"] is False
-        # Verify the returned function was called with the correct args
-        mock_func.assert_called_once_with(revision="001")
+        # Verify the async method was called directly
+        mock_downgrade.assert_called_once_with(revision="001")
 
 
 def test_migration_commands_sync_stamp_delegation(sync_config: SqliteConfig) -> None:
@@ -196,26 +153,15 @@ def test_migration_commands_sync_stamp_delegation(sync_config: SqliteConfig) -> 
         mock_stamp.assert_called_once_with("001")
 
 
-def test_migration_commands_async_stamp_delegation(async_config: AiosqliteConfig) -> None:
-    """Test that async config stamp uses await_ wrapper."""
-    with (
-        patch.object(AsyncMigrationCommands, "stamp", new_callable=AsyncMock) as mock_stamp,
-        patch("sqlspec.migrations.commands.await_") as mock_await,
-    ):
-        # Set up await_ to return a callable that returns None
-        mock_func = Mock(return_value=None)
-        mock_await.return_value = mock_func
-
+async def test_migration_commands_async_stamp_delegation(async_config: AiosqliteConfig) -> None:
+    """Test that async config stamp calls async method directly."""
+    with patch.object(AsyncMigrationCommands, "stamp", new_callable=AsyncMock) as mock_stamp:
         commands = MigrationCommands(async_config)
 
-        commands.stamp("002")
+        await commands.stamp("002")
 
-        # Verify await_ was called with the async method
-        mock_await.assert_called_once()
-        assert mock_await.call_args[0][0] == mock_stamp
-        assert mock_await.call_args[1]["raise_sync_error"] is False
-        # Verify the returned function was called with the correct args
-        mock_func.assert_called_once_with("002")
+        # Verify the async method was called directly
+        mock_stamp.assert_called_once_with("002")
 
 
 def test_migration_commands_sync_revision_delegation(sync_config: SqliteConfig) -> None:
@@ -228,26 +174,38 @@ def test_migration_commands_sync_revision_delegation(sync_config: SqliteConfig) 
         mock_revision.assert_called_once_with("Test revision", "sql")
 
 
-def test_migration_commands_async_revision_delegation(async_config: AiosqliteConfig) -> None:
-    """Test that async config revision uses await_ wrapper."""
-    with (
-        patch.object(AsyncMigrationCommands, "revision", new_callable=AsyncMock) as mock_revision,
-        patch("sqlspec.migrations.commands.await_") as mock_await,
-    ):
-        # Set up await_ to return a callable that returns None
-        mock_func = Mock(return_value=None)
-        mock_await.return_value = mock_func
-
+async def test_migration_commands_async_revision_delegation(async_config: AiosqliteConfig) -> None:
+    """Test that async config revision calls async method directly."""
+    with patch.object(AsyncMigrationCommands, "revision", new_callable=AsyncMock) as mock_revision:
         commands = MigrationCommands(async_config)
 
-        commands.revision("Test async revision", "python")
+        await commands.revision("Test async revision", "python")
 
-        # Verify await_ was called with the async method
-        mock_await.assert_called_once()
-        assert mock_await.call_args[0][0] == mock_revision
-        assert mock_await.call_args[1]["raise_sync_error"] is False
-        # Verify the returned function was called with the correct args
-        mock_func.assert_called_once_with("Test async revision", "python")
+        # Verify the async method was called directly
+        mock_revision.assert_called_once_with("Test async revision", "python")
+
+
+async def test_migration_commands_sync_config_uses_async_wrapper(sync_config: SqliteConfig) -> None:
+    """Test that sync config uses async_() wrapper in unified interface."""
+    with (
+        patch.object(SyncMigrationCommands, "init") as mock_init,
+        patch("sqlspec.migrations.commands.async_") as mock_async,
+    ):
+        # Set up async_ to return an async function
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            return mock_init(*args, **kwargs)
+
+        mock_async.return_value = async_wrapper
+
+        commands = MigrationCommands(sync_config)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            migration_dir = str(Path(temp_dir) / "migrations")
+
+            await commands.init(migration_dir, package=True)
+
+            # Verify async_ was called with the sync method
+            mock_async.assert_called_once_with(mock_init)
 
 
 def test_sync_migration_commands_initialization(sync_config: SqliteConfig) -> None:
@@ -294,32 +252,34 @@ def test_sync_migration_commands_init_without_package(sync_config: SqliteConfig)
         assert not (migration_dir / "__init__.py").exists()
 
 
-def test_migration_commands_error_propagation(async_config: AiosqliteConfig) -> None:
+async def test_migration_commands_error_propagation(async_config: AiosqliteConfig) -> None:
     """Test that errors from underlying implementations are properly propagated."""
-    with (
-        patch.object(AsyncMigrationCommands, "upgrade", side_effect=ValueError("Test error")),
-        patch("sqlspec.migrations.commands.await_") as mock_await,
-    ):
-        # Set up await_ to return a function that raises the error
-        mock_func = Mock(side_effect=ValueError("Test error"))
-        mock_await.return_value = mock_func
-
+    with patch.object(AsyncMigrationCommands, "upgrade", side_effect=ValueError("Test error")):
         commands = MigrationCommands(async_config)
 
         with pytest.raises(ValueError, match="Test error"):
-            commands.upgrade()
+            await commands.upgrade()
 
 
-def test_migration_commands_parameter_forwarding(sync_config: SqliteConfig) -> None:
+async def test_migration_commands_parameter_forwarding(sync_config: SqliteConfig) -> None:
     """Test that all parameters are properly forwarded to underlying implementations."""
-    with patch.object(SyncMigrationCommands, "upgrade") as mock_upgrade:
+    with (
+        patch.object(SyncMigrationCommands, "upgrade") as mock_upgrade,
+        patch("sqlspec.migrations.commands.async_") as mock_async,
+    ):
+        # Set up async_ to return an async function that calls the sync method
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            return mock_upgrade(*args, **kwargs)
+
+        mock_async.return_value = async_wrapper
+
         commands = MigrationCommands(sync_config)
 
         # Test with various parameter combinations
-        commands.upgrade()
+        await commands.upgrade()
         mock_upgrade.assert_called_with(revision="head")
 
-        commands.upgrade("specific_revision")
+        await commands.upgrade("specific_revision")
         mock_upgrade.assert_called_with(revision="specific_revision")
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -349,7 +349,7 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.10.0"
+version = "4.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
@@ -357,9 +357,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/b4/636b3b65173d3ce9a38ef5f0522789614e590dab6a8d505340a4efe4c567/anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6", size = 213252, upload-time = "2025-08-04T08:54:26.451Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/78/7d432127c41b50bccba979505f272c16cbcadcc33645d5fa3a738110ae75/anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4", size = 219094, upload-time = "2025-09-23T09:19:12.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/12/e5e0282d673bb9746bacfb6e2dba8719989d3660cdb2ea79aee9a9651afb/anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1", size = 107213, upload-time = "2025-08-04T08:54:24.882Z" },
+    { url = "https://files.pythonhosted.org/packages/15/b3/9b1a8074496371342ec1e796a96f99c82c945a339cd81a8e73de28b4cf9e/anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc", size = 109097, upload-time = "2025-09-23T09:19:10.601Z" },
 ]
 
 [[package]]
@@ -3914,14 +3914,14 @@ wheels = [
 
 [[package]]
 name = "pygments-styles"
-version = "0.1.0"
+version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/f5/82cc4105cbd0ba249c5a9677d4e074b307bba41047da1b3c84644ad53b78/pygments_styles-0.1.0.tar.gz", hash = "sha256:f1c502518d87af0fa07520acb689ae9aaee8dabec1c536c295b9b6e5ccefa15d", size = 11430, upload-time = "2025-09-22T11:46:21.196Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/38/3516e13cfa5b8ad21642b3b75729246f70edf835ba5f89688d6ac8577fbd/pygments_styles-0.1.1.tar.gz", hash = "sha256:2b6c0468ba5055d0550df77a0c7c7bac7cb21a69c73dec4517abcd16a3397ef6", size = 11711, upload-time = "2025-09-23T12:47:11.476Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/da/ab12276a78174fb42909bcac30fc91748ac1c599a32bbab7dbea5ac6dfd6/pygments_styles-0.1.0-py3-none-any.whl", hash = "sha256:feb21772cecd976164298056649f09cf01a109ec240f05989d6ffd3f4a638d9e", size = 29108, upload-time = "2025-09-22T11:46:20.07Z" },
+    { url = "https://files.pythonhosted.org/packages/15/59/3c047bbaaf2f4a259121fe7c8eb011027930bc780fb1b5e0496d1b439cb2/pygments_styles-0.1.1-py3-none-any.whl", hash = "sha256:57dee9fb8b6956c6b8ce59210313668b8925138f249ecfac4c660fe4ebdbe66c", size = 29484, upload-time = "2025-09-23T12:47:10.065Z" },
 ]
 
 [[package]]
@@ -4353,6 +4353,7 @@ version = "0.2.14"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/e9/39ec4d4b3f91188fad1842748f67d4e749c77c37e353c4e545052ee8e893/ruamel.yaml.clib-0.2.14.tar.gz", hash = "sha256:803f5044b13602d58ea378576dd75aa759f52116a0232608e8fdada4da33752e", size = 225394, upload-time = "2025-09-22T19:51:23.753Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/56/35a0a752415ae01992c68f5a6513bdef0e1b6fbdb60d7619342ce12346a0/ruamel.yaml.clib-0.2.14-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f8b2acb0ffdd2ce8208accbec2dca4a06937d556fdcaefd6473ba1b5daa7e3c4", size = 269216, upload-time = "2025-09-23T14:24:09.742Z" },
     { url = "https://files.pythonhosted.org/packages/98/6a/9a68184ab93619f4607ff1675e4ef01e8accfcbff0d482f4ca44c10d8eab/ruamel.yaml.clib-0.2.14-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:aef953f3b8bd0b50bd52a2e52fb54a6a2171a1889d8dea4a5959d46c6624c451", size = 137092, upload-time = "2025-09-22T19:50:26.906Z" },
     { url = "https://files.pythonhosted.org/packages/2b/3f/cfed5f088628128a9ec66f46794fd4d165642155c7b78c26d83b16c6bf7b/ruamel.yaml.clib-0.2.14-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:a0ac90efbc7a77b0d796c03c8cc4e62fd710b3f1e4c32947713ef2ef52e09543", size = 633768, upload-time = "2025-09-22T19:50:31.228Z" },
     { url = "https://files.pythonhosted.org/packages/3a/d5/5ce2cc156c1da48160171968d91f066d305840fbf930ee955a509d025a44/ruamel.yaml.clib-0.2.14-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9bf6b699223afe6c7fe9f2ef76e0bfa6dd892c21e94ce8c957478987ade76cd8", size = 721253, upload-time = "2025-09-22T19:50:28.776Z" },
@@ -4361,6 +4362,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/34/79/492cfad9baed68914840c39e5f3c1cc251f51a897ddb3f532601215cbb12/ruamel.yaml.clib-0.2.14-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94f3efb718f8f49b031f2071ec7a27dd20cbfe511b4dfd54ecee54c956da2b31", size = 722544, upload-time = "2025-09-22T19:50:34.157Z" },
     { url = "https://files.pythonhosted.org/packages/ca/f5/479ebfd5ba396e209ade90f7282d84b90c57b3e07be8dc6fcd02a6df7ffc/ruamel.yaml.clib-0.2.14-cp310-cp310-win32.whl", hash = "sha256:27c070cf3888e90d992be75dd47292ff9aa17dafd36492812a6a304a1aedc182", size = 100375, upload-time = "2025-09-22T19:50:36.832Z" },
     { url = "https://files.pythonhosted.org/packages/57/31/a044520fdb3bd409889f67f1efebda0658033c7ab3f390cee37531cc9a9e/ruamel.yaml.clib-0.2.14-cp310-cp310-win_amd64.whl", hash = "sha256:4f4a150a737fccae13fb51234d41304ff2222e3b7d4c8e9428ed1a6ab48389b8", size = 118129, upload-time = "2025-09-22T19:50:35.545Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9f/3c51e9578b8c36fcc4bdd271a1a5bb65963a74a4b6ad1a989768a22f6c2a/ruamel.yaml.clib-0.2.14-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5bae1a073ca4244620425cd3d3aa9746bde590992b98ee8c7c8be8c597ca0d4e", size = 270207, upload-time = "2025-09-23T14:24:11.445Z" },
     { url = "https://files.pythonhosted.org/packages/4a/16/cb02815bc2ae9c66760c0c061d23c7358f9ba51dae95ac85247662b7fbe2/ruamel.yaml.clib-0.2.14-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:0a54e5e40a7a691a426c2703b09b0d61a14294d25cfacc00631aa6f9c964df0d", size = 137780, upload-time = "2025-09-22T19:50:37.734Z" },
     { url = "https://files.pythonhosted.org/packages/31/c6/fc687cd1b93bff8e40861eea46d6dc1a6a778d9a085684e4045ff26a8e40/ruamel.yaml.clib-0.2.14-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:10d9595b6a19778f3269399eff6bab642608e5966183abc2adbe558a42d4efc9", size = 641590, upload-time = "2025-09-22T19:50:41.978Z" },
     { url = "https://files.pythonhosted.org/packages/45/5d/65a2bc08b709b08576b3f307bf63951ee68a8e047cbbda6f1c9864ecf9a7/ruamel.yaml.clib-0.2.14-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dba72975485f2b87b786075e18a6e5d07dc2b4d8973beb2732b9b2816f1bad70", size = 738090, upload-time = "2025-09-22T19:50:39.152Z" },
@@ -4369,6 +4371,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/81/50/f899072c38877d8ef5382e0b3d47f8c4346226c1f52d6945d6f64fec6a2f/ruamel.yaml.clib-0.2.14-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e501c096aa3889133d674605ebd018471bc404a59cbc17da3c5924421c54d97c", size = 769529, upload-time = "2025-09-22T19:50:45.707Z" },
     { url = "https://files.pythonhosted.org/packages/99/7c/96d4b5075e30c65ea2064e40c2d657c7c235d7b6ef18751cf89a935b9041/ruamel.yaml.clib-0.2.14-cp311-cp311-win32.whl", hash = "sha256:915748cfc25b8cfd81b14d00f4bfdb2ab227a30d6d43459034533f4d1c207a2a", size = 100256, upload-time = "2025-09-22T19:50:48.26Z" },
     { url = "https://files.pythonhosted.org/packages/7d/8c/73ee2babd04e8bfcf1fd5c20aa553d18bf0ebc24b592b4f831d12ae46cc0/ruamel.yaml.clib-0.2.14-cp311-cp311-win_amd64.whl", hash = "sha256:4ccba93c1e5a40af45b2f08e4591969fa4697eae951c708f3f83dcbf9f6c6bb1", size = 118234, upload-time = "2025-09-22T19:50:47.019Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/42/ccfb34a25289afbbc42017e4d3d4288e61d35b2e00cfc6b92974a6a1f94b/ruamel.yaml.clib-0.2.14-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6aeadc170090ff1889f0d2c3057557f9cd71f975f17535c26a5d37af98f19c27", size = 271775, upload-time = "2025-09-23T14:24:12.771Z" },
     { url = "https://files.pythonhosted.org/packages/82/73/e628a92e80197ff6a79ab81ec3fa00d4cc082d58ab78d3337b7ba7043301/ruamel.yaml.clib-0.2.14-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:5e56ac47260c0eed992789fa0b8efe43404a9adb608608631a948cee4fc2b052", size = 138842, upload-time = "2025-09-22T19:50:49.156Z" },
     { url = "https://files.pythonhosted.org/packages/2b/c5/346c7094344a60419764b4b1334d9e0285031c961176ff88ffb652405b0c/ruamel.yaml.clib-0.2.14-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:a911aa73588d9a8b08d662b9484bc0567949529824a55d3885b77e8dd62a127a", size = 647404, upload-time = "2025-09-22T19:50:52.921Z" },
     { url = "https://files.pythonhosted.org/packages/df/99/65080c863eb06d4498de3d6c86f3e90595e02e159fd8529f1565f56cfe2c/ruamel.yaml.clib-0.2.14-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a05ba88adf3d7189a974b2de7a9d56731548d35dc0a822ec3dc669caa7019b29", size = 753141, upload-time = "2025-09-22T19:50:50.294Z" },
@@ -4377,6 +4380,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/6b/e580a7c18b485e1a5f30a32cda96b20364b0ba649d9d2baaf72f8bd21f83/ruamel.yaml.clib-0.2.14-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c099cafc1834d3c5dac305865d04235f7c21c167c8dd31ebc3d6bbc357e2f023", size = 770200, upload-time = "2025-09-22T19:50:55.718Z" },
     { url = "https://files.pythonhosted.org/packages/ef/44/3455eebc761dc8e8fdced90f2b0a3fa61e32ba38b50de4130e2d57db0f21/ruamel.yaml.clib-0.2.14-cp312-cp312-win32.whl", hash = "sha256:b5b0f7e294700b615a3bcf6d28b26e6da94e8eba63b079f4ec92e9ba6c0d6b54", size = 98829, upload-time = "2025-09-22T19:50:58.895Z" },
     { url = "https://files.pythonhosted.org/packages/76/ab/5121f7f3b651db93de546f8c982c241397aad0a4765d793aca1dac5eadee/ruamel.yaml.clib-0.2.14-cp312-cp312-win_amd64.whl", hash = "sha256:a37f40a859b503304dd740686359fcf541d6fb3ff7fc10f539af7f7150917c68", size = 115570, upload-time = "2025-09-22T19:50:57.981Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ae/e3811f05415594025e96000349d3400978adaed88d8f98d494352d9761ee/ruamel.yaml.clib-0.2.14-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7e4f9da7e7549946e02a6122dcad00b7c1168513acb1f8a726b1aaf504a99d32", size = 269205, upload-time = "2025-09-23T14:24:15.06Z" },
     { url = "https://files.pythonhosted.org/packages/72/06/7d51f4688d6d72bb72fa74254e1593c4f5ebd0036be5b41fe39315b275e9/ruamel.yaml.clib-0.2.14-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:dd7546c851e59c06197a7c651335755e74aa383a835878ca86d2c650c07a2f85", size = 137417, upload-time = "2025-09-22T19:50:59.82Z" },
     { url = "https://files.pythonhosted.org/packages/5a/08/b4499234a420ef42960eeb05585df5cc7eb25ccb8c980490b079e6367050/ruamel.yaml.clib-0.2.14-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:1c1acc3a0209ea9042cc3cfc0790edd2eddd431a2ec3f8283d081e4d5018571e", size = 642558, upload-time = "2025-09-22T19:51:03.388Z" },
     { url = "https://files.pythonhosted.org/packages/b6/ba/1975a27dedf1c4c33306ee67c948121be8710b19387aada29e2f139c43ee/ruamel.yaml.clib-0.2.14-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2070bf0ad1540d5c77a664de07ebcc45eebd1ddcab71a7a06f26936920692beb", size = 744087, upload-time = "2025-09-22T19:51:00.897Z" },
@@ -4385,9 +4389,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/ac/3c5c2b27a183f4fda8a57c82211721c016bcb689a4a175865f7646db9f94/ruamel.yaml.clib-0.2.14-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b30110b29484adc597df6bd92a37b90e63a8c152ca8136aad100a02f8ba6d1b6", size = 765196, upload-time = "2025-09-22T19:51:05.916Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/06f56a71fd55021c993ed6e848c9b2e5e9cfce180a42179f0ddd28253f7c/ruamel.yaml.clib-0.2.14-cp313-cp313-win32.whl", hash = "sha256:f4e97a1cf0b7a30af9e1d9dad10a5671157b9acee790d9e26996391f49b965a2", size = 98635, upload-time = "2025-09-22T19:51:08.183Z" },
     { url = "https://files.pythonhosted.org/packages/51/79/76aba16a1689b50528224b182f71097ece338e7a4ab55e84c2e73443b78a/ruamel.yaml.clib-0.2.14-cp313-cp313-win_amd64.whl", hash = "sha256:090782b5fb9d98df96509eecdbcaffd037d47389a89492320280d52f91330d78", size = 115238, upload-time = "2025-09-22T19:51:07.081Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e2/a59ff65c26aaf21a24eb38df777cb9af5d87ba8fc8107c163c2da9d1e85e/ruamel.yaml.clib-0.2.14-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:7df6f6e9d0e33c7b1d435defb185095386c469109de723d514142632a7b9d07f", size = 271441, upload-time = "2025-09-23T14:24:16.498Z" },
     { url = "https://files.pythonhosted.org/packages/6b/fa/3234f913fe9a6525a7b97c6dad1f51e72b917e6872e051a5e2ffd8b16fbb/ruamel.yaml.clib-0.2.14-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:70eda7703b8126f5e52fcf276e6c0f40b0d314674f896fc58c47b0aef2b9ae83", size = 137970, upload-time = "2025-09-22T19:51:09.472Z" },
     { url = "https://files.pythonhosted.org/packages/ef/ec/4edbf17ac2c87fa0845dd366ef8d5852b96eb58fcd65fc1ecf5fe27b4641/ruamel.yaml.clib-0.2.14-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a0cb71ccc6ef9ce36eecb6272c81afdc2f565950cdcec33ae8e6cd8f7fc86f27", size = 739639, upload-time = "2025-09-22T19:51:10.566Z" },
     { url = "https://files.pythonhosted.org/packages/15/18/b0e1fafe59051de9e79cdd431863b03593ecfa8341c110affad7c8121efc/ruamel.yaml.clib-0.2.14-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7cb9ad1d525d40f7d87b6df7c0ff916a66bc52cb61b66ac1b2a16d0c1b07640", size = 764456, upload-time = "2025-09-22T19:51:11.736Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a0/e709dc2f58054049cd154319a7d37917689785b12ec43ea2df47ea5344ef/ruamel.yaml.clib-0.2.14-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:18c041b28f3456ddef1f1951d4492dbebe0f8114157c1b3c981a4611c2020792", size = 270636, upload-time = "2025-09-23T14:24:17.855Z" },
     { url = "https://files.pythonhosted.org/packages/18/81/491c9e394976e10682a596f2b785ba7066db525cc17f267005ae8ca33c73/ruamel.yaml.clib-0.2.14-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:d8354515ab62f95a07deaf7f845886cc50e2f345ceab240a3d2d09a9f7d77853", size = 137954, upload-time = "2025-09-22T19:51:12.851Z" },
     { url = "https://files.pythonhosted.org/packages/ad/a5/c6d1c767e051bbc00146a93132bf199b3e6ec2c219131b9d3e19eff428f3/ruamel.yaml.clib-0.2.14-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:275f938692013a3883edbd848edde6d9f26825d65c9a2eb1db8baa1adc96a05d", size = 636162, upload-time = "2025-09-22T19:51:16.823Z" },
     { url = "https://files.pythonhosted.org/packages/e3/6f/4746e2e8f60b3489b6cd6fad96a8e2aaa0cf7dd6760de3daad1a6e9f5789/ruamel.yaml.clib-0.2.14-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:16a60d69f4057ad9a92f3444e2367c08490daed6428291aa16cefb445c29b0e9", size = 723934, upload-time = "2025-09-22T19:51:13.948Z" },
@@ -5651,11 +5657,11 @@ wheels = [
 
 [[package]]
 name = "types-docutils"
-version = "0.22.0.20250919"
+version = "0.22.1.20250923"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/37/410c4bd2f97e1f3fa5b438572216a437c94b9f9fabfee9d614941eec8048/types_docutils-0.22.0.20250919.tar.gz", hash = "sha256:2b4e08d811e08e851f17808afbcf767bbf65f195be7e0080009cf983dc4312f0", size = 56554, upload-time = "2025-09-19T02:54:35.454Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/76/3b2b841d2ea3b59685c59cfcfeddd439146287319c1566099796507ee866/types_docutils-0.22.1.20250923.tar.gz", hash = "sha256:f7754c7eeab44144095e287bb3afcb96d6936dc3fa332cff4e5ef5533baa198f", size = 56652, upload-time = "2025-09-23T02:51:20.573Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/a0/fb5b7ff6a659f784fc6f33c70d97469bbdc6edcc7ef88eb695da5a706de8/types_docutils-0.22.0.20250919-py3-none-any.whl", hash = "sha256:67fbc6e25a2ba61d63b639db01172d91debf2beccb8780e83006f97b5cc1c226", size = 91820, upload-time = "2025-09-19T02:54:34.511Z" },
+    { url = "https://files.pythonhosted.org/packages/29/22/c762f76ace7de3c8d469f9f25a8b8870bff47fb31ecc15453ac96426f36a/types_docutils-0.22.1.20250923-py3-none-any.whl", hash = "sha256:a01a8036b373dd578ec1a170db04f4159be1282ca92f0a085e50f4afbeb8d0bc", size = 91872, upload-time = "2025-09-23T02:51:19.305Z" },
 ]
 
 [[package]]
@@ -5792,7 +5798,7 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.36.0"
+version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -5800,9 +5806,9 @@ dependencies = [
     { name = "h11" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/5e/f0cd46063a02fd8515f0e880c37d2657845b7306c16ce6c4ffc44afd9036/uvicorn-0.36.0.tar.gz", hash = "sha256:527dc68d77819919d90a6b267be55f0e76704dca829d34aea9480be831a9b9d9", size = 80032, upload-time = "2025-09-20T01:07:14.418Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/57/1616c8274c3442d802621abf5deb230771c7a0fec9414cb6763900eb3868/uvicorn-0.37.0.tar.gz", hash = "sha256:4115c8add6d3fd536c8ee77f0e14a7fd2ebba939fed9b02583a97f80648f9e13", size = 80367, upload-time = "2025-09-23T13:33:47.486Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/06/5cc0542b47c0338c1cb676b348e24a1c29acabc81000bced518231dded6f/uvicorn-0.36.0-py3-none-any.whl", hash = "sha256:6bb4ba67f16024883af8adf13aba3a9919e415358604ce46780d3f9bdc36d731", size = 67675, upload-time = "2025-09-20T01:07:12.984Z" },
+    { url = "https://files.pythonhosted.org/packages/85/cd/584a2ceb5532af99dd09e50919e3615ba99aa127e9850eafe5f31ddfdb9a/uvicorn-0.37.0-py3-none-any.whl", hash = "sha256:913b2b88672343739927ce381ff9e2ad62541f9f8289664fa1d1d3803fa2ce6c", size = 67976, upload-time = "2025-09-23T13:33:45.842Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements async migration support and callable config functions as outlined in
  the async migrations enhancement plan. This enables Python migrations to use
  `async def up/down` functions and allows the CLI to accept callable configuration
  functions.

Async Migration Support
  - Enhanced `MigrationRunner` to seamlessly handle both sync and async migrations
  - Added `MigrationContext` with async execution awareness and metadata tracking
  - Removed redundant async methods, unified the API around main methods that
  auto-detect driver types

Callable Config Support
  - Added `config_resolver.py` to resolve both direct config instances and callable
  functions
  - Enhanced CLI to support sync/async callable config functions

 CLI Usage:

  ```bash
  # Existing patterns (still supported)
  sqlspec --config myapp.config.database_configs upgrade head

  # New callable config support
  sqlspec --config myapp.config.get_database_configs upgrade head
  sqlspec --config myapp.config.async_get_database_configs upgrade head
```