### PR TITLE
feat!: remove Python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
 
       - name: Set up Python
-        run: uv python install 3.9
+        run: uv python install 3.10
 
       - name: Create virtual environment
         run: uv sync --all-extras --dev
@@ -43,7 +43,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
 
       - name: Set up Python
-        run: uv python install 3.9
+        run: uv python install 3.10
 
       - name: Install dependencies
         run: uv sync --all-extras --dev
@@ -60,7 +60,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
 
       - name: Set up Python
-        run: uv python install 3.9
+        run: uv python install 3.10
 
       - name: Install dependencies
         run: uv sync --all-extras --dev
@@ -77,7 +77,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
 
       - name: Set up Python
-        run: uv python install 3.9
+        run: uv python install 3.10
 
       - name: Install dependencies
         run: uv sync --all-extras --dev
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     timeout-minutes: 30
     steps:
       - name: Check out repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: [  "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -89,7 +89,7 @@ jobs:
           MYPYC_MULTI_FILE: "1"
 
           # Configure cibuildwheel
-          CIBW_BUILD: "cp${{ matrix.python-version == '3.9' && '39' || matrix.python-version == '3.10' && '310' || matrix.python-version == '3.11' && '311' || matrix.python-version == '3.12' && '312' || matrix.python-version == '3.13' && '313' }}-*"
+          CIBW_BUILD: "cp${{  matrix.python-version == '3.10' && '310' || matrix.python-version == '3.11' && '311' || matrix.python-version == '3.12' && '312' || matrix.python-version == '3.13' && '313' }}-*"
           CIBW_BUILD_VERBOSITY: 1
 
           # Platform configuration - comprehensive coverage with QEMU emulation

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ${{ github.event.inputs.test_matrix == 'full' && fromJSON('["3.9", "3.10", "3.11", "3.12", "3.13"]') || fromJSON('["3.12"]') }}
+        python-version: ${{ github.event.inputs.test_matrix == 'full' && fromJSON('["3.10", "3.11", "3.12", "3.13"]') || fromJSON('["3.12"]') }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -101,7 +101,7 @@ jobs:
           MYPYC_MULTI_FILE: "1"
 
           # Configure cibuildwheel
-          CIBW_BUILD: "cp${{ matrix.python-version == '3.9' && '39' || matrix.python-version == '3.10' && '310' || matrix.python-version == '3.11' && '311' || matrix.python-version == '3.12' && '312' || matrix.python-version == '3.13' && '313' }}-*"
+          CIBW_BUILD: "cp${{ matrix.python-version == '3.10' && '310' || matrix.python-version == '3.11' && '311' || matrix.python-version == '3.12' && '312' || matrix.python-version == '3.13' && '313' }}-*"
           CIBW_BUILD_VERBOSITY: 1
 
           # Platform configuration - conditional ARM64 support with QEMU

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,12 @@
 [project]
 authors = [{ name = "Cody Fincher", email = "cody@litestar.dev" }]
-dependencies = [
-  "typing-extensions",
-  "eval_type_backport; python_version < \"3.10\"",
-  "sqlglot>=19.9.0",
-  "mypy-extensions",
-  "rich-click",
-]
+dependencies = ["typing-extensions", "sqlglot>=19.9.0", "mypy-extensions", "rich-click"]
 description = "SQL Experiments in Python"
 license = "MIT"
 maintainers = [{ name = "Litestar Developers", email = "hello@litestar.dev" }]
 name = "sqlspec"
 readme = "README.md"
-requires-python = ">=3.9, <4.0"
+requires-python = ">=3.10, <4.0"
 version = "0.26.0"
 
 [project.urls]
@@ -68,8 +62,7 @@ dev = [
 doc = [
   "auto-pytabs[sphinx]>=0.5.0",
   "shibuya",
-  "sphinx>=7.0.0; python_version <= \"3.9\"",
-  "sphinx>=8.0.0; python_version >= \"3.10\"",
+  "sphinx",
   "sphinx-autobuild>=2021.3.14",
   "sphinx-copybutton>=0.5.2",
   "sphinx-click>=6.0.0",
@@ -91,7 +84,7 @@ extras = [
   "adbc_driver_postgresql",
   "adbc_driver_flightsql",
   "adbc_driver_bigquery",
-  "dishka ; python_version >= \"3.10\"",
+  "dishka",
 ]
 lint = [
   "mypy>=1.13.0",
@@ -309,7 +302,7 @@ testpaths = ["tests"]
 [tool.mypy]
 exclude = ["tmp/", ".tmp/", ".bugs/"]
 packages = ["sqlspec", "tests"]
-python_version = "3.9"
+python_version = "3.10"
 
 disallow_any_generics = false
 disallow_untyped_decorators = true
@@ -366,7 +359,7 @@ module = "tests.*"
 disableBytesTypePromotions = true
 exclude = ["**/node_modules", "**/__pycache__", ".venv", "tools", "docs", "tmp", ".tmp", ".bugs"]
 include = ["sqlspec", "tests"]
-pythonVersion = "3.9"
+pythonVersion = "3.10"
 reportMissingTypeStubs = false
 reportPrivateImportUsage = true
 reportPrivateUsage = true
@@ -384,7 +377,7 @@ strict-imports = false
 exclude = [".venv", "node_modules", "tmp", ".tmp", ".bugs"]
 line-length = 120
 src = ["sqlspec", "tests", "docs/examples", "tools"]
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/sqlspec/_serialization.py
+++ b/sqlspec/_serialization.py
@@ -9,7 +9,7 @@ import datetime
 import enum
 import json
 from abc import ABC, abstractmethod
-from typing import Any, Final, Literal, Optional, Protocol, Union, overload
+from typing import Any, Final, Literal, Protocol, overload
 
 from sqlspec.typing import MSGSPEC_INSTALLED, ORJSON_INSTALLED, PYDANTIC_INSTALLED, BaseModel
 
@@ -43,7 +43,7 @@ class JSONSerializer(Protocol):
     Users can implement this protocol to create custom serializers.
     """
 
-    def encode(self, data: Any, *, as_bytes: bool = False) -> Union[str, bytes]:
+    def encode(self, data: Any, *, as_bytes: bool = False) -> str | bytes:
         """Encode data to JSON.
 
         Args:
@@ -55,7 +55,7 @@ class JSONSerializer(Protocol):
         """
         ...
 
-    def decode(self, data: Union[str, bytes], *, decode_bytes: bool = True) -> Any:
+    def decode(self, data: str | bytes, *, decode_bytes: bool = True) -> Any:
         """Decode from JSON.
 
         Args:
@@ -74,12 +74,12 @@ class BaseJSONSerializer(ABC):
     __slots__ = ()
 
     @abstractmethod
-    def encode(self, data: Any, *, as_bytes: bool = False) -> Union[str, bytes]:
+    def encode(self, data: Any, *, as_bytes: bool = False) -> str | bytes:
         """Encode data to JSON."""
         ...
 
     @abstractmethod
-    def decode(self, data: Union[str, bytes], *, decode_bytes: bool = True) -> Any:
+    def decode(self, data: str | bytes, *, decode_bytes: bool = True) -> Any:
         """Decode from JSON."""
         ...
 
@@ -96,7 +96,7 @@ class MsgspecSerializer(BaseJSONSerializer):
         self._encoder: Final[Encoder] = Encoder(enc_hook=_type_to_string)
         self._decoder: Final[Decoder] = Decoder()
 
-    def encode(self, data: Any, *, as_bytes: bool = False) -> Union[str, bytes]:
+    def encode(self, data: Any, *, as_bytes: bool = False) -> str | bytes:
         """Encode data using msgspec."""
         try:
             if as_bytes:
@@ -107,7 +107,7 @@ class MsgspecSerializer(BaseJSONSerializer):
                 return OrjsonSerializer().encode(data, as_bytes=as_bytes)
             return StandardLibSerializer().encode(data, as_bytes=as_bytes)
 
-    def decode(self, data: Union[str, bytes], *, decode_bytes: bool = True) -> Any:
+    def decode(self, data: str | bytes, *, decode_bytes: bool = True) -> Any:
         """Decode data using msgspec."""
         if isinstance(data, bytes):
             if decode_bytes:
@@ -132,7 +132,7 @@ class OrjsonSerializer(BaseJSONSerializer):
 
     __slots__ = ()
 
-    def encode(self, data: Any, *, as_bytes: bool = False) -> Union[str, bytes]:
+    def encode(self, data: Any, *, as_bytes: bool = False) -> str | bytes:
         """Encode data using orjson."""
         from orjson import (
             OPT_NAIVE_UTC,  # pyright: ignore[reportUnknownVariableType]
@@ -146,7 +146,7 @@ class OrjsonSerializer(BaseJSONSerializer):
         )
         return result if as_bytes else result.decode("utf-8")
 
-    def decode(self, data: Union[str, bytes], *, decode_bytes: bool = True) -> Any:
+    def decode(self, data: str | bytes, *, decode_bytes: bool = True) -> Any:
         """Decode data using orjson."""
         from orjson import loads as _orjson_loads  # pyright: ignore[reportMissingImports]
 
@@ -162,12 +162,12 @@ class StandardLibSerializer(BaseJSONSerializer):
 
     __slots__ = ()
 
-    def encode(self, data: Any, *, as_bytes: bool = False) -> Union[str, bytes]:
+    def encode(self, data: Any, *, as_bytes: bool = False) -> str | bytes:
         """Encode data using standard library json."""
         json_str = json.dumps(data, default=_type_to_string)
         return json_str.encode("utf-8") if as_bytes else json_str
 
-    def decode(self, data: Union[str, bytes], *, decode_bytes: bool = True) -> Any:
+    def decode(self, data: str | bytes, *, decode_bytes: bool = True) -> Any:
         """Decode data using standard library json."""
         if isinstance(data, bytes):
             if decode_bytes:
@@ -176,7 +176,7 @@ class StandardLibSerializer(BaseJSONSerializer):
         return json.loads(data)
 
 
-_default_serializer: Optional[JSONSerializer] = None
+_default_serializer: JSONSerializer | None = None
 
 
 def get_default_serializer() -> JSONSerializer:
@@ -213,7 +213,7 @@ def encode_json(data: Any, *, as_bytes: Literal[False] = ...) -> str: ...  # pra
 def encode_json(data: Any, *, as_bytes: Literal[True]) -> bytes: ...  # pragma: no cover
 
 
-def encode_json(data: Any, *, as_bytes: bool = False) -> Union[str, bytes]:
+def encode_json(data: Any, *, as_bytes: bool = False) -> str | bytes:
     """Encode to JSON, optionally returning bytes for optimal performance.
 
     Args:
@@ -226,7 +226,7 @@ def encode_json(data: Any, *, as_bytes: bool = False) -> Union[str, bytes]:
     return get_default_serializer().encode(data, as_bytes=as_bytes)
 
 
-def decode_json(data: Union[str, bytes], *, decode_bytes: bool = True) -> Any:
+def decode_json(data: str | bytes, *, decode_bytes: bool = True) -> Any:
     """Decode from JSON string or bytes efficiently.
 
     Args:

--- a/sqlspec/_sql.py
+++ b/sqlspec/_sql.py
@@ -4,7 +4,7 @@ Provides statement builders (select, insert, update, etc.) and column expression
 """
 
 import logging
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import sqlglot
 from sqlglot import exp
@@ -205,7 +205,7 @@ class SQLFactory:
             select_builder.select(*columns_or_sql)
         return select_builder
 
-    def insert(self, table_or_sql: Optional[str] = None, dialect: DialectType = None) -> "Insert":
+    def insert(self, table_or_sql: str | None = None, dialect: DialectType = None) -> "Insert":
         builder_dialect = dialect or self.dialect
         builder = Insert(dialect=builder_dialect)
         if table_or_sql:
@@ -222,7 +222,7 @@ class SQLFactory:
             return builder.into(table_or_sql)
         return builder
 
-    def update(self, table_or_sql: Optional[str] = None, dialect: DialectType = None) -> "Update":
+    def update(self, table_or_sql: str | None = None, dialect: DialectType = None) -> "Update":
         builder_dialect = dialect or self.dialect
         builder = Update(dialect=builder_dialect)
         if table_or_sql:
@@ -238,7 +238,7 @@ class SQLFactory:
             return builder.table(table_or_sql)
         return builder
 
-    def delete(self, table_or_sql: Optional[str] = None, dialect: DialectType = None) -> "Delete":
+    def delete(self, table_or_sql: str | None = None, dialect: DialectType = None) -> "Delete":
         builder_dialect = dialect or self.dialect
         builder = Delete(dialect=builder_dialect)
         if table_or_sql and self._looks_like_sql(table_or_sql):
@@ -252,7 +252,7 @@ class SQLFactory:
             return self._populate_delete_from_sql(builder, table_or_sql)
         return builder
 
-    def merge(self, table_or_sql: Optional[str] = None, dialect: DialectType = None) -> "Merge":
+    def merge(self, table_or_sql: str | None = None, dialect: DialectType = None) -> "Merge":
         builder_dialect = dialect or self.dialect
         builder = Merge(dialect=builder_dialect)
         if table_or_sql:
@@ -423,7 +423,7 @@ class SQLFactory:
         return CommentOn(dialect=dialect or self.dialect)
 
     @staticmethod
-    def _looks_like_sql(candidate: str, expected_type: Optional[str] = None) -> bool:
+    def _looks_like_sql(candidate: str, expected_type: str | None = None) -> bool:
         """Determine if a string looks like SQL.
 
         Args:
@@ -525,7 +525,7 @@ class SQLFactory:
             logger.warning("Failed to parse MERGE SQL, falling back to traditional mode: %s", e)
         return builder
 
-    def column(self, name: str, table: Optional[str] = None) -> Column:
+    def column(self, name: str, table: str | None = None) -> Column:
         """Create a column reference.
 
         Args:
@@ -683,7 +683,7 @@ class SQLFactory:
         return Column(name)
 
     @staticmethod
-    def raw(sql_fragment: str, **parameters: Any) -> "Union[exp.Expression, SQL]":
+    def raw(sql_fragment: str, **parameters: Any) -> "exp.Expression | SQL":
         """Create a raw SQL expression from a string fragment with optional parameters.
 
         Args:
@@ -818,7 +818,7 @@ class SQLFactory:
         return AggregateExpression(exp.Min(this=col_expr))
 
     @staticmethod
-    def rollup(*columns: Union[str, exp.Expression]) -> FunctionExpression:
+    def rollup(*columns: str | exp.Expression) -> FunctionExpression:
         """Create a ROLLUP expression for GROUP BY clauses.
 
         Args:
@@ -840,7 +840,7 @@ class SQLFactory:
         return FunctionExpression(exp.Rollup(expressions=column_exprs))
 
     @staticmethod
-    def cube(*columns: Union[str, exp.Expression]) -> FunctionExpression:
+    def cube(*columns: str | exp.Expression) -> FunctionExpression:
         """Create a CUBE expression for GROUP BY clauses.
 
         Args:
@@ -862,7 +862,7 @@ class SQLFactory:
         return FunctionExpression(exp.Cube(expressions=column_exprs))
 
     @staticmethod
-    def grouping_sets(*column_sets: Union[tuple[str, ...], list[str]]) -> FunctionExpression:
+    def grouping_sets(*column_sets: tuple[str, ...] | list[str]) -> FunctionExpression:
         """Create a GROUPING SETS expression for GROUP BY clauses.
 
         Args:
@@ -896,7 +896,7 @@ class SQLFactory:
         return FunctionExpression(exp.GroupingSets(expressions=set_expressions))
 
     @staticmethod
-    def any(values: Union[list[Any], exp.Expression, str]) -> FunctionExpression:
+    def any(values: list[Any] | exp.Expression | str) -> FunctionExpression:
         """Create an ANY expression for use with comparison operators.
 
         Args:
@@ -924,7 +924,7 @@ class SQLFactory:
         return FunctionExpression(exp.Any(this=values))
 
     @staticmethod
-    def not_any_(values: Union[list[Any], exp.Expression, str]) -> FunctionExpression:
+    def not_any_(values: list[Any] | exp.Expression | str) -> FunctionExpression:
         """Create a NOT ANY expression for use with comparison operators.
 
         Args:
@@ -946,7 +946,7 @@ class SQLFactory:
         return SQLFactory.any(values)
 
     @staticmethod
-    def concat(*expressions: Union[str, exp.Expression]) -> StringExpression:
+    def concat(*expressions: str | exp.Expression) -> StringExpression:
         """Create a CONCAT expression.
 
         Args:
@@ -959,7 +959,7 @@ class SQLFactory:
         return StringExpression(exp.Concat(expressions=exprs))
 
     @staticmethod
-    def upper(column: Union[str, exp.Expression]) -> StringExpression:
+    def upper(column: str | exp.Expression) -> StringExpression:
         """Create an UPPER expression.
 
         Args:
@@ -972,7 +972,7 @@ class SQLFactory:
         return StringExpression(exp.Upper(this=col_expr))
 
     @staticmethod
-    def lower(column: Union[str, exp.Expression]) -> StringExpression:
+    def lower(column: str | exp.Expression) -> StringExpression:
         """Create a LOWER expression.
 
         Args:
@@ -985,7 +985,7 @@ class SQLFactory:
         return StringExpression(exp.Lower(this=col_expr))
 
     @staticmethod
-    def length(column: Union[str, exp.Expression]) -> StringExpression:
+    def length(column: str | exp.Expression) -> StringExpression:
         """Create a LENGTH expression.
 
         Args:
@@ -998,7 +998,7 @@ class SQLFactory:
         return StringExpression(exp.Length(this=col_expr))
 
     @staticmethod
-    def round(column: Union[str, exp.Expression], decimals: int = 0) -> MathExpression:
+    def round(column: str | exp.Expression, decimals: int = 0) -> MathExpression:
         """Create a ROUND expression.
 
         Args:
@@ -1036,7 +1036,7 @@ class SQLFactory:
         return FunctionExpression(exp.convert(value))
 
     @staticmethod
-    def decode(column: Union[str, exp.Expression], *args: Union[str, exp.Expression, Any]) -> FunctionExpression:
+    def decode(column: str | exp.Expression, *args: str | exp.Expression | Any) -> FunctionExpression:
         """Create a DECODE expression (Oracle-style conditional logic).
 
         DECODE compares column to each search value and returns the corresponding result.
@@ -1086,7 +1086,7 @@ class SQLFactory:
         return FunctionExpression(exp.Case(ifs=conditions, default=default))
 
     @staticmethod
-    def cast(column: Union[str, exp.Expression], data_type: str) -> ConversionExpression:
+    def cast(column: str | exp.Expression, data_type: str) -> ConversionExpression:
         """Create a CAST expression for type conversion.
 
         Args:
@@ -1100,7 +1100,7 @@ class SQLFactory:
         return ConversionExpression(exp.Cast(this=col_expr, to=exp.DataType.build(data_type)))
 
     @staticmethod
-    def coalesce(*expressions: Union[str, exp.Expression]) -> ConversionExpression:
+    def coalesce(*expressions: str | exp.Expression) -> ConversionExpression:
         """Create a COALESCE expression.
 
         Args:
@@ -1113,9 +1113,7 @@ class SQLFactory:
         return ConversionExpression(exp.Coalesce(expressions=exprs))
 
     @staticmethod
-    def nvl(
-        column: Union[str, exp.Expression], substitute_value: Union[str, exp.Expression, Any]
-    ) -> ConversionExpression:
+    def nvl(column: str | exp.Expression, substitute_value: str | exp.Expression | Any) -> ConversionExpression:
         """Create an NVL (Oracle-style) expression using COALESCE.
 
         Args:
@@ -1131,9 +1129,9 @@ class SQLFactory:
 
     @staticmethod
     def nvl2(
-        column: Union[str, exp.Expression],
-        value_if_not_null: Union[str, exp.Expression, Any],
-        value_if_null: Union[str, exp.Expression, Any],
+        column: str | exp.Expression,
+        value_if_not_null: str | exp.Expression | Any,
+        value_if_null: str | exp.Expression | Any,
     ) -> ConversionExpression:
         """Create an NVL2 (Oracle-style) expression using CASE.
 
@@ -1246,8 +1244,8 @@ class SQLFactory:
 
     def row_number(
         self,
-        partition_by: Optional[Union[str, list[str], exp.Expression]] = None,
-        order_by: Optional[Union[str, list[str], exp.Expression]] = None,
+        partition_by: str | list[str] | exp.Expression | None = None,
+        order_by: str | list[str] | exp.Expression | None = None,
     ) -> FunctionExpression:
         """Create a ROW_NUMBER() window function.
 
@@ -1262,8 +1260,8 @@ class SQLFactory:
 
     def rank(
         self,
-        partition_by: Optional[Union[str, list[str], exp.Expression]] = None,
-        order_by: Optional[Union[str, list[str], exp.Expression]] = None,
+        partition_by: str | list[str] | exp.Expression | None = None,
+        order_by: str | list[str] | exp.Expression | None = None,
     ) -> FunctionExpression:
         """Create a RANK() window function.
 
@@ -1278,8 +1276,8 @@ class SQLFactory:
 
     def dense_rank(
         self,
-        partition_by: Optional[Union[str, list[str], exp.Expression]] = None,
-        order_by: Optional[Union[str, list[str], exp.Expression]] = None,
+        partition_by: str | list[str] | exp.Expression | None = None,
+        order_by: str | list[str] | exp.Expression | None = None,
     ) -> FunctionExpression:
         """Create a DENSE_RANK() window function.
 
@@ -1296,8 +1294,8 @@ class SQLFactory:
     def _create_window_function(
         func_name: str,
         func_args: list[exp.Expression],
-        partition_by: Optional[Union[str, list[str], exp.Expression]] = None,
-        order_by: Optional[Union[str, list[str], exp.Expression]] = None,
+        partition_by: str | list[str] | exp.Expression | None = None,
+        order_by: str | list[str] | exp.Expression | None = None,
     ) -> FunctionExpression:
         """Helper to create window function expressions.
 

--- a/sqlspec/_typing.py
+++ b/sqlspec/_typing.py
@@ -6,9 +6,9 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from enum import Enum
 from importlib.util import find_spec
-from typing import Any, ClassVar, Final, Optional, Protocol, Union, cast, runtime_checkable
+from typing import Any, ClassVar, Final, Literal, Protocol, cast, runtime_checkable
 
-from typing_extensions import Literal, TypeVar, dataclass_transform
+from typing_extensions import TypeVar, dataclass_transform
 
 
 @runtime_checkable
@@ -38,15 +38,15 @@ class BaseModelStub:
         self,
         /,
         *,
-        include: "Optional[Any]" = None,  # noqa: ARG002
-        exclude: "Optional[Any]" = None,  # noqa: ARG002
-        context: "Optional[Any]" = None,  # noqa: ARG002
+        include: "Any | None" = None,  # noqa: ARG002
+        exclude: "Any | None" = None,  # noqa: ARG002
+        context: "Any | None" = None,  # noqa: ARG002
         by_alias: bool = False,  # noqa: ARG002
         exclude_unset: bool = False,  # noqa: ARG002
         exclude_defaults: bool = False,  # noqa: ARG002
         exclude_none: bool = False,  # noqa: ARG002
         round_trip: bool = False,  # noqa: ARG002
-        warnings: "Union[bool, Literal['none', 'warn', 'error']]" = True,  # noqa: ARG002
+        warnings: "bool | Literal['none', 'warn', 'error']" = True,  # noqa: ARG002
         serialize_as_any: bool = False,  # noqa: ARG002
     ) -> "dict[str, Any]":
         """Placeholder implementation."""
@@ -56,15 +56,15 @@ class BaseModelStub:
         self,
         /,
         *,
-        include: "Optional[Any]" = None,  # noqa: ARG002
-        exclude: "Optional[Any]" = None,  # noqa: ARG002
-        context: "Optional[Any]" = None,  # noqa: ARG002
+        include: "Any | None" = None,  # noqa: ARG002
+        exclude: "Any | None" = None,  # noqa: ARG002
+        context: "Any | None" = None,  # noqa: ARG002
         by_alias: bool = False,  # noqa: ARG002
         exclude_unset: bool = False,  # noqa: ARG002
         exclude_defaults: bool = False,  # noqa: ARG002
         exclude_none: bool = False,  # noqa: ARG002
         round_trip: bool = False,  # noqa: ARG002
-        warnings: "Union[bool, Literal['none', 'warn', 'error']]" = True,  # noqa: ARG002
+        warnings: "bool | Literal['none', 'warn', 'error']" = True,  # noqa: ARG002
         serialize_as_any: bool = False,  # noqa: ARG002
     ) -> str:
         """Placeholder implementation."""
@@ -78,9 +78,9 @@ class TypeAdapterStub:
         self,
         type: Any,  # noqa: A002
         *,
-        config: "Optional[Any]" = None,  # noqa: ARG002
+        config: "Any | None" = None,  # noqa: ARG002
         _parent_depth: int = 2,  # noqa: ARG002
-        module: "Optional[str]" = None,  # noqa: ARG002
+        module: "str | None" = None,  # noqa: ARG002
     ) -> None:
         """Initialize."""
         self._type = type
@@ -90,10 +90,10 @@ class TypeAdapterStub:
         object: Any,
         /,
         *,
-        strict: "Optional[bool]" = None,  # noqa: ARG002
-        from_attributes: "Optional[bool]" = None,  # noqa: ARG002
-        context: "Optional[dict[str, Any]]" = None,  # noqa: ARG002
-        experimental_allow_partial: "Union[bool, Literal['off', 'on', 'trailing-strings']]" = False,  # noqa: ARG002
+        strict: "bool | None" = None,  # noqa: ARG002
+        from_attributes: "bool | None" = None,  # noqa: ARG002
+        context: "dict[str, Any] | None" = None,  # noqa: ARG002
+        experimental_allow_partial: "bool | Literal['off', 'on', 'trailing-strings']" = False,  # noqa: ARG002
     ) -> Any:
         """Validate Python object."""
         return object
@@ -143,8 +143,8 @@ def convert_stub(  # noqa: PLR0913
     *,
     strict: bool = True,  # noqa: ARG001
     from_attributes: bool = False,  # noqa: ARG001
-    dec_hook: "Optional[Any]" = None,  # noqa: ARG001
-    builtin_types: "Optional[Any]" = None,  # noqa: ARG001
+    dec_hook: "Any | None" = None,  # noqa: ARG001
+    builtin_types: "Any | None" = None,  # noqa: ARG001
     str_keys: bool = False,  # noqa: ARG001
 ) -> Any:
     """Placeholder implementation."""
@@ -308,7 +308,7 @@ class EmptyEnum(Enum):
     EMPTY = 0
 
 
-EmptyType = Union[Literal[EmptyEnum.EMPTY], UnsetType]
+EmptyType = Literal[EmptyEnum.EMPTY] | UnsetType
 Empty: Final = EmptyEnum.EMPTY
 
 
@@ -336,18 +336,18 @@ class ArrowTableResult(Protocol):
     def from_arrays(
         self,
         arrays: list[Any],
-        names: "Optional[list[str]]" = None,
-        schema: "Optional[Any]" = None,
-        metadata: "Optional[Mapping[str, Any]]" = None,
+        names: "list[str] | None" = None,
+        schema: "Any | None" = None,
+        metadata: "Mapping[str, Any] | None" = None,
     ) -> Any:
         return None
 
     def from_pydict(
-        self, mapping: dict[str, Any], schema: "Optional[Any]" = None, metadata: "Optional[Mapping[str, Any]]" = None
+        self, mapping: dict[str, Any], schema: "Any | None" = None, metadata: "Mapping[str, Any] | None" = None
     ) -> Any:
         return None
 
-    def from_batches(self, batches: Iterable[Any], schema: Optional[Any] = None) -> Any:
+    def from_batches(self, batches: Iterable[Any], schema: Any | None = None) -> Any:
         return None
 
 
@@ -373,7 +373,7 @@ class ArrowRecordBatchResult(Protocol):
     def column(self, i: int) -> Any:
         return None
 
-    def slice(self, offset: int = 0, length: "Optional[int]" = None) -> Any:
+    def slice(self, offset: int = 0, length: "int | None" = None) -> Any:
         return None
 
 
@@ -409,16 +409,16 @@ except ImportError:
         def record_exception(
             self,
             exception: "Exception",
-            attributes: "Optional[Mapping[str, Any]]" = None,
-            timestamp: "Optional[int]" = None,
+            attributes: "Mapping[str, Any] | None" = None,
+            timestamp: "int | None" = None,
             escaped: bool = False,
         ) -> None:
             return None
 
-        def set_status(self, status: Any, description: "Optional[str]" = None) -> None:
+        def set_status(self, status: Any, description: "str | None" = None) -> None:
             return None
 
-        def end(self, end_time: "Optional[int]" = None) -> None:
+        def end(self, end_time: "int | None" = None) -> None:
             return None
 
         def __enter__(self) -> "Span":
@@ -445,8 +445,8 @@ except ImportError:
         def get_tracer(
             self,
             instrumenting_module_name: str,
-            instrumenting_library_version: "Optional[str]" = None,
-            schema_url: "Optional[str]" = None,
+            instrumenting_library_version: "str | None" = None,
+            schema_url: "str | None" = None,
             tracer_provider: Any = None,
         ) -> Tracer:
             return Tracer()  # type: ignore[abstract] # pragma: no cover
@@ -553,7 +553,7 @@ except ImportError:
     aiosql = _AiosqlShim()  # type: ignore[assignment]
 
     # Placeholder types for aiosql protocols
-    AiosqlParamType = Union[dict[str, Any], list[Any], tuple[Any, ...], None]  # type: ignore[misc]
+    AiosqlParamType = dict[str, Any] | list[Any] | tuple[Any, ...] | None  # type: ignore[misc]
 
     class AiosqlSQLOperationType(Enum):  # type: ignore[no-redef]
         """Enumeration of aiosql operation types."""
@@ -580,16 +580,16 @@ except ImportError:
 
         def process_sql(self, query_name: str, op_type: Any, sql: str) -> str: ...
         def select(
-            self, conn: Any, query_name: str, sql: str, parameters: Any, record_class: "Optional[Any]" = None
+            self, conn: Any, query_name: str, sql: str, parameters: Any, record_class: "Any | None" = None
         ) -> Any: ...
         def select_one(
-            self, conn: Any, query_name: str, sql: str, parameters: Any, record_class: "Optional[Any]" = None
-        ) -> "Optional[Any]": ...
-        def select_value(self, conn: Any, query_name: str, sql: str, parameters: Any) -> "Optional[Any]": ...
+            self, conn: Any, query_name: str, sql: str, parameters: Any, record_class: "Any | None" = None
+        ) -> "Any | None": ...
+        def select_value(self, conn: Any, query_name: str, sql: str, parameters: Any) -> "Any | None": ...
         def select_cursor(self, conn: Any, query_name: str, sql: str, parameters: Any) -> Any: ...
         def insert_update_delete(self, conn: Any, query_name: str, sql: str, parameters: Any) -> int: ...
         def insert_update_delete_many(self, conn: Any, query_name: str, sql: str, parameters: Any) -> int: ...
-        def insert_returning(self, conn: Any, query_name: str, sql: str, parameters: Any) -> "Optional[Any]": ...
+        def insert_returning(self, conn: Any, query_name: str, sql: str, parameters: Any) -> "Any | None": ...
 
     @runtime_checkable
     class AiosqlAsyncProtocol(Protocol):  # type: ignore[no-redef]
@@ -599,16 +599,16 @@ except ImportError:
 
         def process_sql(self, query_name: str, op_type: Any, sql: str) -> str: ...
         async def select(
-            self, conn: Any, query_name: str, sql: str, parameters: Any, record_class: "Optional[Any]" = None
+            self, conn: Any, query_name: str, sql: str, parameters: Any, record_class: "Any | None" = None
         ) -> Any: ...
         async def select_one(
-            self, conn: Any, query_name: str, sql: str, parameters: Any, record_class: "Optional[Any]" = None
-        ) -> "Optional[Any]": ...
-        async def select_value(self, conn: Any, query_name: str, sql: str, parameters: Any) -> "Optional[Any]": ...
+            self, conn: Any, query_name: str, sql: str, parameters: Any, record_class: "Any | None" = None
+        ) -> "Any | None": ...
+        async def select_value(self, conn: Any, query_name: str, sql: str, parameters: Any) -> "Any | None": ...
         async def select_cursor(self, conn: Any, query_name: str, sql: str, parameters: Any) -> Any: ...
         async def insert_update_delete(self, conn: Any, query_name: str, sql: str, parameters: Any) -> None: ...
         async def insert_update_delete_many(self, conn: Any, query_name: str, sql: str, parameters: Any) -> None: ...
-        async def insert_returning(self, conn: Any, query_name: str, sql: str, parameters: Any) -> "Optional[Any]": ...
+        async def insert_returning(self, conn: Any, query_name: str, sql: str, parameters: Any) -> "Any | None": ...
 
     AIOSQL_INSTALLED = False  # pyright: ignore[reportConstantRedefinition]  # pyright: ignore[reportConstantRedefinition]
 

--- a/sqlspec/adapters/adbc/_types.py
+++ b/sqlspec/adapters/adbc/_types.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 from adbc_driver_manager.dbapi import Connection
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
     AdbcConnection: TypeAlias = Connection
 else:

--- a/sqlspec/adapters/adbc/config.py
+++ b/sqlspec/adapters/adbc/config.py
@@ -1,8 +1,9 @@
 """ADBC database configuration."""
 
 import logging
+from collections.abc import Callable
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
 
 from typing_extensions import NotRequired
 
@@ -73,11 +74,11 @@ class AdbcConfig(NoPoolSyncConfig[AdbcConnection, AdbcDriver]):
     def __init__(
         self,
         *,
-        connection_config: Optional[Union[AdbcConnectionParams, dict[str, Any]]] = None,
-        migration_config: Optional[dict[str, Any]] = None,
-        statement_config: Optional[StatementConfig] = None,
-        driver_features: Optional[dict[str, Any]] = None,
-        bind_key: Optional[str] = None,
+        connection_config: AdbcConnectionParams | dict[str, Any] | None = None,
+        migration_config: dict[str, Any] | None = None,
+        statement_config: StatementConfig | None = None,
+        driver_features: dict[str, Any] | None = None,
+        bind_key: str | None = None,
     ) -> None:
         """Initialize configuration.
 
@@ -284,7 +285,7 @@ class AdbcConfig(NoPoolSyncConfig[AdbcConnection, AdbcDriver]):
             connection.close()
 
     def provide_session(
-        self, *args: Any, statement_config: "Optional[StatementConfig]" = None, **kwargs: Any
+        self, *args: Any, statement_config: "StatementConfig | None" = None, **kwargs: Any
     ) -> "AbstractContextManager[AdbcDriver]":
         """Provide a driver session context manager.
 

--- a/sqlspec/adapters/adbc/data_dictionary.py
+++ b/sqlspec/adapters/adbc/data_dictionary.py
@@ -1,7 +1,7 @@
 """ADBC multi-dialect data dictionary for metadata queries."""
 
 import re
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, cast
 
 from sqlspec.driver import SyncDataDictionaryBase, SyncDriverAdapterBase, VersionInfo
 from sqlspec.utils.logging import get_logger
@@ -38,7 +38,7 @@ class AdbcDataDictionary(SyncDataDictionaryBase):
         """
         return str(cast("AdbcDriver", driver).dialect)
 
-    def get_version(self, driver: SyncDriverAdapterBase) -> "Optional[VersionInfo]":
+    def get_version(self, driver: SyncDriverAdapterBase) -> "VersionInfo | None":
         """Get database version information based on detected dialect.
 
         Args:

--- a/sqlspec/adapters/adbc/driver.py
+++ b/sqlspec/adapters/adbc/driver.py
@@ -7,7 +7,7 @@ database dialects, parameter style conversion, and transaction management.
 import contextlib
 import datetime
 import decimal
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from sqlglot import exp
 
@@ -340,7 +340,7 @@ class AdbcCursor:
 
     def __init__(self, connection: "AdbcConnection") -> None:
         self.connection = connection
-        self.cursor: Optional[Cursor] = None
+        self.cursor: Cursor | None = None
 
     def __enter__(self) -> "Cursor":
         self.cursor = self.connection.cursor()
@@ -491,8 +491,8 @@ class AdbcDriver(SyncDriverAdapterBase):
     def __init__(
         self,
         connection: "AdbcConnection",
-        statement_config: "Optional[StatementConfig]" = None,
-        driver_features: "Optional[dict[str, Any]]" = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "dict[str, Any] | None" = None,
     ) -> None:
         self._detected_dialect = self._get_dialect(connection)
 
@@ -505,7 +505,7 @@ class AdbcDriver(SyncDriverAdapterBase):
 
         super().__init__(connection=connection, statement_config=statement_config, driver_features=driver_features)
         self.dialect = statement_config.dialect
-        self._data_dictionary: Optional[SyncDataDictionaryBase] = None
+        self._data_dictionary: SyncDataDictionaryBase | None = None
 
     @staticmethod
     def _ensure_pyarrow_installed() -> None:
@@ -573,7 +573,7 @@ class AdbcDriver(SyncDriverAdapterBase):
         parameters: Any,
         statement_config: "StatementConfig",
         is_many: bool = False,
-        prepared_statement: Optional[Any] = None,
+        prepared_statement: Any | None = None,
     ) -> Any:
         """Prepare parameters with cast-aware type coercion for ADBC.
 
@@ -668,7 +668,7 @@ class AdbcDriver(SyncDriverAdapterBase):
         """
         return AdbcExceptionHandler()
 
-    def _try_special_handling(self, cursor: "Cursor", statement: SQL) -> "Optional[SQLResult]":
+    def _try_special_handling(self, cursor: "Cursor", statement: SQL) -> "SQLResult | None":
         """Handle special operations.
 
         Args:
@@ -761,7 +761,7 @@ class AdbcDriver(SyncDriverAdapterBase):
             column_names = [col[0] for col in cursor.description or []]
 
             if fetched_data and isinstance(fetched_data[0], tuple):
-                dict_data: list[dict[Any, Any]] = [dict(zip(column_names, row)) for row in fetched_data]
+                dict_data: list[dict[Any, Any]] = [dict(zip(column_names, row, strict=False)) for row in fetched_data]
             else:
                 dict_data = fetched_data  # type: ignore[assignment]
 

--- a/sqlspec/adapters/aiosqlite/_types.py
+++ b/sqlspec/adapters/aiosqlite/_types.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 import aiosqlite
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
     AiosqliteConnection: TypeAlias = aiosqlite.Connection
 else:

--- a/sqlspec/adapters/aiosqlite/config.py
+++ b/sqlspec/adapters/aiosqlite/config.py
@@ -2,7 +2,7 @@
 
 import logging
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
 
 from typing_extensions import NotRequired
 
@@ -32,7 +32,7 @@ class AiosqliteConnectionParams(TypedDict, total=False):
     database: NotRequired[str]
     timeout: NotRequired[float]
     detect_types: NotRequired[int]
-    isolation_level: NotRequired[Optional[str]]
+    isolation_level: NotRequired[str | None]
     check_same_thread: NotRequired[bool]
     cached_statements: NotRequired[int]
     uri: NotRequired[bool]
@@ -57,12 +57,12 @@ class AiosqliteConfig(AsyncDatabaseConfig["AiosqliteConnection", AiosqliteConnec
     def __init__(
         self,
         *,
-        pool_config: "Optional[Union[AiosqlitePoolParams, dict[str, Any]]]" = None,
-        pool_instance: "Optional[AiosqliteConnectionPool]" = None,
-        migration_config: "Optional[dict[str, Any]]" = None,
-        statement_config: "Optional[StatementConfig]" = None,
-        driver_features: "Optional[dict[str, Any]]" = None,
-        bind_key: "Optional[str]" = None,
+        pool_config: "AiosqlitePoolParams | dict[str, Any] | None" = None,
+        pool_instance: "AiosqliteConnectionPool | None" = None,
+        migration_config: "dict[str, Any] | None" = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "dict[str, Any] | None" = None,
+        bind_key: "str | None" = None,
     ) -> None:
         """Initialize AioSQLite configuration.
 
@@ -138,7 +138,7 @@ class AiosqliteConfig(AsyncDatabaseConfig["AiosqliteConnection", AiosqliteConnec
 
     @asynccontextmanager
     async def provide_session(
-        self, *_args: Any, statement_config: "Optional[StatementConfig]" = None, **_kwargs: Any
+        self, *_args: Any, statement_config: "StatementConfig | None" = None, **_kwargs: Any
     ) -> "AsyncGenerator[AiosqliteDriver, None]":
         """Provide an async driver session context manager.
 

--- a/sqlspec/adapters/aiosqlite/data_dictionary.py
+++ b/sqlspec/adapters/aiosqlite/data_dictionary.py
@@ -1,12 +1,14 @@
 """SQLite-specific data dictionary for metadata queries via aiosqlite."""
 
 import re
-from typing import TYPE_CHECKING, Callable, Optional, cast
+from typing import TYPE_CHECKING, cast
 
 from sqlspec.driver import AsyncDataDictionaryBase, AsyncDriverAdapterBase, VersionInfo
 from sqlspec.utils.logging import get_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from sqlspec.adapters.aiosqlite.driver import AiosqliteDriver
 
 logger = get_logger("adapters.aiosqlite.data_dictionary")
@@ -20,7 +22,7 @@ __all__ = ("AiosqliteAsyncDataDictionary",)
 class AiosqliteAsyncDataDictionary(AsyncDataDictionaryBase):
     """SQLite-specific async data dictionary via aiosqlite."""
 
-    async def get_version(self, driver: AsyncDriverAdapterBase) -> "Optional[VersionInfo]":
+    async def get_version(self, driver: AsyncDriverAdapterBase) -> "VersionInfo | None":
         """Get SQLite database version information.
 
         Args:

--- a/sqlspec/adapters/aiosqlite/pool.py
+++ b/sqlspec/adapters/aiosqlite/pool.py
@@ -5,7 +5,7 @@ import logging
 import time
 import uuid
 from contextlib import asynccontextmanager, suppress
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 import aiosqlite
 
@@ -48,7 +48,7 @@ class AiosqlitePoolConnection:
         """
         self.id = uuid.uuid4().hex
         self.connection = connection
-        self.idle_since: Optional[float] = None
+        self.idle_since: float | None = None
         self._closed = False
 
     @property
@@ -160,12 +160,12 @@ class AiosqliteConnectionPool:
         self._operation_timeout = operation_timeout
 
         self._connection_registry: dict[str, AiosqlitePoolConnection] = {}
-        self._tracked_threads: set[Union[threading.Thread, AiosqliteConnection]] = set()
+        self._tracked_threads: set[threading.Thread | AiosqliteConnection] = set()
         self._wal_initialized = False
 
-        self._queue_instance: Optional[asyncio.Queue[AiosqlitePoolConnection]] = None
-        self._lock_instance: Optional[asyncio.Lock] = None
-        self._closed_event_instance: Optional[asyncio.Event] = None
+        self._queue_instance: asyncio.Queue[AiosqlitePoolConnection] | None = None
+        self._lock_instance: asyncio.Lock | None = None
+        self._closed_event_instance: asyncio.Event | None = None
 
     @property
     def _queue(self) -> "asyncio.Queue[AiosqlitePoolConnection]":
@@ -312,7 +312,7 @@ class AiosqliteConnectionPool:
         except asyncio.TimeoutError:
             logger.warning("Connection %s close timed out during retirement", connection.id)
 
-    async def _try_provision_new_connection(self) -> "Optional[AiosqlitePoolConnection]":
+    async def _try_provision_new_connection(self) -> "AiosqlitePoolConnection | None":
         """Try to create a new connection if under capacity.
 
         Returns:

--- a/sqlspec/adapters/asyncmy/_types.py
+++ b/sqlspec/adapters/asyncmy/_types.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from asyncmy import Connection  # pyright: ignore
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
     AsyncmyConnection: TypeAlias = Connection
 else:

--- a/sqlspec/adapters/asyncmy/config.py
+++ b/sqlspec/adapters/asyncmy/config.py
@@ -3,7 +3,7 @@
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
 
 import asyncmy
 from asyncmy.cursors import Cursor, DictCursor  # pyright: ignore
@@ -44,7 +44,7 @@ class AsyncmyConnectionParams(TypedDict, total=False):
     ssl: NotRequired[Any]
     sql_mode: NotRequired[str]
     init_command: NotRequired[str]
-    cursor_class: NotRequired[Union[type["Cursor"], type["DictCursor"]]]
+    cursor_class: NotRequired[type["Cursor"] | type["DictCursor"]]
     extra: NotRequired[dict[str, Any]]
 
 
@@ -66,12 +66,12 @@ class AsyncmyConfig(AsyncDatabaseConfig[AsyncmyConnection, "AsyncmyPool", Asyncm
     def __init__(
         self,
         *,
-        pool_config: "Optional[Union[AsyncmyPoolParams, dict[str, Any]]]" = None,
-        pool_instance: "Optional[AsyncmyPool]" = None,
-        migration_config: Optional[dict[str, Any]] = None,
-        statement_config: "Optional[StatementConfig]" = None,
-        driver_features: "Optional[dict[str, Any]]" = None,
-        bind_key: "Optional[str]" = None,
+        pool_config: "AsyncmyPoolParams | dict[str, Any] | None" = None,
+        pool_instance: "AsyncmyPool | None" = None,
+        migration_config: dict[str, Any] | None = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "dict[str, Any] | None" = None,
+        bind_key: "str | None" = None,
     ) -> None:
         """Initialize Asyncmy configuration.
 
@@ -146,7 +146,7 @@ class AsyncmyConfig(AsyncDatabaseConfig[AsyncmyConnection, "AsyncmyPool", Asyncm
 
     @asynccontextmanager
     async def provide_session(
-        self, *args: Any, statement_config: "Optional[StatementConfig]" = None, **kwargs: Any
+        self, *args: Any, statement_config: "StatementConfig | None" = None, **kwargs: Any
     ) -> AsyncGenerator[AsyncmyDriver, None]:
         """Provide an async driver session context manager.
 

--- a/sqlspec/adapters/asyncmy/data_dictionary.py
+++ b/sqlspec/adapters/asyncmy/data_dictionary.py
@@ -1,12 +1,14 @@
 """MySQL-specific data dictionary for metadata queries via asyncmy."""
 
 import re
-from typing import TYPE_CHECKING, Callable, Optional, cast
+from typing import TYPE_CHECKING, cast
 
 from sqlspec.driver import AsyncDataDictionaryBase, AsyncDriverAdapterBase, VersionInfo
 from sqlspec.utils.logging import get_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from sqlspec.adapters.asyncmy.driver import AsyncmyDriver
 
 logger = get_logger("adapters.asyncmy.data_dictionary")
@@ -20,7 +22,7 @@ __all__ = ("MySQLAsyncDataDictionary",)
 class MySQLAsyncDataDictionary(AsyncDataDictionaryBase):
     """MySQL-specific async data dictionary."""
 
-    async def get_version(self, driver: AsyncDriverAdapterBase) -> "Optional[VersionInfo]":
+    async def get_version(self, driver: AsyncDriverAdapterBase) -> "VersionInfo | None":
         """Get MySQL database version information.
 
         Args:

--- a/sqlspec/adapters/asyncpg/_types.py
+++ b/sqlspec/adapters/asyncpg/_types.py
@@ -1,17 +1,18 @@
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from asyncpg import Connection
 from asyncpg.pool import PoolConnectionProxy
 
 if TYPE_CHECKING:
+    from typing import TypeAlias
+
     from asyncpg import Record
-    from typing_extensions import TypeAlias
 
 
 if TYPE_CHECKING:
-    AsyncpgConnection: TypeAlias = Union[Connection[Record], PoolConnectionProxy[Record]]
+    AsyncpgConnection: TypeAlias = Connection[Record] | PoolConnectionProxy[Record]
 else:
-    AsyncpgConnection = Union[Connection, PoolConnectionProxy]
+    AsyncpgConnection = Connection | PoolConnectionProxy
 
 
 __all__ = ("AsyncpgConnection",)

--- a/sqlspec/adapters/asyncpg/config.py
+++ b/sqlspec/adapters/asyncpg/config.py
@@ -3,7 +3,7 @@
 import logging
 from collections.abc import Callable
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
 
 from asyncpg import Connection, Record
 from asyncpg import create_pool as asyncpg_create_pool
@@ -79,12 +79,12 @@ class AsyncpgConfig(AsyncDatabaseConfig[AsyncpgConnection, "Pool[Record]", Async
     def __init__(
         self,
         *,
-        pool_config: "Optional[Union[AsyncpgPoolConfig, dict[str, Any]]]" = None,
-        pool_instance: "Optional[Pool[Record]]" = None,
-        migration_config: "Optional[dict[str, Any]]" = None,
-        statement_config: "Optional[StatementConfig]" = None,
-        driver_features: "Optional[Union[AsyncpgDriverFeatures, dict[str, Any]]]" = None,
-        bind_key: "Optional[str]" = None,
+        pool_config: "AsyncpgPoolConfig | dict[str, Any] | None" = None,
+        pool_instance: "Pool[Record] | None" = None,
+        migration_config: "dict[str, Any] | None" = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "AsyncpgDriverFeatures | dict[str, Any] | None" = None,
+        bind_key: "str | None" = None,
     ) -> None:
         """Initialize AsyncPG configuration.
 
@@ -204,7 +204,7 @@ class AsyncpgConfig(AsyncDatabaseConfig[AsyncpgConnection, "Pool[Record]", Async
 
     @asynccontextmanager
     async def provide_session(
-        self, *args: Any, statement_config: "Optional[StatementConfig]" = None, **kwargs: Any
+        self, *args: Any, statement_config: "StatementConfig | None" = None, **kwargs: Any
     ) -> "AsyncGenerator[AsyncpgDriver, None]":
         """Provide an async driver session context manager.
 

--- a/sqlspec/adapters/asyncpg/data_dictionary.py
+++ b/sqlspec/adapters/asyncpg/data_dictionary.py
@@ -1,12 +1,14 @@
 """PostgreSQL-specific data dictionary for metadata queries via asyncpg."""
 
 import re
-from typing import TYPE_CHECKING, Callable, Optional, cast
+from typing import TYPE_CHECKING, cast
 
 from sqlspec.driver import AsyncDataDictionaryBase, AsyncDriverAdapterBase, VersionInfo
 from sqlspec.utils.logging import get_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from sqlspec.adapters.asyncpg.driver import AsyncpgDriver
 
 logger = get_logger("adapters.asyncpg.data_dictionary")
@@ -20,7 +22,7 @@ __all__ = ("PostgresAsyncDataDictionary",)
 class PostgresAsyncDataDictionary(AsyncDataDictionaryBase):
     """PostgreSQL-specific async data dictionary."""
 
-    async def get_version(self, driver: AsyncDriverAdapterBase) -> "Optional[VersionInfo]":
+    async def get_version(self, driver: AsyncDriverAdapterBase) -> "VersionInfo | None":
         """Get PostgreSQL database version information.
 
         Args:

--- a/sqlspec/adapters/asyncpg/driver.py
+++ b/sqlspec/adapters/asyncpg/driver.py
@@ -6,7 +6,7 @@ PostgreSQL COPY operation support, and transaction management.
 
 import datetime
 import re
-from typing import TYPE_CHECKING, Any, Final, Optional
+from typing import TYPE_CHECKING, Any, Final
 
 import asyncpg
 
@@ -222,7 +222,7 @@ class AsyncpgExceptionHandler:
         msg = f"PostgreSQL operational error [{code}]: {e}"
         raise OperationalError(msg) from e
 
-    def _raise_generic_error(self, e: Any, code: "Optional[str]") -> None:
+    def _raise_generic_error(self, e: Any, code: "str | None") -> None:
         msg = f"PostgreSQL database error [{code}]: {e}" if code else f"PostgreSQL database error: {e}"
         raise SQLSpecError(msg) from e
 
@@ -241,8 +241,8 @@ class AsyncpgDriver(AsyncDriverAdapterBase):
     def __init__(
         self,
         connection: "AsyncpgConnection",
-        statement_config: "Optional[StatementConfig]" = None,
-        driver_features: "Optional[dict[str, Any]]" = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "dict[str, Any] | None" = None,
     ) -> None:
         if statement_config is None:
             cache_config = get_cache_config()
@@ -254,7 +254,7 @@ class AsyncpgDriver(AsyncDriverAdapterBase):
             )
 
         super().__init__(connection=connection, statement_config=statement_config, driver_features=driver_features)
-        self._data_dictionary: Optional[AsyncDataDictionaryBase] = None
+        self._data_dictionary: AsyncDataDictionaryBase | None = None
 
     def with_cursor(self, connection: "AsyncpgConnection") -> "AsyncpgCursor":
         """Create context manager for AsyncPG cursor."""
@@ -264,7 +264,7 @@ class AsyncpgDriver(AsyncDriverAdapterBase):
         """Handle database exceptions with PostgreSQL error codes."""
         return AsyncpgExceptionHandler()
 
-    async def _try_special_handling(self, cursor: "AsyncpgConnection", statement: "SQL") -> "Optional[SQLResult]":
+    async def _try_special_handling(self, cursor: "AsyncpgConnection", statement: "SQL") -> "SQLResult | None":
         """Handle PostgreSQL COPY operations and other special cases.
 
         Args:

--- a/sqlspec/adapters/bigquery/_types.py
+++ b/sqlspec/adapters/bigquery/_types.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from google.cloud.bigquery import Client
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
     BigQueryConnection: TypeAlias = Client
 else:

--- a/sqlspec/adapters/bigquery/config.py
+++ b/sqlspec/adapters/bigquery/config.py
@@ -2,7 +2,7 @@
 
 import contextlib
 import logging
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
 
 from google.cloud.bigquery import LoadJobConfig, QueryJobConfig
 from typing_extensions import NotRequired
@@ -14,7 +14,7 @@ from sqlspec.exceptions import ImproperConfigurationError
 from sqlspec.typing import Empty
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
 
     from google.api_core.client_info import ClientInfo
     from google.api_core.client_options import ClientOptions
@@ -90,11 +90,11 @@ class BigQueryConfig(NoPoolSyncConfig[BigQueryConnection, BigQueryDriver]):
     def __init__(
         self,
         *,
-        connection_config: "Optional[Union[BigQueryConnectionParams, dict[str, Any]]]" = None,
-        migration_config: Optional[dict[str, Any]] = None,
-        statement_config: "Optional[StatementConfig]" = None,
-        driver_features: "Optional[Union[BigQueryDriverFeatures, dict[str, Any]]]" = None,
-        bind_key: "Optional[str]" = None,
+        connection_config: "BigQueryConnectionParams | dict[str, Any] | None" = None,
+        migration_config: dict[str, Any] | None = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "BigQueryDriverFeatures | dict[str, Any] | None" = None,
+        bind_key: "str | None" = None,
     ) -> None:
         """Initialize BigQuery configuration.
 
@@ -113,7 +113,7 @@ class BigQueryConfig(NoPoolSyncConfig[BigQueryConnection, BigQueryDriver]):
 
         self.driver_features: dict[str, Any] = dict(driver_features) if driver_features else {}
 
-        self._connection_instance: Optional[BigQueryConnection] = self.driver_features.get("connection_instance")
+        self._connection_instance: BigQueryConnection | None = self.driver_features.get("connection_instance")
 
         if "default_query_job_config" not in self.connection_config:
             self._setup_default_job_config()
@@ -215,7 +215,7 @@ class BigQueryConfig(NoPoolSyncConfig[BigQueryConnection, BigQueryDriver]):
 
     @contextlib.contextmanager
     def provide_session(
-        self, *_args: Any, statement_config: "Optional[StatementConfig]" = None, **_kwargs: Any
+        self, *_args: Any, statement_config: "StatementConfig | None" = None, **_kwargs: Any
     ) -> "Generator[BigQueryDriver, None, None]":
         """Provide a BigQuery driver session context manager.
 

--- a/sqlspec/adapters/bigquery/data_dictionary.py
+++ b/sqlspec/adapters/bigquery/data_dictionary.py
@@ -1,7 +1,5 @@
 """BigQuery-specific data dictionary for metadata queries."""
 
-from typing import Optional
-
 from sqlspec.driver import SyncDataDictionaryBase, SyncDriverAdapterBase, VersionInfo
 from sqlspec.utils.logging import get_logger
 
@@ -13,7 +11,7 @@ __all__ = ("BigQuerySyncDataDictionary",)
 class BigQuerySyncDataDictionary(SyncDataDictionaryBase):
     """BigQuery-specific sync data dictionary."""
 
-    def get_version(self, driver: SyncDriverAdapterBase) -> "Optional[VersionInfo]":
+    def get_version(self, driver: SyncDriverAdapterBase) -> "VersionInfo | None":
         """Get BigQuery version information.
 
         BigQuery is a cloud service without traditional versioning.

--- a/sqlspec/adapters/bigquery/type_converter.py
+++ b/sqlspec/adapters/bigquery/type_converter.py
@@ -5,7 +5,7 @@ for the native BigQuery driver.
 """
 
 from functools import lru_cache
-from typing import Any, Final, Optional
+from typing import Any, Final
 from uuid import UUID
 
 from sqlspec.core.type_conversion import BaseTypeConverter, convert_uuid
@@ -79,7 +79,7 @@ class BigQueryTypeConverter(BaseTypeConverter):
             return value
         return self._convert_cache(value)
 
-    def create_parameter(self, name: str, value: Any) -> Optional[Any]:
+    def create_parameter(self, name: str, value: Any) -> Any | None:
         """Create BigQuery parameter with proper type mapping.
 
         Args:

--- a/sqlspec/adapters/duckdb/_types.py
+++ b/sqlspec/adapters/duckdb/_types.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from duckdb import DuckDBPyConnection  # type: ignore[import-untyped]
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
     DuckDBConnection: TypeAlias = DuckDBPyConnection
 else:

--- a/sqlspec/adapters/duckdb/config.py
+++ b/sqlspec/adapters/duckdb/config.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Sequence
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypedDict, Union, cast
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 
 from typing_extensions import NotRequired
 
@@ -116,7 +116,7 @@ class DuckDBDriverFeatures(TypedDict, total=False):
     """List of extensions to install/load on connection creation."""
     secrets: NotRequired[Sequence[DuckDBSecretConfig]]
     """List of secrets to create for AI/API integrations."""
-    on_connection_create: NotRequired["Callable[[DuckDBConnection], Optional[DuckDBConnection]]"]
+    on_connection_create: NotRequired["Callable[[DuckDBConnection], DuckDBConnection | None]"]
     """Callback executed when connection is created."""
 
 
@@ -144,12 +144,12 @@ class DuckDBConfig(SyncDatabaseConfig[DuckDBConnection, DuckDBConnectionPool, Du
     def __init__(
         self,
         *,
-        pool_config: "Optional[Union[DuckDBPoolParams, dict[str, Any]]]" = None,
-        pool_instance: "Optional[DuckDBConnectionPool]" = None,
-        migration_config: Optional[dict[str, Any]] = None,
-        statement_config: "Optional[StatementConfig]" = None,
-        driver_features: "Optional[Union[DuckDBDriverFeatures, dict[str, Any]]]" = None,
-        bind_key: "Optional[str]" = None,
+        pool_config: "DuckDBPoolParams | dict[str, Any] | None" = None,
+        pool_instance: "DuckDBConnectionPool | None" = None,
+        migration_config: dict[str, Any] | None = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "DuckDBDriverFeatures | dict[str, Any] | None" = None,
+        bind_key: "str | None" = None,
     ) -> None:
         """Initialize DuckDB configuration."""
         if pool_config is None:
@@ -247,7 +247,7 @@ class DuckDBConfig(SyncDatabaseConfig[DuckDBConnection, DuckDBConnectionPool, Du
 
     @contextmanager
     def provide_session(
-        self, *args: Any, statement_config: "Optional[StatementConfig]" = None, **kwargs: Any
+        self, *args: Any, statement_config: "StatementConfig | None" = None, **kwargs: Any
     ) -> "Generator[DuckDBDriver, None, None]":
         """Provide a DuckDB driver session context manager.
 

--- a/sqlspec/adapters/duckdb/data_dictionary.py
+++ b/sqlspec/adapters/duckdb/data_dictionary.py
@@ -1,12 +1,14 @@
 """DuckDB-specific data dictionary for metadata queries."""
 
 import re
-from typing import TYPE_CHECKING, Callable, Optional, cast
+from typing import TYPE_CHECKING, cast
 
 from sqlspec.driver import SyncDataDictionaryBase, SyncDriverAdapterBase, VersionInfo
 from sqlspec.utils.logging import get_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from sqlspec.adapters.duckdb.driver import DuckDBDriver
 
 logger = get_logger("adapters.duckdb.data_dictionary")
@@ -20,7 +22,7 @@ __all__ = ("DuckDBSyncDataDictionary",)
 class DuckDBSyncDataDictionary(SyncDataDictionaryBase):
     """DuckDB-specific sync data dictionary."""
 
-    def get_version(self, driver: SyncDriverAdapterBase) -> "Optional[VersionInfo]":
+    def get_version(self, driver: SyncDriverAdapterBase) -> "VersionInfo | None":
         """Get DuckDB database version information.
 
         Args:

--- a/sqlspec/adapters/duckdb/driver.py
+++ b/sqlspec/adapters/duckdb/driver.py
@@ -2,7 +2,7 @@
 
 import datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, Final, Optional
+from typing import TYPE_CHECKING, Any, Final
 
 import duckdb  # type: ignore[import-untyped]
 from sqlglot import exp
@@ -81,7 +81,7 @@ class DuckDBCursor:
 
     def __init__(self, connection: "DuckDBConnection") -> None:
         self.connection = connection
-        self.cursor: Optional[Any] = None
+        self.cursor: Any | None = None
 
     def __enter__(self) -> Any:
         self.cursor = self.connection.cursor()
@@ -211,8 +211,8 @@ class DuckDBDriver(SyncDriverAdapterBase):
     def __init__(
         self,
         connection: "DuckDBConnection",
-        statement_config: "Optional[StatementConfig]" = None,
-        driver_features: "Optional[dict[str, Any]]" = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "dict[str, Any] | None" = None,
     ) -> None:
         if statement_config is None:
             cache_config = get_cache_config()
@@ -225,7 +225,7 @@ class DuckDBDriver(SyncDriverAdapterBase):
             statement_config = updated_config
 
         super().__init__(connection=connection, statement_config=statement_config, driver_features=driver_features)
-        self._data_dictionary: Optional[SyncDataDictionaryBase] = None
+        self._data_dictionary: SyncDataDictionaryBase | None = None
 
     def with_cursor(self, connection: "DuckDBConnection") -> "DuckDBCursor":
         """Create context manager for DuckDB cursor.
@@ -246,7 +246,7 @@ class DuckDBDriver(SyncDriverAdapterBase):
         """
         return DuckDBExceptionHandler()
 
-    def _try_special_handling(self, cursor: Any, statement: SQL) -> "Optional[SQLResult]":
+    def _try_special_handling(self, cursor: Any, statement: SQL) -> "SQLResult | None":
         """Handle DuckDB-specific special operations.
 
         DuckDB does not require special operation handling, so this method
@@ -361,7 +361,7 @@ class DuckDBDriver(SyncDriverAdapterBase):
             column_names = [col[0] for col in cursor.description or []]
 
             if fetched_data and isinstance(fetched_data[0], tuple):
-                dict_data = [dict(zip(column_names, row)) for row in fetched_data]
+                dict_data = [dict(zip(column_names, row, strict=False)) for row in fetched_data]
             else:
                 dict_data = fetched_data
 

--- a/sqlspec/adapters/duckdb/pool.py
+++ b/sqlspec/adapters/duckdb/pool.py
@@ -4,7 +4,7 @@ import logging
 import threading
 import time
 from contextlib import contextmanager, suppress
-from typing import TYPE_CHECKING, Any, Final, Optional, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 
 import duckdb  # type: ignore[import-untyped]
 
@@ -51,9 +51,9 @@ class DuckDBConnectionPool:
         self,
         connection_config: "dict[str, Any]",
         pool_recycle_seconds: int = POOL_RECYCLE,
-        extensions: "Optional[list[dict[str, Any]]]" = None,
-        secrets: "Optional[list[dict[str, Any]]]" = None,
-        on_connection_create: "Optional[Callable[[DuckDBConnection], None]]" = None,
+        extensions: "list[dict[str, Any]] | None" = None,
+        secrets: "list[dict[str, Any]] | None" = None,
+        on_connection_create: "Callable[[DuckDBConnection], None] | None" = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the thread-local connection manager.

--- a/sqlspec/adapters/oracledb/_types.py
+++ b/sqlspec/adapters/oracledb/_types.py
@@ -3,8 +3,9 @@ from typing import TYPE_CHECKING
 from oracledb import AsyncConnection, Connection
 
 if TYPE_CHECKING:
+    from typing import TypeAlias
+
     from oracledb.pool import AsyncConnectionPool, ConnectionPool
-    from typing_extensions import TypeAlias
 
     OracleSyncConnection: TypeAlias = Connection
     OracleAsyncConnection: TypeAlias = AsyncConnection

--- a/sqlspec/adapters/oracledb/config.py
+++ b/sqlspec/adapters/oracledb/config.py
@@ -3,7 +3,7 @@
 import contextlib
 import logging
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypedDict, Union, cast
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 
 import oracledb
 from typing_extensions import NotRequired
@@ -89,12 +89,12 @@ class OracleSyncConfig(SyncDatabaseConfig[OracleSyncConnection, "OracleSyncConne
     def __init__(
         self,
         *,
-        pool_config: "Optional[Union[OraclePoolParams, dict[str, Any]]]" = None,
-        pool_instance: "Optional[OracleSyncConnectionPool]" = None,
-        migration_config: Optional[dict[str, Any]] = None,
-        statement_config: "Optional[StatementConfig]" = None,
-        driver_features: "Optional[dict[str, Any]]" = None,
-        bind_key: "Optional[str]" = None,
+        pool_config: "OraclePoolParams | dict[str, Any] | None" = None,
+        pool_instance: "OracleSyncConnectionPool | None" = None,
+        migration_config: dict[str, Any] | None = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "dict[str, Any] | None" = None,
+        bind_key: "str | None" = None,
     ) -> None:
         """Initialize Oracle synchronous configuration.
 
@@ -158,7 +158,7 @@ class OracleSyncConfig(SyncDatabaseConfig[OracleSyncConnection, "OracleSyncConne
 
     @contextlib.contextmanager
     def provide_session(
-        self, *args: Any, statement_config: "Optional[StatementConfig]" = None, **kwargs: Any
+        self, *args: Any, statement_config: "StatementConfig | None" = None, **kwargs: Any
     ) -> "Generator[OracleSyncDriver, None, None]":
         """Provide a driver session context manager.
 
@@ -218,12 +218,12 @@ class OracleAsyncConfig(AsyncDatabaseConfig[OracleAsyncConnection, "OracleAsyncC
     def __init__(
         self,
         *,
-        pool_config: "Optional[Union[OraclePoolParams, dict[str, Any]]]" = None,
-        pool_instance: "Optional[OracleAsyncConnectionPool]" = None,
-        migration_config: Optional[dict[str, Any]] = None,
-        statement_config: "Optional[StatementConfig]" = None,
-        driver_features: "Optional[dict[str, Any]]" = None,
-        bind_key: "Optional[str]" = None,
+        pool_config: "OraclePoolParams | dict[str, Any] | None" = None,
+        pool_instance: "OracleAsyncConnectionPool | None" = None,
+        migration_config: dict[str, Any] | None = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "dict[str, Any] | None" = None,
+        bind_key: "str | None" = None,
     ) -> None:
         """Initialize Oracle asynchronous configuration.
 
@@ -291,7 +291,7 @@ class OracleAsyncConfig(AsyncDatabaseConfig[OracleAsyncConnection, "OracleAsyncC
 
     @asynccontextmanager
     async def provide_session(
-        self, *args: Any, statement_config: "Optional[StatementConfig]" = None, **kwargs: Any
+        self, *args: Any, statement_config: "StatementConfig | None" = None, **kwargs: Any
     ) -> "AsyncGenerator[OracleAsyncDriver, None]":
         """Provide an async driver session context manager.
 

--- a/sqlspec/adapters/oracledb/data_dictionary.py
+++ b/sqlspec/adapters/oracledb/data_dictionary.py
@@ -3,7 +3,7 @@
 
 import re
 from contextlib import suppress
-from typing import TYPE_CHECKING, Callable, Optional, cast
+from typing import TYPE_CHECKING, cast
 
 from sqlspec.driver import (
     AsyncDataDictionaryBase,
@@ -15,6 +15,8 @@ from sqlspec.driver import (
 from sqlspec.utils.logging import get_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from sqlspec.adapters.oracledb.driver import OracleAsyncDriver, OracleSyncDriver
 
 logger = get_logger("adapters.oracledb.data_dictionary")
@@ -35,12 +37,7 @@ class OracleVersionInfo(VersionInfo):
     """Oracle database version information."""
 
     def __init__(
-        self,
-        major: int,
-        minor: int = 0,
-        patch: int = 0,
-        compatible: "Optional[str]" = None,
-        is_autonomous: bool = False,
+        self, major: int, minor: int = 0, patch: int = 0, compatible: "str | None" = None, is_autonomous: bool = False
     ) -> None:
         """Initialize Oracle version info.
 
@@ -56,7 +53,7 @@ class OracleVersionInfo(VersionInfo):
         self.is_autonomous = is_autonomous
 
     @property
-    def compatible_major(self) -> "Optional[int]":
+    def compatible_major(self) -> "int | None":
         """Get major version from compatible parameter."""
         if not self.compatible:
             return None
@@ -109,7 +106,7 @@ class OracleDataDictionaryMixin:
 
     __slots__ = ()
 
-    def _get_oracle_version(self, driver: "OracleAsyncDriver | OracleSyncDriver") -> "Optional[OracleVersionInfo]":
+    def _get_oracle_version(self, driver: "OracleAsyncDriver | OracleSyncDriver") -> "OracleVersionInfo | None":
         """Get Oracle database version information.
 
         Args:
@@ -143,7 +140,7 @@ class OracleDataDictionaryMixin:
         logger.debug("Detected Oracle version: %s", version_info)
         return version_info
 
-    def _get_oracle_compatible(self, driver: "OracleAsyncDriver | OracleSyncDriver") -> "Optional[str]":
+    def _get_oracle_compatible(self, driver: "OracleAsyncDriver | OracleSyncDriver") -> "str | None":
         """Get Oracle compatible parameter value.
 
         Args:
@@ -160,7 +157,7 @@ class OracleDataDictionaryMixin:
             logger.warning("Compatible parameter not found")
             return None
 
-    def _get_oracle_json_type(self, version_info: "Optional[OracleVersionInfo]") -> str:
+    def _get_oracle_json_type(self, version_info: "OracleVersionInfo | None") -> str:
         """Determine the appropriate JSON column type for Oracle.
 
         Args:
@@ -202,7 +199,7 @@ class OracleSyncDataDictionary(OracleDataDictionaryMixin, SyncDataDictionaryBase
         result = driver.select_value_or_none("SELECT COUNT(*) as cnt FROM v$pdbs WHERE cloud_identity IS NOT NULL")
         return bool(result and int(result) > 0)
 
-    def get_version(self, driver: SyncDriverAdapterBase) -> "Optional[OracleVersionInfo]":
+    def get_version(self, driver: SyncDriverAdapterBase) -> "OracleVersionInfo | None":
         """Get Oracle database version information.
 
         Args:
@@ -296,7 +293,7 @@ class OracleSyncDataDictionary(OracleDataDictionaryMixin, SyncDataDictionaryBase
 class OracleAsyncDataDictionary(OracleDataDictionaryMixin, AsyncDataDictionaryBase):
     """Oracle-specific async data dictionary."""
 
-    async def get_version(self, driver: AsyncDriverAdapterBase) -> "Optional[OracleVersionInfo]":
+    async def get_version(self, driver: AsyncDriverAdapterBase) -> "OracleVersionInfo | None":
         """Get Oracle database version information.
 
         Args:
@@ -336,7 +333,7 @@ class OracleAsyncDataDictionary(OracleDataDictionaryMixin, AsyncDataDictionaryBa
         logger.debug("Detected Oracle version: %s", version_info)
         return version_info
 
-    async def _get_oracle_compatible_async(self, driver: "OracleAsyncDriver") -> "Optional[str]":
+    async def _get_oracle_compatible_async(self, driver: "OracleAsyncDriver") -> "str | None":
         """Get Oracle compatible parameter value (async version).
 
         Args:

--- a/sqlspec/adapters/oracledb/migrations.py
+++ b/sqlspec/adapters/oracledb/migrations.py
@@ -5,7 +5,7 @@ to handle Oracle's unique SQL syntax requirements.
 """
 
 import getpass
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from sqlspec._sql import sql
 from sqlspec.builder import CreateTable
@@ -85,7 +85,7 @@ class OracleSyncMigrationTracker(OracleMigrationTrackerMixin, BaseMigrationTrack
         driver.execute_script(create_script)
         driver.commit()
 
-    def get_current_version(self, driver: "SyncDriverAdapterBase") -> "Optional[str]":
+    def get_current_version(self, driver: "SyncDriverAdapterBase") -> "str | None":
         """Get the latest applied migration version.
 
         Args:
@@ -181,7 +181,7 @@ class OracleAsyncMigrationTracker(OracleMigrationTrackerMixin, BaseMigrationTrac
         await driver.execute_script(create_script)
         await driver.commit()
 
-    async def get_current_version(self, driver: "AsyncDriverAdapterBase") -> "Optional[str]":
+    async def get_current_version(self, driver: "AsyncDriverAdapterBase") -> "str | None":
         """Get the latest applied migration version.
 
         Args:

--- a/sqlspec/adapters/psqlpy/_types.py
+++ b/sqlspec/adapters/psqlpy/_types.py
@@ -1,8 +1,9 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import TypeAlias
+
     from psqlpy import Connection
-    from typing_extensions import TypeAlias
 
     PsqlpyConnection: TypeAlias = Connection
 else:

--- a/sqlspec/adapters/psqlpy/config.py
+++ b/sqlspec/adapters/psqlpy/config.py
@@ -3,7 +3,7 @@
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
 
 from psqlpy import ConnectionPool
 from typing_extensions import NotRequired
@@ -85,12 +85,12 @@ class PsqlpyConfig(AsyncDatabaseConfig[PsqlpyConnection, ConnectionPool, PsqlpyD
     def __init__(
         self,
         *,
-        pool_config: Optional[Union[PsqlpyPoolParams, dict[str, Any]]] = None,
-        pool_instance: Optional[ConnectionPool] = None,
-        migration_config: Optional[dict[str, Any]] = None,
-        statement_config: Optional[StatementConfig] = None,
-        driver_features: Optional[dict[str, Any]] = None,
-        bind_key: Optional[str] = None,
+        pool_config: PsqlpyPoolParams | dict[str, Any] | None = None,
+        pool_instance: ConnectionPool | None = None,
+        migration_config: dict[str, Any] | None = None,
+        statement_config: StatementConfig | None = None,
+        driver_features: dict[str, Any] | None = None,
+        bind_key: str | None = None,
     ) -> None:
         """Initialize Psqlpy configuration.
 
@@ -185,7 +185,7 @@ class PsqlpyConfig(AsyncDatabaseConfig[PsqlpyConnection, ConnectionPool, PsqlpyD
 
     @asynccontextmanager
     async def provide_session(
-        self, *args: Any, statement_config: "Optional[StatementConfig]" = None, **kwargs: Any
+        self, *args: Any, statement_config: "StatementConfig | None" = None, **kwargs: Any
     ) -> AsyncGenerator[PsqlpyDriver, None]:
         """Provide an async driver session context manager.
 

--- a/sqlspec/adapters/psqlpy/data_dictionary.py
+++ b/sqlspec/adapters/psqlpy/data_dictionary.py
@@ -1,12 +1,14 @@
 """PostgreSQL-specific data dictionary for metadata queries via psqlpy."""
 
 import re
-from typing import TYPE_CHECKING, Callable, Optional, cast
+from typing import TYPE_CHECKING, cast
 
 from sqlspec.driver import AsyncDataDictionaryBase, AsyncDriverAdapterBase, VersionInfo
 from sqlspec.utils.logging import get_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from sqlspec.adapters.psqlpy.driver import PsqlpyDriver
 
 logger = get_logger("adapters.psqlpy.data_dictionary")
@@ -20,7 +22,7 @@ __all__ = ("PsqlpyAsyncDataDictionary",)
 class PsqlpyAsyncDataDictionary(AsyncDataDictionaryBase):
     """PostgreSQL-specific async data dictionary via psqlpy."""
 
-    async def get_version(self, driver: AsyncDriverAdapterBase) -> "Optional[VersionInfo]":
+    async def get_version(self, driver: AsyncDriverAdapterBase) -> "VersionInfo | None":
         """Get PostgreSQL database version information.
 
         Args:

--- a/sqlspec/adapters/psqlpy/driver.py
+++ b/sqlspec/adapters/psqlpy/driver.py
@@ -6,7 +6,7 @@ and transaction management.
 
 import decimal
 import re
-from typing import TYPE_CHECKING, Any, Final, Optional
+from typing import TYPE_CHECKING, Any, Final
 
 import psqlpy
 import psqlpy.exceptions
@@ -155,47 +155,47 @@ class PsqlpyExceptionHandler:
         else:
             self._raise_generic_error(e, None)
 
-    def _raise_unique_violation(self, e: Any, code: "Optional[str]") -> None:
+    def _raise_unique_violation(self, e: Any, code: "str | None") -> None:
         msg = f"PostgreSQL unique constraint violation: {e}"
         raise UniqueViolationError(msg) from e
 
-    def _raise_foreign_key_violation(self, e: Any, code: "Optional[str]") -> None:
+    def _raise_foreign_key_violation(self, e: Any, code: "str | None") -> None:
         msg = f"PostgreSQL foreign key constraint violation: {e}"
         raise ForeignKeyViolationError(msg) from e
 
-    def _raise_not_null_violation(self, e: Any, code: "Optional[str]") -> None:
+    def _raise_not_null_violation(self, e: Any, code: "str | None") -> None:
         msg = f"PostgreSQL not-null constraint violation: {e}"
         raise NotNullViolationError(msg) from e
 
-    def _raise_check_violation(self, e: Any, code: "Optional[str]") -> None:
+    def _raise_check_violation(self, e: Any, code: "str | None") -> None:
         msg = f"PostgreSQL check constraint violation: {e}"
         raise CheckViolationError(msg) from e
 
-    def _raise_integrity_error(self, e: Any, code: "Optional[str]") -> None:
+    def _raise_integrity_error(self, e: Any, code: "str | None") -> None:
         msg = f"PostgreSQL integrity constraint violation: {e}"
         raise IntegrityError(msg) from e
 
-    def _raise_parsing_error(self, e: Any, code: "Optional[str]") -> None:
+    def _raise_parsing_error(self, e: Any, code: "str | None") -> None:
         msg = f"PostgreSQL SQL syntax error: {e}"
         raise SQLParsingError(msg) from e
 
-    def _raise_connection_error(self, e: Any, code: "Optional[str]") -> None:
+    def _raise_connection_error(self, e: Any, code: "str | None") -> None:
         msg = f"PostgreSQL connection error: {e}"
         raise DatabaseConnectionError(msg) from e
 
-    def _raise_transaction_error(self, e: Any, code: "Optional[str]") -> None:
+    def _raise_transaction_error(self, e: Any, code: "str | None") -> None:
         msg = f"PostgreSQL transaction error: {e}"
         raise TransactionError(msg) from e
 
-    def _raise_data_error(self, e: Any, code: "Optional[str]") -> None:
+    def _raise_data_error(self, e: Any, code: "str | None") -> None:
         msg = f"PostgreSQL data error: {e}"
         raise DataError(msg) from e
 
-    def _raise_operational_error(self, e: Any, code: "Optional[str]") -> None:
+    def _raise_operational_error(self, e: Any, code: "str | None") -> None:
         msg = f"PostgreSQL operational error: {e}"
         raise OperationalError(msg) from e
 
-    def _raise_generic_error(self, e: Any, code: "Optional[str]") -> None:
+    def _raise_generic_error(self, e: Any, code: "str | None") -> None:
         msg = f"PostgreSQL database error: {e}"
         raise SQLSpecError(msg) from e
 
@@ -213,8 +213,8 @@ class PsqlpyDriver(AsyncDriverAdapterBase):
     def __init__(
         self,
         connection: "PsqlpyConnection",
-        statement_config: "Optional[StatementConfig]" = None,
-        driver_features: "Optional[dict[str, Any]]" = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "dict[str, Any] | None" = None,
     ) -> None:
         if statement_config is None:
             cache_config = get_cache_config()
@@ -226,7 +226,7 @@ class PsqlpyDriver(AsyncDriverAdapterBase):
             )
 
         super().__init__(connection=connection, statement_config=statement_config, driver_features=driver_features)
-        self._data_dictionary: Optional[AsyncDataDictionaryBase] = None
+        self._data_dictionary: AsyncDataDictionaryBase | None = None
 
     def with_cursor(self, connection: "PsqlpyConnection") -> "PsqlpyCursor":
         """Create context manager for psqlpy cursor.
@@ -247,7 +247,7 @@ class PsqlpyDriver(AsyncDriverAdapterBase):
         """
         return PsqlpyExceptionHandler()
 
-    async def _try_special_handling(self, cursor: "PsqlpyConnection", statement: SQL) -> "Optional[SQLResult]":
+    async def _try_special_handling(self, cursor: "PsqlpyConnection", statement: SQL) -> "SQLResult | None":
         """Hook for psqlpy-specific special operations.
 
         Args:

--- a/sqlspec/adapters/psqlpy/type_converter.py
+++ b/sqlspec/adapters/psqlpy/type_converter.py
@@ -7,7 +7,7 @@ backward compatibility.
 
 import re
 from functools import lru_cache
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from sqlspec.core.type_conversion import BaseTypeConverter
 
@@ -62,7 +62,7 @@ class PostgreSQLTypeConverter(BaseTypeConverter):
             return value
         return self._convert_cache(value)
 
-    def detect_type(self, value: str) -> Optional[str]:
+    def detect_type(self, value: str) -> str | None:
         """Detect types including PostgreSQL-specific types.
 
         Args:

--- a/sqlspec/adapters/psycopg/_types.py
+++ b/sqlspec/adapters/psycopg/_types.py
@@ -3,8 +3,9 @@ from typing import TYPE_CHECKING
 from psycopg.rows import DictRow as PsycopgDictRow
 
 if TYPE_CHECKING:
+    from typing import TypeAlias
+
     from psycopg import AsyncConnection, Connection
-    from typing_extensions import TypeAlias
 
     PsycopgSyncConnection: TypeAlias = Connection[PsycopgDictRow]
     PsycopgAsyncConnection: TypeAlias = AsyncConnection[PsycopgDictRow]

--- a/sqlspec/adapters/psycopg/config.py
+++ b/sqlspec/adapters/psycopg/config.py
@@ -3,7 +3,7 @@
 import contextlib
 import logging
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypedDict, Union, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypedDict, cast
 
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool, ConnectionPool
@@ -83,12 +83,12 @@ class PsycopgSyncConfig(SyncDatabaseConfig[PsycopgSyncConnection, ConnectionPool
     def __init__(
         self,
         *,
-        pool_config: "Optional[Union[PsycopgPoolParams, dict[str, Any]]]" = None,
+        pool_config: "PsycopgPoolParams | dict[str, Any] | None" = None,
         pool_instance: Optional["ConnectionPool"] = None,
-        migration_config: Optional[dict[str, Any]] = None,
-        statement_config: "Optional[StatementConfig]" = None,
-        driver_features: "Optional[dict[str, Any]]" = None,
-        bind_key: "Optional[str]" = None,
+        migration_config: dict[str, Any] | None = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "dict[str, Any] | None" = None,
+        bind_key: "str | None" = None,
     ) -> None:
         """Initialize Psycopg synchronous configuration.
 
@@ -219,7 +219,7 @@ class PsycopgSyncConfig(SyncDatabaseConfig[PsycopgSyncConnection, ConnectionPool
 
     @contextlib.contextmanager
     def provide_session(
-        self, *args: Any, statement_config: "Optional[StatementConfig]" = None, **kwargs: Any
+        self, *args: Any, statement_config: "StatementConfig | None" = None, **kwargs: Any
     ) -> "Generator[PsycopgSyncDriver, None, None]":
         """Provide a driver session context manager.
 
@@ -268,12 +268,12 @@ class PsycopgAsyncConfig(AsyncDatabaseConfig[PsycopgAsyncConnection, AsyncConnec
     def __init__(
         self,
         *,
-        pool_config: "Optional[Union[PsycopgPoolParams, dict[str, Any]]]" = None,
-        pool_instance: "Optional[AsyncConnectionPool]" = None,
-        migration_config: "Optional[dict[str, Any]]" = None,
-        statement_config: "Optional[StatementConfig]" = None,
-        driver_features: "Optional[dict[str, Any]]" = None,
-        bind_key: "Optional[str]" = None,
+        pool_config: "PsycopgPoolParams | dict[str, Any] | None" = None,
+        pool_instance: "AsyncConnectionPool | None" = None,
+        migration_config: "dict[str, Any] | None" = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "dict[str, Any] | None" = None,
+        bind_key: "str | None" = None,
     ) -> None:
         """Initialize Psycopg asynchronous configuration.
 
@@ -394,7 +394,7 @@ class PsycopgAsyncConfig(AsyncDatabaseConfig[PsycopgAsyncConnection, AsyncConnec
 
     @asynccontextmanager
     async def provide_session(
-        self, *args: Any, statement_config: "Optional[StatementConfig]" = None, **kwargs: Any
+        self, *args: Any, statement_config: "StatementConfig | None" = None, **kwargs: Any
     ) -> "AsyncGenerator[PsycopgAsyncDriver, None]":
         """Provide an async driver session context manager.
 

--- a/sqlspec/adapters/psycopg/data_dictionary.py
+++ b/sqlspec/adapters/psycopg/data_dictionary.py
@@ -1,7 +1,7 @@
 """PostgreSQL-specific data dictionary for metadata queries via psycopg."""
 
 import re
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, cast
 
 from sqlspec.driver import (
     AsyncDataDictionaryBase,
@@ -28,7 +28,7 @@ __all__ = ("PostgresAsyncDataDictionary", "PostgresSyncDataDictionary")
 class PostgresSyncDataDictionary(SyncDataDictionaryBase):
     """PostgreSQL-specific sync data dictionary."""
 
-    def get_version(self, driver: SyncDriverAdapterBase) -> "Optional[VersionInfo]":
+    def get_version(self, driver: SyncDriverAdapterBase) -> "VersionInfo | None":
         """Get PostgreSQL database version information.
 
         Args:
@@ -144,7 +144,7 @@ class PostgresSyncDataDictionary(SyncDataDictionaryBase):
 class PostgresAsyncDataDictionary(AsyncDataDictionaryBase):
     """PostgreSQL-specific async data dictionary."""
 
-    async def get_version(self, driver: AsyncDriverAdapterBase) -> "Optional[VersionInfo]":
+    async def get_version(self, driver: AsyncDriverAdapterBase) -> "VersionInfo | None":
         """Get PostgreSQL database version information.
 
         Args:

--- a/sqlspec/adapters/psycopg/driver.py
+++ b/sqlspec/adapters/psycopg/driver.py
@@ -16,7 +16,7 @@ PostgreSQL Features:
 
 import datetime
 import io
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import psycopg
 
@@ -139,7 +139,7 @@ class PsycopgSyncCursor:
 
     def __init__(self, connection: PsycopgSyncConnection) -> None:
         self.connection = connection
-        self.cursor: Optional[Any] = None
+        self.cursor: Any | None = None
 
     def __enter__(self) -> Any:
         self.cursor = self.connection.cursor()
@@ -246,7 +246,7 @@ class PsycopgSyncExceptionHandler:
         msg = f"PostgreSQL operational error [{code}]: {e}"
         raise OperationalError(msg) from e
 
-    def _raise_generic_error(self, e: Any, code: "Optional[str]") -> None:
+    def _raise_generic_error(self, e: Any, code: "str | None") -> None:
         msg = f"PostgreSQL database error [{code}]: {e}" if code else f"PostgreSQL database error: {e}"
         raise SQLSpecError(msg) from e
 
@@ -267,8 +267,8 @@ class PsycopgSyncDriver(SyncDriverAdapterBase):
     def __init__(
         self,
         connection: PsycopgSyncConnection,
-        statement_config: "Optional[StatementConfig]" = None,
-        driver_features: "Optional[dict[str, Any]]" = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "dict[str, Any] | None" = None,
     ) -> None:
         if statement_config is None:
             cache_config = get_cache_config()
@@ -281,7 +281,7 @@ class PsycopgSyncDriver(SyncDriverAdapterBase):
             statement_config = default_config
 
         super().__init__(connection=connection, statement_config=statement_config, driver_features=driver_features)
-        self._data_dictionary: Optional[SyncDataDictionaryBase] = None
+        self._data_dictionary: SyncDataDictionaryBase | None = None
 
     def with_cursor(self, connection: PsycopgSyncConnection) -> PsycopgSyncCursor:
         """Create context manager for PostgreSQL cursor."""
@@ -330,7 +330,7 @@ class PsycopgSyncDriver(SyncDriverAdapterBase):
         except Exception as cleanup_error:
             logger.warning("Failed to cleanup transaction state: %s", cleanup_error)
 
-    def _try_special_handling(self, cursor: Any, statement: "SQL") -> "Optional[SQLResult]":
+    def _try_special_handling(self, cursor: Any, statement: "SQL") -> "SQLResult | None":
         """Hook for PostgreSQL-specific special operations.
 
         Args:
@@ -507,7 +507,7 @@ class PsycopgAsyncCursor:
 
     def __init__(self, connection: "PsycopgAsyncConnection") -> None:
         self.connection = connection
-        self.cursor: Optional[Any] = None
+        self.cursor: Any | None = None
 
     async def __aenter__(self) -> Any:
         self.cursor = self.connection.cursor()
@@ -615,7 +615,7 @@ class PsycopgAsyncExceptionHandler:
         msg = f"PostgreSQL operational error [{code}]: {e}"
         raise OperationalError(msg) from e
 
-    def _raise_generic_error(self, e: Any, code: "Optional[str]") -> None:
+    def _raise_generic_error(self, e: Any, code: "str | None") -> None:
         msg = f"PostgreSQL database error [{code}]: {e}" if code else f"PostgreSQL database error: {e}"
         raise SQLSpecError(msg) from e
 
@@ -637,8 +637,8 @@ class PsycopgAsyncDriver(AsyncDriverAdapterBase):
     def __init__(
         self,
         connection: "PsycopgAsyncConnection",
-        statement_config: "Optional[StatementConfig]" = None,
-        driver_features: "Optional[dict[str, Any]]" = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "dict[str, Any] | None" = None,
     ) -> None:
         if statement_config is None:
             cache_config = get_cache_config()
@@ -651,7 +651,7 @@ class PsycopgAsyncDriver(AsyncDriverAdapterBase):
             statement_config = default_config
 
         super().__init__(connection=connection, statement_config=statement_config, driver_features=driver_features)
-        self._data_dictionary: Optional[AsyncDataDictionaryBase] = None
+        self._data_dictionary: AsyncDataDictionaryBase | None = None
 
     def with_cursor(self, connection: "PsycopgAsyncConnection") -> "PsycopgAsyncCursor":
         """Create async context manager for PostgreSQL cursor."""
@@ -700,7 +700,7 @@ class PsycopgAsyncDriver(AsyncDriverAdapterBase):
         except Exception as cleanup_error:
             logger.warning("Failed to cleanup transaction state: %s", cleanup_error)
 
-    async def _try_special_handling(self, cursor: Any, statement: "SQL") -> "Optional[SQLResult]":
+    async def _try_special_handling(self, cursor: Any, statement: "SQL") -> "SQLResult | None":
         """Hook for PostgreSQL-specific special operations.
 
         Args:

--- a/sqlspec/adapters/sqlite/_types.py
+++ b/sqlspec/adapters/sqlite/_types.py
@@ -2,7 +2,7 @@ import sqlite3
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
     SqliteConnection: TypeAlias = sqlite3.Connection
 else:

--- a/sqlspec/adapters/sqlite/config.py
+++ b/sqlspec/adapters/sqlite/config.py
@@ -2,7 +2,7 @@
 
 import uuid
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypedDict, Union, cast
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 
 from typing_extensions import NotRequired
 
@@ -23,9 +23,9 @@ class SqliteConnectionParams(TypedDict, total=False):
     database: NotRequired[str]
     timeout: NotRequired[float]
     detect_types: NotRequired[int]
-    isolation_level: "NotRequired[Optional[str]]"
+    isolation_level: "NotRequired[str | None]"
     check_same_thread: NotRequired[bool]
-    factory: "NotRequired[Optional[type[SqliteConnection]]]"
+    factory: "NotRequired[type[SqliteConnection] | None]"
     cached_statements: NotRequired[int]
     uri: NotRequired[bool]
 
@@ -42,12 +42,12 @@ class SqliteConfig(SyncDatabaseConfig[SqliteConnection, SqliteConnectionPool, Sq
     def __init__(
         self,
         *,
-        pool_config: "Optional[Union[SqliteConnectionParams, dict[str, Any]]]" = None,
-        pool_instance: "Optional[SqliteConnectionPool]" = None,
-        migration_config: "Optional[dict[str, Any]]" = None,
-        statement_config: "Optional[StatementConfig]" = None,
-        driver_features: "Optional[dict[str, Any]]" = None,
-        bind_key: "Optional[str]" = None,
+        pool_config: "SqliteConnectionParams | dict[str, Any] | None" = None,
+        pool_instance: "SqliteConnectionPool | None" = None,
+        migration_config: "dict[str, Any] | None" = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "dict[str, Any] | None" = None,
+        bind_key: "str | None" = None,
     ) -> None:
         """Initialize SQLite configuration.
 
@@ -113,7 +113,7 @@ class SqliteConfig(SyncDatabaseConfig[SqliteConnection, SqliteConnectionPool, Sq
 
     @contextmanager
     def provide_session(
-        self, *args: "Any", statement_config: "Optional[StatementConfig]" = None, **kwargs: "Any"
+        self, *args: "Any", statement_config: "StatementConfig | None" = None, **kwargs: "Any"
     ) -> "Generator[SqliteDriver, None, None]":
         """Provide a SQLite driver session.
 

--- a/sqlspec/adapters/sqlite/data_dictionary.py
+++ b/sqlspec/adapters/sqlite/data_dictionary.py
@@ -1,12 +1,14 @@
 """SQLite-specific data dictionary for metadata queries."""
 
 import re
-from typing import TYPE_CHECKING, Callable, Optional, cast
+from typing import TYPE_CHECKING, cast
 
 from sqlspec.driver import SyncDataDictionaryBase, SyncDriverAdapterBase, VersionInfo
 from sqlspec.utils.logging import get_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from sqlspec.adapters.sqlite.driver import SqliteDriver
 
 logger = get_logger("adapters.sqlite.data_dictionary")
@@ -20,7 +22,7 @@ __all__ = ("SqliteSyncDataDictionary",)
 class SqliteSyncDataDictionary(SyncDataDictionaryBase):
     """SQLite-specific sync data dictionary."""
 
-    def get_version(self, driver: SyncDriverAdapterBase) -> "Optional[VersionInfo]":
+    def get_version(self, driver: SyncDriverAdapterBase) -> "VersionInfo | None":
         """Get SQLite database version information.
 
         Args:

--- a/sqlspec/adapters/sqlite/pool.py
+++ b/sqlspec/adapters/sqlite/pool.py
@@ -4,7 +4,7 @@ import contextlib
 import sqlite3
 import threading
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Optional, TypedDict, cast
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from typing_extensions import NotRequired
 
@@ -20,9 +20,9 @@ class SqliteConnectionParams(TypedDict, total=False):
     database: NotRequired[str]
     timeout: NotRequired[float]
     detect_types: NotRequired[int]
-    isolation_level: "NotRequired[Optional[str]]"
+    isolation_level: "NotRequired[str | None]"
     check_same_thread: NotRequired[bool]
-    factory: "NotRequired[Optional[type[SqliteConnection]]]"
+    factory: "NotRequired[type[SqliteConnection] | None]"
     cached_statements: NotRequired[int]
     uri: NotRequired[bool]
 

--- a/sqlspec/builder/_base.py
+++ b/sqlspec/builder/_base.py
@@ -6,7 +6,7 @@ Provides abstract base classes and core functionality for SQL query builders.
 import hashlib
 import uuid
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, NoReturn, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 import sqlglot
 from sqlglot import Dialect, exp
@@ -38,9 +38,7 @@ class SafeQuery:
 
     __slots__ = ("dialect", "parameters", "sql")
 
-    def __init__(
-        self, sql: str, parameters: Optional[dict[str, Any]] = None, dialect: Optional[DialectType] = None
-    ) -> None:
+    def __init__(self, sql: str, parameters: dict[str, Any] | None = None, dialect: DialectType | None = None) -> None:
         self.sql = sql
         self.parameters = parameters if parameters is not None else {}
         self.dialect = dialect
@@ -68,8 +66,8 @@ class QueryBuilder(ABC):
 
     def __init__(
         self,
-        dialect: Optional[DialectType] = None,
-        schema: Optional[dict[str, dict[str, str]]] = None,
+        dialect: DialectType | None = None,
+        schema: dict[str, dict[str, str]] | None = None,
         enable_optimization: bool = True,
         optimize_joins: bool = True,
         optimize_predicates: bool = True,
@@ -82,7 +80,7 @@ class QueryBuilder(ABC):
         self.optimize_predicates = optimize_predicates
         self.simplify_expressions = simplify_expressions
 
-        self._expression: Optional[exp.Expression] = None
+        self._expression: exp.Expression | None = None
         self._parameters: dict[str, Any] = {}
         self._parameter_counter: int = 0
         self._with_ctes: dict[str, exp.CTE] = {}
@@ -95,7 +93,7 @@ class QueryBuilder(ABC):
                 "QueryBuilder._create_base_expression must return a valid sqlglot expression."
             )
 
-    def get_expression(self) -> Optional[exp.Expression]:
+    def get_expression(self) -> exp.Expression | None:
         """Get expression reference (no copy).
 
         Returns:
@@ -139,7 +137,7 @@ class QueryBuilder(ABC):
         """
 
     @staticmethod
-    def _raise_sql_builder_error(message: str, cause: Optional[BaseException] = None) -> NoReturn:
+    def _raise_sql_builder_error(message: str, cause: BaseException | None = None) -> NoReturn:
         """Helper to raise SQLBuilderError, potentially with a cause.
 
         Args:
@@ -191,7 +189,7 @@ class QueryBuilder(ABC):
         msg = f"Failed to parse CTE query: {cause!s}"
         raise SQLBuilderError(msg) from cause
 
-    def _add_parameter(self, value: Any, context: Optional[str] = None) -> str:
+    def _add_parameter(self, value: Any, context: str | None = None) -> str:
         """Adds a parameter to the query and returns its placeholder name.
 
         Args:
@@ -232,7 +230,7 @@ class QueryBuilder(ABC):
 
         return expression.transform(replacer, copy=False)
 
-    def add_parameter(self: Self, value: Any, name: Optional[str] = None) -> tuple[Self, str]:
+    def add_parameter(self: Self, value: Any, name: str | None = None) -> tuple[Self, str]:
         """Explicitly adds a parameter to the query.
 
         This is useful for parameters that are not directly tied to a
@@ -313,7 +311,7 @@ class QueryBuilder(ABC):
 
         return expression.transform(placeholder_replacer, copy=False)
 
-    def _generate_builder_cache_key(self, config: "Optional[StatementConfig]" = None) -> str:
+    def _generate_builder_cache_key(self, config: "StatementConfig | None" = None) -> str:
         """Generate cache key based on builder state and configuration.
 
         Args:
@@ -356,7 +354,7 @@ class QueryBuilder(ABC):
         state_string = "|".join(state_parts)
         return f"builder:{hashlib.sha256(state_string.encode()).hexdigest()[:16]}"
 
-    def with_cte(self: Self, alias: str, query: "Union[QueryBuilder, exp.Select, str]") -> Self:
+    def with_cte(self: Self, alias: str, query: "QueryBuilder | exp.Select | str") -> Self:
         """Adds a Common Table Expression (CTE) to the query.
 
         Args:
@@ -475,7 +473,7 @@ class QueryBuilder(ABC):
         else:
             return optimized
 
-    def to_statement(self, config: "Optional[StatementConfig]" = None) -> "SQL":
+    def to_statement(self, config: "StatementConfig | None" = None) -> "SQL":
         """Converts the built query into a SQL statement object.
 
         Args:
@@ -500,7 +498,7 @@ class QueryBuilder(ABC):
 
         return sql_statement
 
-    def _to_statement(self, config: "Optional[StatementConfig]" = None) -> "SQL":
+    def _to_statement(self, config: "StatementConfig | None" = None) -> "SQL":
         """Internal method to create SQL statement.
 
         Args:
@@ -541,7 +539,7 @@ class QueryBuilder(ABC):
 
     def _extract_statement_parameters(
         self, raw_parameters: Any
-    ) -> "tuple[Optional[dict[str, Any]], Optional[tuple[Any, ...]]]":
+    ) -> "tuple[dict[str, Any] | None, tuple[Any, ...] | None]":
         """Extract parameters for SQL statement creation.
 
         Args:
@@ -570,7 +568,7 @@ class QueryBuilder(ABC):
         return self.build().sql
 
     @property
-    def dialect_name(self) -> "Optional[str]":
+    def dialect_name(self) -> "str | None":
         """Returns the name of the dialect, if set."""
         if isinstance(self.dialect, str):
             return self.dialect

--- a/sqlspec/builder/_column.py
+++ b/sqlspec/builder/_column.py
@@ -6,7 +6,7 @@ SQL conditions with parameter binding.
 
 from collections.abc import Iterable
 from datetime import date, datetime
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 from sqlglot import exp
 
@@ -77,7 +77,7 @@ class Column:
 
     __slots__ = ("_expression", "name", "table")
 
-    def __init__(self, name: str, table: Optional[str] = None) -> None:
+    def __init__(self, name: str, table: str | None = None) -> None:
         self.name = name
         self.table = table
 
@@ -122,7 +122,7 @@ class Column:
         """Apply NOT operator (~)."""
         return ColumnExpression(exp.Not(this=self._expression))
 
-    def like(self, pattern: str, escape: Optional[str] = None) -> ColumnExpression:
+    def like(self, pattern: str, escape: str | None = None) -> ColumnExpression:
         """SQL LIKE pattern matching."""
         if escape:
             like_expr = exp.Like(
@@ -159,7 +159,7 @@ class Column:
         """SQL IS NOT NULL."""
         return ColumnExpression(exp.Not(this=exp.Is(this=self._expression, expression=exp.Null())))
 
-    def not_like(self, pattern: str, escape: Optional[str] = None) -> ColumnExpression:
+    def not_like(self, pattern: str, escape: str | None = None) -> ColumnExpression:
         """SQL NOT LIKE pattern matching."""
         return ~self.like(pattern, escape)
 
@@ -211,7 +211,7 @@ class Column:
         """SQL CEIL() function."""
         return FunctionColumn(exp.Ceil(this=self._expression))
 
-    def substring(self, start: int, length: Optional[int] = None) -> "FunctionColumn":
+    def substring(self, start: int, length: int | None = None) -> "FunctionColumn":
         """SQL SUBSTRING() function."""
         args = [self._convert_value(start)]
         if length is not None:

--- a/sqlspec/builder/_delete.py
+++ b/sqlspec/builder/_delete.py
@@ -4,7 +4,7 @@ Provides a fluent interface for building SQL DELETE queries with
 parameter binding and validation.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from sqlglot import exp
 
@@ -24,9 +24,9 @@ class Delete(QueryBuilder, WhereClauseMixin, ReturningClauseMixin, DeleteFromCla
     """
 
     __slots__ = ("_table",)
-    _expression: Optional[exp.Expression]
+    _expression: exp.Expression | None
 
-    def __init__(self, table: Optional[str] = None, **kwargs: Any) -> None:
+    def __init__(self, table: str | None = None, **kwargs: Any) -> None:
         """Initialize DELETE with optional table.
 
         Args:

--- a/sqlspec/builder/_insert.py
+++ b/sqlspec/builder/_insert.py
@@ -4,7 +4,7 @@ Provides a fluent interface for building SQL INSERT queries with
 parameter binding and validation.
 """
 
-from typing import TYPE_CHECKING, Any, Final, Optional
+from typing import TYPE_CHECKING, Any, Final
 
 from sqlglot import exp
 from typing_extensions import Self
@@ -38,7 +38,7 @@ class Insert(QueryBuilder, ReturningClauseMixin, InsertValuesMixin, InsertFromSe
 
     __slots__ = ("_columns", "_table", "_values_added_count")
 
-    def __init__(self, table: Optional[str] = None, **kwargs: Any) -> None:
+    def __init__(self, table: str | None = None, **kwargs: Any) -> None:
         """Initialize INSERT with optional table.
 
         Args:
@@ -47,7 +47,7 @@ class Insert(QueryBuilder, ReturningClauseMixin, InsertValuesMixin, InsertFromSe
         """
         super().__init__(**kwargs)
 
-        self._table: Optional[str] = None
+        self._table: str | None = None
         self._columns: list[str] = []
         self._values_added_count: int = 0
 

--- a/sqlspec/builder/_merge.py
+++ b/sqlspec/builder/_merge.py
@@ -4,7 +4,7 @@ Provides a fluent interface for building SQL MERGE queries with
 parameter binding and validation.
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from sqlglot import exp
 
@@ -38,9 +38,9 @@ class Merge(
     """
 
     __slots__ = ()
-    _expression: Optional[exp.Expression]
+    _expression: exp.Expression | None
 
-    def __init__(self, target_table: Optional[str] = None, **kwargs: Any) -> None:
+    def __init__(self, target_table: str | None = None, **kwargs: Any) -> None:
         """Initialize MERGE with optional target table.
 
         Args:

--- a/sqlspec/builder/_parsing_utils.py
+++ b/sqlspec/builder/_parsing_utils.py
@@ -5,7 +5,7 @@ passed as strings to builder methods.
 """
 
 import contextlib
-from typing import Any, Final, Optional, Union, cast
+from typing import Any, Final, cast
 
 from sqlglot import exp, maybe_parse, parse_one
 
@@ -18,7 +18,7 @@ from sqlspec.utils.type_guards import (
 )
 
 
-def extract_column_name(column: Union[str, exp.Column]) -> str:
+def extract_column_name(column: str | exp.Column) -> str:
     """Extract column name from column expression for parameter naming.
 
     Args:
@@ -39,9 +39,7 @@ def extract_column_name(column: Union[str, exp.Column]) -> str:
     return "column"
 
 
-def parse_column_expression(
-    column_input: Union[str, exp.Expression, Any], builder: Optional[Any] = None
-) -> exp.Expression:
+def parse_column_expression(column_input: str | exp.Expression | Any, builder: Any | None = None) -> exp.Expression:
     """Parse a column input that might be a complex expression.
 
     Handles cases like:
@@ -87,7 +85,7 @@ def parse_column_expression(
     return exp.maybe_parse(column_input) or exp.column(str(column_input))
 
 
-def parse_table_expression(table_input: str, explicit_alias: Optional[str] = None) -> exp.Expression:
+def parse_table_expression(table_input: str, explicit_alias: str | None = None) -> exp.Expression:
     """Parses a table string that can be a name, a name with an alias, or a subquery string."""
     with contextlib.suppress(Exception):
         parsed = parse_one(f"SELECT * FROM {table_input}")
@@ -102,7 +100,7 @@ def parse_table_expression(table_input: str, explicit_alias: Optional[str] = Non
     return exp.to_table(table_input, alias=explicit_alias)
 
 
-def parse_order_expression(order_input: Union[str, exp.Expression]) -> exp.Expression:
+def parse_order_expression(order_input: str | exp.Expression) -> exp.Expression:
     """Parse an ORDER BY expression that might include direction.
 
     Handles cases like:
@@ -129,7 +127,7 @@ def parse_order_expression(order_input: Union[str, exp.Expression]) -> exp.Expre
 
 
 def parse_condition_expression(
-    condition_input: Union[str, exp.Expression, tuple[str, Any]], builder: "Any" = None
+    condition_input: str | exp.Expression | tuple[str, Any], builder: "Any" = None
 ) -> exp.Expression:
     """Parse a condition that might be complex SQL.
 
@@ -193,13 +191,13 @@ def parse_condition_expression(
                 )
         condition_input = converted_condition
 
-    parsed: Optional[exp.Expression] = exp.maybe_parse(condition_input)
+    parsed: exp.Expression | None = exp.maybe_parse(condition_input)
     if parsed:
         return parsed
     return exp.condition(condition_input)
 
 
-def extract_sql_object_expression(value: Any, builder: Optional[Any] = None) -> exp.Expression:
+def extract_sql_object_expression(value: Any, builder: Any | None = None) -> exp.Expression:
     """Extract SQLGlot expression from SQL object value with parameter merging.
 
     Handles the common pattern of:

--- a/sqlspec/builder/_update.py
+++ b/sqlspec/builder/_update.py
@@ -4,7 +4,7 @@ Provides a fluent interface for building SQL UPDATE queries with
 parameter binding and validation.
 """
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from sqlglot import exp
 from typing_extensions import Self
@@ -70,9 +70,9 @@ class Update(
     """
 
     __slots__ = ("_table",)
-    _expression: Optional[exp.Expression]
+    _expression: exp.Expression | None
 
-    def __init__(self, table: Optional[str] = None, **kwargs: Any) -> None:
+    def __init__(self, table: str | None = None, **kwargs: Any) -> None:
         """Initialize UPDATE with optional table.
 
         Args:
@@ -100,9 +100,9 @@ class Update(
 
     def join(
         self,
-        table: "Union[str, exp.Expression, Select]",
-        on: "Union[str, exp.Expression]",
-        alias: "Optional[str]" = None,
+        table: "str | exp.Expression | Select",
+        on: "str | exp.Expression",
+        alias: "str | None" = None,
         join_type: str = "INNER",
     ) -> "Self":
         """Add JOIN clause to the UPDATE statement.

--- a/sqlspec/builder/mixins/_cte_and_set_ops.py
+++ b/sqlspec/builder/mixins/_cte_and_set_ops.py
@@ -5,7 +5,7 @@ Provides mixins for Common Table Expressions (WITH clause) and
 set operations (UNION, INTERSECT, EXCEPT).
 """
 
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from mypy_extensions import trait
 from sqlglot import exp
@@ -26,13 +26,13 @@ class CommonTableExpressionMixin:
     __slots__ = ()
 
     # Type annotations for PyRight - these will be provided by the base class
-    def get_expression(self) -> Optional[exp.Expression]: ...
+    def get_expression(self) -> exp.Expression | None: ...
     def set_expression(self, expression: exp.Expression) -> None: ...
 
     _with_ctes: Any  # Provided by QueryBuilder
     dialect: Any  # Provided by QueryBuilder
 
-    def add_parameter(self, value: Any, name: Optional[str] = None) -> tuple[Any, str]:
+    def add_parameter(self, value: Any, name: str | None = None) -> tuple[Any, str]:
         """Add parameter - provided by QueryBuilder."""
         msg = "Method must be provided by QueryBuilder subclass"
         raise NotImplementedError(msg)
@@ -49,9 +49,7 @@ class CommonTableExpressionMixin:
         msg = "Method must be provided by QueryBuilder subclass"
         raise NotImplementedError(msg)
 
-    def with_(
-        self, name: str, query: Union[Any, str], recursive: bool = False, columns: Optional[list[str]] = None
-    ) -> Self:
+    def with_(self, name: str, query: Any | str, recursive: bool = False, columns: list[str] | None = None) -> Self:
         """Add WITH clause (Common Table Expression).
 
         Args:
@@ -76,7 +74,7 @@ class CommonTableExpressionMixin:
             msg = f"Cannot add WITH clause to {type(expression).__name__} expression."
             raise SQLBuilderError(msg)
 
-        cte_expr: Optional[exp.Expression] = None
+        cte_expr: exp.Expression | None = None
         if isinstance(query, str):
             cte_expr = exp.maybe_parse(query, dialect=self.dialect)
         elif isinstance(query, exp.Expression):
@@ -136,7 +134,7 @@ class SetOperationMixin:
     __slots__ = ()
 
     # Type annotations for PyRight - these will be provided by the base class
-    def get_expression(self) -> Optional[exp.Expression]: ...
+    def get_expression(self) -> exp.Expression | None: ...
     def set_expression(self, expression: exp.Expression) -> None: ...
     def set_parameters(self, parameters: "dict[str, Any]") -> None: ...
 
@@ -162,8 +160,8 @@ class SetOperationMixin:
         """
         left_query = self.build()
         right_query = other.build()
-        left_expr: Optional[exp.Expression] = exp.maybe_parse(left_query.sql, dialect=self.dialect)
-        right_expr: Optional[exp.Expression] = exp.maybe_parse(right_query.sql, dialect=self.dialect)
+        left_expr: exp.Expression | None = exp.maybe_parse(left_query.sql, dialect=self.dialect)
+        right_expr: exp.Expression | None = exp.maybe_parse(right_query.sql, dialect=self.dialect)
         if not left_expr or not right_expr:
             msg = "Could not parse queries for UNION operation"
             raise SQLBuilderError(msg)
@@ -210,8 +208,8 @@ class SetOperationMixin:
         """
         left_query = self.build()
         right_query = other.build()
-        left_expr: Optional[exp.Expression] = exp.maybe_parse(left_query.sql, dialect=self.dialect)
-        right_expr: Optional[exp.Expression] = exp.maybe_parse(right_query.sql, dialect=self.dialect)
+        left_expr: exp.Expression | None = exp.maybe_parse(left_query.sql, dialect=self.dialect)
+        right_expr: exp.Expression | None = exp.maybe_parse(right_query.sql, dialect=self.dialect)
         if not left_expr or not right_expr:
             msg = "Could not parse queries for INTERSECT operation"
             raise SQLBuilderError(msg)
@@ -238,8 +236,8 @@ class SetOperationMixin:
         """
         left_query = self.build()
         right_query = other.build()
-        left_expr: Optional[exp.Expression] = exp.maybe_parse(left_query.sql, dialect=self.dialect)
-        right_expr: Optional[exp.Expression] = exp.maybe_parse(right_query.sql, dialect=self.dialect)
+        left_expr: exp.Expression | None = exp.maybe_parse(left_query.sql, dialect=self.dialect)
+        right_expr: exp.Expression | None = exp.maybe_parse(right_query.sql, dialect=self.dialect)
         if not left_expr or not right_expr:
             msg = "Could not parse queries for EXCEPT operation"
             raise SQLBuilderError(msg)

--- a/sqlspec/builder/mixins/_delete_operations.py
+++ b/sqlspec/builder/mixins/_delete_operations.py
@@ -5,8 +5,6 @@ Provides mixins for DELETE statement functionality including
 FROM clause specification.
 """
 
-from typing import Optional
-
 from mypy_extensions import trait
 from sqlglot import exp
 from typing_extensions import Self
@@ -23,7 +21,7 @@ class DeleteFromClauseMixin:
     __slots__ = ()
 
     # Type annotations for PyRight - these will be provided by the base class
-    def get_expression(self) -> Optional[exp.Expression]: ...
+    def get_expression(self) -> exp.Expression | None: ...
     def set_expression(self, expression: exp.Expression) -> None: ...
 
     def from_(self, table: str) -> Self:

--- a/sqlspec/builder/mixins/_insert_operations.py
+++ b/sqlspec/builder/mixins/_insert_operations.py
@@ -6,7 +6,7 @@ INTO clauses, VALUES clauses, and INSERT FROM SELECT operations.
 """
 
 from collections.abc import Sequence
-from typing import Any, Optional, TypeVar, Union
+from typing import Any, TypeVar
 
 from mypy_extensions import trait
 from sqlglot import exp
@@ -27,7 +27,7 @@ class InsertIntoClauseMixin:
     __slots__ = ()
 
     # Type annotations for PyRight - these will be provided by the base class
-    def get_expression(self) -> Optional[exp.Expression]: ...
+    def get_expression(self) -> exp.Expression | None: ...
     def set_expression(self, expression: exp.Expression) -> None: ...
 
     def into(self, table: str) -> Self:
@@ -63,12 +63,12 @@ class InsertValuesMixin:
     __slots__ = ()
 
     # Type annotations for PyRight - these will be provided by the base class
-    def get_expression(self) -> Optional[exp.Expression]: ...
+    def get_expression(self) -> exp.Expression | None: ...
     def set_expression(self, expression: exp.Expression) -> None: ...
 
     _columns: Any  # Provided by QueryBuilder
 
-    def add_parameter(self, value: Any, name: Optional[str] = None) -> tuple[Any, str]:
+    def add_parameter(self, value: Any, name: str | None = None) -> tuple[Any, str]:
         """Add parameter - provided by QueryBuilder."""
         msg = "Method must be provided by QueryBuilder subclass"
         raise NotImplementedError(msg)
@@ -78,7 +78,7 @@ class InsertValuesMixin:
         msg = "Method must be provided by QueryBuilder subclass"
         raise NotImplementedError(msg)
 
-    def columns(self, *columns: Union[str, exp.Expression]) -> Self:
+    def columns(self, *columns: str | exp.Expression) -> Self:
         """Set the columns for the INSERT statement and synchronize the _columns attribute on the builder."""
         current_expr = self.get_expression()
         if current_expr is None:
@@ -232,12 +232,12 @@ class InsertFromSelectMixin:
     __slots__ = ()
 
     # Type annotations for PyRight - these will be provided by the base class
-    def get_expression(self) -> Optional[exp.Expression]: ...
+    def get_expression(self) -> exp.Expression | None: ...
     def set_expression(self, expression: exp.Expression) -> None: ...
 
     _table: Any  # Provided by QueryBuilder
 
-    def add_parameter(self, value: Any, name: Optional[str] = None) -> tuple[Any, str]:
+    def add_parameter(self, value: Any, name: str | None = None) -> tuple[Any, str]:
         """Add parameter - provided by QueryBuilder."""
         msg = "Method must be provided by QueryBuilder subclass"
         raise NotImplementedError(msg)

--- a/sqlspec/builder/mixins/_order_limit_operations.py
+++ b/sqlspec/builder/mixins/_order_limit_operations.py
@@ -5,7 +5,7 @@ Provides mixins for query result ordering, limiting, and result
 returning functionality.
 """
 
-from typing import TYPE_CHECKING, Optional, Union, cast
+from typing import TYPE_CHECKING, Union, cast
 
 from mypy_extensions import trait
 from sqlglot import exp
@@ -29,7 +29,7 @@ class OrderByClauseMixin:
 
     __slots__ = ()
 
-    _expression: Optional[exp.Expression]
+    _expression: exp.Expression | None
 
     def order_by(self, *items: Union[str, exp.Ordered, "Column"], desc: bool = False) -> Self:
         """Add ORDER BY clause.
@@ -72,7 +72,7 @@ class LimitOffsetClauseMixin:
 
     __slots__ = ()
 
-    _expression: Optional[exp.Expression]
+    _expression: exp.Expression | None
 
     def limit(self, value: int) -> Self:
         """Add LIMIT clause.
@@ -118,7 +118,7 @@ class ReturningClauseMixin:
     """Mixin providing RETURNING clause."""
 
     __slots__ = ()
-    _expression: Optional[exp.Expression]
+    _expression: exp.Expression | None
 
     def returning(self, *columns: Union[str, exp.Expression, "Column", "ExpressionWrapper", "Case"]) -> Self:
         """Add RETURNING clause to the statement.

--- a/sqlspec/builder/mixins/_pivot_operations.py
+++ b/sqlspec/builder/mixins/_pivot_operations.py
@@ -4,7 +4,7 @@
 Provides mixins for PIVOT and UNPIVOT operations in SELECT statements.
 """
 
-from typing import TYPE_CHECKING, Optional, Union, cast
+from typing import TYPE_CHECKING, cast
 
 from mypy_extensions import trait
 from sqlglot import exp
@@ -23,17 +23,17 @@ class PivotClauseMixin:
 
     __slots__ = ()
     # Type annotation for PyRight - this will be provided by the base class
-    _expression: Optional[exp.Expression]
+    _expression: exp.Expression | None
 
     dialect: "DialectType" = None
 
     def pivot(
         self: "PivotClauseMixin",
-        aggregate_function: Union[str, exp.Expression],
-        aggregate_column: Union[str, exp.Expression],
-        pivot_column: Union[str, exp.Expression],
-        pivot_values: list[Union[str, int, float, exp.Expression]],
-        alias: Optional[str] = None,
+        aggregate_function: str | exp.Expression,
+        aggregate_column: str | exp.Expression,
+        pivot_column: str | exp.Expression,
+        pivot_values: list[str | int | float | exp.Expression],
+        alias: str | None = None,
     ) -> "Select":
         """Adds a PIVOT clause to the SELECT statement.
 
@@ -94,7 +94,7 @@ class UnpivotClauseMixin:
 
     __slots__ = ()
     # Type annotation for PyRight - this will be provided by the base class
-    _expression: Optional[exp.Expression]
+    _expression: exp.Expression | None
 
     dialect: "DialectType" = None
 
@@ -102,8 +102,8 @@ class UnpivotClauseMixin:
         self: "UnpivotClauseMixin",
         value_column_name: str,
         name_column_name: str,
-        columns_to_unpivot: list[Union[str, exp.Expression]],
-        alias: Optional[str] = None,
+        columns_to_unpivot: list[str | exp.Expression],
+        alias: str | None = None,
     ) -> "Select":
         """Adds an UNPIVOT clause to the SELECT statement.
 

--- a/sqlspec/builder/mixins/_select_operations.py
+++ b/sqlspec/builder/mixins/_select_operations.py
@@ -5,7 +5,7 @@ Provides mixins for SELECT statement functionality including column selection,
 CASE expressions, subqueries, and window functions.
 """
 
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Union, cast
 
 from mypy_extensions import trait
 from sqlglot import exp
@@ -29,7 +29,7 @@ class SelectClauseMixin:
 
     __slots__ = ()
 
-    def get_expression(self) -> Optional[exp.Expression]: ...
+    def get_expression(self) -> exp.Expression | None: ...
     def set_expression(self, expression: exp.Expression) -> None: ...
 
     def select(self, *columns: Union[str, exp.Expression, "Column", "FunctionColumn", "SQL", "Case"]) -> Self:
@@ -80,7 +80,7 @@ class SelectClauseMixin:
             builder._expression.set("distinct", exp.Distinct(expressions=distinct_columns))
         return cast("Self", builder)
 
-    def from_(self, table: Union[str, exp.Expression, Any], alias: Optional[str] = None) -> Self:
+    def from_(self, table: str | exp.Expression | Any, alias: str | None = None) -> Self:
         """Add FROM clause.
 
         Args:
@@ -124,7 +124,7 @@ class SelectClauseMixin:
         builder._expression = builder._expression.from_(from_expr, copy=False)
         return cast("Self", builder)
 
-    def group_by(self, *columns: Union[str, exp.Expression]) -> Self:
+    def group_by(self, *columns: str | exp.Expression) -> Self:
         """Add GROUP BY clause.
 
         Args:
@@ -143,7 +143,7 @@ class SelectClauseMixin:
         self.set_expression(current_expr)
         return self
 
-    def group_by_rollup(self, *columns: Union[str, exp.Expression]) -> Self:
+    def group_by_rollup(self, *columns: str | exp.Expression) -> Self:
         """Add GROUP BY ROLLUP clause.
 
         ROLLUP generates subtotals and grand totals for a hierarchical set of columns.
@@ -167,7 +167,7 @@ class SelectClauseMixin:
         rollup_expr = exp.Rollup(expressions=column_exprs)
         return self.group_by(rollup_expr)
 
-    def group_by_cube(self, *columns: Union[str, exp.Expression]) -> Self:
+    def group_by_cube(self, *columns: str | exp.Expression) -> Self:
         """Add GROUP BY CUBE clause.
 
         CUBE generates subtotals for all possible combinations of the specified columns.
@@ -191,7 +191,7 @@ class SelectClauseMixin:
         cube_expr = exp.Cube(expressions=column_exprs)
         return self.group_by(cube_expr)
 
-    def group_by_grouping_sets(self, *column_sets: Union[tuple[str, ...], list[str]]) -> Self:
+    def group_by_grouping_sets(self, *column_sets: tuple[str, ...] | list[str]) -> Self:
         """Add GROUP BY GROUPING SETS clause.
 
         GROUPING SETS allows you to specify multiple grouping sets in a single query.
@@ -226,7 +226,7 @@ class SelectClauseMixin:
         grouping_sets_expr = exp.GroupingSets(expressions=set_expressions)
         return self.group_by(grouping_sets_expr)
 
-    def count_(self, column: "Union[str, exp.Expression]" = "*", alias: Optional[str] = None) -> Self:
+    def count_(self, column: "str | exp.Expression" = "*", alias: str | None = None) -> Self:
         """Add COUNT function to SELECT clause.
 
         Args:
@@ -246,7 +246,7 @@ class SelectClauseMixin:
         select_expr = exp.alias_(count_expr, alias) if alias else count_expr
         return cast("Self", builder.select(select_expr))
 
-    def sum_(self, column: Union[str, exp.Expression], alias: Optional[str] = None) -> Self:
+    def sum_(self, column: str | exp.Expression, alias: str | None = None) -> Self:
         """Add SUM function to SELECT clause.
 
         Args:
@@ -262,7 +262,7 @@ class SelectClauseMixin:
         select_expr = exp.alias_(sum_expr, alias) if alias else sum_expr
         return cast("Self", builder.select(select_expr))
 
-    def avg_(self, column: Union[str, exp.Expression], alias: Optional[str] = None) -> Self:
+    def avg_(self, column: str | exp.Expression, alias: str | None = None) -> Self:
         """Add AVG function to SELECT clause.
 
         Args:
@@ -278,7 +278,7 @@ class SelectClauseMixin:
         select_expr = exp.alias_(avg_expr, alias) if alias else avg_expr
         return cast("Self", builder.select(select_expr))
 
-    def max_(self, column: Union[str, exp.Expression], alias: Optional[str] = None) -> Self:
+    def max_(self, column: str | exp.Expression, alias: str | None = None) -> Self:
         """Add MAX function to SELECT clause.
 
         Args:
@@ -294,7 +294,7 @@ class SelectClauseMixin:
         select_expr = exp.alias_(max_expr, alias) if alias else max_expr
         return cast("Self", builder.select(select_expr))
 
-    def min_(self, column: Union[str, exp.Expression], alias: Optional[str] = None) -> Self:
+    def min_(self, column: str | exp.Expression, alias: str | None = None) -> Self:
         """Add MIN function to SELECT clause.
 
         Args:
@@ -310,7 +310,7 @@ class SelectClauseMixin:
         select_expr = exp.alias_(min_expr, alias) if alias else min_expr
         return cast("Self", builder.select(select_expr))
 
-    def array_agg(self, column: Union[str, exp.Expression], alias: Optional[str] = None) -> Self:
+    def array_agg(self, column: str | exp.Expression, alias: str | None = None) -> Self:
         """Add ARRAY_AGG aggregate function to SELECT clause.
 
         Args:
@@ -326,7 +326,7 @@ class SelectClauseMixin:
         select_expr = exp.alias_(array_agg_expr, alias) if alias else array_agg_expr
         return cast("Self", builder.select(select_expr))
 
-    def count_distinct(self, column: Union[str, exp.Expression], alias: Optional[str] = None) -> Self:
+    def count_distinct(self, column: str | exp.Expression, alias: str | None = None) -> Self:
         """Add COUNT(DISTINCT column) to SELECT clause.
 
         Args:
@@ -342,7 +342,7 @@ class SelectClauseMixin:
         select_expr = exp.alias_(count_expr, alias) if alias else count_expr
         return cast("Self", builder.select(select_expr))
 
-    def stddev(self, column: Union[str, exp.Expression], alias: Optional[str] = None) -> Self:
+    def stddev(self, column: str | exp.Expression, alias: str | None = None) -> Self:
         """Add STDDEV aggregate function to SELECT clause.
 
         Args:
@@ -358,7 +358,7 @@ class SelectClauseMixin:
         select_expr = exp.alias_(stddev_expr, alias) if alias else stddev_expr
         return cast("Self", builder.select(select_expr))
 
-    def stddev_pop(self, column: Union[str, exp.Expression], alias: Optional[str] = None) -> Self:
+    def stddev_pop(self, column: str | exp.Expression, alias: str | None = None) -> Self:
         """Add STDDEV_POP aggregate function to SELECT clause.
 
         Args:
@@ -374,7 +374,7 @@ class SelectClauseMixin:
         select_expr = exp.alias_(stddev_pop_expr, alias) if alias else stddev_pop_expr
         return cast("Self", builder.select(select_expr))
 
-    def stddev_samp(self, column: Union[str, exp.Expression], alias: Optional[str] = None) -> Self:
+    def stddev_samp(self, column: str | exp.Expression, alias: str | None = None) -> Self:
         """Add STDDEV_SAMP aggregate function to SELECT clause.
 
         Args:
@@ -390,7 +390,7 @@ class SelectClauseMixin:
         select_expr = exp.alias_(stddev_samp_expr, alias) if alias else stddev_samp_expr
         return cast("Self", builder.select(select_expr))
 
-    def variance(self, column: Union[str, exp.Expression], alias: Optional[str] = None) -> Self:
+    def variance(self, column: str | exp.Expression, alias: str | None = None) -> Self:
         """Add VARIANCE aggregate function to SELECT clause.
 
         Args:
@@ -406,7 +406,7 @@ class SelectClauseMixin:
         select_expr = exp.alias_(variance_expr, alias) if alias else variance_expr
         return cast("Self", builder.select(select_expr))
 
-    def var_pop(self, column: Union[str, exp.Expression], alias: Optional[str] = None) -> Self:
+    def var_pop(self, column: str | exp.Expression, alias: str | None = None) -> Self:
         """Add VAR_POP aggregate function to SELECT clause.
 
         Args:
@@ -422,7 +422,7 @@ class SelectClauseMixin:
         select_expr = exp.alias_(var_pop_expr, alias) if alias else var_pop_expr
         return cast("Self", builder.select(select_expr))
 
-    def string_agg(self, column: Union[str, exp.Expression], separator: str = ",", alias: Optional[str] = None) -> Self:
+    def string_agg(self, column: str | exp.Expression, separator: str = ",", alias: str | None = None) -> Self:
         """Add STRING_AGG aggregate function to SELECT clause.
 
         Args:
@@ -446,7 +446,7 @@ class SelectClauseMixin:
         select_expr = exp.alias_(string_agg_expr, alias) if alias else string_agg_expr
         return cast("Self", builder.select(select_expr))
 
-    def json_agg(self, column: Union[str, exp.Expression], alias: Optional[str] = None) -> Self:
+    def json_agg(self, column: str | exp.Expression, alias: str | None = None) -> Self:
         """Add JSON_AGG aggregate function to SELECT clause.
 
         Args:
@@ -464,11 +464,11 @@ class SelectClauseMixin:
 
     def window(
         self,
-        function_expr: Union[str, exp.Expression],
-        partition_by: Optional[Union[str, list[str], exp.Expression, list[exp.Expression]]] = None,
-        order_by: Optional[Union[str, list[str], exp.Expression, list[exp.Expression]]] = None,
-        frame: Optional[str] = None,
-        alias: Optional[str] = None,
+        function_expr: str | exp.Expression,
+        partition_by: str | list[str] | exp.Expression | list[exp.Expression] | None = None,
+        order_by: str | list[str] | exp.Expression | list[exp.Expression] | None = None,
+        frame: str | None = None,
+        alias: str | None = None,
     ) -> Self:
         """Add a window function to the SELECT clause.
 
@@ -496,7 +496,7 @@ class SelectClauseMixin:
 
         func_expr_parsed: exp.Expression
         if isinstance(function_expr, str):
-            parsed: Optional[exp.Expression] = exp.maybe_parse(function_expr, dialect=getattr(self, "dialect", None))
+            parsed: exp.Expression | None = exp.maybe_parse(function_expr, dialect=getattr(self, "dialect", None))
             if not parsed:
                 msg = f"Could not parse function expression: {function_expr}"
                 raise SQLBuilderError(msg)
@@ -517,7 +517,7 @@ class SelectClauseMixin:
             if isinstance(order_by, str):
                 over_args["order"] = exp.column(order_by).asc()
             elif isinstance(order_by, list):
-                order_expressions: list[Union[exp.Expression, exp.Column]] = []
+                order_expressions: list[exp.Expression | exp.Column] = []
                 for col in order_by:
                     if isinstance(col, str):
                         order_expressions.append(exp.column(col).asc())
@@ -528,7 +528,7 @@ class SelectClauseMixin:
                 over_args["order"] = order_by
 
         if frame:
-            frame_expr: Optional[exp.Expression] = exp.maybe_parse(frame, dialect=getattr(self, "dialect", None))
+            frame_expr: exp.Expression | None = exp.maybe_parse(frame, dialect=getattr(self, "dialect", None))
             if frame_expr:
                 over_args["frame"] = frame_expr
 
@@ -537,7 +537,7 @@ class SelectClauseMixin:
         self.set_expression(current_expr)
         return self
 
-    def case_(self, alias: "Optional[str]" = None) -> "CaseBuilder":
+    def case_(self, alias: "str | None" = None) -> "CaseBuilder":
         """Create a CASE expression for the SELECT clause.
 
         Args:
@@ -555,7 +555,7 @@ class CaseBuilder:
 
     __slots__ = ("_alias", "_case_expr", "_parent")
 
-    def __init__(self, parent: "SelectBuilderProtocol", alias: "Optional[str]" = None) -> None:
+    def __init__(self, parent: "SelectBuilderProtocol", alias: "str | None" = None) -> None:
         """Initialize CaseBuilder.
 
         Args:
@@ -566,7 +566,7 @@ class CaseBuilder:
         self._alias = alias
         self._case_expr = exp.Case()
 
-    def when(self, condition: "Union[str, exp.Expression]", value: "Any") -> "CaseBuilder":
+    def when(self, condition: "str | exp.Expression", value: "Any") -> "CaseBuilder":
         """Add WHEN clause to CASE expression.
 
         Args:
@@ -639,7 +639,7 @@ class WindowFunctionBuilder:
         self._function_name = function_name
         self._partition_by_cols: list[exp.Expression] = []
         self._order_by_cols: list[exp.Expression] = []
-        self._alias: Optional[str] = None
+        self._alias: str | None = None
 
     def __eq__(self, other: object) -> "ColumnExpression":  # type: ignore[override]
         """Equal to (==) - convert to expression then compare."""
@@ -654,7 +654,7 @@ class WindowFunctionBuilder:
         """Make WindowFunctionBuilder hashable."""
         return hash(id(self))
 
-    def partition_by(self, *columns: Union[str, exp.Expression]) -> "WindowFunctionBuilder":
+    def partition_by(self, *columns: str | exp.Expression) -> "WindowFunctionBuilder":
         """Add PARTITION BY clause.
 
         Args:
@@ -668,7 +668,7 @@ class WindowFunctionBuilder:
             self._partition_by_cols.append(col_expr)
         return self
 
-    def order_by(self, *columns: Union[str, exp.Expression]) -> "WindowFunctionBuilder":
+    def order_by(self, *columns: str | exp.Expression) -> "WindowFunctionBuilder":
         """Add ORDER BY clause.
 
         Args:
@@ -770,7 +770,7 @@ class SubqueryBuilder:
         """Make SubqueryBuilder hashable."""
         return hash(id(self))
 
-    def __call__(self, subquery: Union[str, exp.Expression, Any]) -> exp.Expression:
+    def __call__(self, subquery: str | exp.Expression | Any) -> exp.Expression:
         """Build the subquery expression.
 
         Args:
@@ -782,7 +782,7 @@ class SubqueryBuilder:
         subquery_expr: exp.Expression
         if isinstance(subquery, str):
             # Parse as SQL
-            parsed: Optional[exp.Expression] = exp.maybe_parse(subquery)
+            parsed: exp.Expression | None = exp.maybe_parse(subquery)
             if not parsed:
                 msg = f"Could not parse subquery SQL: {subquery}"
                 raise SQLBuilderError(msg)
@@ -839,7 +839,7 @@ class Case:
     def __init__(self) -> None:
         """Initialize the CASE expression builder."""
         self._conditions: list[exp.If] = []
-        self._default: Optional[exp.Expression] = None
+        self._default: exp.Expression | None = None
 
     def __eq__(self, other: object) -> "ColumnExpression":  # type: ignore[override]
         """Equal to (==) - convert to expression then compare."""
@@ -854,7 +854,7 @@ class Case:
         """Make Case hashable."""
         return hash(id(self))
 
-    def when(self, condition: Union[str, exp.Expression], value: Union[str, exp.Expression, Any]) -> Self:
+    def when(self, condition: str | exp.Expression, value: str | exp.Expression | Any) -> Self:
         """Add a WHEN clause.
 
         Args:
@@ -871,7 +871,7 @@ class Case:
         self._conditions.append(when_clause)
         return self
 
-    def else_(self, value: Union[str, exp.Expression, Any]) -> Self:
+    def else_(self, value: str | exp.Expression | Any) -> Self:
         """Add an ELSE clause.
 
         Args:
@@ -921,7 +921,7 @@ class Case:
         return self._conditions
 
     @property
-    def default(self) -> Optional[exp.Expression]:
+    def default(self) -> exp.Expression | None:
         """Get CASE default value (public API).
 
         Returns:

--- a/sqlspec/builder/mixins/_update_operations.py
+++ b/sqlspec/builder/mixins/_update_operations.py
@@ -6,7 +6,7 @@ table specification, SET clauses, and FROM clauses.
 """
 
 from collections.abc import Mapping
-from typing import Any, Optional, Union
+from typing import Any
 
 from mypy_extensions import trait
 from sqlglot import exp
@@ -27,10 +27,10 @@ class UpdateTableClauseMixin:
 
     __slots__ = ()
 
-    def get_expression(self) -> Optional[exp.Expression]: ...
+    def get_expression(self) -> exp.Expression | None: ...
     def set_expression(self, expression: exp.Expression) -> None: ...
 
-    def table(self, table_name: str, alias: Optional[str] = None) -> Self:
+    def table(self, table_name: str, alias: str | None = None) -> Self:
         """Set the table to update.
 
         Args:
@@ -58,10 +58,10 @@ class UpdateSetClauseMixin:
 
     __slots__ = ()
 
-    def get_expression(self) -> Optional[exp.Expression]: ...
+    def get_expression(self) -> exp.Expression | None: ...
     def set_expression(self, expression: exp.Expression) -> None: ...
 
-    def add_parameter(self, value: Any, name: Optional[str] = None) -> tuple[Any, str]:
+    def add_parameter(self, value: Any, name: str | None = None) -> tuple[Any, str]:
         """Add parameter - provided by QueryBuilder."""
         msg = "Method must be provided by QueryBuilder subclass"
         raise NotImplementedError(msg)
@@ -152,10 +152,10 @@ class UpdateFromClauseMixin:
 
     __slots__ = ()
 
-    def get_expression(self) -> Optional[exp.Expression]: ...
+    def get_expression(self) -> exp.Expression | None: ...
     def set_expression(self, expression: exp.Expression) -> None: ...
 
-    def from_(self, table: Union[str, exp.Expression, Any], alias: Optional[str] = None) -> Self:
+    def from_(self, table: str | exp.Expression | Any, alias: str | None = None) -> Self:
         """Add a FROM clause to the UPDATE statement.
 
         Args:

--- a/sqlspec/core/compiler.py
+++ b/sqlspec/core/compiler.py
@@ -8,13 +8,12 @@ Components:
 
 import hashlib
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import sqlglot
 from mypy_extensions import mypyc_attr
 from sqlglot import expressions as exp
 from sqlglot.errors import ParseError
-from typing_extensions import Literal
 
 from sqlspec.core.parameters import ParameterProcessor
 from sqlspec.exceptions import SQLSpecError
@@ -85,7 +84,7 @@ class CompiledSQL:
         execution_parameters: Any,
         operation_type: "OperationType",
         expression: Optional["exp.Expression"] = None,
-        parameter_style: Optional[str] = None,
+        parameter_style: str | None = None,
         supports_many: bool = False,
         parameter_casts: Optional["dict[int, str]"] = None,
     ) -> None:
@@ -107,7 +106,7 @@ class CompiledSQL:
         self.parameter_style = parameter_style
         self.supports_many = supports_many
         self.parameter_casts = parameter_casts or {}
-        self._hash: Optional[int] = None
+        self._hash: int | None = None
 
     def __hash__(self) -> int:
         """Cached hash value."""
@@ -382,7 +381,7 @@ class SQLProcessor:
         return cast_positions
 
     def _apply_final_transformations(
-        self, expression: "Optional[exp.Expression]", sql: str, parameters: Any, dialect_str: "Optional[str]"
+        self, expression: "exp.Expression | None", sql: str, parameters: Any, dialect_str: "str | None"
     ) -> "tuple[str, Any]":
         """Apply final transformations.
 

--- a/sqlspec/core/filters.py
+++ b/sqlspec/core/filters.py
@@ -23,11 +23,11 @@ from abc import ABC, abstractmethod
 from collections import abc
 from collections.abc import Sequence
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Generic, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeAlias
 
 import sqlglot
 from sqlglot import exp
-from typing_extensions import TypeAlias, TypeVar
+from typing_extensions import TypeVar
 
 if TYPE_CHECKING:
     from sqlglot.expressions import Condition
@@ -125,7 +125,7 @@ class BeforeAfterFilter(StatementFilter):
 
     __slots__ = ("_after", "_before", "_field_name")
 
-    def __init__(self, field_name: str, before: Optional[datetime] = None, after: Optional[datetime] = None) -> None:
+    def __init__(self, field_name: str, before: datetime | None = None, after: datetime | None = None) -> None:
         self._field_name = field_name
         self._before = before
         self._after = after
@@ -135,11 +135,11 @@ class BeforeAfterFilter(StatementFilter):
         return self._field_name
 
     @property
-    def before(self) -> Optional[datetime]:
+    def before(self) -> datetime | None:
         return self._before
 
     @property
-    def after(self) -> Optional[datetime]:
+    def after(self) -> datetime | None:
         return self._after
 
     def get_param_names(self) -> list[str]:
@@ -206,7 +206,7 @@ class OnBeforeAfterFilter(StatementFilter):
     __slots__ = ("_field_name", "_on_or_after", "_on_or_before")
 
     def __init__(
-        self, field_name: str, on_or_before: Optional[datetime] = None, on_or_after: Optional[datetime] = None
+        self, field_name: str, on_or_before: datetime | None = None, on_or_after: datetime | None = None
     ) -> None:
         self._field_name = field_name
         self._on_or_before = on_or_before
@@ -217,11 +217,11 @@ class OnBeforeAfterFilter(StatementFilter):
         return self._field_name
 
     @property
-    def on_or_before(self) -> Optional[datetime]:
+    def on_or_before(self) -> datetime | None:
         return self._on_or_before
 
     @property
-    def on_or_after(self) -> Optional[datetime]:
+    def on_or_after(self) -> datetime | None:
         return self._on_or_after
 
     def get_param_names(self) -> list[str]:
@@ -298,7 +298,7 @@ class InCollectionFilter(InAnyFilter[T]):
 
     __slots__ = ("_field_name", "_values")
 
-    def __init__(self, field_name: str, values: Optional[abc.Collection[T]] = None) -> None:
+    def __init__(self, field_name: str, values: abc.Collection[T] | None = None) -> None:
         self._field_name = field_name
         self._values = values
 
@@ -307,7 +307,7 @@ class InCollectionFilter(InAnyFilter[T]):
         return self._field_name
 
     @property
-    def values(self) -> Optional[abc.Collection[T]]:
+    def values(self) -> abc.Collection[T] | None:
         return self._values
 
     def get_param_names(self) -> list[str]:
@@ -340,7 +340,7 @@ class InCollectionFilter(InAnyFilter[T]):
 
         result = statement.where(exp.In(this=exp.column(self.field_name), expressions=placeholder_expressions))
 
-        for resolved_name, value in zip(resolved_names, self.values):
+        for resolved_name, value in zip(resolved_names, self.values, strict=False):
             result = result.add_named_parameter(resolved_name, value)
         return result
 
@@ -358,7 +358,7 @@ class NotInCollectionFilter(InAnyFilter[T]):
 
     __slots__ = ("_field_name", "_values")
 
-    def __init__(self, field_name: str, values: Optional[abc.Collection[T]] = None) -> None:
+    def __init__(self, field_name: str, values: abc.Collection[T] | None = None) -> None:
         self._field_name = field_name
         self._values = values
 
@@ -367,7 +367,7 @@ class NotInCollectionFilter(InAnyFilter[T]):
         return self._field_name
 
     @property
-    def values(self) -> Optional[abc.Collection[T]]:
+    def values(self) -> abc.Collection[T] | None:
         return self._values
 
     def get_param_names(self) -> list[str]:
@@ -400,7 +400,7 @@ class NotInCollectionFilter(InAnyFilter[T]):
             exp.Not(this=exp.In(this=exp.column(self.field_name), expressions=placeholder_expressions))
         )
 
-        for resolved_name, value in zip(resolved_names, self.values):
+        for resolved_name, value in zip(resolved_names, self.values, strict=False):
             result = result.add_named_parameter(resolved_name, value)
         return result
 
@@ -418,7 +418,7 @@ class AnyCollectionFilter(InAnyFilter[T]):
 
     __slots__ = ("_field_name", "_values")
 
-    def __init__(self, field_name: str, values: Optional[abc.Collection[T]] = None) -> None:
+    def __init__(self, field_name: str, values: abc.Collection[T] | None = None) -> None:
         self._field_name = field_name
         self._values = values
 
@@ -427,7 +427,7 @@ class AnyCollectionFilter(InAnyFilter[T]):
         return self._field_name
 
     @property
-    def values(self) -> Optional[abc.Collection[T]]:
+    def values(self) -> abc.Collection[T] | None:
         return self._values
 
     def get_param_names(self) -> list[str]:
@@ -461,7 +461,7 @@ class AnyCollectionFilter(InAnyFilter[T]):
         array_expr = exp.Array(expressions=placeholder_expressions)
         result = statement.where(exp.EQ(this=exp.column(self.field_name), expression=exp.Any(this=array_expr)))
 
-        for resolved_name, value in zip(resolved_names, self.values):
+        for resolved_name, value in zip(resolved_names, self.values, strict=False):
             result = result.add_named_parameter(resolved_name, value)
         return result
 
@@ -479,7 +479,7 @@ class NotAnyCollectionFilter(InAnyFilter[T]):
 
     __slots__ = ("_field_name", "_values")
 
-    def __init__(self, field_name: str, values: Optional[abc.Collection[T]] = None) -> None:
+    def __init__(self, field_name: str, values: abc.Collection[T] | None = None) -> None:
         self._field_name = field_name
         self._values = values
 
@@ -488,7 +488,7 @@ class NotAnyCollectionFilter(InAnyFilter[T]):
         return self._field_name
 
     @property
-    def values(self) -> Optional[abc.Collection[T]]:
+    def values(self) -> abc.Collection[T] | None:
         return self._values
 
     def get_param_names(self) -> list[str]:
@@ -520,7 +520,7 @@ class NotAnyCollectionFilter(InAnyFilter[T]):
         condition = exp.EQ(this=exp.column(self.field_name), expression=exp.Any(this=array_expr))
         result = statement.where(exp.Not(this=condition))
 
-        for resolved_name, value in zip(resolved_names, self.values):
+        for resolved_name, value in zip(resolved_names, self.values, strict=False):
             result = result.add_named_parameter(resolved_name, value)
         return result
 
@@ -650,13 +650,13 @@ class SearchFilter(StatementFilter):
 
     __slots__ = ("_field_name", "_ignore_case", "_value")
 
-    def __init__(self, field_name: Union[str, set[str]], value: str, ignore_case: Optional[bool] = False) -> None:
+    def __init__(self, field_name: str | set[str], value: str, ignore_case: bool | None = False) -> None:
         self._field_name = field_name
         self._value = value
         self._ignore_case = ignore_case
 
     @property
-    def field_name(self) -> Union[str, set[str]]:
+    def field_name(self) -> str | set[str]:
         return self._field_name
 
     @property
@@ -664,10 +664,10 @@ class SearchFilter(StatementFilter):
         return self._value
 
     @property
-    def ignore_case(self) -> Optional[bool]:
+    def ignore_case(self) -> bool | None:
         return self._ignore_case
 
-    def get_param_name(self) -> Optional[str]:
+    def get_param_name(self) -> str | None:
         """Get parameter name without storing it."""
         if not self.value:
             return None
@@ -726,7 +726,7 @@ class NotInSearchFilter(SearchFilter):
     Constructs WHERE field_name NOT LIKE '%value%' clauses.
     """
 
-    def get_param_name(self) -> Optional[str]:
+    def get_param_name(self) -> str | None:
         """Get parameter name without storing it."""
         if not self.value:
             return None
@@ -817,18 +817,18 @@ def apply_filter(statement: "SQL", filter_obj: StatementFilter) -> "SQL":
     return filter_obj.append_to_statement(statement)
 
 
-FilterTypes: TypeAlias = Union[
-    BeforeAfterFilter,
-    OnBeforeAfterFilter,
-    InCollectionFilter[Any],
-    LimitOffsetFilter,
-    OrderByFilter,
-    SearchFilter,
-    NotInCollectionFilter[Any],
-    NotInSearchFilter,
-    AnyCollectionFilter[Any],
-    NotAnyCollectionFilter[Any],
-]
+FilterTypes: TypeAlias = (
+    BeforeAfterFilter
+    | OnBeforeAfterFilter
+    | InCollectionFilter[Any]
+    | LimitOffsetFilter
+    | OrderByFilter
+    | SearchFilter
+    | NotInCollectionFilter[Any]
+    | NotInSearchFilter
+    | AnyCollectionFilter[Any]
+    | NotAnyCollectionFilter[Any]
+)
 
 
 def create_filters(filters: "list[StatementFilter]") -> tuple["StatementFilter", ...]:

--- a/sqlspec/core/hashing.py
+++ b/sqlspec/core/hashing.py
@@ -4,7 +4,7 @@ Provides hashing functions for SQL statements, expressions, parameters,
 filters, and AST sub-expressions.
 """
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from sqlglot import exp
 
@@ -23,7 +23,7 @@ __all__ = (
 )
 
 
-def hash_expression(expr: Optional[exp.Expression], _seen: Optional[set[int]] = None) -> int:
+def hash_expression(expr: exp.Expression | None, _seen: set[int] | None = None) -> int:
     """Generate hash from AST structure.
 
     Args:
@@ -77,9 +77,9 @@ def _hash_value(value: Any, _seen: set[int]) -> int:
 
 
 def hash_parameters(
-    positional_parameters: Optional[list[Any]] = None,
-    named_parameters: Optional[dict[str, Any]] = None,
-    original_parameters: Optional[Any] = None,
+    positional_parameters: list[Any] | None = None,
+    named_parameters: dict[str, Any] | None = None,
+    original_parameters: Any | None = None,
 ) -> int:
     """Generate hash for SQL parameters.
 
@@ -148,7 +148,7 @@ def _hash_filter_value(value: Any) -> int:
         return hash(repr(value))
 
 
-def hash_filters(filters: Optional[list["StatementFilter"]] = None) -> int:
+def hash_filters(filters: list["StatementFilter"] | None = None) -> int:
     """Generate hash for statement filters.
 
     Args:
@@ -208,7 +208,7 @@ def hash_sql_statement(statement: "SQL") -> str:
     return f"sql:{hash(tuple(state_components))}"
 
 
-def hash_expression_node(node: exp.Expression, include_children: bool = True, dialect: Optional[str] = None) -> str:
+def hash_expression_node(node: exp.Expression, include_children: bool = True, dialect: str | None = None) -> str:
     """Generate cache key for an expression node.
 
     Args:
@@ -235,8 +235,8 @@ def hash_expression_node(node: exp.Expression, include_children: bool = True, di
 def hash_optimized_expression(
     expr: exp.Expression,
     dialect: str,
-    schema: Optional[dict[str, Any]] = None,
-    optimizer_settings: Optional[dict[str, Any]] = None,
+    schema: dict[str, Any] | None = None,
+    optimizer_settings: dict[str, Any] | None = None,
 ) -> str:
     """Generate cache key for optimized expressions.
 

--- a/sqlspec/core/result.py
+++ b/sqlspec/core/result.py
@@ -10,7 +10,7 @@ Classes:
 """
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 from mypy_extensions import mypyc_attr
 from typing_extensions import TypeVar
@@ -52,8 +52,8 @@ class StatementResult(ABC):
         statement: "SQL",
         data: Any = None,
         rows_affected: int = 0,
-        last_inserted_id: Optional[Union[int, str]] = None,
-        execution_time: Optional[float] = None,
+        last_inserted_id: int | str | None = None,
+        execution_time: float | None = None,
         metadata: Optional["dict[str, Any]"] = None,
     ) -> None:
         """Initialize statement result.
@@ -164,19 +164,19 @@ class SQLResult(StatementResult):
     def __init__(
         self,
         statement: "SQL",
-        data: Optional[list[dict[str, Any]]] = None,
+        data: list[dict[str, Any]] | None = None,
         rows_affected: int = 0,
-        last_inserted_id: Optional[Union[int, str]] = None,
-        execution_time: Optional[float] = None,
+        last_inserted_id: int | str | None = None,
+        execution_time: float | None = None,
         metadata: Optional["dict[str, Any]"] = None,
-        error: Optional[Exception] = None,
+        error: Exception | None = None,
         operation_type: OperationType = "SELECT",
-        operation_index: Optional[int] = None,
-        parameters: Optional[Any] = None,
+        operation_index: int | None = None,
+        parameters: Any | None = None,
         column_names: Optional["list[str]"] = None,
-        total_count: Optional[int] = None,
+        total_count: int | None = None,
         has_more: bool = False,
-        inserted_ids: Optional["list[Union[int, str]]"] = None,
+        inserted_ids: Optional["list[int | str]"] = None,
         statement_results: Optional["list[SQLResult]"] = None,
         errors: Optional["list[str]"] = None,
         total_statements: int = 0,
@@ -348,7 +348,7 @@ class SQLResult(StatementResult):
         """
         return len(self.column_names) if self.column_names else 0
 
-    def get_first(self) -> "Optional[dict[str, Any]]":
+    def get_first(self) -> "dict[str, Any] | None":
         """Get the first row from the result, if any.
 
         Returns:
@@ -465,7 +465,7 @@ class SQLResult(StatementResult):
 
         return cast("dict[str, Any]", self.data[0])
 
-    def one_or_none(self) -> "Optional[dict[str, Any]]":
+    def one_or_none(self) -> "dict[str, Any] | None":
         """Return at most one row.
 
         Returns:
@@ -527,8 +527,8 @@ class ArrowResult(StatementResult):
         statement: "SQL",
         data: Any,
         rows_affected: int = 0,
-        last_inserted_id: Optional[Union[int, str]] = None,
-        execution_time: Optional[float] = None,
+        last_inserted_id: int | str | None = None,
+        execution_time: float | None = None,
         metadata: Optional["dict[str, Any]"] = None,
         schema: Optional["dict[str, Any]"] = None,
     ) -> None:
@@ -627,10 +627,10 @@ class ArrowResult(StatementResult):
 
 def create_sql_result(
     statement: "SQL",
-    data: Optional[list[dict[str, Any]]] = None,
+    data: list[dict[str, Any]] | None = None,
     rows_affected: int = 0,
-    last_inserted_id: Optional[Union[int, str]] = None,
-    execution_time: Optional[float] = None,
+    last_inserted_id: int | str | None = None,
+    execution_time: float | None = None,
     metadata: Optional["dict[str, Any]"] = None,
     **kwargs: Any,
 ) -> SQLResult:
@@ -663,8 +663,8 @@ def create_arrow_result(
     statement: "SQL",
     data: Any,
     rows_affected: int = 0,
-    last_inserted_id: Optional[Union[int, str]] = None,
-    execution_time: Optional[float] = None,
+    last_inserted_id: int | str | None = None,
+    execution_time: float | None = None,
     metadata: Optional["dict[str, Any]"] = None,
     schema: Optional["dict[str, Any]"] = None,
 ) -> ArrowResult:

--- a/sqlspec/core/type_conversion.py
+++ b/sqlspec/core/type_conversion.py
@@ -5,9 +5,10 @@ adapters, with MyPyC-compatible optimizations.
 """
 
 import re
+from collections.abc import Callable
 from datetime import date, datetime, time, timezone
 from decimal import Decimal
-from typing import Any, Callable, Final, Optional
+from typing import Any, Final
 from uuid import UUID
 
 from sqlspec._serialization import decode_json
@@ -38,7 +39,7 @@ class BaseTypeConverter:
 
     __slots__ = ()
 
-    def detect_type(self, value: str) -> Optional[str]:
+    def detect_type(self, value: str) -> str | None:
         """Detect special types from string values.
 
         Args:

--- a/sqlspec/driver/__init__.py
+++ b/sqlspec/driver/__init__.py
@@ -1,7 +1,5 @@
 """Driver protocols and base classes for database adapters."""
 
-from typing import Union
-
 from sqlspec.driver import mixins
 from sqlspec.driver._async import AsyncDataDictionaryBase, AsyncDriverAdapterBase
 from sqlspec.driver._common import CommonDriverAttributesMixin, ExecutionResult, VersionInfo
@@ -19,4 +17,4 @@ __all__ = (
     "mixins",
 )
 
-DriverAdapterProtocol = Union[SyncDriverAdapterBase, AsyncDriverAdapterBase]
+DriverAdapterProtocol = SyncDriverAdapterBase | AsyncDriverAdapterBase

--- a/sqlspec/driver/_async.py
+++ b/sqlspec/driver/_async.py
@@ -1,7 +1,7 @@
 """Asynchronous driver protocol implementation."""
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Final, NoReturn, Optional, TypeVar, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Final, NoReturn, TypeVar, cast, overload
 
 from sqlspec.core import SQL, Statement
 from sqlspec.driver._common import CommonDriverAttributesMixin, DataDictionaryMixin, ExecutionResult, VersionInfo
@@ -96,7 +96,7 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, To
         """Commit the current transaction on the current connection."""
 
     @abstractmethod
-    async def _try_special_handling(self, cursor: Any, statement: "SQL") -> "Optional[SQLResult]":
+    async def _try_special_handling(self, cursor: Any, statement: "SQL") -> "SQLResult | None":
         """Hook for database-specific special operations (e.g., PostgreSQL COPY, bulk operations).
 
         This method is called first in dispatch_statement_execution() to allow drivers to handle
@@ -169,10 +169,10 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, To
 
     async def execute(
         self,
-        statement: "Union[SQL, Statement, QueryBuilder]",
+        statement: "SQL | Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
-        statement_config: "Optional[StatementConfig]" = None,
+        *parameters: "StatementParameters | StatementFilter",
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> "SQLResult":
         """Execute a statement with parameter handling."""
@@ -183,11 +183,11 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, To
 
     async def execute_many(
         self,
-        statement: "Union[SQL, Statement, QueryBuilder]",
+        statement: "SQL | Statement | QueryBuilder",
         /,
         parameters: "Sequence[StatementParameters]",
-        *filters: "Union[StatementParameters, StatementFilter]",
-        statement_config: "Optional[StatementConfig]" = None,
+        *filters: "StatementParameters | StatementFilter",
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> "SQLResult":
         """Execute statement multiple times with different parameters.
@@ -206,10 +206,10 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, To
 
     async def execute_script(
         self,
-        statement: "Union[str, SQL]",
+        statement: "str | SQL",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
-        statement_config: "Optional[StatementConfig]" = None,
+        *parameters: "StatementParameters | StatementFilter",
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> "SQLResult":
         """Execute a multi-statement script.
@@ -225,34 +225,34 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, To
     @overload
     async def select_one(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
+        *parameters: "StatementParameters | StatementFilter",
         schema_type: "type[ModelDTOT]",
-        statement_config: "Optional[StatementConfig]" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> "ModelDTOT": ...
 
     @overload
     async def select_one(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
+        *parameters: "StatementParameters | StatementFilter",
         schema_type: None = None,
-        statement_config: "Optional[StatementConfig]" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> "dict[str, Any]": ...
 
     async def select_one(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
-        schema_type: "Optional[type[ModelDTOT]]" = None,
-        statement_config: "Optional[StatementConfig]" = None,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: "type[ModelDTOT] | None" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "Union[dict[str, Any], ModelDTOT]":
+    ) -> "dict[str, Any] | ModelDTOT":
         """Execute a select statement and return exactly one row.
 
         Raises an exception if no rows or more than one row is returned.
@@ -270,34 +270,34 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, To
     @overload
     async def select_one_or_none(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
+        *parameters: "StatementParameters | StatementFilter",
         schema_type: "type[ModelDTOT]",
-        statement_config: "Optional[StatementConfig]" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "Optional[ModelDTOT]": ...
+    ) -> "ModelDTOT | None": ...
 
     @overload
     async def select_one_or_none(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
+        *parameters: "StatementParameters | StatementFilter",
         schema_type: None = None,
-        statement_config: "Optional[StatementConfig]" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "Optional[dict[str, Any]]": ...
+    ) -> "dict[str, Any] | None": ...
 
     async def select_one_or_none(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
-        schema_type: "Optional[type[ModelDTOT]]" = None,
-        statement_config: "Optional[StatementConfig]" = None,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: "type[ModelDTOT] | None" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "Optional[Union[dict[str, Any], ModelDTOT]]":
+    ) -> "dict[str, Any] | ModelDTOT | None":
         """Execute a select statement and return at most one row.
 
         Returns None if no rows are found.
@@ -312,53 +312,53 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, To
             self._raise_expected_at_most_one_row(data_len)
         first_row = data[0]
         return cast(
-            "Optional[Union[dict[str, Any], ModelDTOT]]",
+            "dict[str, Any] | ModelDTOT | None",
             self.to_schema(first_row, schema_type=schema_type) if schema_type else first_row,
         )
 
     @overload
     async def select(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
+        *parameters: "StatementParameters | StatementFilter",
         schema_type: "type[ModelDTOT]",
-        statement_config: "Optional[StatementConfig]" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> "list[ModelDTOT]": ...
 
     @overload
     async def select(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
+        *parameters: "StatementParameters | StatementFilter",
         schema_type: None = None,
-        statement_config: "Optional[StatementConfig]" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> "list[dict[str, Any]]": ...
 
     async def select(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
-        schema_type: "Optional[type[ModelDTOT]]" = None,
-        statement_config: "Optional[StatementConfig]" = None,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: "type[ModelDTOT] | None" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "Union[list[dict[str, Any]], list[ModelDTOT]]":
+    ) -> "list[dict[str, Any]] | list[ModelDTOT]":
         """Execute a select statement and return all rows."""
         result = await self.execute(statement, *parameters, statement_config=statement_config, **kwargs)
         return cast(
-            "Union[list[dict[str, Any]], list[ModelDTOT]]", self.to_schema(result.get_data(), schema_type=schema_type)
+            "list[dict[str, Any]] | list[ModelDTOT]", self.to_schema(result.get_data(), schema_type=schema_type)
         )
 
     async def select_value(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
-        statement_config: "Optional[StatementConfig]" = None,
+        *parameters: "StatementParameters | StatementFilter",
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> Any:
         """Execute a select statement and return a single scalar value.
@@ -386,10 +386,10 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, To
 
     async def select_value_or_none(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
-        statement_config: "Optional[StatementConfig]" = None,
+        *parameters: "StatementParameters | StatementFilter",
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> Any:
         """Execute a select statement and return a single scalar value or None.
@@ -418,34 +418,34 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, To
     @overload
     async def select_with_total(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
+        *parameters: "StatementParameters | StatementFilter",
         schema_type: "type[ModelDTOT]",
-        statement_config: "Optional[StatementConfig]" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> "tuple[list[ModelDTOT], int]": ...
 
     @overload
     async def select_with_total(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
+        *parameters: "StatementParameters | StatementFilter",
         schema_type: None = None,
-        statement_config: "Optional[StatementConfig]" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> "tuple[list[dict[str, Any]], int]": ...
 
     async def select_with_total(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
-        schema_type: "Optional[type[ModelDTOT]]" = None,
-        statement_config: "Optional[StatementConfig]" = None,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: "type[ModelDTOT] | None" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "tuple[Union[list[dict[str, Any]], list[ModelDTOT]], int]":
+    ) -> "tuple[list[dict[str, Any]] | list[ModelDTOT], int]":
         """Execute a select statement and return both the data and total count.
 
         This method is designed for pagination scenarios where you need both
@@ -504,7 +504,7 @@ class AsyncDataDictionaryBase(DataDictionaryMixin):
     """Base class for asynchronous data dictionary implementations."""
 
     @abstractmethod
-    async def get_version(self, driver: "AsyncDriverAdapterBase") -> "Optional[VersionInfo]":
+    async def get_version(self, driver: "AsyncDriverAdapterBase") -> "VersionInfo | None":
         """Get database version information.
 
         Args:
@@ -538,7 +538,7 @@ class AsyncDataDictionaryBase(DataDictionaryMixin):
             Database-specific type name
         """
 
-    async def get_tables(self, driver: "AsyncDriverAdapterBase", schema: "Optional[str]" = None) -> "list[str]":
+    async def get_tables(self, driver: "AsyncDriverAdapterBase", schema: "str | None" = None) -> "list[str]":
         """Get list of tables in schema.
 
         Args:
@@ -552,7 +552,7 @@ class AsyncDataDictionaryBase(DataDictionaryMixin):
         return []
 
     async def get_columns(
-        self, driver: "AsyncDriverAdapterBase", table: str, schema: "Optional[str]" = None
+        self, driver: "AsyncDriverAdapterBase", table: str, schema: "str | None" = None
     ) -> "list[dict[str, Any]]":
         """Get column information for a table.
 
@@ -568,7 +568,7 @@ class AsyncDataDictionaryBase(DataDictionaryMixin):
         return []
 
     async def get_indexes(
-        self, driver: "AsyncDriverAdapterBase", table: str, schema: "Optional[str]" = None
+        self, driver: "AsyncDriverAdapterBase", table: str, schema: "str | None" = None
     ) -> "list[dict[str, Any]]":
         """Get index information for a table.
 

--- a/sqlspec/driver/_common.py
+++ b/sqlspec/driver/_common.py
@@ -2,7 +2,7 @@
 
 import re
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, Final, NamedTuple, Optional, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Final, NamedTuple, Optional, TypeVar, cast
 
 from mypy_extensions import trait
 from sqlglot import exp
@@ -100,7 +100,7 @@ class VersionInfo:
 class DataDictionaryMixin:
     """Mixin providing common data dictionary functionality."""
 
-    def parse_version_string(self, version_str: str) -> "Optional[VersionInfo]":
+    def parse_version_string(self, version_str: str) -> "VersionInfo | None":
         """Parse version string into VersionInfo.
 
         Args:
@@ -128,7 +128,7 @@ class DataDictionaryMixin:
 
         return None
 
-    def detect_version_with_queries(self, driver: Any, queries: "list[str]") -> "Optional[VersionInfo]":
+    def detect_version_with_queries(self, driver: Any, queries: "list[str]") -> "VersionInfo | None":
         """Try multiple version queries to detect database version.
 
         Args:
@@ -184,7 +184,7 @@ class ScriptExecutionResult(NamedTuple):
     """Result from script execution with statement count information."""
 
     cursor_result: Any
-    rowcount_override: Optional[int]
+    rowcount_override: int | None
     special_data: Any
     statement_count: int
     successful_statements: int
@@ -194,23 +194,23 @@ class ExecutionResult(NamedTuple):
     """Execution result containing all data needed for SQLResult building."""
 
     cursor_result: Any
-    rowcount_override: Optional[int]
+    rowcount_override: int | None
     special_data: Any
     selected_data: Optional["list[dict[str, Any]]"]
     column_names: Optional["list[str]"]
-    data_row_count: Optional[int]
-    statement_count: Optional[int]
-    successful_statements: Optional[int]
+    data_row_count: int | None
+    statement_count: int | None
+    successful_statements: int | None
     is_script_result: bool
     is_select_result: bool
     is_many_result: bool
-    last_inserted_id: Optional[Union[int, str]] = None
+    last_inserted_id: int | str | None = None
 
 
 EXEC_CURSOR_RESULT: Final[int] = 0
 EXEC_ROWCOUNT_OVERRIDE: Final[int] = 1
 EXEC_SPECIAL_DATA: Final[int] = 2
-DEFAULT_EXECUTION_RESULT: Final[tuple[Any, Optional[int], Any]] = (None, None, None)
+DEFAULT_EXECUTION_RESULT: Final[tuple[Any, int | None, Any]] = (None, None, None)
 
 
 @trait
@@ -223,7 +223,7 @@ class CommonDriverAttributesMixin:
     driver_features: "dict[str, Any]"
 
     def __init__(
-        self, connection: "Any", statement_config: "StatementConfig", driver_features: "Optional[dict[str, Any]]" = None
+        self, connection: "Any", statement_config: "StatementConfig", driver_features: "dict[str, Any] | None" = None
     ) -> None:
         """Initialize driver adapter with connection and configuration.
 
@@ -240,17 +240,17 @@ class CommonDriverAttributesMixin:
         self,
         cursor_result: Any,
         *,
-        rowcount_override: Optional[int] = None,
+        rowcount_override: int | None = None,
         special_data: Any = None,
         selected_data: Optional["list[dict[str, Any]]"] = None,
         column_names: Optional["list[str]"] = None,
-        data_row_count: Optional[int] = None,
-        statement_count: Optional[int] = None,
-        successful_statements: Optional[int] = None,
+        data_row_count: int | None = None,
+        statement_count: int | None = None,
+        successful_statements: int | None = None,
         is_script_result: bool = False,
         is_select_result: bool = False,
         is_many_result: bool = False,
-        last_inserted_id: Optional[Union[int, str]] = None,
+        last_inserted_id: int | str | None = None,
     ) -> ExecutionResult:
         """Create ExecutionResult with all necessary data for any operation type.
 
@@ -328,11 +328,11 @@ class CommonDriverAttributesMixin:
 
     def prepare_statement(
         self,
-        statement: "Union[Statement, QueryBuilder]",
-        parameters: "tuple[Union[StatementParameters, StatementFilter], ...]" = (),
+        statement: "Statement | QueryBuilder",
+        parameters: "tuple[StatementParameters | StatementFilter, ...]" = (),
         *,
         statement_config: "StatementConfig",
-        kwargs: "Optional[dict[str, Any]]" = None,
+        kwargs: "dict[str, Any] | None" = None,
     ) -> "SQL":
         """Build SQL statement from various input types.
 
@@ -421,7 +421,7 @@ class CommonDriverAttributesMixin:
         parameters: Any,
         statement_config: "StatementConfig",
         is_many: bool = False,
-        prepared_statement: Optional[Any] = None,  # pyright: ignore[reportUnusedParameter]
+        prepared_statement: Any | None = None,  # pyright: ignore[reportUnusedParameter]
     ) -> Any:
         """Prepare parameters for database driver consumption.
 
@@ -655,7 +655,7 @@ class CommonDriverAttributesMixin:
         base_hash = hash((statement.sql, params_key, statement.is_many, statement.is_script))
         return f"compiled:{base_hash}:{context_hash}"
 
-    def _get_dominant_parameter_style(self, parameters: "list[Any]") -> "Optional[ParameterStyle]":
+    def _get_dominant_parameter_style(self, parameters: "list[Any]") -> "ParameterStyle | None":
         """Determine the dominant parameter style from parameter info list.
 
         Args:
@@ -688,7 +688,7 @@ class CommonDriverAttributesMixin:
     def find_filter(
         filter_type: "type[FilterTypeT]",
         filters: "Sequence[StatementFilter | StatementParameters] | Sequence[StatementFilter]",
-    ) -> "Optional[FilterTypeT]":
+    ) -> "FilterTypeT | None":
         """Get the filter specified by filter type from the filters.
 
         Args:

--- a/sqlspec/driver/_sync.py
+++ b/sqlspec/driver/_sync.py
@@ -1,7 +1,7 @@
 """Synchronous driver protocol implementation."""
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Final, NoReturn, Optional, TypeVar, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Final, NoReturn, TypeVar, cast, overload
 
 from sqlspec.core import SQL
 from sqlspec.driver._common import CommonDriverAttributesMixin, DataDictionaryMixin, ExecutionResult, VersionInfo
@@ -96,7 +96,7 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToS
         """Commit the current transaction on the current connection."""
 
     @abstractmethod
-    def _try_special_handling(self, cursor: Any, statement: "SQL") -> "Optional[SQLResult]":
+    def _try_special_handling(self, cursor: Any, statement: "SQL") -> "SQLResult | None":
         """Hook for database-specific special operations (e.g., PostgreSQL COPY, bulk operations).
 
         This method is called first in dispatch_statement_execution() to allow drivers to handle
@@ -169,10 +169,10 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToS
 
     def execute(
         self,
-        statement: "Union[SQL, Statement, QueryBuilder]",
+        statement: "SQL | Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
-        statement_config: "Optional[StatementConfig]" = None,
+        *parameters: "StatementParameters | StatementFilter",
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> "SQLResult":
         """Execute a statement with parameter handling."""
@@ -183,11 +183,11 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToS
 
     def execute_many(
         self,
-        statement: "Union[SQL, Statement, QueryBuilder]",
+        statement: "SQL | Statement | QueryBuilder",
         /,
         parameters: "Sequence[StatementParameters]",
-        *filters: "Union[StatementParameters, StatementFilter]",
-        statement_config: "Optional[StatementConfig]" = None,
+        *filters: "StatementParameters | StatementFilter",
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> "SQLResult":
         """Execute statement multiple times with different parameters.
@@ -206,10 +206,10 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToS
 
     def execute_script(
         self,
-        statement: "Union[str, SQL]",
+        statement: "str | SQL",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
-        statement_config: "Optional[StatementConfig]" = None,
+        *parameters: "StatementParameters | StatementFilter",
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> "SQLResult":
         """Execute a multi-statement script.
@@ -225,34 +225,34 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToS
     @overload
     def select_one(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
+        *parameters: "StatementParameters | StatementFilter",
         schema_type: "type[ModelDTOT]",
-        statement_config: "Optional[StatementConfig]" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> "ModelDTOT": ...
 
     @overload
     def select_one(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
+        *parameters: "StatementParameters | StatementFilter",
         schema_type: None = None,
-        statement_config: "Optional[StatementConfig]" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> "dict[str, Any]": ...
 
     def select_one(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
-        schema_type: "Optional[type[ModelDTOT]]" = None,
-        statement_config: "Optional[StatementConfig]" = None,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: "type[ModelDTOT] | None" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "Union[dict[str, Any], ModelDTOT]":
+    ) -> "dict[str, Any] | ModelDTOT":
         """Execute a select statement and return exactly one row.
 
         Raises an exception if no rows or more than one row is returned.
@@ -270,34 +270,34 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToS
     @overload
     def select_one_or_none(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
+        *parameters: "StatementParameters | StatementFilter",
         schema_type: "type[ModelDTOT]",
-        statement_config: "Optional[StatementConfig]" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "Optional[ModelDTOT]": ...
+    ) -> "ModelDTOT | None": ...
 
     @overload
     def select_one_or_none(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
+        *parameters: "StatementParameters | StatementFilter",
         schema_type: None = None,
-        statement_config: "Optional[StatementConfig]" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "Optional[dict[str, Any]]": ...
+    ) -> "dict[str, Any] | None": ...
 
     def select_one_or_none(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
-        schema_type: "Optional[type[ModelDTOT]]" = None,
-        statement_config: "Optional[StatementConfig]" = None,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: "type[ModelDTOT] | None" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "Optional[Union[dict[str, Any], ModelDTOT]]":
+    ) -> "dict[str, Any] | ModelDTOT | None":
         """Execute a select statement and return at most one row.
 
         Returns None if no rows are found.
@@ -312,53 +312,53 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToS
             self._raise_expected_at_most_one_row(data_len)
         first_row = data[0]
         return cast(
-            "Optional[Union[dict[str, Any], ModelDTOT]]",
+            "dict[str, Any] | ModelDTOT | None",
             self.to_schema(first_row, schema_type=schema_type) if schema_type else first_row,
         )
 
     @overload
     def select(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
+        *parameters: "StatementParameters | StatementFilter",
         schema_type: "type[ModelDTOT]",
-        statement_config: "Optional[StatementConfig]" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> "list[ModelDTOT]": ...
 
     @overload
     def select(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
+        *parameters: "StatementParameters | StatementFilter",
         schema_type: None = None,
-        statement_config: "Optional[StatementConfig]" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> "list[dict[str, Any]]": ...
 
     def select(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
-        schema_type: "Optional[type[ModelDTOT]]" = None,
-        statement_config: "Optional[StatementConfig]" = None,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: "type[ModelDTOT] | None" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "Union[list[dict[str, Any]], list[ModelDTOT]]":
+    ) -> "list[dict[str, Any]] | list[ModelDTOT]":
         """Execute a select statement and return all rows."""
         result = self.execute(statement, *parameters, statement_config=statement_config, **kwargs)
         return cast(
-            "Union[list[dict[str, Any]], list[ModelDTOT]]", self.to_schema(result.get_data(), schema_type=schema_type)
+            "list[dict[str, Any]] | list[ModelDTOT]", self.to_schema(result.get_data(), schema_type=schema_type)
         )
 
     def select_value(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
-        statement_config: "Optional[StatementConfig]" = None,
+        *parameters: "StatementParameters | StatementFilter",
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> Any:
         """Execute a select statement and return a single scalar value.
@@ -386,10 +386,10 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToS
 
     def select_value_or_none(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
-        statement_config: "Optional[StatementConfig]" = None,
+        *parameters: "StatementParameters | StatementFilter",
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> Any:
         """Execute a select statement and return a single scalar value or None.
@@ -419,34 +419,34 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToS
     @overload
     def select_with_total(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
+        *parameters: "StatementParameters | StatementFilter",
         schema_type: "type[ModelDTOT]",
-        statement_config: "Optional[StatementConfig]" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> "tuple[list[ModelDTOT], int]": ...
 
     @overload
     def select_with_total(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
+        *parameters: "StatementParameters | StatementFilter",
         schema_type: None = None,
-        statement_config: "Optional[StatementConfig]" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
     ) -> "tuple[list[dict[str, Any]], int]": ...
 
     def select_with_total(
         self,
-        statement: "Union[Statement, QueryBuilder]",
+        statement: "Statement | QueryBuilder",
         /,
-        *parameters: "Union[StatementParameters, StatementFilter]",
-        schema_type: "Optional[type[ModelDTOT]]" = None,
-        statement_config: "Optional[StatementConfig]" = None,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: "type[ModelDTOT] | None" = None,
+        statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "tuple[Union[list[dict[str, Any]], list[ModelDTOT]], int]":
+    ) -> "tuple[list[dict[str, Any]] | list[ModelDTOT], int]":
         """Execute a select statement and return both the data and total count.
 
         This method is designed for pagination scenarios where you need both
@@ -505,7 +505,7 @@ class SyncDataDictionaryBase(DataDictionaryMixin):
     """Base class for synchronous data dictionary implementations."""
 
     @abstractmethod
-    def get_version(self, driver: "SyncDriverAdapterBase") -> "Optional[VersionInfo]":
+    def get_version(self, driver: "SyncDriverAdapterBase") -> "VersionInfo | None":
         """Get database version information.
 
         Args:
@@ -539,7 +539,7 @@ class SyncDataDictionaryBase(DataDictionaryMixin):
             Database-specific type name
         """
 
-    def get_tables(self, driver: "SyncDriverAdapterBase", schema: "Optional[str]" = None) -> "list[str]":
+    def get_tables(self, driver: "SyncDriverAdapterBase", schema: "str | None" = None) -> "list[str]":
         """Get list of tables in schema.
 
         Args:
@@ -553,7 +553,7 @@ class SyncDataDictionaryBase(DataDictionaryMixin):
         return []
 
     def get_columns(
-        self, driver: "SyncDriverAdapterBase", table: str, schema: "Optional[str]" = None
+        self, driver: "SyncDriverAdapterBase", table: str, schema: "str | None" = None
     ) -> "list[dict[str, Any]]":
         """Get column information for a table.
 
@@ -569,7 +569,7 @@ class SyncDataDictionaryBase(DataDictionaryMixin):
         return []
 
     def get_indexes(
-        self, driver: "SyncDriverAdapterBase", table: str, schema: "Optional[str]" = None
+        self, driver: "SyncDriverAdapterBase", table: str, schema: "str | None" = None
     ) -> "list[dict[str, Any]]":
         """Get index information for a table.
 

--- a/sqlspec/driver/mixins/_result_tools.py
+++ b/sqlspec/driver/mixins/_result_tools.py
@@ -2,11 +2,11 @@
 
 import datetime
 import logging
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from enum import Enum
 from functools import lru_cache, partial
 from pathlib import Path, PurePath
-from typing import Any, Callable, Final, Optional, TypeVar, Union, overload
+from typing import Any, Final, TypeVar, overload
 from uuid import UUID
 
 from mypy_extensions import trait
@@ -78,7 +78,7 @@ _DEFAULT_TYPE_DECODERS: Final[list[tuple[Callable[[Any], bool], Callable[[Any, A
 
 
 def _default_msgspec_deserializer(
-    target_type: Any, value: Any, type_decoders: "Optional[Sequence[tuple[Any, Any]]]" = None
+    target_type: Any, value: Any, type_decoders: "Sequence[tuple[Any, Any]] | None" = None
 ) -> Any:
     """Convert msgspec types with type decoder support.
 
@@ -130,7 +130,7 @@ def _default_msgspec_deserializer(
 
 
 @lru_cache(maxsize=1000)
-def _detect_schema_type(schema_type: "type[Any]") -> "Optional[str]":
+def _detect_schema_type(schema_type: "type[Any]") -> "str | None":
     """Detect schema type with LRU caching.
 
     Args:
@@ -297,7 +297,7 @@ class ToSchemaMixin:
     def to_schema(data: Any, *, schema_type: None = None) -> Any: ...
 
     @staticmethod  # type: ignore[misc,unused-ignore]
-    def to_schema(data: Any, *, schema_type: "Optional[type[Union[ModelDTOT, TypedDictT]]]" = None) -> Any:  # type: ignore[misc,unused-ignore]
+    def to_schema(data: Any, *, schema_type: "type[ModelDTOT | TypedDictT] | None" = None) -> Any:  # type: ignore[misc,unused-ignore]
         """Convert data to a specified schema type.
 
         Args:

--- a/sqlspec/driver/mixins/_sql_translator.py
+++ b/sqlspec/driver/mixins/_sql_translator.py
@@ -1,6 +1,6 @@
 """SQL translation mixin for cross-database compatibility."""
 
-from typing import Final, NoReturn, Optional
+from typing import Final, NoReturn
 
 from mypy_extensions import trait
 from sqlglot import exp, parse_one
@@ -20,10 +20,10 @@ class SQLTranslatorMixin:
     """Mixin for drivers supporting SQL translation."""
 
     __slots__ = ()
-    dialect: "Optional[DialectType]"
+    dialect: "DialectType | None"
 
     def convert_to_dialect(
-        self, statement: "Statement", to_dialect: "Optional[DialectType]" = None, pretty: bool = _DEFAULT_PRETTY
+        self, statement: "Statement", to_dialect: "DialectType | None" = None, pretty: bool = _DEFAULT_PRETTY
     ) -> str:
         """Convert a statement to a target SQL dialect.
 
@@ -38,7 +38,7 @@ class SQLTranslatorMixin:
 
         """
 
-        parsed_expression: Optional[exp.Expression] = None
+        parsed_expression: exp.Expression | None = None
 
         if statement is not None and isinstance(statement, SQL):
             if statement.expression is None:

--- a/sqlspec/exceptions.py
+++ b/sqlspec/exceptions.py
@@ -1,6 +1,6 @@
 from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Any, Optional, Union
+from typing import Any
 
 __all__ = (
     "CheckViolationError",
@@ -63,7 +63,7 @@ class SQLSpecError(Exception):
 class MissingDependencyError(SQLSpecError, ImportError):
     """Raised when a required dependency is not installed."""
 
-    def __init__(self, package: str, install_package: Optional[str] = None) -> None:
+    def __init__(self, package: str, install_package: str | None = None) -> None:
         super().__init__(
             f"Package {package!r} is not installed but required. You can install it by running "
             f"'pip install sqlspec[{install_package or package}]' to install sqlspec with the required extra "
@@ -85,7 +85,7 @@ class ConfigResolverError(SQLSpecError):
 class SQLParsingError(SQLSpecError):
     """Issues parsing SQL statements."""
 
-    def __init__(self, message: Optional[str] = None) -> None:
+    def __init__(self, message: str | None = None) -> None:
         if message is None:
             message = "Issues parsing SQL statement."
         super().__init__(message)
@@ -94,7 +94,7 @@ class SQLParsingError(SQLSpecError):
 class SQLBuilderError(SQLSpecError):
     """Issues Building or Generating SQL statements."""
 
-    def __init__(self, message: Optional[str] = None) -> None:
+    def __init__(self, message: str | None = None) -> None:
         if message is None:
             message = "Issues building SQL statement."
         super().__init__(message)
@@ -103,7 +103,7 @@ class SQLBuilderError(SQLSpecError):
 class SQLConversionError(SQLSpecError):
     """Issues converting SQL statements."""
 
-    def __init__(self, message: Optional[str] = None) -> None:
+    def __init__(self, message: str | None = None) -> None:
         if message is None:
             message = "Issues converting SQL statement."
         super().__init__(message)
@@ -176,7 +176,7 @@ class FileNotFoundInStorageError(StorageOperationFailedError):
 class SQLFileNotFoundError(SQLSpecError):
     """Raised when a SQL file cannot be found."""
 
-    def __init__(self, name: str, path: "Optional[str]" = None) -> None:
+    def __init__(self, name: str, path: "str | None" = None) -> None:
         """Initialize the error.
 
         Args:
@@ -209,7 +209,7 @@ class SQLFileParseError(SQLSpecError):
 
 @contextmanager
 def wrap_exceptions(
-    wrap_exceptions: bool = True, suppress: "Optional[Union[type[Exception], tuple[type[Exception], ...]]]" = None
+    wrap_exceptions: bool = True, suppress: "type[Exception] | tuple[type[Exception], ...] | None" = None
 ) -> Generator[None, None, None]:
     """Context manager for exception handling with optional suppression.
 

--- a/sqlspec/extensions/aiosql/adapter.py
+++ b/sqlspec/extensions/aiosql/adapter.py
@@ -8,7 +8,7 @@ from files using aiosql while using SQLSpec's features for execution and type ma
 import logging
 from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager, contextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, cast
 
 from sqlspec.core.result import SQLResult
 from sqlspec.core.statement import SQL, StatementConfig
@@ -34,7 +34,7 @@ class AsyncCursorLike:
             return list(self.result.data)
         return []
 
-    async def fetchone(self) -> Optional[Any]:
+    async def fetchone(self) -> Any | None:
         rows = await self.fetchall()
         return rows[0] if rows else None
 
@@ -48,7 +48,7 @@ class CursorLike:
             return list(self.result.data)
         return []
 
-    def fetchone(self) -> Optional[Any]:
+    def fetchone(self) -> Any | None:
         rows = self.fetchall()
         return rows[0] if rows else None
 
@@ -59,7 +59,7 @@ def _check_aiosql_available() -> None:
         raise MissingDependencyError(msg, "aiosql")
 
 
-def _normalize_dialect(dialect: "Union[str, Any, None]") -> str:
+def _normalize_dialect(dialect: "str | Any | None") -> str:
     """Normalize dialect name for SQLGlot compatibility.
 
     Args:
@@ -94,7 +94,7 @@ def _normalize_dialect(dialect: "Union[str, Any, None]") -> str:
 class _AiosqlAdapterBase:
     """Base adapter class providing common functionality for aiosql integration."""
 
-    def __init__(self, driver: "Union[SyncDriverAdapterBase, AsyncDriverAdapterBase]") -> None:
+    def __init__(self, driver: "SyncDriverAdapterBase | AsyncDriverAdapterBase") -> None:
         """Initialize the base adapter.
 
         Args:
@@ -152,7 +152,7 @@ class AiosqlSyncAdapter(_AiosqlAdapterBase):
         super().__init__(driver)
 
     def select(
-        self, conn: Any, query_name: str, sql: str, parameters: "Any", record_class: Optional[Any] = None
+        self, conn: Any, query_name: str, sql: str, parameters: "Any", record_class: Any | None = None
     ) -> Generator[Any, None, None]:
         """Execute a SELECT query and return results as generator.
 
@@ -182,8 +182,8 @@ class AiosqlSyncAdapter(_AiosqlAdapterBase):
             yield from result.data
 
     def select_one(
-        self, conn: Any, query_name: str, sql: str, parameters: "Any", record_class: Optional[Any] = None
-    ) -> Optional[dict[str, Any]]:
+        self, conn: Any, query_name: str, sql: str, parameters: "Any", record_class: Any | None = None
+    ) -> dict[str, Any] | None:
         """Execute a SELECT query and return first result.
 
         Args:
@@ -209,10 +209,10 @@ class AiosqlSyncAdapter(_AiosqlAdapterBase):
         result = cast("SQLResult", self.driver.execute(self._create_sql_object(sql, parameters), connection=conn))
 
         if hasattr(result, "data") and result.data and isinstance(result, SQLResult):
-            return cast("Optional[dict[str, Any]]", result.data[0])
+            return cast("dict[str, Any] | None", result.data[0])
         return None
 
-    def select_value(self, conn: Any, query_name: str, sql: str, parameters: "Any") -> Optional[Any]:
+    def select_value(self, conn: Any, query_name: str, sql: str, parameters: "Any") -> Any | None:
         """Execute a SELECT query and return first value of first row.
 
         Args:
@@ -285,7 +285,7 @@ class AiosqlSyncAdapter(_AiosqlAdapterBase):
 
         return result.rows_affected if hasattr(result, "rows_affected") else 0
 
-    def insert_returning(self, conn: Any, query_name: str, sql: str, parameters: "Any") -> Optional[Any]:
+    def insert_returning(self, conn: Any, query_name: str, sql: str, parameters: "Any") -> Any | None:
         """Execute INSERT with RETURNING and return result.
 
         Args:
@@ -318,7 +318,7 @@ class AiosqlAsyncAdapter(_AiosqlAdapterBase):
         super().__init__(driver)
 
     async def select(
-        self, conn: Any, query_name: str, sql: str, parameters: "Any", record_class: Optional[Any] = None
+        self, conn: Any, query_name: str, sql: str, parameters: "Any", record_class: Any | None = None
     ) -> list[Any]:
         """Execute a SELECT query and return results as list.
 
@@ -349,8 +349,8 @@ class AiosqlAsyncAdapter(_AiosqlAdapterBase):
         return []
 
     async def select_one(
-        self, conn: Any, query_name: str, sql: str, parameters: "Any", record_class: Optional[Any] = None
-    ) -> Optional[Any]:
+        self, conn: Any, query_name: str, sql: str, parameters: "Any", record_class: Any | None = None
+    ) -> Any | None:
         """Execute a SELECT query and return first result.
 
         Args:
@@ -379,7 +379,7 @@ class AiosqlAsyncAdapter(_AiosqlAdapterBase):
             return result.data[0]
         return None
 
-    async def select_value(self, conn: Any, query_name: str, sql: str, parameters: "Any") -> Optional[Any]:
+    async def select_value(self, conn: Any, query_name: str, sql: str, parameters: "Any") -> Any | None:
         """Execute a SELECT query and return first value of first row.
 
         Args:
@@ -446,7 +446,7 @@ class AiosqlAsyncAdapter(_AiosqlAdapterBase):
         """
         await self.driver.execute_many(self._create_sql_object(sql), parameters=parameters, connection=conn)  # type: ignore[misc]
 
-    async def insert_returning(self, conn: Any, query_name: str, sql: str, parameters: "Any") -> Optional[Any]:
+    async def insert_returning(self, conn: Any, query_name: str, sql: str, parameters: "Any") -> Any | None:
         """Execute INSERT with RETURNING and return result.
 
         Args:

--- a/sqlspec/extensions/litestar/handlers.py
+++ b/sqlspec/extensions/litestar/handlers.py
@@ -1,8 +1,8 @@
 import contextlib
 import inspect
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 from contextlib import AbstractAsyncContextManager
-from typing import TYPE_CHECKING, Any, Callable, Optional, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from litestar.constants import HTTP_DISCONNECT, HTTP_RESPONSE_START, WEBSOCKET_CLOSE, WEBSOCKET_DISCONNECT
 
@@ -66,8 +66,8 @@ def manual_handler_maker(connection_scope_key: str) -> "Callable[[Message, Scope
 def autocommit_handler_maker(
     connection_scope_key: str,
     commit_on_redirect: bool = False,
-    extra_commit_statuses: "Optional[set[int]]" = None,
-    extra_rollback_statuses: "Optional[set[int]]" = None,
+    extra_commit_statuses: "set[int] | None" = None,
+    extra_rollback_statuses: "set[int] | None" = None,
 ) -> "Callable[[Message, Scope], Coroutine[Any, Any, None]]":
     """Create handler for automatic transaction commit/rollback based on response status.
 

--- a/sqlspec/extensions/litestar/plugin.py
+++ b/sqlspec/extensions/litestar/plugin.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Union, cast, overload
 
 from litestar.di import Provide
 from litestar.plugins import CLIPlugin, InitPluginProtocol
@@ -31,7 +31,7 @@ class SQLSpec(SQLSpecBase, InitPluginProtocol, CLIPlugin):
         self,
         config: Union["SyncConfigT", "AsyncConfigT", "DatabaseConfig", list["DatabaseConfig"]],
         *,
-        loader: "Optional[SQLFileLoader]" = None,
+        loader: "SQLFileLoader | None" = None,
     ) -> None:
         """Initialize SQLSpec plugin.
 
@@ -111,7 +111,7 @@ class SQLSpec(SQLSpecBase, InitPluginProtocol, CLIPlugin):
 
         return app_config
 
-    def get_annotations(self) -> "list[type[Union[SyncConfigT, AsyncConfigT]]]":  # pyright: ignore[reportInvalidTypeVarUse]
+    def get_annotations(self) -> "list[type[SyncConfigT | AsyncConfigT]]":  # pyright: ignore[reportInvalidTypeVarUse]
         """Return the list of annotations.
 
         Returns:
@@ -120,8 +120,8 @@ class SQLSpec(SQLSpecBase, InitPluginProtocol, CLIPlugin):
         return [c.annotation for c in self.config]
 
     def get_annotation(
-        self, key: "Union[str, SyncConfigT, AsyncConfigT, type[Union[SyncConfigT, AsyncConfigT]]]"
-    ) -> "type[Union[SyncConfigT, AsyncConfigT]]":
+        self, key: "str | SyncConfigT | AsyncConfigT | type[SyncConfigT | AsyncConfigT]"
+    ) -> "type[SyncConfigT | AsyncConfigT]":
         """Return the annotation for the given configuration.
 
         Args:
@@ -162,8 +162,8 @@ class SQLSpec(SQLSpecBase, InitPluginProtocol, CLIPlugin):
     def get_config(self, name: "type[AsyncDatabaseConfig]") -> "AsyncDatabaseConfig": ...
 
     def get_config(
-        self, name: "Union[type[DatabaseConfigProtocol[ConnectionT, PoolT, DriverT]], str, Any]"
-    ) -> "Union[DatabaseConfigProtocol[ConnectionT, PoolT, DriverT], DatabaseConfig, SyncDatabaseConfig, AsyncDatabaseConfig]":
+        self, name: "type[DatabaseConfigProtocol[ConnectionT, PoolT, DriverT]] | str | Any"
+    ) -> "DatabaseConfigProtocol[ConnectionT, PoolT, DriverT] | DatabaseConfig | SyncDatabaseConfig | AsyncDatabaseConfig":
         """Get a configuration instance by name, supporting both base behavior and Litestar extensions.
 
         This method extends the base get_config to support Litestar-specific lookup patterns
@@ -210,11 +210,8 @@ class SQLSpec(SQLSpecBase, InitPluginProtocol, CLIPlugin):
         raise KeyError(msg)
 
     def provide_request_session(
-        self,
-        key: "Union[str, SyncConfigT, AsyncConfigT, type[Union[SyncConfigT, AsyncConfigT]]]",
-        state: "State",
-        scope: "Scope",
-    ) -> "Union[SyncDriverAdapterBase, AsyncDriverAdapterBase]":
+        self, key: "str | SyncConfigT | AsyncConfigT | type[SyncConfigT | AsyncConfigT]", state: "State", scope: "Scope"
+    ) -> "SyncDriverAdapterBase | AsyncDriverAdapterBase":
         """Provide a database session for the specified configuration key from request scope.
 
         This is a convenience method that combines get_config and get_request_session
@@ -243,7 +240,7 @@ class SQLSpec(SQLSpecBase, InitPluginProtocol, CLIPlugin):
         return db_config.get_request_session(state, scope)
 
     def provide_sync_request_session(
-        self, key: "Union[str, SyncConfigT, type[SyncConfigT]]", state: "State", scope: "Scope"
+        self, key: "str | SyncConfigT | type[SyncConfigT]", state: "State", scope: "Scope"
     ) -> "SyncDriverAdapterBase":
         """Provide a sync database session for the specified configuration key from request scope.
 
@@ -271,7 +268,7 @@ class SQLSpec(SQLSpecBase, InitPluginProtocol, CLIPlugin):
         return cast("SyncDriverAdapterBase", session)
 
     def provide_async_request_session(
-        self, key: "Union[str, AsyncConfigT, type[AsyncConfigT]]", state: "State", scope: "Scope"
+        self, key: "str | AsyncConfigT | type[AsyncConfigT]", state: "State", scope: "Scope"
     ) -> "AsyncDriverAdapterBase":
         """Provide an async database session for the specified configuration key from request scope.
 
@@ -299,10 +296,7 @@ class SQLSpec(SQLSpecBase, InitPluginProtocol, CLIPlugin):
         return cast("AsyncDriverAdapterBase", session)
 
     def provide_request_connection(
-        self,
-        key: "Union[str, SyncConfigT, AsyncConfigT, type[Union[SyncConfigT, AsyncConfigT]]]",
-        state: "State",
-        scope: "Scope",
+        self, key: "str | SyncConfigT | AsyncConfigT | type[SyncConfigT | AsyncConfigT]", state: "State", scope: "Scope"
     ) -> Any:
         """Provide a database connection for the specified configuration key from request scope.
 
@@ -332,7 +326,7 @@ class SQLSpec(SQLSpecBase, InitPluginProtocol, CLIPlugin):
         return db_config.get_request_connection(state, scope)
 
     def _get_database_config(
-        self, key: "Union[str, SyncConfigT, AsyncConfigT, type[Union[SyncConfigT, AsyncConfigT]]]"
+        self, key: "str | SyncConfigT | AsyncConfigT | type[SyncConfigT | AsyncConfigT]"
     ) -> DatabaseConfig:
         """Get a DatabaseConfig wrapper instance by name.
 

--- a/sqlspec/extensions/litestar/providers.py
+++ b/sqlspec/extensions/litestar/providers.py
@@ -7,7 +7,7 @@ This module contains functions to create dependency providers for services and f
 import datetime
 import inspect
 from collections.abc import Callable
-from typing import Any, Literal, NamedTuple, Optional, TypedDict, Union, cast
+from typing import Any, Literal, NamedTuple, TypedDict, cast
 from uuid import UUID
 
 from litestar.di import Provide
@@ -44,15 +44,15 @@ __all__ = (
     "dep_cache",
 )
 
-DTorNone = Optional[datetime.datetime]
-StringOrNone = Optional[str]
-UuidOrNone = Optional[UUID]
-IntOrNone = Optional[int]
-BooleanOrNone = Optional[bool]
+DTorNone = datetime.datetime | None
+StringOrNone = str | None
+UuidOrNone = UUID | None
+IntOrNone = int | None
+BooleanOrNone = bool | None
 SortOrder = Literal["asc", "desc"]
-SortOrderOrNone = Optional[SortOrder]
-HashableValue = Union[str, int, float, bool, None]
-HashableType = Union[HashableValue, tuple[Any, ...], tuple[tuple[str, Any], ...], tuple[HashableValue, ...]]
+SortOrderOrNone = SortOrder | None
+HashableValue = str | int | float | bool | None
+HashableType = HashableValue | tuple[Any, ...] | tuple[tuple[str, Any], ...] | tuple[HashableValue, ...]
 
 
 class DependencyDefaults:
@@ -79,30 +79,30 @@ class FieldNameType(NamedTuple):
 class FilterConfig(TypedDict):
     """Configuration for generating dynamic filters."""
 
-    id_filter: NotRequired[type[Union[UUID, int, str]]]
+    id_filter: NotRequired[type[UUID | int | str]]
     id_field: NotRequired[str]
     sort_field: NotRequired[str]
     sort_order: NotRequired[SortOrder]
     pagination_type: NotRequired[Literal["limit_offset"]]
     pagination_size: NotRequired[int]
-    search: NotRequired[Union[str, set[str], list[str]]]
+    search: NotRequired[str | set[str] | list[str]]
     search_ignore_case: NotRequired[bool]
     created_at: NotRequired[bool]
     updated_at: NotRequired[bool]
-    not_in_fields: NotRequired[Union[FieldNameType, set[FieldNameType], list[Union[str, FieldNameType]]]]
-    in_fields: NotRequired[Union[FieldNameType, set[FieldNameType], list[Union[str, FieldNameType]]]]
+    not_in_fields: NotRequired[FieldNameType | set[FieldNameType] | list[str | FieldNameType]]
+    in_fields: NotRequired[FieldNameType | set[FieldNameType] | list[str | FieldNameType]]
 
 
 class DependencyCache(metaclass=SingletonMeta):
     """Dependency cache for memoizing dynamically generated dependencies."""
 
     def __init__(self) -> None:
-        self.dependencies: dict[Union[int, str], dict[str, Provide]] = {}
+        self.dependencies: dict[int | str, dict[str, Provide]] = {}
 
-    def add_dependencies(self, key: Union[int, str], dependencies: dict[str, Provide]) -> None:
+    def add_dependencies(self, key: int | str, dependencies: dict[str, Provide]) -> None:
         self.dependencies[key] = dependencies
 
-    def get_dependencies(self, key: Union[int, str]) -> Optional[dict[str, Provide]]:
+    def get_dependencies(self, key: int | str) -> dict[str, Provide] | None:
         return self.dependencies.get(key)
 
 
@@ -169,7 +169,7 @@ def _create_statement_filters(
     if config.get("id_filter", False):
 
         def provide_id_filter(  # pyright: ignore[reportUnknownParameterType]
-            ids: Optional[list[str]] = Parameter(query="ids", default=None, required=False),
+            ids: list[str] | None = Parameter(query="ids", default=None, required=False),
         ) -> InCollectionFilter:  # pyright: ignore[reportMissingTypeArgument]
             return InCollectionFilter(field_name=config.get("id_field", "id"), values=ids)
 
@@ -257,12 +257,12 @@ def _create_statement_filters(
 
             def create_not_in_filter_provider(  # pyright: ignore
                 field_name: FieldNameType,
-            ) -> Callable[..., Optional[NotInCollectionFilter[field_def.type_hint]]]:  # type: ignore
+            ) -> Callable[..., NotInCollectionFilter[field_def.type_hint] | None]:  # type: ignore
                 def provide_not_in_filter(  # pyright: ignore
-                    values: Optional[list[field_name.type_hint]] = Parameter(  # type: ignore
+                    values: list[field_name.type_hint] | None = Parameter(  # type: ignore
                         query=camelize(f"{field_name.name}_not_in"), default=None, required=False
                     ),
-                ) -> Optional[NotInCollectionFilter[field_name.type_hint]]:  # type: ignore
+                ) -> NotInCollectionFilter[field_name.type_hint] | None:  # type: ignore
                     return (
                         NotInCollectionFilter[field_name.type_hint](field_name=field_name.name, values=values)  # type: ignore
                         if values
@@ -282,12 +282,12 @@ def _create_statement_filters(
 
             def create_in_filter_provider(  # pyright: ignore
                 field_name: FieldNameType,
-            ) -> Callable[..., Optional[InCollectionFilter[field_def.type_hint]]]:  # type: ignore # pyright: ignore
+            ) -> Callable[..., InCollectionFilter[field_def.type_hint] | None]:  # type: ignore # pyright: ignore
                 def provide_in_filter(  # pyright: ignore
-                    values: Optional[list[field_name.type_hint]] = Parameter(  # type: ignore # pyright: ignore
+                    values: list[field_name.type_hint] | None = Parameter(  # type: ignore # pyright: ignore
                         query=camelize(f"{field_name.name}_in"), default=None, required=False
                     ),
-                ) -> Optional[InCollectionFilter[field_name.type_hint]]:  # type: ignore # pyright: ignore
+                ) -> InCollectionFilter[field_name.type_hint] | None:  # type: ignore # pyright: ignore
                     return (
                         InCollectionFilter[field_name.type_hint](field_name=field_name.name, values=values)  # type: ignore  # pyright: ignore
                         if values
@@ -415,14 +415,14 @@ def _create_filter_aggregate_function(config: FilterConfig) -> Callable[..., lis
         if updated_filter := kwargs.get("updated_filter"):
             filters.append(updated_filter)
         if (
-            (search_filter := cast("Optional[SearchFilter]", kwargs.get("search_filter")))
+            (search_filter := cast("SearchFilter | None", kwargs.get("search_filter")))
             and search_filter is not None  # pyright: ignore[reportUnnecessaryComparison]
             and search_filter.field_name is not None  # pyright: ignore[reportUnnecessaryComparison]
             and search_filter.value is not None  # pyright: ignore[reportUnnecessaryComparison]
         ):
             filters.append(search_filter)
         if (
-            (order_by := cast("Optional[OrderByFilter]", kwargs.get("order_by_filter")))
+            (order_by := cast("OrderByFilter | None", kwargs.get("order_by_filter")))
             and order_by is not None  # pyright: ignore[reportUnnecessaryComparison]
             and order_by.field_name is not None  # pyright: ignore[reportUnnecessaryComparison]
         ):

--- a/sqlspec/loader.py
+++ b/sqlspec/loader.py
@@ -9,7 +9,7 @@ import re
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Optional, Union
+from typing import TYPE_CHECKING, Any, Final
 from urllib.parse import unquote, urlparse
 
 from sqlspec.core.cache import get_cache, get_cache_config
@@ -95,7 +95,7 @@ class NamedStatement:
 
     __slots__ = ("dialect", "name", "sql", "start_line")
 
-    def __init__(self, name: str, sql: str, dialect: "Optional[str]" = None, start_line: int = 0) -> None:
+    def __init__(self, name: str, sql: str, dialect: "str | None" = None, start_line: int = 0) -> None:
         self.name = name
         self.sql = sql
         self.dialect = dialect
@@ -112,11 +112,7 @@ class SQLFile:
     __slots__ = ("checksum", "content", "loaded_at", "metadata", "path")
 
     def __init__(
-        self,
-        content: str,
-        path: str,
-        metadata: "Optional[dict[str, Any]]" = None,
-        loaded_at: "Optional[datetime]" = None,
+        self, content: str, path: str, metadata: "dict[str, Any] | None" = None, loaded_at: "datetime | None" = None
     ) -> None:
         """Initialize SQLFile.
 
@@ -163,7 +159,7 @@ class SQLFileLoader:
 
     __slots__ = ("_files", "_queries", "_query_to_file", "encoding", "storage_registry")
 
-    def __init__(self, *, encoding: str = "utf-8", storage_registry: "Optional[StorageRegistry]" = None) -> None:
+    def __init__(self, *, encoding: str = "utf-8", storage_registry: "StorageRegistry | None" = None) -> None:
         """Initialize the SQL file loader.
 
         Args:
@@ -188,7 +184,7 @@ class SQLFileLoader:
         """
         raise SQLFileNotFoundError(path)
 
-    def _generate_file_cache_key(self, path: Union[str, Path]) -> str:
+    def _generate_file_cache_key(self, path: str | Path) -> str:
         """Generate cache key for a file path.
 
         Args:
@@ -201,7 +197,7 @@ class SQLFileLoader:
         path_hash = hashlib.md5(path_str.encode(), usedforsecurity=False).hexdigest()
         return f"file:{path_hash[:16]}"
 
-    def _calculate_file_checksum(self, path: Union[str, Path]) -> str:
+    def _calculate_file_checksum(self, path: str | Path) -> str:
         """Calculate checksum for file content validation.
 
         Args:
@@ -218,7 +214,7 @@ class SQLFileLoader:
         except Exception as e:
             raise SQLFileParseError(str(path), str(path), e) from e
 
-    def _is_file_unchanged(self, path: Union[str, Path], cached_file: CachedSQLFile) -> bool:
+    def _is_file_unchanged(self, path: str | Path, cached_file: CachedSQLFile) -> bool:
         """Check if file has changed since caching.
 
         Args:
@@ -235,7 +231,7 @@ class SQLFileLoader:
         else:
             return current_checksum == cached_file.sql_file.checksum
 
-    def _read_file_content(self, path: Union[str, Path]) -> str:
+    def _read_file_content(self, path: str | Path) -> str:
         """Read file content using storage backend.
 
         Args:
@@ -349,7 +345,7 @@ class SQLFileLoader:
 
         return statements
 
-    def load_sql(self, *paths: Union[str, Path]) -> None:
+    def load_sql(self, *paths: str | Path) -> None:
         """Load SQL files and parse named queries.
 
         Args:
@@ -420,7 +416,7 @@ class SQLFileLoader:
             self._load_single_file(file_path, ".".join(namespace_parts) if namespace_parts else None)
         return len(sql_files)
 
-    def _load_single_file(self, file_path: Union[str, Path], namespace: Optional[str]) -> None:
+    def _load_single_file(self, file_path: str | Path, namespace: str | None) -> None:
         """Load a single SQL file with optional namespace.
 
         Args:
@@ -476,7 +472,7 @@ class SQLFileLoader:
             cached_file_data = CachedSQLFile(sql_file=sql_file, parsed_statements=file_statements)
             cache.put("file", cache_key_str, cached_file_data)
 
-    def _load_file_without_cache(self, file_path: Union[str, Path], namespace: Optional[str]) -> None:
+    def _load_file_without_cache(self, file_path: str | Path, namespace: str | None) -> None:
         """Load a single SQL file without using cache.
 
         Args:
@@ -503,7 +499,7 @@ class SQLFileLoader:
             self._queries[namespaced_name] = statement
             self._query_to_file[namespaced_name] = path_str
 
-    def add_named_sql(self, name: str, sql: str, dialect: "Optional[str]" = None) -> None:
+    def add_named_sql(self, name: str, sql: str, dialect: "str | None" = None) -> None:
         """Add a named SQL query directly without loading from a file.
 
         Args:
@@ -529,7 +525,7 @@ class SQLFileLoader:
         self._queries[normalized_name] = statement
         self._query_to_file[normalized_name] = "<directly added>"
 
-    def get_file(self, path: Union[str, Path]) -> "Optional[SQLFile]":
+    def get_file(self, path: str | Path) -> "SQLFile | None":
         """Get a loaded SQLFile object by path.
 
         Args:
@@ -540,7 +536,7 @@ class SQLFileLoader:
         """
         return self._files.get(str(path))
 
-    def get_file_for_query(self, name: str) -> "Optional[SQLFile]":
+    def get_file_for_query(self, name: str) -> "SQLFile | None":
         """Get the SQLFile object containing a query.
 
         Args:

--- a/sqlspec/migrations/base.py
+++ b/sqlspec/migrations/base.py
@@ -7,7 +7,7 @@ import hashlib
 import operator
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Generic, Optional, TypeVar, cast
+from typing import Any, Generic, TypeVar, cast
 
 from sqlspec._sql import sql
 from sqlspec.builder import Delete, Insert, Select
@@ -141,9 +141,9 @@ class BaseMigrationRunner(ABC, Generic[DriverT]):
     def __init__(
         self,
         migrations_path: Path,
-        extension_migrations: "Optional[dict[str, Path]]" = None,
-        context: "Optional[Any]" = None,
-        extension_configs: "Optional[dict[str, dict[str, Any]]]" = None,
+        extension_migrations: "dict[str, Path] | None" = None,
+        context: "Any | None" = None,
+        extension_configs: "dict[str, dict[str, Any]] | None" = None,
     ) -> None:
         """Initialize the migration runner.
 
@@ -156,11 +156,11 @@ class BaseMigrationRunner(ABC, Generic[DriverT]):
         self.migrations_path = migrations_path
         self.extension_migrations = extension_migrations or {}
         self.loader = SQLFileLoader()
-        self.project_root: Optional[Path] = None
+        self.project_root: Path | None = None
         self.context = context
         self.extension_configs = extension_configs or {}
 
-    def _extract_version(self, filename: str) -> Optional[str]:
+    def _extract_version(self, filename: str) -> str | None:
         """Extract version from filename.
 
         Args:
@@ -302,7 +302,7 @@ class BaseMigrationRunner(ABC, Generic[DriverT]):
             "loader": loader,
         }
 
-    def _get_migration_sql(self, migration: "dict[str, Any]", direction: str) -> "Optional[list[str]]":
+    def _get_migration_sql(self, migration: "dict[str, Any]", direction: str) -> "list[str] | None":
         """Get migration SQL for given direction.
 
         Args:

--- a/sqlspec/migrations/commands.py
+++ b/sqlspec/migrations/commands.py
@@ -3,7 +3,7 @@
 This module provides the main command interface for database migrations.
 """
 
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from rich.console import Console
 from rich.table import Table
@@ -53,7 +53,7 @@ class SyncMigrationCommands(BaseMigrationCommands["SyncConfigT", Any]):
         """
         self.init_directory(directory, package)
 
-    def current(self, verbose: bool = False) -> "Optional[str]":
+    def current(self, verbose: bool = False) -> "str | None":
         """Show current migration version.
 
         Args:
@@ -93,7 +93,7 @@ class SyncMigrationCommands(BaseMigrationCommands["SyncConfigT", Any]):
 
                 console.print(table)
 
-            return cast("Optional[str]", current)
+            return cast("str | None", current)
 
     def upgrade(self, revision: str = "head") -> None:
         """Upgrade to a target revision.
@@ -236,7 +236,7 @@ class AsyncMigrationCommands(BaseMigrationCommands["AsyncConfigT", Any]):
         """
         self.init_directory(directory, package)
 
-    async def current(self, verbose: bool = False) -> "Optional[str]":
+    async def current(self, verbose: bool = False) -> "str | None":
         """Show current migration version.
 
         Args:
@@ -272,7 +272,7 @@ class AsyncMigrationCommands(BaseMigrationCommands["AsyncConfigT", Any]):
                     )
                 console.print(table)
 
-            return cast("Optional[str]", current)
+            return cast("str | None", current)
 
     async def upgrade(self, revision: str = "head") -> None:
         """Upgrade to a target revision.
@@ -385,8 +385,8 @@ class AsyncMigrationCommands(BaseMigrationCommands["AsyncConfigT", Any]):
 
 
 def create_migration_commands(
-    config: "Union[SyncConfigT, AsyncConfigT]",
-) -> "Union[SyncMigrationCommands[Any], AsyncMigrationCommands[Any]]":
+    config: "SyncConfigT | AsyncConfigT",
+) -> "SyncMigrationCommands[SyncConfigT] | AsyncMigrationCommands[AsyncConfigT]":
     """Factory function to create the appropriate migration commands.
 
     Args:
@@ -396,5 +396,5 @@ def create_migration_commands(
         Appropriate migration commands instance.
     """
     if config.is_async:
-        return AsyncMigrationCommands(cast("AsyncConfigT", config))
-    return SyncMigrationCommands(cast("SyncConfigT", config))
+        return cast("AsyncMigrationCommands[AsyncConfigT]", AsyncMigrationCommands(cast("AsyncConfigT", config)))
+    return cast("SyncMigrationCommands[SyncConfigT]", SyncMigrationCommands(cast("SyncConfigT", config)))

--- a/sqlspec/migrations/context.py
+++ b/sqlspec/migrations/context.py
@@ -3,7 +3,7 @@
 import asyncio
 import inspect
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from sqlspec.utils.logging import get_logger
 
@@ -23,16 +23,16 @@ class MigrationContext:
     to migration functions, allowing them to generate dialect-specific SQL.
     """
 
-    config: "Optional[Any]" = None
+    config: "Any | None" = None
     """Database configuration object."""
-    dialect: "Optional[str]" = None
+    dialect: "str | None" = None
     """Database dialect (e.g., 'postgres', 'mysql', 'sqlite')."""
-    metadata: "Optional[dict[str, Any]]" = None
+    metadata: "dict[str, Any] | None" = None
     """Additional metadata for the migration."""
-    extension_config: "Optional[dict[str, Any]]" = None
+    extension_config: "dict[str, Any] | None" = None
     """Extension-specific configuration options."""
 
-    driver: "Optional[Union[SyncDriverAdapterBase, AsyncDriverAdapterBase]]" = None
+    driver: "SyncDriverAdapterBase | AsyncDriverAdapterBase | None" = None
     """Database driver instance (available during execution)."""
 
     _execution_metadata: "dict[str, Any]" = field(default_factory=dict)

--- a/sqlspec/migrations/loaders.py
+++ b/sqlspec/migrations/loaders.py
@@ -10,7 +10,7 @@ import types
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from sqlspec.loader import SQLFileLoader as CoreSQLFileLoader
 
@@ -166,9 +166,7 @@ class PythonFileLoader(BaseMigrationLoader):
 
     __slots__ = ("context", "migrations_dir", "project_root")
 
-    def __init__(
-        self, migrations_dir: Path, project_root: "Optional[Path]" = None, context: "Optional[Any]" = None
-    ) -> None:
+    def __init__(self, migrations_dir: Path, project_root: "Path | None" = None, context: "Any | None" = None) -> None:
         """Initialize Python file loader.
 
         Args:
@@ -396,7 +394,7 @@ class PythonFileLoader(BaseMigrationLoader):
 
 
 def get_migration_loader(
-    file_path: Path, migrations_dir: Path, project_root: "Optional[Path]" = None, context: "Optional[Any]" = None
+    file_path: Path, migrations_dir: Path, project_root: "Path | None" = None, context: "Any | None" = None
 ) -> BaseMigrationLoader:
     """Factory function to get appropriate loader for migration file.
 

--- a/sqlspec/migrations/runner.py
+++ b/sqlspec/migrations/runner.py
@@ -8,7 +8,7 @@ import operator
 import time
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, Union, cast, overload
 
 from sqlspec.core.statement import SQL
 from sqlspec.migrations.context import MigrationContext
@@ -32,9 +32,9 @@ class BaseMigrationRunner(ABC):
     def __init__(
         self,
         migrations_path: Path,
-        extension_migrations: "Optional[dict[str, Path]]" = None,
-        context: "Optional[MigrationContext]" = None,
-        extension_configs: "Optional[dict[str, dict[str, Any]]]" = None,
+        extension_migrations: "dict[str, Path] | None" = None,
+        context: "MigrationContext | None" = None,
+        extension_configs: "dict[str, dict[str, Any]] | None" = None,
     ) -> None:
         """Initialize the migration runner.
 
@@ -49,11 +49,11 @@ class BaseMigrationRunner(ABC):
         from sqlspec.loader import SQLFileLoader
 
         self.loader = SQLFileLoader()
-        self.project_root: Optional[Path] = None
+        self.project_root: Path | None = None
         self.context = context
         self.extension_configs = extension_configs or {}
 
-    def _extract_version(self, filename: str) -> "Optional[str]":
+    def _extract_version(self, filename: str) -> "str | None":
         """Extract version from filename.
 
         Args:
@@ -161,7 +161,7 @@ class BaseMigrationRunner(ABC):
             "content": content,
         }
 
-    def _get_context_for_migration(self, file_path: Path) -> "Optional[MigrationContext]":
+    def _get_context_for_migration(self, file_path: Path) -> "MigrationContext | None":
         """Get the appropriate context for a migration file.
 
         Args:
@@ -238,9 +238,7 @@ class SyncMigrationRunner(BaseMigrationRunner):
         metadata.update({"has_upgrade": has_upgrade, "has_downgrade": has_downgrade, "loader": loader})
         return metadata
 
-    def execute_upgrade(
-        self, driver: "SyncDriverAdapterBase", migration: "dict[str, Any]"
-    ) -> "tuple[Optional[str], int]":
+    def execute_upgrade(self, driver: "SyncDriverAdapterBase", migration: "dict[str, Any]") -> "tuple[str | None, int]":
         """Execute an upgrade migration.
 
         Args:
@@ -264,7 +262,7 @@ class SyncMigrationRunner(BaseMigrationRunner):
 
     def execute_downgrade(
         self, driver: "SyncDriverAdapterBase", migration: "dict[str, Any]"
-    ) -> "tuple[Optional[str], int]":
+    ) -> "tuple[str | None, int]":
         """Execute a downgrade migration.
 
         Args:
@@ -286,7 +284,7 @@ class SyncMigrationRunner(BaseMigrationRunner):
         execution_time = int((time.time() - start_time) * 1000)
         return None, execution_time
 
-    def _get_migration_sql_sync(self, migration: "dict[str, Any]", direction: str) -> "Optional[list[str]]":
+    def _get_migration_sql_sync(self, migration: "dict[str, Any]", direction: str) -> "list[str] | None":
         """Get migration SQL for given direction (sync version).
 
         Args:
@@ -410,7 +408,7 @@ class AsyncMigrationRunner(BaseMigrationRunner):
 
     async def execute_upgrade(
         self, driver: "AsyncDriverAdapterBase", migration: "dict[str, Any]"
-    ) -> "tuple[Optional[str], int]":
+    ) -> "tuple[str | None, int]":
         """Execute an upgrade migration.
 
         Args:
@@ -434,7 +432,7 @@ class AsyncMigrationRunner(BaseMigrationRunner):
 
     async def execute_downgrade(
         self, driver: "AsyncDriverAdapterBase", migration: "dict[str, Any]"
-    ) -> "tuple[Optional[str], int]":
+    ) -> "tuple[str | None, int]":
         """Execute a downgrade migration.
 
         Args:
@@ -456,7 +454,7 @@ class AsyncMigrationRunner(BaseMigrationRunner):
         execution_time = int((time.time() - start_time) * 1000)
         return None, execution_time
 
-    async def _get_migration_sql_async(self, migration: "dict[str, Any]", direction: str) -> "Optional[list[str]]":
+    async def _get_migration_sql_async(self, migration: "dict[str, Any]", direction: str) -> "list[str] | None":
         """Get migration SQL for given direction (async version).
 
         Args:
@@ -528,7 +526,7 @@ class AsyncMigrationRunner(BaseMigrationRunner):
 def create_migration_runner(
     migrations_path: Path,
     extension_migrations: "dict[str, Path]",
-    context: "Optional[MigrationContext]",
+    context: "MigrationContext | None",
     extension_configs: "dict[str, Any]",
     is_async: "Literal[False]" = False,
 ) -> SyncMigrationRunner: ...
@@ -538,7 +536,7 @@ def create_migration_runner(
 def create_migration_runner(
     migrations_path: Path,
     extension_migrations: "dict[str, Path]",
-    context: "Optional[MigrationContext]",
+    context: "MigrationContext | None",
     extension_configs: "dict[str, Any]",
     is_async: "Literal[True]",
 ) -> AsyncMigrationRunner: ...
@@ -547,10 +545,10 @@ def create_migration_runner(
 def create_migration_runner(
     migrations_path: Path,
     extension_migrations: "dict[str, Path]",
-    context: "Optional[MigrationContext]",
+    context: "MigrationContext | None",
     extension_configs: "dict[str, Any]",
     is_async: bool = False,
-) -> "Union[SyncMigrationRunner, AsyncMigrationRunner]":
+) -> "SyncMigrationRunner | AsyncMigrationRunner":
     """Factory function to create the appropriate migration runner.
 
     Args:

--- a/sqlspec/migrations/tracker.py
+++ b/sqlspec/migrations/tracker.py
@@ -4,7 +4,7 @@ This module provides functionality to track applied migrations in the database.
 """
 
 import os
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from sqlspec.migrations.base import BaseMigrationTracker
 from sqlspec.utils.logging import get_logger
@@ -29,7 +29,7 @@ class SyncMigrationTracker(BaseMigrationTracker["SyncDriverAdapterBase"]):
         driver.execute(self._get_create_table_sql())
         self._safe_commit(driver)
 
-    def get_current_version(self, driver: "SyncDriverAdapterBase") -> Optional[str]:
+    def get_current_version(self, driver: "SyncDriverAdapterBase") -> str | None:
         """Get the latest applied migration version.
 
         Args:
@@ -114,7 +114,7 @@ class AsyncMigrationTracker(BaseMigrationTracker["AsyncDriverAdapterBase"]):
         await driver.execute(self._get_create_table_sql())
         await self._safe_commit_async(driver)
 
-    async def get_current_version(self, driver: "AsyncDriverAdapterBase") -> Optional[str]:
+    async def get_current_version(self, driver: "AsyncDriverAdapterBase") -> str | None:
         """Get the latest applied migration version.
 
         Args:

--- a/sqlspec/migrations/utils.py
+++ b/sqlspec/migrations/utils.py
@@ -6,7 +6,7 @@ This module provides helper functions for migration operations.
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from sqlspec.driver import AsyncDriverAdapterBase
@@ -114,7 +114,7 @@ def get_author() -> str:
     return os.environ.get("USER", "unknown")
 
 
-async def drop_all(engine: "AsyncDriverAdapterBase", version_table_name: str, metadata: Optional[Any] = None) -> None:
+async def drop_all(engine: "AsyncDriverAdapterBase", version_table_name: str, metadata: Any | None = None) -> None:
     """Drop all tables from the database.
 
     Args:

--- a/sqlspec/protocols.py
+++ b/sqlspec/protocols.py
@@ -4,7 +4,7 @@ This module provides protocols that can be used for static type checking
 and runtime isinstance() checks.
 """
 
-from typing import TYPE_CHECKING, Any, Optional, Protocol, Union, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from typing_extensions import Self
 
@@ -186,7 +186,7 @@ class ObjectStoreItemProtocol(Protocol):
     """Protocol for object store items with path/key attributes."""
 
     path: str
-    key: "Optional[str]"
+    key: "str | None"
 
 
 @runtime_checkable
@@ -199,35 +199,35 @@ class ObjectStoreProtocol(Protocol):
     def __init__(self, uri: str, **kwargs: Any) -> None:
         return
 
-    def read_bytes(self, path: "Union[str, Path]", **kwargs: Any) -> bytes:
+    def read_bytes(self, path: "str | Path", **kwargs: Any) -> bytes:
         """Read bytes from an object."""
         return b""
 
-    def write_bytes(self, path: "Union[str, Path]", data: bytes, **kwargs: Any) -> None:
+    def write_bytes(self, path: "str | Path", data: bytes, **kwargs: Any) -> None:
         """Write bytes to an object."""
         return
 
-    def read_text(self, path: "Union[str, Path]", encoding: str = "utf-8", **kwargs: Any) -> str:
+    def read_text(self, path: "str | Path", encoding: str = "utf-8", **kwargs: Any) -> str:
         """Read text from an object."""
         return ""
 
-    def write_text(self, path: "Union[str, Path]", data: str, encoding: str = "utf-8", **kwargs: Any) -> None:
+    def write_text(self, path: "str | Path", data: str, encoding: str = "utf-8", **kwargs: Any) -> None:
         """Write text to an object."""
         return
 
-    def exists(self, path: "Union[str, Path]", **kwargs: Any) -> bool:
+    def exists(self, path: "str | Path", **kwargs: Any) -> bool:
         """Check if an object exists."""
         return False
 
-    def delete(self, path: "Union[str, Path]", **kwargs: Any) -> None:
+    def delete(self, path: "str | Path", **kwargs: Any) -> None:
         """Delete an object."""
         return
 
-    def copy(self, source: "Union[str, Path]", destination: "Union[str, Path]", **kwargs: Any) -> None:
+    def copy(self, source: "str | Path", destination: "str | Path", **kwargs: Any) -> None:
         """Copy an object."""
         return
 
-    def move(self, source: "Union[str, Path]", destination: "Union[str, Path]", **kwargs: Any) -> None:
+    def move(self, source: "str | Path", destination: "str | Path", **kwargs: Any) -> None:
         """Move an object."""
         return
 
@@ -239,24 +239,24 @@ class ObjectStoreProtocol(Protocol):
         """Find objects matching a glob pattern."""
         return []
 
-    def is_object(self, path: "Union[str, Path]") -> bool:
+    def is_object(self, path: "str | Path") -> bool:
         """Check if path points to an object."""
         return False
 
-    def is_path(self, path: "Union[str, Path]") -> bool:
+    def is_path(self, path: "str | Path") -> bool:
         """Check if path points to a prefix (directory-like)."""
         return False
 
-    def get_metadata(self, path: "Union[str, Path]", **kwargs: Any) -> dict[str, Any]:
+    def get_metadata(self, path: "str | Path", **kwargs: Any) -> dict[str, Any]:
         """Get object metadata."""
         return {}
 
-    def read_arrow(self, path: "Union[str, Path]", **kwargs: Any) -> "ArrowTable":
+    def read_arrow(self, path: "str | Path", **kwargs: Any) -> "ArrowTable":
         """Read an Arrow table from storage."""
         msg = "Arrow reading not implemented"
         raise NotImplementedError(msg)
 
-    def write_arrow(self, path: "Union[str, Path]", table: "ArrowTable", **kwargs: Any) -> None:
+    def write_arrow(self, path: "str | Path", table: "ArrowTable", **kwargs: Any) -> None:
         """Write an Arrow table to storage."""
         msg = "Arrow writing not implemented"
         raise NotImplementedError(msg)
@@ -266,34 +266,32 @@ class ObjectStoreProtocol(Protocol):
         msg = "Arrow streaming not implemented"
         raise NotImplementedError(msg)
 
-    async def read_bytes_async(self, path: "Union[str, Path]", **kwargs: Any) -> bytes:
+    async def read_bytes_async(self, path: "str | Path", **kwargs: Any) -> bytes:
         """Async read bytes from an object."""
         msg = "Async operations not implemented"
         raise NotImplementedError(msg)
 
-    async def write_bytes_async(self, path: "Union[str, Path]", data: bytes, **kwargs: Any) -> None:
+    async def write_bytes_async(self, path: "str | Path", data: bytes, **kwargs: Any) -> None:
         """Async write bytes to an object."""
         msg = "Async operations not implemented"
         raise NotImplementedError(msg)
 
-    async def read_text_async(self, path: "Union[str, Path]", encoding: str = "utf-8", **kwargs: Any) -> str:
+    async def read_text_async(self, path: "str | Path", encoding: str = "utf-8", **kwargs: Any) -> str:
         """Async read text from an object."""
         msg = "Async operations not implemented"
         raise NotImplementedError(msg)
 
-    async def write_text_async(
-        self, path: "Union[str, Path]", data: str, encoding: str = "utf-8", **kwargs: Any
-    ) -> None:
+    async def write_text_async(self, path: "str | Path", data: str, encoding: str = "utf-8", **kwargs: Any) -> None:
         """Async write text to an object."""
         msg = "Async operations not implemented"
         raise NotImplementedError(msg)
 
-    async def exists_async(self, path: "Union[str, Path]", **kwargs: Any) -> bool:
+    async def exists_async(self, path: "str | Path", **kwargs: Any) -> bool:
         """Async check if an object exists."""
         msg = "Async operations not implemented"
         raise NotImplementedError(msg)
 
-    async def delete_async(self, path: "Union[str, Path]", **kwargs: Any) -> None:
+    async def delete_async(self, path: "str | Path", **kwargs: Any) -> None:
         """Async delete an object."""
         msg = "Async operations not implemented"
         raise NotImplementedError(msg)
@@ -303,27 +301,27 @@ class ObjectStoreProtocol(Protocol):
         msg = "Async operations not implemented"
         raise NotImplementedError(msg)
 
-    async def copy_async(self, source: "Union[str, Path]", destination: "Union[str, Path]", **kwargs: Any) -> None:
+    async def copy_async(self, source: "str | Path", destination: "str | Path", **kwargs: Any) -> None:
         """Async copy an object."""
         msg = "Async operations not implemented"
         raise NotImplementedError(msg)
 
-    async def move_async(self, source: "Union[str, Path]", destination: "Union[str, Path]", **kwargs: Any) -> None:
+    async def move_async(self, source: "str | Path", destination: "str | Path", **kwargs: Any) -> None:
         """Async move an object."""
         msg = "Async operations not implemented"
         raise NotImplementedError(msg)
 
-    async def get_metadata_async(self, path: "Union[str, Path]", **kwargs: Any) -> dict[str, Any]:
+    async def get_metadata_async(self, path: "str | Path", **kwargs: Any) -> dict[str, Any]:
         """Async get object metadata."""
         msg = "Async operations not implemented"
         raise NotImplementedError(msg)
 
-    async def read_arrow_async(self, path: "Union[str, Path]", **kwargs: Any) -> "ArrowTable":
+    async def read_arrow_async(self, path: "str | Path", **kwargs: Any) -> "ArrowTable":
         """Async read an Arrow table from storage."""
         msg = "Async arrow reading not implemented"
         raise NotImplementedError(msg)
 
-    async def write_arrow_async(self, path: "Union[str, Path]", table: "ArrowTable", **kwargs: Any) -> None:
+    async def write_arrow_async(self, path: "str | Path", table: "ArrowTable", **kwargs: Any) -> None:
         """Async write an Arrow table to storage."""
         msg = "Async arrow writing not implemented"
         raise NotImplementedError(msg)
@@ -339,7 +337,7 @@ class HasSQLGlotExpressionProtocol(Protocol):
     """Protocol for objects with a sqlglot_expression property."""
 
     @property
-    def sqlglot_expression(self) -> "Optional[exp.Expression]":
+    def sqlglot_expression(self) -> "exp.Expression | None":
         """Return the SQLGlot expression for this object."""
         ...
 
@@ -348,7 +346,7 @@ class HasSQLGlotExpressionProtocol(Protocol):
 class HasParameterBuilderProtocol(Protocol):
     """Protocol for objects that can add parameters."""
 
-    def add_parameter(self, value: Any, name: "Optional[str]" = None) -> tuple[Any, str]:
+    def add_parameter(self, value: Any, name: "str | None" = None) -> tuple[Any, str]:
         """Add a parameter to the builder."""
         ...
 
@@ -357,7 +355,7 @@ class HasParameterBuilderProtocol(Protocol):
 class HasExpressionProtocol(Protocol):
     """Protocol for objects with an _expression attribute."""
 
-    _expression: "Optional[exp.Expression]"
+    _expression: "exp.Expression | None"
 
 
 @runtime_checkable
@@ -373,21 +371,21 @@ class HasToStatementProtocol(Protocol):
 class SQLBuilderProtocol(Protocol):
     """Protocol for SQL query builders."""
 
-    _expression: "Optional[exp.Expression]"
+    _expression: "exp.Expression | None"
     _parameters: dict[str, Any]
     _parameter_counter: int
     _columns: Any  # Optional attribute for some builders
     _table: Any  # Optional attribute for some builders
     _with_ctes: Any  # Optional attribute for some builders
     dialect: Any
-    dialect_name: "Optional[str]"
+    dialect_name: "str | None"
 
     @property
     def parameters(self) -> dict[str, Any]:
         """Public access to query parameters."""
         ...
 
-    def add_parameter(self, value: Any, name: "Optional[str]" = None) -> tuple[Any, str]:
+    def add_parameter(self, value: Any, name: "str | None" = None) -> tuple[Any, str]:
         """Add a parameter to the builder."""
         ...
 
@@ -399,7 +397,7 @@ class SQLBuilderProtocol(Protocol):
         """Replace literal values in an expression with bound parameters."""
         ...
 
-    def build(self) -> "Union[exp.Expression, Any]":
+    def build(self) -> "exp.Expression | Any":
         """Build and return the final expression."""
         ...
 
@@ -407,6 +405,6 @@ class SQLBuilderProtocol(Protocol):
 class SelectBuilderProtocol(SQLBuilderProtocol, Protocol):
     """Protocol for SELECT query builders."""
 
-    def select(self, *columns: "Union[str, exp.Expression]") -> Self:
+    def select(self, *columns: "str | exp.Expression") -> Self:
         """Add SELECT columns to the query."""
         ...

--- a/sqlspec/storage/registry.py
+++ b/sqlspec/storage/registry.py
@@ -8,7 +8,7 @@ scheme-based routing, and named aliases for common configurations.
 import logging
 import re
 from pathlib import Path
-from typing import Any, Final, Optional, Union, cast
+from typing import Any, Final, cast
 
 from mypy_extensions import mypyc_attr
 
@@ -74,7 +74,7 @@ class StorageRegistry:
     def __init__(self) -> None:
         self._alias_configs: dict[str, tuple[type[ObjectStoreProtocol], str, dict[str, Any]]] = {}
         self._aliases: dict[str, dict[str, Any]] = {}
-        self._instances: dict[Union[str, tuple[str, tuple[tuple[str, Any], ...]]], ObjectStoreProtocol] = {}
+        self._instances: dict[str | tuple[str, tuple[tuple[str, Any], ...]], ObjectStoreProtocol] = {}
         self._cache: dict[str, tuple[str, type[ObjectStoreProtocol]]] = {}
 
     def _make_hashable(self, obj: Any) -> Any:
@@ -88,7 +88,7 @@ class StorageRegistry:
         return obj
 
     def register_alias(
-        self, alias: str, uri: str, *, backend: Optional[str] = None, base_path: str = "", **kwargs: Any
+        self, alias: str, uri: str, *, backend: str | None = None, base_path: str = "", **kwargs: Any
     ) -> None:
         """Register a named alias for a storage configuration.
 
@@ -110,9 +110,7 @@ class StorageRegistry:
         test_config["uri"] = uri
         self._aliases[alias] = test_config
 
-    def get(
-        self, uri_or_alias: Union[str, Path], *, backend: Optional[str] = None, **kwargs: Any
-    ) -> ObjectStoreProtocol:
+    def get(self, uri_or_alias: str | Path, *, backend: str | None = None, **kwargs: Any) -> ObjectStoreProtocol:
         """Get backend instance using URI-first routing with automatic backend selection.
 
         Args:
@@ -154,9 +152,7 @@ class StorageRegistry:
         self._instances[cache_key] = instance
         return instance
 
-    def _resolve_from_uri(
-        self, uri: str, *, backend_override: Optional[str] = None, **kwargs: Any
-    ) -> ObjectStoreProtocol:
+    def _resolve_from_uri(self, uri: str, *, backend_override: str | None = None, **kwargs: Any) -> ObjectStoreProtocol:
         """Resolve backend from URI with optional backend override."""
         if backend_override:
             return self._create_backend(backend_override, uri, **kwargs)
@@ -229,7 +225,7 @@ class StorageRegistry:
         """Create backend instance for URI."""
         return self._get_backend_class(backend_type)(uri, **kwargs)
 
-    def _get_scheme(self, uri: str) -> Optional[str]:
+    def _get_scheme(self, uri: str) -> str | None:
         """Extract the scheme from a URI using regex."""
         if not uri:
             return None
@@ -244,7 +240,7 @@ class StorageRegistry:
         """List all registered aliases."""
         return list(self._alias_configs.keys())
 
-    def clear_cache(self, uri_or_alias: Optional[str] = None) -> None:
+    def clear_cache(self, uri_or_alias: str | None = None) -> None:
         """Clear resolved backend cache."""
         if uri_or_alias:
             self._instances.pop(uri_or_alias, None)

--- a/sqlspec/typing.py
+++ b/sqlspec/typing.py
@@ -1,9 +1,9 @@
 # pyright: ignore[reportAttributeAccessIssue]
 from collections.abc import Iterator, Mapping
 from functools import lru_cache
-from typing import TYPE_CHECKING, Annotated, Any, Protocol, Union
+from typing import TYPE_CHECKING, Annotated, Any, Protocol, TypeAlias
 
-from typing_extensions import TypeAlias, TypeVar
+from typing_extensions import TypeVar
 
 from sqlspec._typing import (
     AIOSQL_INSTALLED,
@@ -92,7 +92,7 @@ PoolT_co = TypeVar("PoolT_co", covariant=True)
 
 :class:`~sqlspec.typing.PoolT_co`
 """
-ModelT = TypeVar("ModelT", bound="Union[DictLike, StructStub, BaseModelStub, DataclassProtocol, AttrsInstanceStub]")
+ModelT = TypeVar("ModelT", bound="DictLike | StructStub | BaseModelStub | DataclassProtocol | AttrsInstanceStub")
 """Type variable for model types.
 
 :class:`DictLike` | :class:`msgspec.Struct` | :class:`pydantic.BaseModel` | :class:`DataclassProtocol` | :class:`AttrsInstance`
@@ -105,12 +105,12 @@ DictRow: TypeAlias = "dict[str, Any]"
 TupleRow: TypeAlias = "tuple[Any, ...]"
 """Type variable for TupleRow types."""
 
-SupportedSchemaModel: TypeAlias = "Union[DictLike, StructStub, BaseModelStub, DataclassProtocol, AttrsInstanceStub]"
+SupportedSchemaModel: TypeAlias = "DictLike | StructStub | BaseModelStub | DataclassProtocol | AttrsInstanceStub"
 """Type alias for pydantic or msgspec models.
 
 :class:`msgspec.Struct` | :class:`pydantic.BaseModel` | :class:`DataclassProtocol` | :class:`AttrsInstance`
 """
-StatementParameters: TypeAlias = "Union[Any, dict[str, Any], list[Any], tuple[Any, ...], None]"
+StatementParameters: TypeAlias = "Any | dict[str, Any] | list[Any] | tuple[Any, ...] | None"
 """Type alias for statement parameters.
 
 Represents:
@@ -130,7 +130,7 @@ PydanticOrMsgspecT = SupportedSchemaModel
 :class:`msgspec.Struct` or :class:`pydantic.BaseModel`
 """
 ModelDict: TypeAlias = (
-    "Union[dict[str, Any], Union[DictLike, StructStub, BaseModelStub, DataclassProtocol, AttrsInstanceStub], Any]"
+    "dict[str, Any] | DictLike | StructStub | BaseModelStub | DataclassProtocol | AttrsInstanceStub | Any"
 )
 """Type alias for model dictionaries.
 
@@ -138,7 +138,7 @@ Represents:
 - :type:`dict[str, Any]` | :class:`DataclassProtocol` | :class:`msgspec.Struct` |  :class:`pydantic.BaseModel`
 """
 ModelDictList: TypeAlias = (
-    "Sequence[Union[dict[str, Any], Union[DictLike, StructStub, BaseModelStub, DataclassProtocol, AttrsInstanceStub]]]"
+    "Sequence[dict[str, Any] | DictLike | StructStub | BaseModelStub | DataclassProtocol | AttrsInstanceStub]"
 )
 """Type alias for model dictionary lists.
 
@@ -146,7 +146,9 @@ A list or sequence of any of the following:
 - :type:`Sequence`[:type:`dict[str, Any]` | :class:`DataclassProtocol` | :class:`msgspec.Struct` | :class:`pydantic.BaseModel`]
 
 """
-BulkModelDict: TypeAlias = "Union[Sequence[Union[dict[str, Any], Union[DictLike, StructStub, BaseModelStub, DataclassProtocol, AttrsInstanceStub]]], Any]"
+BulkModelDict: TypeAlias = (
+    "Sequence[dict[str, Any] | DictLike | StructStub | BaseModelStub | DataclassProtocol | AttrsInstanceStub] | Any"
+)
 """Type alias for bulk model dictionaries.
 
 Represents:

--- a/sqlspec/utils/config_resolver.py
+++ b/sqlspec/utils/config_resolver.py
@@ -7,7 +7,7 @@ Supports both synchronous and asynchronous callable functions.
 
 import inspect
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from sqlspec.exceptions import ConfigResolverError
 from sqlspec.utils.module_loader import import_string
@@ -21,7 +21,7 @@ __all__ = ("resolve_config_async", "resolve_config_sync")
 
 async def resolve_config_async(
     config_path: str,
-) -> "Union[list[Union[AsyncDatabaseConfig, SyncDatabaseConfig]], Union[AsyncDatabaseConfig, SyncDatabaseConfig]]":
+) -> "list[AsyncDatabaseConfig | SyncDatabaseConfig] | AsyncDatabaseConfig | SyncDatabaseConfig":
     """Resolve config from dotted path, handling callables and direct instances.
 
     This is the async-first version that handles both sync and async callables efficiently.
@@ -58,7 +58,7 @@ async def resolve_config_async(
 
 def resolve_config_sync(
     config_path: str,
-) -> "Union[list[Union[AsyncDatabaseConfig, SyncDatabaseConfig]], Union[AsyncDatabaseConfig, SyncDatabaseConfig]]":
+) -> "list[AsyncDatabaseConfig | SyncDatabaseConfig] | AsyncDatabaseConfig | SyncDatabaseConfig":
     """Synchronous wrapper for resolve_config.
 
     Args:
@@ -90,7 +90,7 @@ def resolve_config_sync(
 
 def _validate_config_result(
     config_result: Any, config_path: str
-) -> "Union[list[Union[AsyncDatabaseConfig, SyncDatabaseConfig]], Union[AsyncDatabaseConfig, SyncDatabaseConfig]]":
+) -> "list[AsyncDatabaseConfig | SyncDatabaseConfig] | AsyncDatabaseConfig | SyncDatabaseConfig":
     """Validate that the config result is a valid config or list of configs.
 
     Args:
@@ -117,13 +117,13 @@ def _validate_config_result(
                 msg = f"Config '{config_path}' returned invalid config at index {i}. Expected database config instance."
                 raise ConfigResolverError(msg)
 
-        return cast("list[Union[AsyncDatabaseConfig, SyncDatabaseConfig]]", list(config_result))
+        return cast("list[AsyncDatabaseConfig | SyncDatabaseConfig]", list(config_result))
 
     if not _is_valid_config(config_result):
         msg = f"Config '{config_path}' returned invalid type '{type(config_result).__name__}'. Expected database config instance or list."
         raise ConfigResolverError(msg)
 
-    return cast("Union[AsyncDatabaseConfig, SyncDatabaseConfig]", config_result)
+    return cast("AsyncDatabaseConfig | SyncDatabaseConfig", config_result)
 
 
 def _is_valid_config(config: Any) -> bool:

--- a/sqlspec/utils/data_transformation.py
+++ b/sqlspec/utils/data_transformation.py
@@ -5,7 +5,8 @@ field name conversion when mapping database results to schema objects.
 Used primarily for msgspec field name conversion with rename configurations.
 """
 
-from typing import Any, Callable, Union
+from collections.abc import Callable
+from typing import Any
 
 __all__ = ("transform_dict_keys",)
 
@@ -30,7 +31,7 @@ def _safe_convert_key(key: Any, converter: Callable[[str], str]) -> Any:
         return key
 
 
-def transform_dict_keys(data: Union[dict, list, Any], converter: Callable[[str], str]) -> Union[dict, list, Any]:
+def transform_dict_keys(data: dict | list | Any, converter: Callable[[str], str]) -> dict | list | Any:
     """Transform dictionary keys using the provided converter function.
 
     Recursively transforms all dictionary keys in a data structure using

--- a/sqlspec/utils/deprecation.py
+++ b/sqlspec/utils/deprecation.py
@@ -5,8 +5,9 @@ Used to communicate API changes and migration paths to users.
 """
 
 import inspect
+from collections.abc import Callable
 from functools import wraps
-from typing import Callable, Literal, Optional
+from typing import Literal
 from warnings import warn
 
 from typing_extensions import ParamSpec, TypeVar
@@ -24,9 +25,9 @@ def warn_deprecation(
     deprecated_name: str,
     kind: DeprecatedKind,
     *,
-    removal_in: Optional[str] = None,
-    alternative: Optional[str] = None,
-    info: Optional[str] = None,
+    removal_in: str | None = None,
+    alternative: str | None = None,
+    info: str | None = None,
     pending: bool = False,
 ) -> None:
     """Warn about a call to a deprecated function.
@@ -72,11 +73,11 @@ def warn_deprecation(
 def deprecated(
     version: str,
     *,
-    removal_in: Optional[str] = None,
-    alternative: Optional[str] = None,
-    info: Optional[str] = None,
+    removal_in: str | None = None,
+    alternative: str | None = None,
+    info: str | None = None,
     pending: bool = False,
-    kind: Optional[Literal["function", "method", "classmethod", "property"]] = None,
+    kind: Literal["function", "method", "classmethod", "property"] | None = None,
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """Create a decorator wrapping a function, method or property with a deprecation warning.
 

--- a/sqlspec/utils/fixtures.py
+++ b/sqlspec/utils/fixtures.py
@@ -7,7 +7,7 @@ used in testing and development. Supports both sync and async operations.
 import gzip
 import zipfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from sqlspec.storage import storage_registry
 from sqlspec.utils.serializers import from_json as decode_json
@@ -171,7 +171,7 @@ def _serialize_data(data: Any) -> str:
 def write_fixture(
     fixtures_path: str,
     table_name: str,
-    data: "Union[ModelDictList, list[dict[str, Any]], SupportedSchemaModel]",
+    data: "ModelDictList | list[dict[str, Any]] | SupportedSchemaModel",
     storage_backend: str = "local",
     compress: bool = False,
     **storage_kwargs: Any,
@@ -219,7 +219,7 @@ def write_fixture(
 async def write_fixture_async(
     fixtures_path: str,
     table_name: str,
-    data: "Union[ModelDictList, list[dict[str, Any]], SupportedSchemaModel]",
+    data: "ModelDictList | list[dict[str, Any]] | SupportedSchemaModel",
     storage_backend: str = "local",
     compress: bool = False,
     **storage_kwargs: Any,

--- a/sqlspec/utils/logging.py
+++ b/sqlspec/utils/logging.py
@@ -8,7 +8,7 @@ SQLSpec provides StructuredFormatter for JSON-formatted logs if desired.
 import logging
 from contextvars import ContextVar
 from logging import LogRecord
-from typing import Any, Optional
+from typing import Any
 
 from sqlspec._serialization import encode_json
 
@@ -22,10 +22,10 @@ __all__ = (
     "suppress_erroneous_sqlglot_log_messages",
 )
 
-correlation_id_var: "ContextVar[Optional[str]]" = ContextVar("correlation_id", default=None)
+correlation_id_var: "ContextVar[str | None]" = ContextVar("correlation_id", default=None)
 
 
-def set_correlation_id(correlation_id: "Optional[str]") -> None:
+def set_correlation_id(correlation_id: "str | None") -> None:
     """Set the correlation ID for the current context.
 
     Args:
@@ -34,7 +34,7 @@ def set_correlation_id(correlation_id: "Optional[str]") -> None:
     correlation_id_var.set(correlation_id)
 
 
-def get_correlation_id() -> "Optional[str]":
+def get_correlation_id() -> "str | None":
     """Get the current correlation ID.
 
     Returns:
@@ -114,7 +114,7 @@ class SqlglotCommandFallbackFilter(logging.Filter):
         return "Falling back to parsing as a 'Command'" not in record.getMessage()
 
 
-def get_logger(name: "Optional[str]" = None) -> logging.Logger:
+def get_logger(name: "str | None" = None) -> logging.Logger:
     """Get a logger instance with standardized configuration.
 
     Args:

--- a/sqlspec/utils/module_loader.py
+++ b/sqlspec/utils/module_loader.py
@@ -7,7 +7,7 @@ Used for loading modules from dotted paths and converting module paths to filesy
 import importlib
 from importlib.util import find_spec
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 __all__ = ("import_string", "module_to_os_path")
 
@@ -46,7 +46,7 @@ def import_string(dotted_path: str) -> "Any":
         The imported object.
     """
 
-    def _raise_import_error(msg: str, exc: "Optional[Exception]" = None) -> None:
+    def _raise_import_error(msg: str, exc: "Exception | None" = None) -> None:
         if exc is not None:
             raise ImportError(msg) from exc
         raise ImportError(msg)

--- a/sqlspec/utils/serializers.py
+++ b/sqlspec/utils/serializers.py
@@ -4,7 +4,7 @@ Re-exports common JSON encoding and decoding functions from the core
 serialization module for convenient access.
 """
 
-from typing import Any, Literal, Union, overload
+from typing import Any, Literal, overload
 
 from sqlspec._serialization import decode_json, encode_json
 
@@ -17,7 +17,7 @@ def to_json(data: Any, *, as_bytes: Literal[False] = ...) -> str: ...
 def to_json(data: Any, *, as_bytes: Literal[True]) -> bytes: ...
 
 
-def to_json(data: Any, *, as_bytes: bool = False) -> Union[str, bytes]:
+def to_json(data: Any, *, as_bytes: bool = False) -> str | bytes:
     """Encode data to JSON string or bytes.
 
     Args:
@@ -40,7 +40,7 @@ def from_json(data: str) -> Any: ...
 def from_json(data: bytes, *, decode_bytes: bool = ...) -> Any: ...
 
 
-def from_json(data: Union[str, bytes], *, decode_bytes: bool = True) -> Any:
+def from_json(data: str | bytes, *, decode_bytes: bool = True) -> Any:
     """Decode JSON string or bytes to Python object.
 
     Args:

--- a/sqlspec/utils/text.py
+++ b/sqlspec/utils/text.py
@@ -8,7 +8,6 @@ generation and data validation.
 import re
 import unicodedata
 from functools import lru_cache
-from typing import Optional
 
 _SLUGIFY_REMOVE_NON_ALPHANUMERIC = re.compile(r"[^\w]+", re.UNICODE)
 _SLUGIFY_HYPHEN_COLLAPSE = re.compile(r"-+")
@@ -22,7 +21,7 @@ _SNAKE_CASE_MULTIPLE_UNDERSCORES = re.compile(r"__+", re.UNICODE)
 __all__ = ("camelize", "kebabize", "pascalize", "slugify", "snake_case")
 
 
-def slugify(value: str, allow_unicode: bool = False, separator: Optional[str] = None) -> str:
+def slugify(value: str, allow_unicode: bool = False, separator: str | None = None) -> str:
     """Convert a string to a URL-friendly slug.
 
     Args:

--- a/sqlspec/utils/type_guards.py
+++ b/sqlspec/utils/type_guards.py
@@ -7,7 +7,7 @@ understand type narrowing, replacing defensive hasattr() and duck typing pattern
 from collections.abc import Sequence
 from collections.abc import Set as AbstractSet
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from typing_extensions import is_typeddict
 
@@ -26,9 +26,9 @@ from sqlspec.typing import (
 
 if TYPE_CHECKING:
     from dataclasses import Field
+    from typing import TypeGuard
 
     from sqlglot import exp
-    from typing_extensions import TypeGuard
 
     from sqlspec._typing import AttrsInstanceStub, BaseModelStub, DTODataStub, StructStub
     from sqlspec.builder import Select
@@ -449,7 +449,7 @@ def is_msgspec_struct_without_field(obj: Any, field_name: str) -> "TypeGuard[Str
 
 
 @lru_cache(maxsize=500)
-def _detect_rename_pattern(field_name: str, encode_name: str) -> "Optional[str]":
+def _detect_rename_pattern(field_name: str, encode_name: str) -> "str | None":
     """Detect the rename pattern by comparing field name transformations.
 
     Args:
@@ -473,7 +473,7 @@ def _detect_rename_pattern(field_name: str, encode_name: str) -> "Optional[str]"
     return None
 
 
-def get_msgspec_rename_config(schema_type: type) -> "Optional[str]":
+def get_msgspec_rename_config(schema_type: type) -> "str | None":
     """Extract msgspec rename configuration from a struct type.
 
     Analyzes field name transformations to detect the rename pattern used by msgspec.
@@ -626,7 +626,7 @@ def is_schema(obj: Any) -> "TypeGuard[SupportedSchemaModel]":
     )
 
 
-def is_schema_or_dict(obj: Any) -> "TypeGuard[Union[SupportedSchemaModel, dict[str, Any]]]":
+def is_schema_or_dict(obj: Any) -> "TypeGuard[SupportedSchemaModel | dict[str, Any]]":
     """Check if a value is a msgspec Struct, Pydantic model, or dict.
 
     Args:
@@ -664,7 +664,7 @@ def is_schema_without_field(obj: Any, field_name: str) -> "TypeGuard[SupportedSc
     return not is_schema_with_field(obj, field_name)
 
 
-def is_schema_or_dict_with_field(obj: Any, field_name: str) -> "TypeGuard[Union[SupportedSchemaModel, dict[str, Any]]]":
+def is_schema_or_dict_with_field(obj: Any, field_name: str) -> "TypeGuard[SupportedSchemaModel | dict[str, Any]]":
     """Check if a value is a msgspec Struct, Pydantic model, or dict with a specific field.
 
     Args:
@@ -677,9 +677,7 @@ def is_schema_or_dict_with_field(obj: Any, field_name: str) -> "TypeGuard[Union[
     return is_schema_with_field(obj, field_name) or is_dict_with_field(obj, field_name)
 
 
-def is_schema_or_dict_without_field(
-    obj: Any, field_name: str
-) -> "TypeGuard[Union[SupportedSchemaModel, dict[str, Any]]]":
+def is_schema_or_dict_without_field(obj: Any, field_name: str) -> "TypeGuard[SupportedSchemaModel | dict[str, Any]]":
     """Check if a value is a msgspec Struct, Pydantic model, or dict without a specific field.
 
     Args:
@@ -736,8 +734,8 @@ def extract_dataclass_fields(
     obj: "DataclassProtocol",
     exclude_none: bool = False,
     exclude_empty: bool = False,
-    include: "Optional[AbstractSet[str]]" = None,
-    exclude: "Optional[AbstractSet[str]]" = None,
+    include: "AbstractSet[str] | None" = None,
+    exclude: "AbstractSet[str] | None" = None,
 ) -> "tuple[Field[Any], ...]":
     """Extract dataclass fields.
 
@@ -782,8 +780,8 @@ def extract_dataclass_items(
     obj: "DataclassProtocol",
     exclude_none: bool = False,
     exclude_empty: bool = False,
-    include: "Optional[AbstractSet[str]]" = None,
-    exclude: "Optional[AbstractSet[str]]" = None,
+    include: "AbstractSet[str] | None" = None,
+    exclude: "AbstractSet[str] | None" = None,
 ) -> "tuple[tuple[str, Any], ...]":
     """Extract name-value pairs from a dataclass instance.
 
@@ -806,7 +804,7 @@ def dataclass_to_dict(
     exclude_none: bool = False,
     exclude_empty: bool = False,
     convert_nested: bool = True,
-    exclude: "Optional[AbstractSet[str]]" = None,
+    exclude: "AbstractSet[str] | None" = None,
 ) -> "dict[str, Any]":
     """Convert a dataclass instance to a dictionary.
 
@@ -993,7 +991,7 @@ def has_attr(obj: Any, attr: str) -> bool:
     return True
 
 
-def get_node_this(node: "exp.Expression", default: Optional[Any] = None) -> Any:
+def get_node_this(node: "exp.Expression", default: Any | None = None) -> Any:
     """Safely get the 'this' attribute from a SQLGlot node.
 
     Args:
@@ -1025,7 +1023,7 @@ def has_this_attribute(node: "exp.Expression") -> bool:
     return True
 
 
-def get_node_expressions(node: "exp.Expression", default: Optional[Any] = None) -> Any:
+def get_node_expressions(node: "exp.Expression", default: Any | None = None) -> Any:
     """Safely get the 'expressions' attribute from a SQLGlot node.
 
     Args:
@@ -1057,7 +1055,7 @@ def has_expressions_attribute(node: "exp.Expression") -> bool:
     return True
 
 
-def get_literal_parent(literal: "exp.Expression", default: Optional[Any] = None) -> Any:
+def get_literal_parent(literal: "exp.Expression", default: Any | None = None) -> Any:
     """Safely get the 'parent' attribute from a SQLGlot literal.
 
     Args:
@@ -1128,7 +1126,7 @@ def is_number_literal(literal: "exp.Literal") -> bool:
         return False
 
 
-def get_initial_expression(context: Any) -> "Optional[exp.Expression]":
+def get_initial_expression(context: Any) -> "exp.Expression | None":
     """Safely get initial_expression from context.
 
     Args:
@@ -1143,7 +1141,7 @@ def get_initial_expression(context: Any) -> "Optional[exp.Expression]":
         return None
 
 
-def expression_has_limit(expr: "Optional[exp.Expression]") -> bool:
+def expression_has_limit(expr: "exp.Expression | None") -> bool:
     """Check if an expression has a limit clause.
 
     Args:
@@ -1175,7 +1173,7 @@ def get_value_attribute(obj: Any) -> Any:
         return obj
 
 
-def get_param_style_and_name(param: Any) -> "tuple[Optional[str], Optional[str]]":
+def get_param_style_and_name(param: Any) -> "tuple[str | None, str | None]":
     """Safely get style and name attributes from a parameter.
 
     Args:

--- a/tests/fixtures/example_usage.py
+++ b/tests/fixtures/example_usage.py
@@ -1,6 +1,6 @@
 """Example usage of SQL formatting utilities."""
 
-from typing import Any, Union
+from typing import Any
 
 from tests.fixtures.sql_utils import create_tuple_or_dict_parameters, format_placeholder, format_sql_parameters
 
@@ -23,9 +23,7 @@ def example_direct_placeholder(style: str, dialect: str = "postgres") -> str:
 
 
 # Example 2: Using format_sql_parameters for a more complex query
-def example_with_formatting(
-    style: str, dialect: str = "postgres"
-) -> tuple[str, Union[tuple[Any, ...], dict[str, Any]]]:
+def example_with_formatting(style: str, dialect: str = "postgres") -> tuple[str, tuple[Any, ...] | dict[str, Any]]:
     """Example of using format_sql_parameters for a query with multiple parameters."""
     sql_template = """
     INSERT INTO test_table (name, id, created_at)
@@ -37,7 +35,7 @@ def example_with_formatting(
     return formatted_sql, empty_parameters
 
 
-def example_param_creation(style: str, name: str, id_value: int) -> Union[tuple[Any, ...], dict[str, Any]]:
+def example_param_creation(style: str, name: str, id_value: int) -> tuple[Any, ...] | dict[str, Any]:
     """Example of creating parameter objects based on style."""
     values = [name, id_value]
     field_names = ["name", "id"]

--- a/tests/fixtures/sql_utils.py
+++ b/tests/fixtures/sql_utils.py
@@ -1,7 +1,7 @@
-from typing import Any, Optional, Union
+from typing import Any
 
 
-def format_placeholder(field_name: str, style: str, dialect: Optional[str] = None) -> str:
+def format_placeholder(field_name: str, style: str, dialect: str | None = None) -> str:
     """Format a placeholder in SQL based on the parameter style.
 
     Args:
@@ -25,7 +25,7 @@ def format_placeholder(field_name: str, style: str, dialect: Optional[str] = Non
     return f"%({field_name})s"
 
 
-def format_sql(sql_template: str, field_names: list[str], style: str, dialect: Optional[str] = None) -> str:
+def format_sql(sql_template: str, field_names: list[str], style: str, dialect: str | None = None) -> str:
     """Format a SQL string by replacing template placeholders with dialect/style-specific placeholders.
 
     This function can handle multiple placeholders in a single SQL string.
@@ -55,8 +55,8 @@ def format_sql(sql_template: str, field_names: list[str], style: str, dialect: O
 
 
 def format_sql_parameters(
-    sql_template: str, param_fields: list[str], style: str, dialect: Optional[str] = None
-) -> tuple[str, Union[tuple[Any, ...], dict[str, Any]]]:
+    sql_template: str, param_fields: list[str], style: str, dialect: str | None = None
+) -> tuple[str, tuple[Any, ...] | dict[str, Any]]:
     """Format SQL template and create the appropriate parameter object based on style.
 
     Args:
@@ -71,14 +71,14 @@ def format_sql_parameters(
     formatted_sql = format_sql(sql_template, param_fields, style, dialect)
 
     # Return appropriate empty parameter container based on style
-    empty_parameters: Union[tuple[Any, ...], dict[str, Any]] = () if style == "tuple_binds" else {}
+    empty_parameters: tuple[Any, ...] | dict[str, Any] = () if style == "tuple_binds" else {}
 
     return formatted_sql, empty_parameters
 
 
 def create_tuple_or_dict_parameters(
     values: list[Any], field_names: list[str], style: str
-) -> Union[tuple[Any, ...], dict[str, Any]]:
+) -> tuple[Any, ...] | dict[str, Any]:
     """Create the appropriate parameter object based on values and style.
 
     Args:

--- a/tests/integration/test_adapters/test_adbc/conftest.py
+++ b/tests/integration/test_adapters/test_adbc/conftest.py
@@ -1,8 +1,8 @@
 """Test fixtures and configuration for ADBC integration tests."""
 
 import functools
-from collections.abc import Generator
-from typing import Any, Callable, TypeVar, cast
+from collections.abc import Callable, Generator
+from typing import Any, TypeVar, cast
 
 import pytest
 from pytest_databases.docker.postgres import PostgresService

--- a/tests/integration/test_adapters/test_adbc/test_migrations.py
+++ b/tests/integration/test_adapters/test_adbc/test_migrations.py
@@ -2,11 +2,12 @@
 
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from sqlspec.adapters.adbc.config import AdbcConfig
-from sqlspec.migrations.commands import create_migration_commands
+from sqlspec.migrations.commands import AsyncMigrationCommands, SyncMigrationCommands, create_migration_commands
 
 # xdist_group is assigned per test based on database backend to enable parallel execution
 
@@ -22,7 +23,7 @@ def test_adbc_sqlite_migration_full_workflow() -> None:
             connection_config={"driver_name": "adbc_driver_sqlite", "uri": f"file:{db_path}", "autocommit": True},
             migration_config={"script_location": str(migration_dir), "version_table_name": "sqlspec_migrations"},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 
@@ -89,7 +90,7 @@ def test_adbc_multiple_migrations_workflow() -> None:
             connection_config={"driver_name": "adbc_driver_sqlite", "uri": f"file:{db_path}", "autocommit": True},
             migration_config={"script_location": str(migration_dir), "version_table_name": "sqlspec_migrations"},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 
@@ -183,7 +184,7 @@ def test_adbc_migration_current_command() -> None:
             connection_config={"driver_name": "adbc_driver_sqlite", "uri": f"file:{db_path}", "autocommit": True},
             migration_config={"script_location": str(migration_dir), "version_table_name": "sqlspec_migrations"},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 
@@ -220,7 +221,7 @@ def test_adbc_migration_error_handling() -> None:
             connection_config={"driver_name": "adbc_driver_sqlite", "uri": f"file:{db_path}", "autocommit": True},
             migration_config={"script_location": str(migration_dir), "version_table_name": "sqlspec_migrations"},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 
@@ -254,7 +255,7 @@ def test_adbc_migration_with_transactions() -> None:
             connection_config={"driver_name": "adbc_driver_sqlite", "uri": f"file:{db_path}", "autocommit": True},
             migration_config={"script_location": str(migration_dir), "version_table_name": "sqlspec_migrations"},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 

--- a/tests/integration/test_adapters/test_duckdb/test_migrations.py
+++ b/tests/integration/test_adapters/test_duckdb/test_migrations.py
@@ -2,11 +2,12 @@
 
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from sqlspec.adapters.duckdb.config import DuckDBConfig
-from sqlspec.migrations.commands import create_migration_commands
+from sqlspec.migrations.commands import AsyncMigrationCommands, SyncMigrationCommands, create_migration_commands
 
 pytestmark = pytest.mark.xdist_group("duckdb")
 
@@ -21,7 +22,7 @@ def test_duckdb_migration_full_workflow() -> None:
             pool_config={"database": str(db_path)},
             migration_config={"script_location": str(migration_dir), "version_table_name": "sqlspec_migrations"},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 
@@ -81,7 +82,7 @@ def test_duckdb_multiple_migrations_workflow() -> None:
             pool_config={"database": str(db_path)},
             migration_config={"script_location": str(migration_dir), "version_table_name": "sqlspec_migrations"},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 
@@ -178,7 +179,7 @@ def test_duckdb_migration_current_command() -> None:
             pool_config={"database": str(db_path)},
             migration_config={"script_location": str(migration_dir), "version_table_name": "sqlspec_migrations"},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 
@@ -214,7 +215,7 @@ def test_duckdb_migration_error_handling() -> None:
             pool_config={"database": str(db_path)},
             migration_config={"script_location": str(migration_dir), "version_table_name": "sqlspec_migrations"},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 
@@ -247,7 +248,7 @@ def test_duckdb_migration_with_transactions() -> None:
             pool_config={"database": str(db_path)},
             migration_config={"script_location": str(migration_dir), "version_table_name": "sqlspec_migrations"},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 

--- a/tests/integration/test_adapters/test_duckdb/utils.py
+++ b/tests/integration/test_adapters/test_duckdb/utils.py
@@ -1,7 +1,6 @@
 """Utility functions for DuckDB integration tests."""
 
 import uuid
-from typing import Optional
 
 
 def get_unique_table_name(base_name: str = "test_table") -> str:
@@ -17,7 +16,7 @@ def get_unique_table_name(base_name: str = "test_table") -> str:
     return f"{base_name}_{suffix}"
 
 
-def get_test_table_ddl(table_name: Optional[str] = None) -> tuple[str, str]:
+def get_test_table_ddl(table_name: str | None = None) -> tuple[str, str]:
     """Get DDL for creating a test table with a unique name.
 
     Args:

--- a/tests/integration/test_adapters/test_oracledb/test_execute_many.py
+++ b/tests/integration/test_adapters/test_oracledb/test_execute_many.py
@@ -1,13 +1,13 @@
 """Test Oracle execute_many functionality."""
 
-from typing import Any, Union
+from typing import Any
 
 import pytest
 
 from sqlspec.adapters.oracledb import OracleAsyncDriver, OracleSyncDriver
 from sqlspec.core.result import SQLResult
 
-BatchParameters = Union[list[tuple[Any, ...]], list[dict[str, Any]], list[list[Any]]]
+BatchParameters = list[tuple[Any, ...]] | list[dict[str, Any]] | list[list[Any]]
 pytestmark = pytest.mark.xdist_group("oracle")
 
 

--- a/tests/integration/test_adapters/test_oracledb/test_migrations.py
+++ b/tests/integration/test_adapters/test_oracledb/test_migrations.py
@@ -2,12 +2,13 @@
 
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 from pytest_databases.docker.oracle import OracleService
 
 from sqlspec.adapters.oracledb.config import OracleAsyncConfig, OracleSyncConfig
-from sqlspec.migrations.commands import AsyncMigrationCommands, create_migration_commands
+from sqlspec.migrations.commands import AsyncMigrationCommands, SyncMigrationCommands, create_migration_commands
 
 pytestmark = pytest.mark.xdist_group("oracle")
 
@@ -32,7 +33,7 @@ def test_oracledb_sync_migration_full_workflow(oracle_23ai_service: OracleServic
             },
             migration_config={"script_location": str(migration_dir), "version_table_name": migration_table},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 
@@ -195,7 +196,7 @@ def test_oracledb_sync_multiple_migrations_workflow(oracle_23ai_service: OracleS
             },
             migration_config={"script_location": str(migration_dir), "version_table_name": migration_table},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 
@@ -424,7 +425,7 @@ def test_oracledb_sync_migration_current_command(oracle_23ai_service: OracleServ
             },
             migration_config={"script_location": str(migration_dir), "version_table_name": migration_table},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         try:
             commands.init(str(migration_dir), package=True)
@@ -547,7 +548,7 @@ def test_oracledb_sync_migration_error_handling(oracle_23ai_service: OracleServi
             },
             migration_config={"script_location": str(migration_dir), "version_table_name": migration_table},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         try:
             commands.init(str(migration_dir), package=True)
@@ -654,7 +655,7 @@ def test_oracledb_sync_migration_with_transactions(oracle_23ai_service: OracleSe
             },
             migration_config={"script_location": str(migration_dir), "version_table_name": migration_table},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         try:
             commands.init(str(migration_dir), package=True)

--- a/tests/integration/test_adapters/test_oracledb/test_parameter_styles.py
+++ b/tests/integration/test_adapters/test_oracledb/test_parameter_styles.py
@@ -1,6 +1,6 @@
 """Test Oracle parameter style conversion."""
 
-from typing import Any, Union
+from typing import Any
 
 import pytest
 
@@ -9,7 +9,7 @@ from sqlspec.core.result import SQLResult
 
 pytestmark = pytest.mark.xdist_group("oracle")
 
-OracleParamData = Union[tuple[Any, ...], list[Any], dict[str, Any]]
+OracleParamData = tuple[Any, ...] | list[Any] | dict[str, Any]
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_adapters/test_psycopg/test_migrations.py
+++ b/tests/integration/test_adapters/test_psycopg/test_migrations.py
@@ -2,13 +2,14 @@
 
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 from pytest_databases.docker.postgres import PostgresService
 
 from sqlspec.adapters.psycopg import PsycopgAsyncConfig
 from sqlspec.adapters.psycopg.config import PsycopgSyncConfig
-from sqlspec.migrations.commands import AsyncMigrationCommands, create_migration_commands
+from sqlspec.migrations.commands import AsyncMigrationCommands, SyncMigrationCommands, create_migration_commands
 
 pytestmark = pytest.mark.xdist_group("postgres")
 
@@ -29,7 +30,7 @@ def test_psycopg_sync_migration_full_workflow(postgres_service: PostgresService)
             },
             migration_config={"script_location": str(migration_dir), "version_table_name": migration_table},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 
@@ -192,7 +193,7 @@ def test_psycopg_sync_multiple_migrations_workflow(postgres_service: PostgresSer
             },
             migration_config={"script_location": str(migration_dir), "version_table_name": migration_table},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 
@@ -408,7 +409,7 @@ def test_psycopg_sync_migration_current_command(postgres_service: PostgresServic
             },
             migration_config={"script_location": str(migration_dir), "version_table_name": migration_table},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         try:
             commands.init(str(migration_dir), package=True)
@@ -535,7 +536,7 @@ def test_psycopg_sync_migration_error_handling(postgres_service: PostgresService
                 "version_table_name": "sqlspec_migrations_psycopg_sync_error",
             },
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         try:
             commands.init(str(migration_dir), package=True)
@@ -648,7 +649,7 @@ def test_psycopg_sync_migration_with_transactions(postgres_service: PostgresServ
             },
             migration_config={"script_location": str(migration_dir), "version_table_name": migration_table},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         try:
             commands.init(str(migration_dir), package=True)

--- a/tests/integration/test_adapters/test_sqlite/test_migrations.py
+++ b/tests/integration/test_adapters/test_sqlite/test_migrations.py
@@ -2,11 +2,12 @@
 
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from sqlspec.adapters.sqlite.config import SqliteConfig
-from sqlspec.migrations.commands import create_migration_commands
+from sqlspec.migrations.commands import AsyncMigrationCommands, SyncMigrationCommands, create_migration_commands
 
 pytestmark = pytest.mark.xdist_group("sqlite")
 
@@ -21,7 +22,7 @@ def test_sqlite_migration_full_workflow() -> None:
             pool_config={"database": temp_db},
             migration_config={"script_location": str(migration_dir), "version_table_name": "sqlspec_migrations"},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 
@@ -81,7 +82,7 @@ def test_sqlite_multiple_migrations_workflow() -> None:
             pool_config={"database": temp_db},
             migration_config={"script_location": str(migration_dir), "version_table_name": "sqlspec_migrations"},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 
@@ -174,7 +175,7 @@ def test_sqlite_migration_current_command() -> None:
             pool_config={"database": temp_db},
             migration_config={"script_location": str(migration_dir), "version_table_name": "sqlspec_migrations"},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 
@@ -210,7 +211,7 @@ def test_sqlite_migration_error_handling() -> None:
             pool_config={"database": temp_db},
             migration_config={"script_location": str(migration_dir), "version_table_name": "sqlspec_migrations"},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 
@@ -243,7 +244,7 @@ def test_sqlite_migration_with_transactions() -> None:
             pool_config={"database": temp_db},
             migration_config={"script_location": str(migration_dir), "version_table_name": "sqlspec_migrations"},
         )
-        commands = create_migration_commands(config)
+        commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
 
         commands.init(str(migration_dir), package=True)
 

--- a/tests/unit/test_adapters/conftest.py
+++ b/tests/unit/test_adapters/conftest.py
@@ -46,7 +46,7 @@ class MockSyncConnection:
         self.cursor_results: list[dict[str, Any]] = []
         self.execute_count = 0
         self.execute_many_count = 0
-        self.last_sql: Optional[str] = None
+        self.last_sql: str | None = None
         self.last_parameters: Any = None
 
     def cursor(self) -> "MockSyncCursor":
@@ -82,7 +82,7 @@ class MockAsyncConnection:
         self.cursor_results: list[dict[str, Any]] = []
         self.execute_count = 0
         self.execute_many_count = 0
-        self.last_sql: Optional[str] = None
+        self.last_sql: str | None = None
         self.last_parameters: Any = None
 
     async def cursor(self) -> "MockAsyncCursor":
@@ -114,7 +114,7 @@ class MockSyncCursor:
     def __init__(self, connection: MockSyncConnection) -> None:
         self.connection = connection
         self.rowcount = 0
-        self.description: Optional[list[tuple[str, ...]]] = None
+        self.description: list[tuple[str, ...]] | None = None
         self.fetchall_result: list[tuple[Any, ...]] = []
         self.closed = False
 
@@ -156,7 +156,7 @@ class MockAsyncCursor:
     def __init__(self, connection: MockAsyncConnection) -> None:
         self.connection = connection
         self.rowcount = 0
-        self.description: Optional[list[tuple[str, ...]]] = None
+        self.description: list[tuple[str, ...]] | None = None
         self.fetchall_result: list[tuple[Any, ...]] = []
         self.closed = False
 
@@ -203,7 +203,7 @@ class MockAsyncCursor:
 class MockSyncDataDictionary(SyncDataDictionaryBase):
     """Mock sync data dictionary for testing."""
 
-    def get_version(self, driver: SyncDriverAdapterBase) -> "Optional[VersionInfo]":
+    def get_version(self, driver: SyncDriverAdapterBase) -> "VersionInfo | None":
         """Return mock version info."""
         return VersionInfo(3, 42, 0)
 
@@ -223,7 +223,7 @@ class MockSyncDataDictionary(SyncDataDictionaryBase):
 class MockAsyncDataDictionary(AsyncDataDictionaryBase):
     """Mock async data dictionary for testing."""
 
-    async def get_version(self, driver: AsyncDriverAdapterBase) -> "Optional[VersionInfo]":
+    async def get_version(self, driver: AsyncDriverAdapterBase) -> "VersionInfo | None":
         """Return mock version info."""
         return VersionInfo(3, 42, 0)
 
@@ -248,7 +248,7 @@ class MockSyncDriver(SyncDriverAdapterBase):
     def __init__(
         self,
         connection: MockSyncConnection,
-        statement_config: Optional[StatementConfig] = None,
+        statement_config: StatementConfig | None = None,
         driver_features: Optional["dict[str, Any]"] = None,
     ) -> None:
         if statement_config is None:
@@ -260,7 +260,7 @@ class MockSyncDriver(SyncDriverAdapterBase):
                 ),
             )
         super().__init__(connection, statement_config, driver_features)
-        self._data_dictionary: Optional[SyncDataDictionaryBase] = None
+        self._data_dictionary: SyncDataDictionaryBase | None = None
 
     @property
     def data_dictionary(self) -> "SyncDataDictionaryBase":
@@ -286,7 +286,7 @@ class MockSyncDriver(SyncDriverAdapterBase):
         except Exception as e:
             raise SQLSpecError(f"Mock database error: {e}") from e
 
-    def _try_special_handling(self, cursor: MockSyncCursor, statement: SQL) -> Optional[Any]:
+    def _try_special_handling(self, cursor: MockSyncCursor, statement: SQL) -> Any | None:
         """Mock special handling - always return None."""
         return None
 
@@ -359,7 +359,7 @@ class MockAsyncDriver(AsyncDriverAdapterBase):
     def __init__(
         self,
         connection: MockAsyncConnection,
-        statement_config: Optional[StatementConfig] = None,
+        statement_config: StatementConfig | None = None,
         driver_features: Optional["dict[str, Any]"] = None,
     ) -> None:
         if statement_config is None:
@@ -371,7 +371,7 @@ class MockAsyncDriver(AsyncDriverAdapterBase):
                 ),
             )
         super().__init__(connection, statement_config, driver_features)
-        self._data_dictionary: Optional[AsyncDataDictionaryBase] = None
+        self._data_dictionary: AsyncDataDictionaryBase | None = None
 
     @property
     def data_dictionary(self) -> "AsyncDataDictionaryBase":
@@ -397,7 +397,7 @@ class MockAsyncDriver(AsyncDriverAdapterBase):
         except Exception as e:
             raise SQLSpecError(f"Mock async database error: {e}") from e
 
-    async def _try_special_handling(self, cursor: MockAsyncCursor, statement: SQL) -> Optional[Any]:
+    async def _try_special_handling(self, cursor: MockAsyncCursor, statement: SQL) -> Any | None:
         """Mock async special handling - always return None."""
         return None
 

--- a/tests/unit/test_core/test_parameters.py
+++ b/tests/unit/test_core/test_parameters.py
@@ -11,7 +11,7 @@ Tests the 2-Phase Parameter Conversion System:
 import math
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -171,7 +171,7 @@ def test_wrap_with_type_no_wrapping_needed() -> None:
     ],
 )
 def test_parameter_info_creation(
-    name: Optional[str], style: ParameterStyle, position: int, ordinal: int, placeholder_text: str
+    name: str | None, style: ParameterStyle, position: int, ordinal: int, placeholder_text: str
 ) -> None:
     """Test ParameterInfo creation with various parameter types."""
     param_info = ParameterInfo(
@@ -481,7 +481,7 @@ def test_parameter_position_tracking(validator: ParameterValidator) -> None:
     ],
 )
 def test_get_sqlglot_incompatible_styles(
-    validator: ParameterValidator, dialect: Optional[str], expected_incompatible: set[ParameterStyle]
+    validator: ParameterValidator, dialect: str | None, expected_incompatible: set[ParameterStyle]
 ) -> None:
     """Test dialect-specific SQLGlot incompatible style detection."""
     incompatible = validator.get_sqlglot_incompatible_styles(dialect)

--- a/tests/unit/test_driver/test_result_tools.py
+++ b/tests/unit/test_driver/test_result_tools.py
@@ -5,7 +5,7 @@ Tests numpy array handling, msgspec deserialization, and type conversion functio
 Uses function-based pytest approach as per CLAUDE.md requirements.
 """
 
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import Mock, patch
 
 import msgspec
@@ -30,7 +30,7 @@ class SampleMsgspecStruct(msgspec.Struct):
 
     name: str
     embedding: "list[float]"
-    metadata: "Optional[dict[str, Any]]" = None
+    metadata: "dict[str, Any] | None" = None
 
 
 class SampleMsgspecStructWithIntList(msgspec.Struct):
@@ -45,7 +45,7 @@ class SampleTypedDict(TypedDict):
 
     name: str
     age: int
-    optional_field: "Optional[str]"
+    optional_field: "str | None"
 
 
 # Test _is_list_type_target function

--- a/tests/unit/test_migrations/test_migration_commands.py
+++ b/tests/unit/test_migrations/test_migration_commands.py
@@ -198,7 +198,9 @@ async def test_migration_commands_async_revision_delegation(async_config: Aiosql
 
 def test_migration_commands_factory_returns_sync_for_sync_config(sync_config: SqliteConfig) -> None:
     """Test that sync config returns SyncMigrationCommands from factory."""
-    commands = create_migration_commands(sync_config)
+    commands: SyncMigrationCommands[SqliteConfig] | AsyncMigrationCommands[AiosqliteConfig] = create_migration_commands(
+        sync_config
+    )
 
     # Should return a SyncMigrationCommands instance
     assert isinstance(commands, SyncMigrationCommands)
@@ -270,7 +272,9 @@ async def test_migration_commands_error_propagation(async_config: AiosqliteConfi
 def test_migration_commands_sync_parameter_forwarding(sync_config: SqliteConfig) -> None:
     """Test that all parameters are properly forwarded to sync implementations."""
     with patch.object(SyncMigrationCommands, "upgrade") as mock_upgrade:
-        commands = create_migration_commands(sync_config)
+        commands: SyncMigrationCommands[SqliteConfig] | AsyncMigrationCommands[AiosqliteConfig] = (
+            create_migration_commands(sync_config)
+        )
 
         # Test with various parameter combinations
         commands.upgrade()

--- a/tests/unit/test_sql_factory.py
+++ b/tests/unit/test_sql_factory.py
@@ -48,7 +48,8 @@ def test_where_neq_uses_placeholder() -> None:
 
 def test_where_comparison_operators_use_placeholders() -> None:
     """Test all comparison WHERE methods use proper parameter binding."""
-    from typing import Any, Callable
+    from collections.abc import Callable
+    from typing import Any
 
     test_cases: list[tuple[str, Callable[[Any], Any], str]] = [
         ("where_lt", lambda q: q.where_lt("age", 18), "age"),

--- a/tests/unit/test_utils/test_type_guards.py
+++ b/tests/unit/test_utils/test_type_guards.py
@@ -5,7 +5,7 @@ Uses function-based pytest approach as per CLAUDE.md requirements.
 """
 
 from dataclasses import dataclass
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 import msgspec
 import pytest
@@ -73,7 +73,7 @@ class SampleDataclass:
 
     name: str
     age: int
-    optional_field: "Optional[str]" = None
+    optional_field: "str | None" = None
 
 
 class SampleTypedDict(TypedDict):
@@ -81,7 +81,7 @@ class SampleTypedDict(TypedDict):
 
     name: str
     age: int
-    optional_field: "Optional[str]"
+    optional_field: "str | None"
 
 
 class MockSQLGlotExpression:
@@ -92,11 +92,7 @@ class MockSQLGlotExpression:
     """
 
     def __init__(
-        self,
-        this: Any = _UNSET,
-        expressions: Any = _UNSET,
-        parent: Any = _UNSET,
-        args: "Optional[dict[str, Any]]" = None,
+        self, this: Any = _UNSET, expressions: Any = _UNSET, parent: Any = _UNSET, args: "dict[str, Any] | None" = None
     ) -> None:
         # Only set attributes if they were explicitly provided
         if this is not _UNSET:
@@ -120,11 +116,7 @@ class MockLiteral:
     """Mock literal for testing."""
 
     def __init__(
-        self,
-        this: "Optional[Any]" = None,
-        is_string: bool = False,
-        is_number: bool = False,
-        parent: "Optional[Any]" = None,
+        self, this: "Any | None" = None, is_string: bool = False, is_number: bool = False, parent: "Any | None" = None
     ) -> None:
         if this is not None:
             self.this = this
@@ -139,7 +131,7 @@ class MockLiteral:
 class MockParameterProtocol:
     """Mock parameter with protocol attributes."""
 
-    def __init__(self, style: "Optional[str]" = None, name: "Optional[str]" = None) -> None:
+    def __init__(self, style: "str | None" = None, name: "str | None" = None) -> None:
         if style is not None:
             self.style = style
         if name is not None:

--- a/uv.lock
+++ b/uv.lock
@@ -1,13 +1,12 @@
 version = 1
 revision = 3
-requires-python = ">=3.9, <4.0"
+requires-python = ">=3.10, <4.0"
 resolution-markers = [
     "python_full_version >= '3.14'",
     "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-    "python_full_version < '3.10'",
+    "python_full_version < '3.11'",
 ]
 
 [[package]]
@@ -81,11 +80,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/bf/ce5efe35be83b652e4b6059cfff48b59d648560a9dc99caac8da0a3441cd/adbc_driver_manager-1.8.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d5ec92af49a76345db1ae0a3890789797078b5b9948d550a47e8cfaa27cc19", size = 3089760, upload-time = "2025-09-12T12:30:28.772Z" },
     { url = "https://files.pythonhosted.org/packages/f2/b3/d3254595b61890da1dc6d44178abe10262136d20aeffae4a86d3e289371e/adbc_driver_manager-1.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4f68df12cfbffaf4bec832ed406fb6ce978fd7dba8a4e8e377c9658fcd83b6a3", size = 3147028, upload-time = "2025-09-12T12:30:30.53Z" },
     { url = "https://files.pythonhosted.org/packages/68/ba/82d1f9521bc755d8d0d66eaac47032e147c2fe850eb308ba613710b27493/adbc_driver_manager-1.8.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a4402633d548e3ecdcf89a7133fd72b88a807a3c438e13bdb61ccc79d6239a65", size = 3133693, upload-time = "2025-09-12T12:30:32.357Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/33/5016dffbf2bdfcf181c17db5cae0f9fb4bee34605c87d1a3894e8963f888/adbc_driver_manager-1.8.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:151e21b46dedbbd48be4c7d904efd08fcdce3c1db7faff1ce32c520f3a4ed508", size = 535678, upload-time = "2025-09-12T12:30:33.87Z" },
-    { url = "https://files.pythonhosted.org/packages/41/08/d089492c2df0d66f87c16a4223f98cd9e04571c55ba3d2147c25ef6f9d57/adbc_driver_manager-1.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a1c839a4b8c7a19d56bc0592596b123ecbdf6e76e28c7db28e562b6ce47f67cf", size = 512661, upload-time = "2025-09-12T12:30:35.604Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/56/5024e4da87544d4cf04df4c1f8231c9e91b9b818dd5fc208a5944455dafc/adbc_driver_manager-1.8.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eda25c53cec08290ba8c58f18dbec07ff21b0480e5e0641acc2410f79e477031", size = 3020784, upload-time = "2025-09-12T12:30:37.58Z" },
-    { url = "https://files.pythonhosted.org/packages/66/22/d299a8a6aa0a51eecbe0c052aa457c24fbd499c9c096de889c40e7fb1a46/adbc_driver_manager-1.8.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c0d7fedaec1ecc1079c19eb0b55bd28e10f68f5c76fd523a37498588b7450ecf", size = 3037489, upload-time = "2025-09-12T12:30:39.838Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/37/ab055f5680f7b9dc2019303526f13c1db6a844d03fbaaa36cd36baa2348c/adbc_driver_manager-1.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:07188498dec41bd93753a2ad568dbca779e83f56a4e0339dbfc9cf75bc2e5f01", size = 712651, upload-time = "2025-09-12T12:30:41.658Z" },
 ]
 
 [[package]]
@@ -233,32 +227,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/05/6a/ea199e61b67f25ba688d3ce93f63b49b0a4e3b3d380f03971b4646412fc6/aiohttp-3.12.15-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ad702e57dc385cae679c39d318def49aef754455f237499d5b99bea4ef582e51", size = 1710050, upload-time = "2025-07-29T05:51:48.203Z" },
     { url = "https://files.pythonhosted.org/packages/b4/2e/ffeb7f6256b33635c29dbed29a22a723ff2dd7401fff42ea60cf2060abfb/aiohttp-3.12.15-cp313-cp313-win32.whl", hash = "sha256:f813c3e9032331024de2eb2e32a88d86afb69291fbc37a3a3ae81cc9917fb3d0", size = 422647, upload-time = "2025-07-29T05:51:50.718Z" },
     { url = "https://files.pythonhosted.org/packages/1b/8e/78ee35774201f38d5e1ba079c9958f7629b1fd079459aea9467441dbfbf5/aiohttp-3.12.15-cp313-cp313-win_amd64.whl", hash = "sha256:1a649001580bdb37c6fdb1bebbd7e3bc688e8ec2b5c6f52edbb664662b17dc84", size = 449067, upload-time = "2025-07-29T05:51:52.549Z" },
-    { url = "https://files.pythonhosted.org/packages/18/8d/da08099af8db234d1cd43163e6ffc8e9313d0e988cee1901610f2fa5c764/aiohttp-3.12.15-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:691d203c2bdf4f4637792efbbcdcd157ae11e55eaeb5e9c360c1206fb03d4d98", size = 706829, upload-time = "2025-07-29T05:51:54.434Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/94/8eed385cfb60cf4fdb5b8a165f6148f3bebeb365f08663d83c35a5f273ef/aiohttp-3.12.15-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8e995e1abc4ed2a454c731385bf4082be06f875822adc4c6d9eaadf96e20d406", size = 481806, upload-time = "2025-07-29T05:51:56.355Z" },
-    { url = "https://files.pythonhosted.org/packages/38/68/b13e1a34584fbf263151b3a72a084e89f2102afe38df1dce5a05a15b83e9/aiohttp-3.12.15-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:bd44d5936ab3193c617bfd6c9a7d8d1085a8dc8c3f44d5f1dcf554d17d04cf7d", size = 469205, upload-time = "2025-07-29T05:51:58.277Z" },
-    { url = "https://files.pythonhosted.org/packages/38/14/3d7348bf53aa4af54416bc64cbef3a2ac5e8b9bfa97cc45f1cf9a94d9c8d/aiohttp-3.12.15-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46749be6e89cd78d6068cdf7da51dbcfa4321147ab8e4116ee6678d9a056a0cf", size = 1644174, upload-time = "2025-07-29T05:52:00.23Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/ed/fd9b5b22b0f6ca1a85c33bb4868cbcc6ae5eae070a0f4c9c5cad003c89d7/aiohttp-3.12.15-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0c643f4d75adea39e92c0f01b3fb83d57abdec8c9279b3078b68a3a52b3933b6", size = 1618672, upload-time = "2025-07-29T05:52:02.272Z" },
-    { url = "https://files.pythonhosted.org/packages/39/f7/f6530ab5f8c8c409e44a63fcad35e839c87aabecdfe5b8e96d671ed12f64/aiohttp-3.12.15-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0a23918fedc05806966a2438489dcffccbdf83e921a1170773b6178d04ade142", size = 1692295, upload-time = "2025-07-29T05:52:04.546Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/dc/3cf483bb0106566dc97ebaa2bb097f5e44d4bc4ab650a6f107151cd7b193/aiohttp-3.12.15-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:74bdd8c864b36c3673741023343565d95bfbd778ffe1eb4d412c135a28a8dc89", size = 1731609, upload-time = "2025-07-29T05:52:06.552Z" },
-    { url = "https://files.pythonhosted.org/packages/de/a4/fd04bf807851197077d9cac9381d58f86d91c95c06cbaf9d3a776ac4467a/aiohttp-3.12.15-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a146708808c9b7a988a4af3821379e379e0f0e5e466ca31a73dbdd0325b0263", size = 1637852, upload-time = "2025-07-29T05:52:08.975Z" },
-    { url = "https://files.pythonhosted.org/packages/98/03/29d626ca3bcdcafbd74b45d77ca42645a5c94d396f2ee3446880ad2405fb/aiohttp-3.12.15-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b7011a70b56facde58d6d26da4fec3280cc8e2a78c714c96b7a01a87930a9530", size = 1572852, upload-time = "2025-07-29T05:52:11.508Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/cd/b4777a9e204f4e01091091027e5d1e2fa86decd0fee5067bc168e4fa1e76/aiohttp-3.12.15-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:3bdd6e17e16e1dbd3db74d7f989e8af29c4d2e025f9828e6ef45fbdee158ec75", size = 1620813, upload-time = "2025-07-29T05:52:13.891Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/26/1a44a6e8417e84057beaf8c462529b9e05d4b53b8605784f1eb571f0ff68/aiohttp-3.12.15-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:57d16590a351dfc914670bd72530fd78344b885a00b250e992faea565b7fdc05", size = 1630951, upload-time = "2025-07-29T05:52:15.955Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/7f/10c605dbd01c40e2b27df7ef9004bec75d156f0705141e11047ecdfe264d/aiohttp-3.12.15-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:bc9a0f6569ff990e0bbd75506c8d8fe7214c8f6579cca32f0546e54372a3bb54", size = 1607595, upload-time = "2025-07-29T05:52:18.089Z" },
-    { url = "https://files.pythonhosted.org/packages/66/f6/2560dcb01731c1d7df1d34b64de95bc4b3ed02bb78830fd82299c1eb314e/aiohttp-3.12.15-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:536ad7234747a37e50e7b6794ea868833d5220b49c92806ae2d7e8a9d6b5de02", size = 1695194, upload-time = "2025-07-29T05:52:20.255Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/02/ee105ae82dc2b981039fd25b0cf6eaa52b493731960f9bc861375a72b463/aiohttp-3.12.15-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:f0adb4177fa748072546fb650d9bd7398caaf0e15b370ed3317280b13f4083b0", size = 1710872, upload-time = "2025-07-29T05:52:22.769Z" },
-    { url = "https://files.pythonhosted.org/packages/88/16/70c4e42ed6a04f78fb58d1a46500a6ce560741d13afde2a5f33840746a5f/aiohttp-3.12.15-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:14954a2988feae3987f1eb49c706bff39947605f4b6fa4027c1d75743723eb09", size = 1640539, upload-time = "2025-07-29T05:52:25.733Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/1d/a7eb5fa8a6967117c5c0ad5ab4b1dec0d21e178c89aa08bc442a0b836392/aiohttp-3.12.15-cp39-cp39-win32.whl", hash = "sha256:b784d6ed757f27574dca1c336f968f4e81130b27595e458e69457e6878251f5d", size = 430164, upload-time = "2025-07-29T05:52:27.905Z" },
-    { url = "https://files.pythonhosted.org/packages/14/25/e0cf8793aedc41c6d7f2aad646a27e27bdacafe3b402bb373d7651c94d73/aiohttp-3.12.15-cp39-cp39-win_amd64.whl", hash = "sha256:86ceded4e78a992f835209e236617bffae649371c4a50d5e5a3987f237db84b8", size = 453370, upload-time = "2025-07-29T05:52:29.936Z" },
 ]
 
 [[package]]
 name = "aioitertools"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/06/de/38491a84ab323b47c7f86e94d2830e748780525f7a10c8600b67ead7e9ea/aioitertools-0.12.0.tar.gz", hash = "sha256:c2a9055b4fbb7705f561b9d86053e8af5d10cc845d22c32008c43490b2d8dd6b", size = 19369, upload-time = "2024-09-02T03:33:40.349Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/13/58b70a580de00893223d61de8fea167877a3aed97d4a5e1405c9159ef925/aioitertools-0.12.0-py3-none-any.whl", hash = "sha256:fc1f5fac3d737354de8831cbba3eb04f79dd649d8f3afb4c5b114925e662a796", size = 24345, upload-time = "2024-09-02T03:34:59.454Z" },
@@ -312,27 +286,8 @@ wheels = [
 
 [[package]]
 name = "alabaster"
-version = "0.7.16"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/3e/13dd8e5ed9094e734ac430b5d0eb4f2bb001708a8b7856cbf8e084e001ba/alabaster-0.7.16.tar.gz", hash = "sha256:75a8b99c28a5dad50dd7f8ccdd447a121ddb3892da9e53d1ca5cca3106d58d65", size = 23776, upload-time = "2024-01-10T00:56:10.189Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/34/d4e1c02d3bee589efb5dfa17f88ea08bdb3e3eac12bc475462aec52ed223/alabaster-0.7.16-py3-none-any.whl", hash = "sha256:b46733c07dce03ae4e150330b975c75737fa60f0a7c591b6c8bf4928a28e2c92", size = 13511, upload-time = "2024-01-10T00:56:08.388Z" },
-]
-
-[[package]]
-name = "alabaster"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e", size = 24210, upload-time = "2024-07-26T18:15:03.762Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b", size = 13929, upload-time = "2024-07-26T18:15:02.05Z" },
@@ -477,24 +432,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/23/6d05254d1c89ad15e7f32eb3df277afc7bbb2220faa83a76bea0b7bc6407/asyncmy-0.2.10-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:16d398b1aad0550c6fe1655b6758455e3554125af8aaf1f5abdc1546078c7257", size = 5548799, upload-time = "2024-12-13T02:36:29.945Z" },
     { url = "https://files.pythonhosted.org/packages/fe/32/b7ce9782c741b6a821a0d11772f180f431a5c3ba6eaf2e6dfa1c3cbcf4df/asyncmy-0.2.10-cp312-cp312-win32.whl", hash = "sha256:59d2639dcc23939ae82b93b40a683c15a091460a3f77fa6aef1854c0a0af99cc", size = 1597544, upload-time = "2024-12-13T02:36:31.574Z" },
     { url = "https://files.pythonhosted.org/packages/94/08/7de4f4a17196c355e4706ceba0ab60627541c78011881a7c69f41c6414c5/asyncmy-0.2.10-cp312-cp312-win_amd64.whl", hash = "sha256:4c6674073be97ffb7ac7f909e803008b23e50281131fef4e30b7b2162141a574", size = 1679064, upload-time = "2024-12-13T02:36:39.479Z" },
-    { url = "https://files.pythonhosted.org/packages/12/c8/eaa11a1716ce4505fa4d06d04abd8e1bda3aaa71c7d29209330dbd061b7a/asyncmy-0.2.10-cp39-cp39-macosx_13_0_x86_64.whl", hash = "sha256:244289bd1bea84384866bde50b09fe5b24856640e30a04073eacb71987b7b6ad", size = 1807310, upload-time = "2024-12-13T02:36:16.401Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/50/4137cb6f0e2e57bee6ff71c5cbabea66efb88b90abc9d409609368d8314a/asyncmy-0.2.10-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:6c9d024b160b9f869a21e62c4ef34a7b7a4b5a886ae03019d4182621ea804d2c", size = 1739290, upload-time = "2024-12-13T02:36:32.437Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/e9/46a7315d8a927ac012806c9502fd4d0b210554b415ef4a44319f961475b6/asyncmy-0.2.10-cp39-cp39-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:b57594eea942224626203503f24fa88a47eaab3f13c9f24435091ea910f4b966", size = 4967850, upload-time = "2024-12-13T02:35:35.221Z" },
-    { url = "https://files.pythonhosted.org/packages/98/a2/fc991b329594bb372ddba296c89d7ace34271e35d92260cbea397abec40c/asyncmy-0.2.10-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:346192941470ac2d315f97afa14c0131ff846c911da14861baf8a1f8ed541664", size = 5169902, upload-time = "2024-12-13T02:35:37.81Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/c6/754aaf8d28ea76cf86cef6d07489f277221dbc8e1fd38490a037a3138e58/asyncmy-0.2.10-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:957c2b48c5228e5f91fdf389daf38261a7b8989ad0eb0d1ba4e5680ef2a4a078", size = 5012169, upload-time = "2024-12-13T02:35:41.364Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/6e/b66524785b89929da09adb5373ab360cc4ac2d97153dbd5b32e9904ac375/asyncmy-0.2.10-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:472989d7bfa405c108a7f3c408bbed52306504fb3aa28963d833cb7eeaafece0", size = 5186908, upload-time = "2024-12-13T02:35:44.398Z" },
-    { url = "https://files.pythonhosted.org/packages/90/2f/36fbf0a7555507ce06bf5fa6f743d94f7bc38c1e6bfb5e9ba5dd51001b33/asyncmy-0.2.10-cp39-cp39-win32.whl", hash = "sha256:714b0fdadd72031e972de2bbbd14e35a19d5a7e001594f0c8a69f92f0d05acc9", size = 1626531, upload-time = "2024-12-13T02:36:07.777Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/99/cd737fbc8c1c14a0c39ca6d7e8f482c73a3990ecb150f2e7b2c5f2d665ab/asyncmy-0.2.10-cp39-cp39-win_amd64.whl", hash = "sha256:9fb58645d3da0b91db384f8519b16edc7dc421c966ada8647756318915d63696", size = 1696557, upload-time = "2024-12-13T02:36:10.045Z" },
     { url = "https://files.pythonhosted.org/packages/83/32/3317d5290737a3c4685343fe37e02567518357c46ed87c51f47139d31ded/asyncmy-0.2.10-pp310-pypy310_pp73-macosx_13_0_x86_64.whl", hash = "sha256:f10c977c60a95bd6ec6b8654e20c8f53bad566911562a7ad7117ca94618f05d3", size = 1627680, upload-time = "2024-12-13T02:36:42.605Z" },
     { url = "https://files.pythonhosted.org/packages/e9/e1/afeb50deb0554006c48b9f4f7b6b726e0aa42fa96d7cfbd3fdd0800765e2/asyncmy-0.2.10-pp310-pypy310_pp73-macosx_14_0_arm64.whl", hash = "sha256:aab07fbdb9466beaffef136ffabe388f0d295d8d2adb8f62c272f1d4076515b9", size = 1593957, upload-time = "2024-12-13T02:37:00.344Z" },
     { url = "https://files.pythonhosted.org/packages/be/c1/56d3721e2b2eab84320058c3458da168d143446031eca3799aed481c33d2/asyncmy-0.2.10-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:63144322ade68262201baae73ad0c8a06b98a3c6ae39d1f3f21c41cc5287066a", size = 1756531, upload-time = "2024-12-13T02:36:59.477Z" },
     { url = "https://files.pythonhosted.org/packages/ac/1a/295f06eb8e5926749265e08da9e2dc0dc14e0244bf36843997a1c8e18a50/asyncmy-0.2.10-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9659d95c6f2a611aec15bdd928950df937bf68bc4bbb68b809ee8924b6756067", size = 1752746, upload-time = "2024-12-13T02:37:01.999Z" },
     { url = "https://files.pythonhosted.org/packages/ab/09/3a5351acc6273c28333cad8193184de0070c617fd8385fd8ba23d789e08d/asyncmy-0.2.10-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:8ced4bd938e95ede0fb9fa54755773df47bdb9f29f142512501e613dd95cf4a4", size = 1614903, upload-time = "2024-12-13T02:36:53Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/d1/28829c381e52166563706f2bc5e8043ab8599fc1d7e9c8ab26b21f2b33f4/asyncmy-0.2.10-pp39-pypy39_pp73-macosx_13_0_x86_64.whl", hash = "sha256:4651caaee6f4d7a8eb478a0dc460f8e91ab09a2d8d32444bc2b235544c791947", size = 1625889, upload-time = "2024-12-13T02:36:40.475Z" },
-    { url = "https://files.pythonhosted.org/packages/00/7f/110e9ef7cb38ff599725bbed08b76f656b2eae7505971ebc2a78b20716b9/asyncmy-0.2.10-pp39-pypy39_pp73-macosx_14_0_arm64.whl", hash = "sha256:ac091b327f01c38d91c697c810ba49e5f836890d48f6879ba0738040bb244290", size = 1592247, upload-time = "2024-12-13T02:36:58.319Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/e6/036d5c23193f2c24b8dd4610eeae70380034d9ef37c29785c1624a19c92f/asyncmy-0.2.10-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:e1d2d9387cd3971297486c21098e035c620149c9033369491f58fe4fc08825b6", size = 1754251, upload-time = "2024-12-13T02:36:52.178Z" },
-    { url = "https://files.pythonhosted.org/packages/94/59/f97378316a48168e380948c814b346038f0f72fd99c986c42cba493edc7e/asyncmy-0.2.10-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux_2_5_x86_64.manylinux1_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a760cb486ddb2c936711325236e6b9213564a9bb5deb2f6949dbd16c8e4d739e", size = 1751010, upload-time = "2024-12-13T02:36:56.784Z" },
-    { url = "https://files.pythonhosted.org/packages/24/7b/3f90c33daab8409498a6e57760c6bd23ba3ecef3c684b59c9c6177030073/asyncmy-0.2.10-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:1586f26633c05b16bcfc46d86e9875f4941280e12afa79a741cdf77ae4ccfb4d", size = 1613533, upload-time = "2024-12-13T02:36:48.203Z" },
 ]
 
 [[package]]
@@ -538,14 +480,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/5f/0bf65511d4eeac3a1f41c54034a492515a707c6edbc642174ae79034d3ba/asyncpg-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04ff0785ae7eed6cc138e73fc67b8e51d54ee7a3ce9b63666ce55a0bf095f7ba", size = 3662720, upload-time = "2024-10-20T00:30:04.501Z" },
     { url = "https://files.pythonhosted.org/packages/e7/31/1513d5a6412b98052c3ed9158d783b1e09d0910f51fbe0e05f56cc370bc4/asyncpg-0.30.0-cp313-cp313-win32.whl", hash = "sha256:ae374585f51c2b444510cdf3595b97ece4f233fde739aa14b50e0d64e8a7a590", size = 560404, upload-time = "2024-10-20T00:30:06.537Z" },
     { url = "https://files.pythonhosted.org/packages/c8/a4/cec76b3389c4c5ff66301cd100fe88c318563ec8a520e0b2e792b5b84972/asyncpg-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:f59b430b8e27557c3fb9869222559f7417ced18688375825f8f12302c34e915e", size = 621623, upload-time = "2024-10-20T00:30:09.024Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/82/d94f3ed6921136a0ef40a825740eda19437ccdad7d92d924302dca1d5c9e/asyncpg-0.30.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6f4e83f067b35ab5e6371f8a4c93296e0439857b4569850b178a01385e82e9ad", size = 673026, upload-time = "2024-10-20T00:30:26.928Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/db/7db8b73c5d86ec9a21807f405e0698f8f637a8a3ca14b7b6fd4259b66bcf/asyncpg-0.30.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5df69d55add4efcd25ea2a3b02025b669a285b767bfbf06e356d68dbce4234ff", size = 644732, upload-time = "2024-10-20T00:30:28.393Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/a0/1f1910659d08050cb3e8f7d82b32983974798d7fd4ddf7620b8e2023d4ac/asyncpg-0.30.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3479a0d9a852c7c84e822c073622baca862d1217b10a02dd57ee4a7a081f708", size = 2911761, upload-time = "2024-10-20T00:30:30.569Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/53/5aa0d92488ded50bab2b6626430ed9743b0b7e2d864a2b435af1ccbf219a/asyncpg-0.30.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26683d3b9a62836fad771a18ecf4659a30f348a561279d6227dab96182f46144", size = 2946595, upload-time = "2024-10-20T00:30:32.244Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/cd/d6d548d8ee721f4e0f7fbbe509bbac140d556c2e45814d945540c96cf7d4/asyncpg-0.30.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1b982daf2441a0ed314bd10817f1606f1c28b1136abd9e4f11335358c2c631cb", size = 2890135, upload-time = "2024-10-20T00:30:33.817Z" },
-    { url = "https://files.pythonhosted.org/packages/46/f0/28df398b685dabee20235e24880e1f6486d84ae7e6b0d11bdebc17740e7a/asyncpg-0.30.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1c06a3a50d014b303e5f6fc1e5f95eb28d2cee89cf58384b700da621e5d5e547", size = 3011889, upload-time = "2024-10-20T00:30:35.378Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/07/8c7ffe6fe8bccff9b12fcb6410b1b2fa74b917fd8b837806a40217d5228b/asyncpg-0.30.0-cp39-cp39-win32.whl", hash = "sha256:1b11a555a198b08f5c4baa8f8231c74a366d190755aa4f99aacec5970afe929a", size = 569406, upload-time = "2024-10-20T00:30:37.644Z" },
-    { url = "https://files.pythonhosted.org/packages/05/51/f59e4df6d9b8937530d4b9fdee1598b93db40c631fe94ff3ce64207b7a95/asyncpg-0.30.0-cp39-cp39-win_amd64.whl", hash = "sha256:8b684a3c858a83cd876f05958823b68e8d14ec01bb0c0d14a6704c5bf9711773", size = 626581, upload-time = "2024-10-20T00:30:39.69Z" },
 ]
 
 [[package]]
@@ -584,8 +518,7 @@ wheels = [
 
 [package.optional-dependencies]
 sphinx = [
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
@@ -594,8 +527,7 @@ name = "autodocsumm"
 version = "0.2.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/03/96/92afe8a7912b327c01f0a8b6408c9556ee13b1aba5b98d587ac7327ff32d/autodocsumm-0.2.14.tar.gz", hash = "sha256:2839a9d4facc3c4eccd306c08695540911042b46eeafcdc3203e6d0bab40bc77", size = 46357, upload-time = "2024-10-23T18:51:47.369Z" }
@@ -650,8 +582,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/91/2e745382793fa7d30810a7d5ca3e05f6817b6db07601ca5aaab12720caf9/botocore-1.40.18.tar.gz", hash = "sha256:afd69bdadd8c55cc89d69de0799829e555193a352d87867f746e19020271cc0f", size = 14375007, upload-time = "2025-08-26T19:21:24.996Z" }
 wheels = [
@@ -672,8 +603,7 @@ name = "bump-my-version"
 version = "1.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "click" },
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -818,18 +748,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/cc/08ed5a43f2996a16b462f64a7055c6e962803534924b9b2f1371d8c00b7b/cffi-2.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf", size = 184288, upload-time = "2025-09-08T23:23:48.404Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/de/38d9726324e127f727b4ecc376bc85e505bfe61ef130eaf3f290c6847dd4/cffi-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7", size = 180509, upload-time = "2025-09-08T23:23:49.73Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/13/c92e36358fbcc39cf0962e83223c9522154ee8630e1df7c0b3a39a8124e2/cffi-2.0.0-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c", size = 208813, upload-time = "2025-09-08T23:23:51.263Z" },
-    { url = "https://files.pythonhosted.org/packages/15/12/a7a79bd0df4c3bff744b2d7e52cc1b68d5e7e427b384252c42366dc1ecbc/cffi-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165", size = 216498, upload-time = "2025-09-08T23:23:52.494Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/ad/5c51c1c7600bdd7ed9a24a203ec255dccdd0ebf4527f7b922a0bde2fb6ed/cffi-2.0.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534", size = 203243, upload-time = "2025-09-08T23:23:53.836Z" },
-    { url = "https://files.pythonhosted.org/packages/32/f2/81b63e288295928739d715d00952c8c6034cb6c6a516b17d37e0c8be5600/cffi-2.0.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f", size = 203158, upload-time = "2025-09-08T23:23:55.169Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/74/cc4096ce66f5939042ae094e2e96f53426a979864aa1f96a621ad128be27/cffi-2.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63", size = 216548, upload-time = "2025-09-08T23:23:56.506Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/be/f6424d1dc46b1091ffcc8964fa7c0ab0cd36839dd2761b49c90481a6ba1b/cffi-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2", size = 218897, upload-time = "2025-09-08T23:23:57.825Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/e0/dda537c2309817edf60109e39265f24f24aa7f050767e22c98c53fe7f48b/cffi-2.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65", size = 211249, upload-time = "2025-09-08T23:23:59.139Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/e7/7c769804eb75e4c4b35e658dba01de1640a351a9653c3d49ca89d16ccc91/cffi-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322", size = 218041, upload-time = "2025-09-08T23:24:00.496Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/d9/6218d78f920dcd7507fc16a766b5ef8f3b913cc7aa938e7fc80b9978d089/cffi-2.0.0-cp39-cp39-win32.whl", hash = "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a", size = 172138, upload-time = "2025-09-08T23:24:01.7Z" },
-    { url = "https://files.pythonhosted.org/packages/54/8f/a1e836f82d8e32a97e6b29cc8f641779181ac7363734f12df27db803ebda/cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9", size = 182794, upload-time = "2025-09-08T23:24:02.943Z" },
 ]
 
 [[package]]
@@ -902,48 +820,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/72/2a/aff5dd112b2f14bcc3462c312dce5445806bfc8ab3a7328555da95330e4b/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d716a916938e03231e86e43782ca7878fb602a125a91e7acb8b5112e2e96ac16", size = 152224, upload-time = "2025-08-09T07:56:51.369Z" },
     { url = "https://files.pythonhosted.org/packages/b7/8c/9839225320046ed279c6e839d51f028342eb77c91c89b8ef2549f951f3ec/charset_normalizer-3.4.3-cp314-cp314-win32.whl", hash = "sha256:c6dbd0ccdda3a2ba7c2ecd9d77b37f3b5831687d8dc1b6ca5f56a4880cc7b7ce", size = 100086, upload-time = "2025-08-09T07:56:52.722Z" },
     { url = "https://files.pythonhosted.org/packages/ee/7a/36fbcf646e41f710ce0a563c1c9a343c6edf9be80786edeb15b6f62e17db/charset_normalizer-3.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:73dc19b562516fc9bcf6e5d6e596df0b4eb98d87e4f79f3ae71840e6ed21361c", size = 107400, upload-time = "2025-08-09T07:56:55.172Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/ca/9a0983dd5c8e9733565cf3db4df2b0a2e9a82659fd8aa2a868ac6e4a991f/charset_normalizer-3.4.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:70bfc5f2c318afece2f5838ea5e4c3febada0be750fcf4775641052bbba14d05", size = 207520, upload-time = "2025-08-09T07:57:11.026Z" },
-    { url = "https://files.pythonhosted.org/packages/39/c6/99271dc37243a4f925b09090493fb96c9333d7992c6187f5cfe5312008d2/charset_normalizer-3.4.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23b6b24d74478dc833444cbd927c338349d6ae852ba53a0d02a2de1fce45b96e", size = 147307, upload-time = "2025-08-09T07:57:12.4Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/69/132eab043356bba06eb333cc2cc60c6340857d0a2e4ca6dc2b51312886b3/charset_normalizer-3.4.3-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:34a7f768e3f985abdb42841e20e17b330ad3aaf4bb7e7aeeb73db2e70f077b99", size = 160448, upload-time = "2025-08-09T07:57:13.712Z" },
-    { url = "https://files.pythonhosted.org/packages/04/9a/914d294daa4809c57667b77470533e65def9c0be1ef8b4c1183a99170e9d/charset_normalizer-3.4.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fb731e5deb0c7ef82d698b0f4c5bb724633ee2a489401594c5c88b02e6cb15f7", size = 157758, upload-time = "2025-08-09T07:57:14.979Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/a8/6f5bcf1bcf63cb45625f7c5cadca026121ff8a6c8a3256d8d8cd59302663/charset_normalizer-3.4.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:257f26fed7d7ff59921b78244f3cd93ed2af1800ff048c33f624c87475819dd7", size = 152487, upload-time = "2025-08-09T07:57:16.332Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/72/d3d0e9592f4e504f9dea08b8db270821c909558c353dc3b457ed2509f2fb/charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1ef99f0456d3d46a50945c98de1774da86f8e992ab5c77865ea8b8195341fc19", size = 150054, upload-time = "2025-08-09T07:57:17.576Z" },
-    { url = "https://files.pythonhosted.org/packages/20/30/5f64fe3981677fe63fa987b80e6c01042eb5ff653ff7cec1b7bd9268e54e/charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:2c322db9c8c89009a990ef07c3bcc9f011a3269bc06782f916cd3d9eed7c9312", size = 161703, upload-time = "2025-08-09T07:57:20.012Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/ef/dd08b2cac9284fd59e70f7d97382c33a3d0a926e45b15fc21b3308324ffd/charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:511729f456829ef86ac41ca78c63a5cb55240ed23b4b737faca0eb1abb1c41bc", size = 159096, upload-time = "2025-08-09T07:57:21.329Z" },
-    { url = "https://files.pythonhosted.org/packages/45/8c/dcef87cfc2b3f002a6478f38906f9040302c68aebe21468090e39cde1445/charset_normalizer-3.4.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:88ab34806dea0671532d3f82d82b85e8fc23d7b2dd12fa837978dad9bb392a34", size = 153852, upload-time = "2025-08-09T07:57:22.608Z" },
-    { url = "https://files.pythonhosted.org/packages/63/86/9cbd533bd37883d467fcd1bd491b3547a3532d0fbb46de2b99feeebf185e/charset_normalizer-3.4.3-cp39-cp39-win32.whl", hash = "sha256:16a8770207946ac75703458e2c743631c79c59c5890c80011d536248f8eaa432", size = 99840, upload-time = "2025-08-09T07:57:23.883Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/d6/7e805c8e5c46ff9729c49950acc4ee0aeb55efb8b3a56687658ad10c3216/charset_normalizer-3.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:d22dbedd33326a4a5190dd4fe9e9e693ef12160c77382d9e87919bce54f3d4ca", size = 107438, upload-time = "2025-08-09T07:57:25.287Z" },
     { url = "https://files.pythonhosted.org/packages/8a/1f/f041989e93b001bc4e44bb1669ccdcf54d3f00e628229a85b08d330615c5/charset_normalizer-3.4.3-py3-none-any.whl", hash = "sha256:ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a", size = 53175, upload-time = "2025-08-09T07:57:26.864Z" },
-]
-
-[[package]]
-name = "click"
-version = "8.1.8"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
 ]
 
 [[package]]
 name = "click"
 version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
 wheels = [
@@ -1055,18 +940,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/dc/101f3fa3a45146db0cb03f5b4376e24c0aac818309da23e2de0c75295a91/coverage-7.10.7-cp314-cp314t-win32.whl", hash = "sha256:67f8c5cbcd3deb7a60b3345dffc89a961a484ed0af1f6f73de91705cc6e31235", size = 221784, upload-time = "2025-09-21T20:03:24.769Z" },
     { url = "https://files.pythonhosted.org/packages/4c/a1/74c51803fc70a8a40d7346660379e144be772bab4ac7bb6e6b905152345c/coverage-7.10.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e1ed71194ef6dea7ed2d5cb5f7243d4bcd334bfb63e59878519be558078f848d", size = 222905, upload-time = "2025-09-21T20:03:26.93Z" },
     { url = "https://files.pythonhosted.org/packages/12/65/f116a6d2127df30bcafbceef0302d8a64ba87488bf6f73a6d8eebf060873/coverage-7.10.7-cp314-cp314t-win_arm64.whl", hash = "sha256:7fe650342addd8524ca63d77b2362b02345e5f1a093266787d210c70a50b471a", size = 220922, upload-time = "2025-09-21T20:03:28.672Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/ad/d1c25053764b4c42eb294aae92ab617d2e4f803397f9c7c8295caa77a260/coverage-7.10.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fff7b9c3f19957020cac546c70025331113d2e61537f6e2441bc7657913de7d3", size = 217978, upload-time = "2025-09-21T20:03:30.362Z" },
-    { url = "https://files.pythonhosted.org/packages/52/2f/b9f9daa39b80ece0b9548bbb723381e29bc664822d9a12c2135f8922c22b/coverage-7.10.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:bc91b314cef27742da486d6839b677b3f2793dfe52b51bbbb7cf736d5c29281c", size = 218370, upload-time = "2025-09-21T20:03:32.147Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/6e/30d006c3b469e58449650642383dddf1c8fb63d44fdf92994bfd46570695/coverage-7.10.7-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:567f5c155eda8df1d3d439d40a45a6a5f029b429b06648235f1e7e51b522b396", size = 244802, upload-time = "2025-09-21T20:03:33.919Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/49/8a070782ce7e6b94ff6a0b6d7c65ba6bc3091d92a92cef4cd4eb0767965c/coverage-7.10.7-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2af88deffcc8a4d5974cf2d502251bc3b2db8461f0b66d80a449c33757aa9f40", size = 246625, upload-time = "2025-09-21T20:03:36.09Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/92/1c1c5a9e8677ce56d42b97bdaca337b2d4d9ebe703d8c174ede52dbabd5f/coverage-7.10.7-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7315339eae3b24c2d2fa1ed7d7a38654cba34a13ef19fbcb9425da46d3dc594", size = 248399, upload-time = "2025-09-21T20:03:38.342Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/54/b140edee7257e815de7426d5d9846b58505dffc29795fff2dfb7f8a1c5a0/coverage-7.10.7-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:912e6ebc7a6e4adfdbb1aec371ad04c68854cd3bf3608b3514e7ff9062931d8a", size = 245142, upload-time = "2025-09-21T20:03:40.591Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/9e/6d6b8295940b118e8b7083b29226c71f6154f7ff41e9ca431f03de2eac0d/coverage-7.10.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:f49a05acd3dfe1ce9715b657e28d138578bc40126760efb962322c56e9ca344b", size = 246284, upload-time = "2025-09-21T20:03:42.355Z" },
-    { url = "https://files.pythonhosted.org/packages/db/e5/5e957ca747d43dbe4d9714358375c7546cb3cb533007b6813fc20fce37ad/coverage-7.10.7-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:cce2109b6219f22ece99db7644b9622f54a4e915dad65660ec435e89a3ea7cc3", size = 244353, upload-time = "2025-09-21T20:03:44.218Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/45/540fc5cc92536a1b783b7ef99450bd55a4b3af234aae35a18a339973ce30/coverage-7.10.7-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:f3c887f96407cea3916294046fc7dab611c2552beadbed4ea901cbc6a40cc7a0", size = 244430, upload-time = "2025-09-21T20:03:46.065Z" },
-    { url = "https://files.pythonhosted.org/packages/75/0b/8287b2e5b38c8fe15d7e3398849bb58d382aedc0864ea0fa1820e8630491/coverage-7.10.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:635adb9a4507c9fd2ed65f39693fa31c9a3ee3a8e6dc64df033e8fdf52a7003f", size = 245311, upload-time = "2025-09-21T20:03:48.19Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/1d/29724999984740f0c86d03e6420b942439bf5bd7f54d4382cae386a9d1e9/coverage-7.10.7-cp39-cp39-win32.whl", hash = "sha256:5a02d5a850e2979b0a014c412573953995174743a3f7fa4ea5a6e9a3c5617431", size = 220500, upload-time = "2025-09-21T20:03:50.024Z" },
-    { url = "https://files.pythonhosted.org/packages/43/11/4b1e6b129943f905ca54c339f343877b55b365ae2558806c1be4f7476ed5/coverage-7.10.7-cp39-cp39-win_amd64.whl", hash = "sha256:c134869d5ffe34547d14e174c866fd8fe2254918cc0a95e99052903bc1543e07", size = 221408, upload-time = "2025-09-21T20:03:51.803Z" },
     { url = "https://files.pythonhosted.org/packages/ec/16/114df1c291c22cac3b0c127a73e0af5c12ed7bbb6558d310429a0ae24023/coverage-7.10.7-py3-none-any.whl", hash = "sha256:f7941f6f2fe6dd6807a1208737b8a0cbcf1cc6d7b07d24998ad2d63590868260", size = 209952, upload-time = "2025-09-21T20:03:53.918Z" },
 ]
 
@@ -1170,7 +1043,7 @@ name = "dishka"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/d7/1be31f5ef32387059190353f9fa493ff4d07a1c75fa856c7566ca45e0800/dishka-1.7.2.tar.gz", hash = "sha256:47d4cb5162b28c61bf5541860e605ed5eaf5c667122299c7ef657c86fc8d5a49", size = 68132, upload-time = "2025-09-24T21:23:05.135Z" }
 wheels = [
@@ -1193,8 +1066,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
 wheels = [
@@ -1253,21 +1125,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/23/32/57866cf8881288b3dfb9212720221fb890daaa534dbdc6fe3fff3979ecd1/duckdb-1.4.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2de258a93435c977a0ec3a74ec8f60c2f215ddc73d427ee49adc4119558facd3", size = 18421289, upload-time = "2025-09-16T10:22:21.564Z" },
     { url = "https://files.pythonhosted.org/packages/a0/83/7438fb43be451a7d4a04650aaaf662b2ff2d95895bbffe3e0e28cbe030c9/duckdb-1.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6d3659641d517dd9ed1ab66f110cdbdaa6900106f116effaf2dbedd83c38de3", size = 20426547, upload-time = "2025-09-16T10:22:23.759Z" },
     { url = "https://files.pythonhosted.org/packages/21/b2/98fb89ae81611855f35984e96f648d871f3967bb3f524b51d1372d052f0c/duckdb-1.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:07fcc612ea5f0fe6032b92bcc93693034eb00e7a23eb9146576911d5326af4f7", size = 12290467, upload-time = "2025-09-16T10:22:25.923Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/42/0f355319b3e8ee1703d0e17378dd829db391434306621f85c110134f2763/duckdb-1.4.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:1c97ee61c582002b654331f7fd967d6b1e83bf7fdb0772f409dfd4b6af3a70f4", size = 31292373, upload-time = "2025-09-16T10:22:28.118Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/52/091dbef5eb2ac4e60a9c6d38fcc7c7530a75fafa0f37658450e8731a265b/duckdb-1.4.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:74e3d6295355160df5d3588b880e8bcae23fdd6f573f538793a8a1abf4c2c29d", size = 17288145, upload-time = "2025-09-16T10:22:30.346Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/6c/879317d9c3ac7a2a1f0618ca536a48ebfa4b9fe202f9783e07070e168192/duckdb-1.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d0c76425e4ffe98069dd4fc4752ab919a4125dc0d176bb676b3065fdea152c42", size = 14816258, upload-time = "2025-09-16T10:22:32.442Z" },
-    { url = "https://files.pythonhosted.org/packages/95/87/83ac8e67c0530b69fe39f91bbb7f3bd0a49b0c24216cffa9c5561fb2845c/duckdb-1.4.0-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c122bd7d80ab5057f53024ee3922d7612a5cdc99583fae730990964aebc3fd4", size = 18391043, upload-time = "2025-09-16T10:22:34.616Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/01/1d70bd6c594ef915c004edc0f1119d1602173dc5ce91c1eed7368f6aab34/duckdb-1.4.0-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:30689c1436bca723526be6102fe1f4f82ea6d4780fb9ca196bda7ed5ec227950", size = 20385348, upload-time = "2025-09-16T10:22:36.982Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/04/0650128cdcdc5208c4f51341a0a3f8db436ecaba51032c6065e20ea0baae/duckdb-1.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:4c55a367c1296617cff89c5e1c7153f1dc3c3b556ef70711a45b0236515f80c2", size = 12283322, upload-time = "2025-09-16T10:22:39.388Z" },
-]
-
-[[package]]
-name = "eval-type-backport"
-version = "0.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/ea/8b0ac4469d4c347c6a385ff09dc3c048c2d021696664e26c7ee6791631b5/eval_type_backport-0.2.2.tar.gz", hash = "sha256:f0576b4cf01ebb5bd358d02314d31846af5e07678387486e2c798af0e7d849c1", size = 9079, upload-time = "2024-12-21T20:09:46.005Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/31/55cd413eaccd39125368be33c46de24a1f639f2e12349b0361b4678f3915/eval_type_backport-0.2.2-py3-none-any.whl", hash = "sha256:cb6ad7c393517f476f96d456d0412ea80f0a8cf96f6892834cd9340149111b0a", size = 5830, upload-time = "2024-12-21T20:09:44.175Z" },
 ]
 
 [[package]]
@@ -1387,18 +1244,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/30/0037e0d426561fdd46866b04e7214cae854aab050f8c91d4f45ddfd4034f/fastnanoid-0.4.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:b42a90da8c0c085911bef93323cd8244f3a7e6b327ecbfa2432bc3db04086014", size = 404473, upload-time = "2025-06-30T14:43:28.378Z" },
     { url = "https://files.pythonhosted.org/packages/47/a1/5b3938464cf0ba235c76b15b1d0fe2d61cfd47dac848595bc47fc1fe541e/fastnanoid-0.4.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5833bb7a1814e105f713731f7aac4aadb06e14517139d70080cacce458026eb", size = 234388, upload-time = "2025-06-30T14:42:35.479Z" },
     { url = "https://files.pythonhosted.org/packages/59/30/6dd2f979a78783848fcff31251cc5bc45c315eb9314a5c9b485e76fc818d/fastnanoid-0.4.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:39fb393f81eb5ce37135418a9a10560b670682eeca4c062b985a1bc6fec45705", size = 249086, upload-time = "2025-06-30T14:42:22.718Z" },
-    { url = "https://files.pythonhosted.org/packages/88/11/38634f8c3d469cc6cd30297317d9d5ba62df7bc3334581e83e6bac22bd68/fastnanoid-0.4.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:157555b4ecf883a4e0ce560d5ff701c05af69dfae97881076814e44c34de5044", size = 232587, upload-time = "2025-06-30T14:41:37.027Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/d2/d710b0d17c11f6ecb4f23a6cf3b2e1f7fd4521ec66f9a8de6c82f9b1481e/fastnanoid-0.4.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6f180616b7e55fdf78ad26d99f2e041b25e5c46b0a4b11ab84d372810d0c8684", size = 241477, upload-time = "2025-06-30T14:41:50.33Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/35/f60c61522b236b46701638842b349bdba4a81def6c320cf345f7057bd6bc/fastnanoid-0.4.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4add77f0e0cae6bd12361d9a247d6a0f518e14a3507d0192aade38414a3f6577", size = 370450, upload-time = "2025-06-30T14:42:02.63Z" },
-    { url = "https://files.pythonhosted.org/packages/51/48/c8ba72e52a5eb5f401c62cbe935cd2e325a30b65e515951954ee712aa3c2/fastnanoid-0.4.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a684e5c839383675ca8b613fe069d699a5b63d9e86ea87a145f2da4fcfffd123", size = 261818, upload-time = "2025-06-30T14:42:13.378Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/1f/b2009781320f8c1b81a712bacff3096a44c80f4e6aeb26303a2a1b3b76c9/fastnanoid-0.4.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ce115103692b201700c791bca8cc97e321fdf1d886f0ac1c0553a3f5d50c002", size = 236326, upload-time = "2025-06-30T14:42:37.88Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/5b/3db8ac970894c5a674ea0d87967e077dd609f02d09b4361ff644936d3ab9/fastnanoid-0.4.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b7da3e6091fa02154e7a7a2a8422e4a7901994ea96ab5a56d7ca1fe8c137ebc2", size = 250816, upload-time = "2025-06-30T14:42:26.077Z" },
-    { url = "https://files.pythonhosted.org/packages/af/63/c1ddd4853515f83e2e76307e0e82fbbcf157e28c46d669bda28187b46e1f/fastnanoid-0.4.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9827c9e52c2f6a988b5a47c30acdc5dc7cf6bc13515b65e89cc390c80622e53a", size = 411251, upload-time = "2025-06-30T14:42:54.748Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/32/35663e48fe03b45ef5db204cc26019ebe8814d9eade9a4c2b6b08e309d01/fastnanoid-0.4.3-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:56e2763bfd490163549d53abcec6a2223f3f22c12d75c53f2f3ba8a7c9a0bf4c", size = 503903, upload-time = "2025-06-30T14:43:06.456Z" },
-    { url = "https://files.pythonhosted.org/packages/35/93/eca7bb497a1d92c75e7349b1bb0f8b0b0d5ca4607520ee7d574c996fcfee/fastnanoid-0.4.3-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:c475acaa7f3286e2cba08e308f16af530f51f8a8eb0aa91638cd2f83fc272a1a", size = 431440, upload-time = "2025-06-30T14:43:18.932Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/2d/0edf05d43486f5ff49fdac9e67a0803f277d5ebd8c28a661efcce0d297f2/fastnanoid-0.4.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c0103d4ddc8a34e69b8bed3a04c12cd46e9c4b998707269140d7e593245ca599", size = 406585, upload-time = "2025-06-30T14:43:30.883Z" },
-    { url = "https://files.pythonhosted.org/packages/68/92/4d5cfb81c63b433602d85a5394bdb583ffaf0f8ba99efc29f1f6d4513f47/fastnanoid-0.4.3-cp39-cp39-win32.whl", hash = "sha256:065f346175660e1c3fb3bb0d0e906ea8fe23c597fd7969734d9d27a6d1cb06f1", size = 102859, upload-time = "2025-06-30T14:43:47.717Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/f9/ce1bcf7c6c36f2342aa1298a7c3e935c5fabb8cbccc0b387da191e5cb3a8/fastnanoid-0.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:0ca7a36fa419785b21474e92032f423c6de966bfb8b052bf0a02116b70556ea9", size = 109967, upload-time = "2025-06-30T14:43:40.512Z" },
     { url = "https://files.pythonhosted.org/packages/1f/64/de3ee84c9672f7e7392cc349da896dbc0ac9239bef1cc6c23f0607e00371/fastnanoid-0.4.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c06dffcd4ec8520c2ca5476a484275a8dce592b4707495e6a74cdc2ac0aa7922", size = 232734, upload-time = "2025-06-30T14:41:38.116Z" },
     { url = "https://files.pythonhosted.org/packages/79/ea/48907f92cf2b7fa35adcce975d5c29d086050e7a406acde503e7e0d58a60/fastnanoid-0.4.3-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:aa71ef4ba1143da200ba79b16bc82352632ad0fce36aab16710c7b4d3d5f75d6", size = 242244, upload-time = "2025-06-30T14:41:51.469Z" },
     { url = "https://files.pythonhosted.org/packages/d6/b4/9d9b6258421b3669185fc82a4569bd0af3b73db70770661578ce88317b96/fastnanoid-0.4.3-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f5b3143f298528835bb1821e0da161a07631aed9ccbe93eca7c00ef0248402fd", size = 368223, upload-time = "2025-06-30T14:42:03.645Z" },
@@ -1419,14 +1264,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/69/2c71353ff382bc16b6ec902153a4d5f3199a8df1fd87fbc0b1da64066102/fastnanoid-0.4.3-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:8e93359bff01947ed884f01cf44766d8fa4af8a26df56a212ea308fb6e93f658", size = 504674, upload-time = "2025-06-30T14:43:08.815Z" },
     { url = "https://files.pythonhosted.org/packages/88/7b/7e63ee606e97c4e18a9338b06cb96b96a82ec222b9df7a497fe8a122df9f/fastnanoid-0.4.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:db1759eb65a1fd027a88f0c6f6f63bf0b3063f8c488b9dd17f869d1ab423a387", size = 431910, upload-time = "2025-06-30T14:43:21.109Z" },
     { url = "https://files.pythonhosted.org/packages/dd/38/3844c9e3fc23708566d3e9efb3ccbeb9981e87cc431c141a67ad110b7d18/fastnanoid-0.4.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:16b8692b5a59981e1644efbb83b87feac9cea1a2b8fb0dbc19f402dae26008bc", size = 406405, upload-time = "2025-06-30T14:43:33.247Z" },
-    { url = "https://files.pythonhosted.org/packages/97/91/ac61901f7da8765dd157d740433291cf8940147212458c80f0a3d69a6abb/fastnanoid-0.4.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bfb7cefe42f32fd52f375ee4f023d5b15263e910b26dca743901c672bbf1307e", size = 232919, upload-time = "2025-06-30T14:41:40.19Z" },
-    { url = "https://files.pythonhosted.org/packages/75/ad/ff570a53da80d8653dc58d2a46c3b378008dd9903a10d8d5cb6998ed01ed/fastnanoid-0.4.3-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0597a30e1dc7b036f156fe9e2dfcf42e55eece625b2ee5aec9f9da50e1516e6a", size = 241970, upload-time = "2025-06-30T14:41:53.56Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/6c/c536b4aa96c44ef398ad88b1990d059a7f487fa116c1434c1a9176777f5f/fastnanoid-0.4.3-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e32bd26ca9b32e5aad1121cf3e0fc163250b5ed2ee05f4355a990b577c03871f", size = 371196, upload-time = "2025-06-30T14:42:06.152Z" },
-    { url = "https://files.pythonhosted.org/packages/71/02/6f1b7a185a45b8682b7ee6fd45af710a86c940ced34455509120b743f9e7/fastnanoid-0.4.3-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8ff7bad516258544e5d9d37507a69fd0a3af7d37ad0c87d14bbd4d95383e4b0e", size = 262467, upload-time = "2025-06-30T14:42:16.546Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/1c/7eabd68cf0c0ab0b12e8fd309c8b364fc7b673cc85f3d4056801041a925b/fastnanoid-0.4.3-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:3c95323959066f30bcc16da1101663d12522c01e83a4bffe26569cb48dfde75c", size = 411536, upload-time = "2025-06-30T14:42:58.516Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/f5/5095125d49dbd06017a5df5f1ba41afbf59e2c0d8bad909e4a1cf1f35c78/fastnanoid-0.4.3-pp39-pypy39_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:d61602b26addf9da6b4083b4d90c252c394262a7808f22c9aba33a1c9223a163", size = 504679, upload-time = "2025-06-30T14:43:09.94Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/e5/eae60c88633bdc025dd1671bb0905cbb044e4d00eabd60e8c9ba756d1e57/fastnanoid-0.4.3-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:16e91a7afbff5bfcf159ca0bf3faa642cb069549d91f79f0de4b3f696b64d86c", size = 431969, upload-time = "2025-06-30T14:43:22.267Z" },
-    { url = "https://files.pythonhosted.org/packages/63/4d/8b27d5daca0020dd41839a65837e74a6d264d273f0e29f85ee53a635cd5c/fastnanoid-0.4.3-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:744686d495636f9b9e235e23308536dede26a2d564cc9ae5e7008a65b69d461c", size = 407079, upload-time = "2025-06-30T14:43:34.689Z" },
 ]
 
 [[package]]
@@ -1444,9 +1281,7 @@ version = "3.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blinker" },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
+    { name = "click" },
     { name = "itsdangerous" },
     { name = "jinja2" },
     { name = "markupsafe" },
@@ -1548,23 +1383,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/40/37/5f9f3c3fd7f7746082ec67bcdc204db72dad081f4f83a503d33220a92973/frozenlist-1.7.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:1a85e345b4c43db8b842cab1feb41be5cc0b10a1830e6295b69d7310f99becaf", size = 282620, upload-time = "2025-06-09T23:02:00.493Z" },
     { url = "https://files.pythonhosted.org/packages/0b/31/8fbc5af2d183bff20f21aa743b4088eac4445d2bb1cdece449ae80e4e2d1/frozenlist-1.7.0-cp313-cp313t-win32.whl", hash = "sha256:3a14027124ddb70dfcee5148979998066897e79f89f64b13328595c4bdf77c81", size = 43059, upload-time = "2025-06-09T23:02:02.072Z" },
     { url = "https://files.pythonhosted.org/packages/bb/ed/41956f52105b8dbc26e457c5705340c67c8cc2b79f394b79bffc09d0e938/frozenlist-1.7.0-cp313-cp313t-win_amd64.whl", hash = "sha256:3bf8010d71d4507775f658e9823210b7427be36625b387221642725b515dcf3e", size = 47516, upload-time = "2025-06-09T23:02:03.779Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/b1/ee59496f51cd244039330015d60f13ce5a54a0f2bd8d79e4a4a375ab7469/frozenlist-1.7.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:cea3dbd15aea1341ea2de490574a4a37ca080b2ae24e4b4f4b51b9057b4c3630", size = 82434, upload-time = "2025-06-09T23:02:05.195Z" },
-    { url = "https://files.pythonhosted.org/packages/75/e1/d518391ce36a6279b3fa5bc14327dde80bcb646bb50d059c6ca0756b8d05/frozenlist-1.7.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7d536ee086b23fecc36c2073c371572374ff50ef4db515e4e503925361c24f71", size = 48232, upload-time = "2025-06-09T23:02:07.728Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/8d/a0d04f28b6e821a9685c22e67b5fb798a5a7b68752f104bfbc2dccf080c4/frozenlist-1.7.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:dfcebf56f703cb2e346315431699f00db126d158455e513bd14089d992101e44", size = 47186, upload-time = "2025-06-09T23:02:09.243Z" },
-    { url = "https://files.pythonhosted.org/packages/93/3a/a5334c0535c8b7c78eeabda1579179e44fe3d644e07118e59a2276dedaf1/frozenlist-1.7.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:974c5336e61d6e7eb1ea5b929cb645e882aadab0095c5a6974a111e6479f8878", size = 226617, upload-time = "2025-06-09T23:02:10.949Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/67/8258d971f519dc3f278c55069a775096cda6610a267b53f6248152b72b2f/frozenlist-1.7.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c70db4a0ab5ab20878432c40563573229a7ed9241506181bba12f6b7d0dc41cb", size = 224179, upload-time = "2025-06-09T23:02:12.603Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/89/8225905bf889b97c6d935dd3aeb45668461e59d415cb019619383a8a7c3b/frozenlist-1.7.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1137b78384eebaf70560a36b7b229f752fb64d463d38d1304939984d5cb887b6", size = 235783, upload-time = "2025-06-09T23:02:14.678Z" },
-    { url = "https://files.pythonhosted.org/packages/54/6e/ef52375aa93d4bc510d061df06205fa6dcfd94cd631dd22956b09128f0d4/frozenlist-1.7.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e793a9f01b3e8b5c0bc646fb59140ce0efcc580d22a3468d70766091beb81b35", size = 229210, upload-time = "2025-06-09T23:02:16.313Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/55/62c87d1a6547bfbcd645df10432c129100c5bd0fd92a384de6e3378b07c1/frozenlist-1.7.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:74739ba8e4e38221d2c5c03d90a7e542cb8ad681915f4ca8f68d04f810ee0a87", size = 215994, upload-time = "2025-06-09T23:02:17.9Z" },
-    { url = "https://files.pythonhosted.org/packages/45/d2/263fea1f658b8ad648c7d94d18a87bca7e8c67bd6a1bbf5445b1bd5b158c/frozenlist-1.7.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e63344c4e929b1a01e29bc184bbb5fd82954869033765bfe8d65d09e336a677", size = 225122, upload-time = "2025-06-09T23:02:19.479Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/22/7145e35d12fb368d92124f679bea87309495e2e9ddf14c6533990cb69218/frozenlist-1.7.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:2ea2a7369eb76de2217a842f22087913cdf75f63cf1307b9024ab82dfb525938", size = 224019, upload-time = "2025-06-09T23:02:20.969Z" },
-    { url = "https://files.pythonhosted.org/packages/44/1e/7dae8c54301beb87bcafc6144b9a103bfd2c8f38078c7902984c9a0c4e5b/frozenlist-1.7.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:836b42f472a0e006e02499cef9352ce8097f33df43baaba3e0a28a964c26c7d2", size = 239925, upload-time = "2025-06-09T23:02:22.466Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/1e/99c93e54aa382e949a98976a73b9b20c3aae6d9d893f31bbe4991f64e3a8/frozenlist-1.7.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:e22b9a99741294b2571667c07d9f8cceec07cb92aae5ccda39ea1b6052ed4319", size = 220881, upload-time = "2025-06-09T23:02:24.521Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/9c/ca5105fa7fb5abdfa8837581be790447ae051da75d32f25c8f81082ffc45/frozenlist-1.7.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:9a19e85cc503d958abe5218953df722748d87172f71b73cf3c9257a91b999890", size = 234046, upload-time = "2025-06-09T23:02:26.206Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/4d/e99014756093b4ddbb67fb8f0df11fe7a415760d69ace98e2ac6d5d43402/frozenlist-1.7.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:f22dac33bb3ee8fe3e013aa7b91dc12f60d61d05b7fe32191ffa84c3aafe77bd", size = 235756, upload-time = "2025-06-09T23:02:27.79Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/72/a19a40bcdaa28a51add2aaa3a1a294ec357f36f27bd836a012e070c5e8a5/frozenlist-1.7.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:9ccec739a99e4ccf664ea0775149f2749b8a6418eb5b8384b4dc0a7d15d304cb", size = 222894, upload-time = "2025-06-09T23:02:29.848Z" },
-    { url = "https://files.pythonhosted.org/packages/08/49/0042469993e023a758af81db68c76907cd29e847d772334d4d201cbe9a42/frozenlist-1.7.0-cp39-cp39-win32.whl", hash = "sha256:b3950f11058310008a87757f3eee16a8e1ca97979833239439586857bc25482e", size = 39848, upload-time = "2025-06-09T23:02:31.413Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/45/827d86ee475c877f5f766fbc23fb6acb6fada9e52f1c9720e2ba3eae32da/frozenlist-1.7.0-cp39-cp39-win_amd64.whl", hash = "sha256:43a82fce6769c70f2f5a06248b614a7d268080a9d20f7457ef10ecee5af82b63", size = 44102, upload-time = "2025-06-09T23:02:32.808Z" },
     { url = "https://files.pythonhosted.org/packages/ee/45/b82e3c16be2182bff01179db177fe144d58b5dc787a7d4492c6ed8b9317f/frozenlist-1.7.0-py3-none-any.whl", hash = "sha256:9a5af342e34f7e97caf8c995864c7a396418ae2859cc6fdf1b1073020d516a7e", size = 13106, upload-time = "2025-06-09T23:02:34.204Z" },
 ]
 
@@ -1696,12 +1514,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/32/a22a281806e3ef21b72db16f948cad22ec68e4bdd384139291e00ff82fe2/google_crc32c-1.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:0f99eaa09a9a7e642a61e06742856eec8b19fc0037832e03f941fe7cf0c8e4db", size = 33475, upload-time = "2025-03-26T14:29:11.771Z" },
     { url = "https://files.pythonhosted.org/packages/b8/c5/002975aff514e57fc084ba155697a049b3f9b52225ec3bc0f542871dd524/google_crc32c-1.7.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32d1da0d74ec5634a05f53ef7df18fc646666a25efaaca9fc7dcfd4caf1d98c3", size = 33243, upload-time = "2025-03-26T14:41:35.975Z" },
     { url = "https://files.pythonhosted.org/packages/61/cb/c585282a03a0cea70fcaa1bf55d5d702d0f2351094d663ec3be1c6c67c52/google_crc32c-1.7.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e10554d4abc5238823112c2ad7e4560f96c7bf3820b202660373d769d9e6e4c9", size = 32870, upload-time = "2025-03-26T14:41:37.08Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/89/940d170a9f24e6e711666a7c5596561358243023b4060869d9adae97a762/google_crc32c-1.7.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:9fc196f0b8d8bd2789352c6a522db03f89e83a0ed6b64315923c396d7a932315", size = 30462, upload-time = "2025-03-26T14:29:25.969Z" },
-    { url = "https://files.pythonhosted.org/packages/42/0c/22bebe2517368e914a63e5378aab74e2b6357eb739d94b6bc0e830979a37/google_crc32c-1.7.1-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:bb5e35dcd8552f76eed9461a23de1030920a3c953c1982f324be8f97946e7127", size = 30304, upload-time = "2025-03-26T14:49:16.642Z" },
-    { url = "https://files.pythonhosted.org/packages/36/32/2daf4c46f875aaa3a057ecc8569406979cb29fb1e2389e4f2570d8ed6a5c/google_crc32c-1.7.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f2226b6a8da04f1d9e61d3e357f2460b9551c5e6950071437e122c958a18ae14", size = 37734, upload-time = "2025-03-26T14:41:37.88Z" },
-    { url = "https://files.pythonhosted.org/packages/76/b5/b3e220b68d5d265c4aacd2878301fdb2df72715c45ba49acc19f310d4555/google_crc32c-1.7.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f2b3522222746fff0e04a9bd0a23ea003ba3cccc8cf21385c564deb1f223242", size = 32869, upload-time = "2025-03-26T14:41:38.965Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/90/2931c3c8d2de1e7cde89945d3ceb2c4258a1f23f0c22c3c1c921c3c026a6/google_crc32c-1.7.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3bda0fcb632d390e3ea8b6b07bf6b4f4a66c9d02dcd6fbf7ba00a197c143f582", size = 37875, upload-time = "2025-03-26T14:41:41.732Z" },
-    { url = "https://files.pythonhosted.org/packages/30/9e/0aaed8a209ea6fa4b50f66fed2d977f05c6c799e10bb509f5523a5a5c90c/google_crc32c-1.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:713121af19f1a617054c41f952294764e0c5443d5a5d9034b2cd60f5dd7e0349", size = 33471, upload-time = "2025-03-26T14:29:12.578Z" },
     { url = "https://files.pythonhosted.org/packages/0b/43/31e57ce04530794917dfe25243860ec141de9fadf4aa9783dffe7dac7c39/google_crc32c-1.7.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a8e9afc74168b0b2232fb32dd202c93e46b7d5e4bf03e66ba5dc273bb3559589", size = 28242, upload-time = "2025-03-26T14:41:42.858Z" },
     { url = "https://files.pythonhosted.org/packages/eb/f3/8b84cd4e0ad111e63e30eb89453f8dd308e3ad36f42305cf8c202461cdf0/google_crc32c-1.7.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa8136cc14dd27f34a3221c0f16fd42d8a40e4778273e61a3c19aedaa44daf6b", size = 28049, upload-time = "2025-03-26T14:41:44.651Z" },
     { url = "https://files.pythonhosted.org/packages/16/1b/1693372bf423ada422f80fd88260dbfd140754adb15cbc4d7e9a68b1cb8e/google_crc32c-1.7.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:85fef7fae11494e747c9fd1359a527e5970fc9603c90764843caabd3a16a0a48", size = 28241, upload-time = "2025-03-26T14:41:45.898Z" },
@@ -1786,16 +1598,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/e3/a5/6ddab2b4c112be95601c13428db1d8b6608a8b6039816f2ba09c346c08fc/greenlet-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:e37ab26028f12dbb0ff65f29a8d3d44a765c61e729647bf2ddfbbed621726f01", size = 303425, upload-time = "2025-08-07T13:32:27.59Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/c0/93885c4106d2626bf51fdec377d6aef740dfa5c4877461889a7cf8e565cc/greenlet-3.2.4-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:b6a7c19cf0d2742d0809a4c05975db036fdff50cd294a93632d6a310bf9ac02c", size = 269859, upload-time = "2025-08-07T13:16:16.003Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/f5/33f05dc3ba10a02dedb1485870cf81c109227d3d3aa280f0e48486cac248/greenlet-3.2.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:27890167f55d2387576d1f41d9487ef171849ea0359ce1510ca6e06c8bece11d", size = 627610, upload-time = "2025-08-07T13:43:01.345Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/a7/9476decef51a0844195f99ed5dc611d212e9b3515512ecdf7321543a7225/greenlet-3.2.4-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:18d9260df2b5fbf41ae5139e1be4e796d99655f023a636cd0e11e6406cca7d58", size = 639417, upload-time = "2025-08-07T13:45:32.094Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/e0/849b9159cbb176f8c0af5caaff1faffdece7a8417fcc6fe1869770e33e21/greenlet-3.2.4-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:671df96c1f23c4a0d4077a325483c1503c96a1b7d9db26592ae770daa41233d4", size = 634751, upload-time = "2025-08-07T13:53:18.848Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/d3/844e714a9bbd39034144dca8b658dcd01839b72bb0ec7d8014e33e3705f0/greenlet-3.2.4-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:16458c245a38991aa19676900d48bd1a6f2ce3e16595051a4db9d012154e8433", size = 634020, upload-time = "2025-08-07T13:18:36.841Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/4c/f3de2a8de0e840ecb0253ad0dc7e2bb3747348e798ec7e397d783a3cb380/greenlet-3.2.4-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9913f1a30e4526f432991f89ae263459b1c64d1608c0d22a5c79c287b3c70df", size = 582817, upload-time = "2025-08-07T13:18:35.48Z" },
-    { url = "https://files.pythonhosted.org/packages/89/80/7332915adc766035c8980b161c2e5d50b2f941f453af232c164cff5e0aeb/greenlet-3.2.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b90654e092f928f110e0007f572007c9727b5265f7632c2fa7415b4689351594", size = 1111985, upload-time = "2025-08-07T13:42:42.425Z" },
-    { url = "https://files.pythonhosted.org/packages/66/71/1928e2c80197353bcb9b50aa19c4d8e26ee6d7a900c564907665cf4b9a41/greenlet-3.2.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:81701fd84f26330f0d5f4944d4e92e61afe6319dcd9775e39396e39d7c3e5f98", size = 1136137, upload-time = "2025-08-07T13:18:26.168Z" },
-    { url = "https://files.pythonhosted.org/packages/89/48/a5dc74dde38aeb2b15d418cec76ed50e1dd3d620ccda84d8199703248968/greenlet-3.2.4-cp39-cp39-win32.whl", hash = "sha256:65458b409c1ed459ea899e939f0e1cdb14f58dbc803f2f93c5eab5694d32671b", size = 281400, upload-time = "2025-08-07T14:02:20.263Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/44/342c4591db50db1076b8bda86ed0ad59240e3e1da17806a4cf10a6d0e447/greenlet-3.2.4-cp39-cp39-win_amd64.whl", hash = "sha256:d2e685ade4dafd447ede19c31277a224a239a0a1a4eca4e6390efedf20260cfb", size = 298533, upload-time = "2025-08-07T13:56:34.168Z" },
 ]
 
 [[package]]
@@ -1883,16 +1685,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/67/8e/3204b94ac30b0f675ab1c06540ab5578660dc8b690db71854d3116f20d00/grpcio-1.75.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aad1c774f4ebf0696a7f148a56d39a3432550612597331792528895258966dc0", size = 7464478, upload-time = "2025-09-26T09:03:03.096Z" },
     { url = "https://files.pythonhosted.org/packages/b7/97/2d90652b213863b2cf466d9c1260ca7e7b67a16780431b3eb1d0420e3d5b/grpcio-1.75.1-cp314-cp314-win32.whl", hash = "sha256:62ce42d9994446b307649cb2a23335fa8e927f7ab2cbf5fcb844d6acb4d85f9c", size = 4012672, upload-time = "2025-09-26T09:03:05.477Z" },
     { url = "https://files.pythonhosted.org/packages/f9/df/e2e6e9fc1c985cd1a59e6996a05647c720fe8a03b92f5ec2d60d366c531e/grpcio-1.75.1-cp314-cp314-win_amd64.whl", hash = "sha256:f86e92275710bea3000cb79feca1762dc0ad3b27830dd1a74e82ab321d4ee464", size = 4772475, upload-time = "2025-09-26T09:03:07.661Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/e2/33efd823a879dc7b60c10192df1900ee5c200f8e782663a41a3b2aecd143/grpcio-1.75.1-cp39-cp39-linux_armv7l.whl", hash = "sha256:c09fba33327c3ac11b5c33dbdd8218eef8990d78f83b1656d628831812a8c0fb", size = 5706679, upload-time = "2025-09-26T09:03:10.218Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/13/17e39ee4897f1cd12dd463e863b830e64643b13e9a4af5062b4a6f0790be/grpcio-1.75.1-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:7e21400b037be29545704889e72e586c238e346dcb2d08d8a7288d16c883a9ec", size = 11490271, upload-time = "2025-09-26T09:03:12.778Z" },
-    { url = "https://files.pythonhosted.org/packages/77/90/b80e75f8cce758425b2772742eed4e9db765a965d902ba4b7f239b2513de/grpcio-1.75.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c12121e509b9f8b0914d10054d24120237d19e870b1cd82acbb8a9b9ddd198a3", size = 6291926, upload-time = "2025-09-26T09:03:16.282Z" },
-    { url = "https://files.pythonhosted.org/packages/40/5f/e6033d8f99063350e20873a46225468b73045b9ef2c8cba73d66a87c3fd5/grpcio-1.75.1-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:73577a93e692b3474b1bfe84285d098de36705dbd838bb4d6a056d326e4dc880", size = 6950040, upload-time = "2025-09-26T09:03:18.874Z" },
-    { url = "https://files.pythonhosted.org/packages/01/12/34076c079b45af5aed40f037fffe388d7fbe90dd539ed01e4744c926d227/grpcio-1.75.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e19e7dfa0d7ca7dea22be464339e18ac608fd75d88c56770c646cdabe54bc724", size = 6465780, upload-time = "2025-09-26T09:03:21.219Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/c5/ee6fd69a9f6e7288d04da010ad7480a0566d2aac81097ff4dafbc5ffa9b6/grpcio-1.75.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4e1c28f51c1cf67eccdfc1065e8e866c9ed622f09773ca60947089c117f848a1", size = 7098308, upload-time = "2025-09-26T09:03:23.875Z" },
-    { url = "https://files.pythonhosted.org/packages/78/32/f2be13f13035361768923159fe20470a7d22db2c7c692b952e21284f56e5/grpcio-1.75.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:030a6164bc2ca726052778c0cf8e3249617a34e368354f9e6107c27ad4af8c28", size = 8042268, upload-time = "2025-09-26T09:03:26.268Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/2d/1bb0572f0a2eaab100b4635c6c2cd0d37e3cda5554037e3f90b1bc428d56/grpcio-1.75.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:67697efef5a98d46d5db7b1720fa4043536f8b8e5072a5d61cfca762f287e939", size = 7491470, upload-time = "2025-09-26T09:03:28.906Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/e0/1e962dcb64019bbd87eedcfacdedb83af0f66da01f2f6e03d69b0aa1b7f0/grpcio-1.75.1-cp39-cp39-win32.whl", hash = "sha256:52015cf73eb5d76f6404e0ce0505a69b51fd1f35810b3a01233b34b10baafb41", size = 3951697, upload-time = "2025-09-26T09:03:31.535Z" },
-    { url = "https://files.pythonhosted.org/packages/87/bc/47fb3aaa77e7d657999937ec1026beba9e37f3199599fe510f762d31da97/grpcio-1.75.1-cp39-cp39-win_amd64.whl", hash = "sha256:9fe51e4a1f896ea84ac750900eae34d9e9b896b5b1e4a30b02dc31ad29f36383", size = 4645764, upload-time = "2025-09-26T09:03:34.071Z" },
 ]
 
 [[package]]
@@ -2033,9 +1825,6 @@ wheels = [
 name = "importlib-resources"
 version = "6.5.2"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.10'" },
-]
 sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693, upload-time = "2025-01-03T18:51:56.698Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/ed/1f1afb2e9e7f38a545d628f864d562a5ae64fe6f7a10e28ffb9b185b4e89/importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec", size = 37461, upload-time = "2025-01-03T18:51:54.306Z" },
@@ -2086,11 +1875,9 @@ version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "click" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "httpx" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "litestar-htmx" },
     { name = "msgspec" },
     { name = "multidict" },
@@ -2210,47 +1997,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
-    { url = "https://files.pythonhosted.org/packages/56/23/0d8c13a44bde9154821586520840643467aee574d8ce79a17da539ee7fed/markupsafe-3.0.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:15d939a21d546304880945ca1ecb8a039db6b4dc49b2c5a400387cdae6a62e26", size = 11623, upload-time = "2025-09-27T18:37:29.296Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/23/07a2cb9a8045d5f3f0890a8c3bc0859d7a47bfd9a560b563899bec7b72ed/markupsafe-3.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f71a396b3bf33ecaa1626c255855702aca4d3d9fea5e051b41ac59a9c1c41edc", size = 12049, upload-time = "2025-09-27T18:37:30.234Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/e4/6be85eb81503f8e11b61c0b6369b6e077dcf0a74adbd9ebf6b349937b4e9/markupsafe-3.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f4b68347f8c5eab4a13419215bdfd7f8c9b19f2b25520968adfad23eb0ce60c", size = 21923, upload-time = "2025-09-27T18:37:31.177Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/bc/4dc914ead3fe6ddaef035341fee0fc956949bbd27335b611829292b89ee2/markupsafe-3.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8fc20152abba6b83724d7ff268c249fa196d8259ff481f3b1476383f8f24e42", size = 20543, upload-time = "2025-09-27T18:37:32.168Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6e/5fe81fbcfba4aef4093d5f856e5c774ec2057946052d18d168219b7bd9f9/markupsafe-3.0.3-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:949b8d66bc381ee8b007cd945914c721d9aba8e27f71959d750a46f7c282b20b", size = 20585, upload-time = "2025-09-27T18:37:33.166Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f6/e0e5a3d3ae9c4020f696cd055f940ef86b64fe88de26f3a0308b9d3d048c/markupsafe-3.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:3537e01efc9d4dccdf77221fb1cb3b8e1a38d5428920e0657ce299b20324d758", size = 21387, upload-time = "2025-09-27T18:37:34.185Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/25/651753ef4dea08ea790f4fbb65146a9a44a014986996ca40102e237aa49a/markupsafe-3.0.3-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:591ae9f2a647529ca990bc681daebdd52c8791ff06c2bfa05b65163e28102ef2", size = 20133, upload-time = "2025-09-27T18:37:35.138Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/0a/c3cf2b4fef5f0426e8a6d7fce3cb966a17817c568ce59d76b92a233fdbec/markupsafe-3.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a320721ab5a1aba0a233739394eb907f8c8da5c98c9181d1161e77a0c8e36f2d", size = 20588, upload-time = "2025-09-27T18:37:36.096Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/1b/a7782984844bd519ad4ffdbebbba2671ec5d0ebbeac34736c15fb86399e8/markupsafe-3.0.3-cp39-cp39-win32.whl", hash = "sha256:df2449253ef108a379b8b5d6b43f4b1a8e81a061d6537becd5582fba5f9196d7", size = 14566, upload-time = "2025-09-27T18:37:37.09Z" },
-    { url = "https://files.pythonhosted.org/packages/18/1f/8d9c20e1c9440e215a44be5ab64359e207fcb4f675543f1cf9a2a7f648d0/markupsafe-3.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:7c3fb7d25180895632e5d3148dbdc29ea38ccb7fd210aa27acbd1201a1902c6e", size = 15053, upload-time = "2025-09-27T18:37:38.054Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/d3/fe08482b5cd995033556d45041a4f4e76e7f0521112a9c9991d40d39825f/markupsafe-3.0.3-cp39-cp39-win_arm64.whl", hash = "sha256:38664109c14ffc9e7437e86b4dceb442b0096dfe3541d7864d9cbe1da4cf36c8", size = 13928, upload-time = "2025-09-27T18:37:39.037Z" },
-]
-
-[[package]]
-name = "mdit-py-plugins"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "markdown-it-py", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/03/a2ecab526543b152300717cf232bb4bb8605b6edb946c845016fa9c9c9fd/mdit_py_plugins-0.4.2.tar.gz", hash = "sha256:5f2cd1fdb606ddf152d37ec30e46101a60512bc0e5fa1a7002c36647b09e26b5", size = 43542, upload-time = "2024-09-09T20:27:49.564Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/f7/7782a043553ee469c1ff49cfa1cdace2d6bf99a1f333cf38676b3ddf30da/mdit_py_plugins-0.4.2-py3-none-any.whl", hash = "sha256:0c673c3f889399a33b95e88d2f0d111b4447bdfea7f237dab2d488f459835636", size = 55316, upload-time = "2024-09-09T20:27:48.397Z" },
 ]
 
 [[package]]
 name = "mdit-py-plugins"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "markdown-it-py", marker = "python_full_version >= '3.10'" },
+    { name = "markdown-it-py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
 wheels = [
@@ -2275,8 +2029,7 @@ dependencies = [
     { name = "certifi" },
     { name = "pycryptodome" },
     { name = "typing-extensions" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/99/1ad8733fa3f2fa82726e470f8c321e17f9321083b234ab45ad6b59d80d9f/minio-7.2.18.tar.gz", hash = "sha256:173402a5716099159c5659f9de75be204ebe248557b9f1cc9cf45aa70e9d3024", size = 135544, upload-time = "2025-09-29T17:00:28.238Z" }
 wheels = [
@@ -2338,16 +2091,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/66/36c78af2efaffcc15a5a61ae0df53a1d025f2680122e2a9eb8442fed3ae4/msgpack-1.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4147151acabb9caed4e474c3344181e91ff7a388b888f1e19ea04f7e73dc7ad5", size = 424172, upload-time = "2025-06-13T06:52:25.704Z" },
     { url = "https://files.pythonhosted.org/packages/8c/87/a75eb622b555708fe0427fab96056d39d4c9892b0c784b3a721088c7ee37/msgpack-1.1.1-cp313-cp313-win32.whl", hash = "sha256:500e85823a27d6d9bba1d057c871b4210c1dd6fb01fbb764e37e4e8847376323", size = 65347, upload-time = "2025-06-13T06:52:26.846Z" },
     { url = "https://files.pythonhosted.org/packages/ca/91/7dc28d5e2a11a5ad804cf2b7f7a5fcb1eb5a4966d66a5d2b41aee6376543/msgpack-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:6d489fba546295983abd142812bda76b57e33d0b9f5d5b71c09a583285506f69", size = 72341, upload-time = "2025-06-13T06:52:27.835Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/bd/0792be119d7fe7dc2148689ef65c90507d82d20a204aab3b98c74a1f8684/msgpack-1.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f5be6b6bc52fad84d010cb45433720327ce886009d862f46b26d4d154001994b", size = 81882, upload-time = "2025-06-13T06:52:39.316Z" },
-    { url = "https://files.pythonhosted.org/packages/75/77/ce06c8e26a816ae8730a8e030d263c5289adcaff9f0476f9b270bdd7c5c2/msgpack-1.1.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3a89cd8c087ea67e64844287ea52888239cbd2940884eafd2dcd25754fb72232", size = 78414, upload-time = "2025-06-13T06:52:40.341Z" },
-    { url = "https://files.pythonhosted.org/packages/73/27/190576c497677fb4a0d05d896b24aea6cdccd910f206aaa7b511901befed/msgpack-1.1.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d75f3807a9900a7d575d8d6674a3a47e9f227e8716256f35bc6f03fc597ffbf", size = 400927, upload-time = "2025-06-13T06:52:41.399Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/af/6a0aa5a06762e70726ec3c10fb966600d84a7220b52635cb0ab2dc64d32f/msgpack-1.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d182dac0221eb8faef2e6f44701812b467c02674a322c739355c39e94730cdbf", size = 405903, upload-time = "2025-06-13T06:52:42.699Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/80/3f3da358cecbbe8eb12360814bd1277d59d2608485934742a074d99894a9/msgpack-1.1.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1b13fe0fb4aac1aa5320cd693b297fe6fdef0e7bea5518cbc2dd5299f873ae90", size = 393192, upload-time = "2025-06-13T06:52:43.986Z" },
-    { url = "https://files.pythonhosted.org/packages/98/c6/3a0ec7fdebbb4f3f8f254696cd91d491c29c501dbebd86286c17e8f68cd7/msgpack-1.1.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:435807eeb1bc791ceb3247d13c79868deb22184e1fc4224808750f0d7d1affc1", size = 393851, upload-time = "2025-06-13T06:52:45.177Z" },
-    { url = "https://files.pythonhosted.org/packages/39/37/df50d5f8e68514b60fbe70f6e8337ea2b32ae2be030871bcd9d1cf7d4b62/msgpack-1.1.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:4835d17af722609a45e16037bb1d4d78b7bdf19d6c0128116d178956618c4e88", size = 400292, upload-time = "2025-06-13T06:52:46.381Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/ec/1e067292e02d2ceb4c8cb5ba222c4f7bb28730eef5676740609dc2627e0f/msgpack-1.1.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a8ef6e342c137888ebbfb233e02b8fbd689bb5b5fcc59b34711ac47ebd504478", size = 401873, upload-time = "2025-06-13T06:52:47.957Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/31/e8c9c6b5b58d64c9efa99c8d181fcc25f38ead357b0360379fbc8a4234ad/msgpack-1.1.1-cp39-cp39-win32.whl", hash = "sha256:61abccf9de335d9efd149e2fff97ed5974f2481b3353772e8e2dd3402ba2bd57", size = 65028, upload-time = "2025-06-13T06:52:49.166Z" },
-    { url = "https://files.pythonhosted.org/packages/20/d6/cd62cded572e5e25892747a5d27850170bcd03c855e9c69c538e024de6f9/msgpack-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:40eae974c873b2992fd36424a5d9407f93e97656d999f43fca9d29f820899084", size = 71700, upload-time = "2025-06-13T06:52:50.244Z" },
 ]
 
 [[package]]
@@ -2384,13 +2127,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/53/2f/2b1c2b056894fbaa975f68f81e3014bb447516a8b010f1bed3fb0e016ed7/msgspec-0.19.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac7f7c377c122b649f7545810c6cd1b47586e3aa3059126ce3516ac7ccc6a6a9", size = 213996, upload-time = "2024-12-27T17:40:12.244Z" },
     { url = "https://files.pythonhosted.org/packages/aa/5a/4cd408d90d1417e8d2ce6a22b98a6853c1b4d7cb7669153e4424d60087f6/msgspec-0.19.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a5bc1472223a643f5ffb5bf46ccdede7f9795078194f14edd69e3aab7020d327", size = 219087, upload-time = "2024-12-27T17:40:14.881Z" },
     { url = "https://files.pythonhosted.org/packages/23/d8/f15b40611c2d5753d1abb0ca0da0c75348daf1252220e5dda2867bd81062/msgspec-0.19.0-cp313-cp313-win_amd64.whl", hash = "sha256:317050bc0f7739cb30d257ff09152ca309bf5a369854bbf1e57dffc310c1f20f", size = 187432, upload-time = "2024-12-27T17:40:16.256Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/d0/323f867eaec1f2236ba30adf613777b1c97a7e8698e2e881656b21871fa4/msgspec-0.19.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:15c1e86fff77184c20a2932cd9742bf33fe23125fa3fcf332df9ad2f7d483044", size = 189926, upload-time = "2024-12-27T17:40:18.939Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/37/c3e1b39bdae90a7258d77959f5f5e36ad44b40e2be91cff83eea33c54d43/msgspec-0.19.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3b5541b2b3294e5ffabe31a09d604e23a88533ace36ac288fa32a420aa38d229", size = 183873, upload-time = "2024-12-27T17:40:20.214Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/a2/48f2c15c7644668e51f4dce99d5f709bd55314e47acb02e90682f5880f35/msgspec-0.19.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f5c043ace7962ef188746e83b99faaa9e3e699ab857ca3f367b309c8e2c6b12", size = 209272, upload-time = "2024-12-27T17:40:21.534Z" },
-    { url = "https://files.pythonhosted.org/packages/25/3c/aa339cf08b990c3f07e67b229a3a8aa31bf129ed974b35e5daa0df7d9d56/msgspec-0.19.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca06aa08e39bf57e39a258e1996474f84d0dd8130d486c00bec26d797b8c5446", size = 211396, upload-time = "2024-12-27T17:40:22.897Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/00/c7fb9d524327c558b2803973cc3f988c5100a1708879970a9e377bdf6f4f/msgspec-0.19.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:e695dad6897896e9384cf5e2687d9ae9feaef50e802f93602d35458e20d1fb19", size = 215002, upload-time = "2024-12-27T17:40:24.341Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/bf/d9f9fff026c1248cde84a5ce62b3742e8a63a3c4e811f99f00c8babf7615/msgspec-0.19.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:3be5c02e1fee57b54130316a08fe40cca53af92999a302a6054cd451700ea7db", size = 218132, upload-time = "2024-12-27T17:40:25.744Z" },
-    { url = "https://files.pythonhosted.org/packages/00/03/b92011210f79794958167a3a3ea64a71135d9a2034cfb7597b545a42606d/msgspec-0.19.0-cp39-cp39-win_amd64.whl", hash = "sha256:0684573a821be3c749912acf5848cce78af4298345cb2d7a8b8948a0a5a27cfe", size = 186301, upload-time = "2024-12-27T17:40:27.076Z" },
 ]
 
 [[package]]
@@ -2492,24 +2228,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/50/b0/a6fae46071b645ae98786ab738447de1ef53742eaad949f27e960864bb49/multidict-6.6.4-cp313-cp313t-win32.whl", hash = "sha256:f93b2b2279883d1d0a9e1bd01f312d6fc315c5e4c1f09e112e4736e2f650bc4e", size = 47775, upload-time = "2025-08-11T12:08:12.439Z" },
     { url = "https://files.pythonhosted.org/packages/b2/0a/2436550b1520091af0600dff547913cb2d66fbac27a8c33bc1b1bccd8d98/multidict-6.6.4-cp313-cp313t-win_amd64.whl", hash = "sha256:6d46a180acdf6e87cc41dc15d8f5c2986e1e8739dc25dbb7dac826731ef381a4", size = 53100, upload-time = "2025-08-11T12:08:13.823Z" },
     { url = "https://files.pythonhosted.org/packages/97/ea/43ac51faff934086db9c072a94d327d71b7d8b40cd5dcb47311330929ef0/multidict-6.6.4-cp313-cp313t-win_arm64.whl", hash = "sha256:756989334015e3335d087a27331659820d53ba432befdef6a718398b0a8493ad", size = 45501, upload-time = "2025-08-11T12:08:15.173Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/d3/f04c5db316caee9b5b2cbba66270b358c922a959855995bedde87134287c/multidict-6.6.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:af7618b591bae552b40dbb6f93f5518328a949dac626ee75927bba1ecdeea9f4", size = 76977, upload-time = "2025-08-11T12:08:16.667Z" },
-    { url = "https://files.pythonhosted.org/packages/70/39/a6200417d883e510728ab3caec02d3b66ff09e1c85e0aab2ba311abfdf06/multidict-6.6.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b6819f83aef06f560cb15482d619d0e623ce9bf155115150a85ab11b8342a665", size = 44878, upload-time = "2025-08-11T12:08:18.157Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/7e/815be31ed35571b137d65232816f61513fcd97b2717d6a9d7800b5a0c6e0/multidict-6.6.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4d09384e75788861e046330308e7af54dd306aaf20eb760eb1d0de26b2bea2cb", size = 44546, upload-time = "2025-08-11T12:08:19.694Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/f1/21b5bff6a8c3e2aff56956c241941ace6b8820e1abe6b12d3c52868a773d/multidict-6.6.4-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:a59c63061f1a07b861c004e53869eb1211ffd1a4acbca330e3322efa6dd02978", size = 223020, upload-time = "2025-08-11T12:08:21.554Z" },
-    { url = "https://files.pythonhosted.org/packages/15/59/37083f1dd3439979a0ffeb1906818d978d88b4cc7f4600a9f89b1cb6713c/multidict-6.6.4-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:350f6b0fe1ced61e778037fdc7613f4051c8baf64b1ee19371b42a3acdb016a0", size = 240528, upload-time = "2025-08-11T12:08:23.45Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/f0/f054d123c87784307a27324c829eb55bcfd2e261eb785fcabbd832c8dc4a/multidict-6.6.4-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0c5cbac6b55ad69cb6aa17ee9343dfbba903118fd530348c330211dc7aa756d1", size = 219540, upload-time = "2025-08-11T12:08:24.965Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/26/8f78ce17b7118149c17f238f28fba2a850b660b860f9b024a34d0191030f/multidict-6.6.4-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:630f70c32b8066ddfd920350bc236225814ad94dfa493fe1910ee17fe4365cbb", size = 251182, upload-time = "2025-08-11T12:08:26.511Z" },
-    { url = "https://files.pythonhosted.org/packages/00/c3/a21466322d69f6594fe22d9379200f99194d21c12a5bbf8c2a39a46b83b6/multidict-6.6.4-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f8d4916a81697faec6cb724a273bd5457e4c6c43d82b29f9dc02c5542fd21fc9", size = 249371, upload-time = "2025-08-11T12:08:28.075Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/8e/2e673124eb05cf8dc82e9265eccde01a36bcbd3193e27799b8377123c976/multidict-6.6.4-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e42332cf8276bb7645d310cdecca93a16920256a5b01bebf747365f86a1675b", size = 239235, upload-time = "2025-08-11T12:08:29.937Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/2d/bdd9f05e7c89e30a4b0e4faf0681a30748f8d1310f68cfdc0e3571e75bd5/multidict-6.6.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:f3be27440f7644ab9a13a6fc86f09cdd90b347c3c5e30c6d6d860de822d7cb53", size = 237410, upload-time = "2025-08-11T12:08:31.872Z" },
-    { url = "https://files.pythonhosted.org/packages/46/4c/3237b83f8ca9a2673bb08fc340c15da005a80f5cc49748b587c8ae83823b/multidict-6.6.4-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:21f216669109e02ef3e2415ede07f4f8987f00de8cdfa0cc0b3440d42534f9f0", size = 232979, upload-time = "2025-08-11T12:08:33.399Z" },
-    { url = "https://files.pythonhosted.org/packages/55/a6/a765decff625ae9bc581aed303cd1837955177dafc558859a69f56f56ba8/multidict-6.6.4-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:d9890d68c45d1aeac5178ded1d1cccf3bc8d7accf1f976f79bf63099fb16e4bd", size = 240979, upload-time = "2025-08-11T12:08:35.02Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/2d/9c75975cb0c66ea33cae1443bb265b2b3cd689bffcbc68872565f401da23/multidict-6.6.4-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:edfdcae97cdc5d1a89477c436b61f472c4d40971774ac4729c613b4b133163cb", size = 246849, upload-time = "2025-08-11T12:08:37.038Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/71/d21ac0843c1d8751fb5dcf8a1f436625d39d4577bc27829799d09b419af7/multidict-6.6.4-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:0b2e886624be5773e69cf32bcb8534aecdeb38943520b240fed3d5596a430f2f", size = 241798, upload-time = "2025-08-11T12:08:38.669Z" },
-    { url = "https://files.pythonhosted.org/packages/94/3d/1d8911e53092837bd11b1c99d71de3e2a9a26f8911f864554677663242aa/multidict-6.6.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:be5bf4b3224948032a845d12ab0f69f208293742df96dc14c4ff9b09e508fc17", size = 235315, upload-time = "2025-08-11T12:08:40.266Z" },
-    { url = "https://files.pythonhosted.org/packages/86/c5/4b758df96376f73e936b1942c6c2dfc17e37ed9d5ff3b01a811496966ca0/multidict-6.6.4-cp39-cp39-win32.whl", hash = "sha256:10a68a9191f284fe9d501fef4efe93226e74df92ce7a24e301371293bd4918ae", size = 41434, upload-time = "2025-08-11T12:08:41.965Z" },
-    { url = "https://files.pythonhosted.org/packages/58/16/f1dfa2a0f25f2717a5e9e5fe8fd30613f7fe95e3530cec8d11f5de0b709c/multidict-6.6.4-cp39-cp39-win_amd64.whl", hash = "sha256:ee25f82f53262f9ac93bd7e58e47ea1bdcc3393cef815847e397cba17e284210", size = 46186, upload-time = "2025-08-11T12:08:43.367Z" },
-    { url = "https://files.pythonhosted.org/packages/88/7d/a0568bac65438c494cb6950b29f394d875a796a237536ac724879cf710c9/multidict-6.6.4-cp39-cp39-win_arm64.whl", hash = "sha256:f9867e55590e0855bcec60d4f9a092b69476db64573c9fe17e92b0c50614c16a", size = 43115, upload-time = "2025-08-11T12:08:45.126Z" },
     { url = "https://files.pythonhosted.org/packages/fd/69/b547032297c7e63ba2af494edba695d781af8a0c6e89e4d06cf848b21d80/multidict-6.6.4-py3-none-any.whl", hash = "sha256:27d8f8e125c07cb954e54d75d04905a9bba8a439c1d84aca94949d4d03d8601c", size = 12313, upload-time = "2025-08-11T12:08:46.891Z" },
 ]
 
@@ -2564,12 +2282,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/11/040983fad5132d85914c874a2836252bbc57832065548885b5bb5b0d4359/mypy-1.18.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d924eef3795cc89fecf6bedc6ed32b33ac13e8321344f6ddbf8ee89f706c05cb", size = 13326683, upload-time = "2025-09-19T00:09:55.572Z" },
     { url = "https://files.pythonhosted.org/packages/e9/ba/89b2901dd77414dd7a8c8729985832a5735053be15b744c18e4586e506ef/mypy-1.18.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20c02215a080e3a2be3aa50506c67242df1c151eaba0dcbc1e4e557922a26075", size = 13514749, upload-time = "2025-09-19T00:10:44.827Z" },
     { url = "https://files.pythonhosted.org/packages/25/bc/cc98767cffd6b2928ba680f3e5bc969c4152bf7c2d83f92f5a504b92b0eb/mypy-1.18.2-cp314-cp314-win_amd64.whl", hash = "sha256:749b5f83198f1ca64345603118a6f01a4e99ad4bf9d103ddc5a3200cc4614adf", size = 9982959, upload-time = "2025-09-19T00:10:37.344Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/a6/490ff491d8ecddf8ab91762d4f67635040202f76a44171420bcbe38ceee5/mypy-1.18.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:25a9c8fb67b00599f839cf472713f54249a62efd53a54b565eb61956a7e3296b", size = 12807230, upload-time = "2025-09-19T00:09:49.471Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/2e/60076fc829645d167ece9e80db9e8375648d210dab44cc98beb5b322a826/mypy-1.18.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c2b9c7e284ee20e7598d6f42e13ca40b4928e6957ed6813d1ab6348aa3f47133", size = 11895666, upload-time = "2025-09-19T00:10:53.678Z" },
-    { url = "https://files.pythonhosted.org/packages/97/4a/1e2880a2a5dda4dc8d9ecd1a7e7606bc0b0e14813637eeda40c38624e037/mypy-1.18.2-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d6985ed057513e344e43a26cc1cd815c7a94602fb6a3130a34798625bc2f07b6", size = 12499608, upload-time = "2025-09-19T00:09:36.204Z" },
-    { url = "https://files.pythonhosted.org/packages/00/81/a117f1b73a3015b076b20246b1f341c34a578ebd9662848c6b80ad5c4138/mypy-1.18.2-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22f27105f1525ec024b5c630c0b9f36d5c1cc4d447d61fe51ff4bd60633f47ac", size = 13244551, upload-time = "2025-09-19T00:10:17.531Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/61/b9f48e1714ce87c7bf0358eb93f60663740ebb08f9ea886ffc670cea7933/mypy-1.18.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:030c52d0ea8144e721e49b1f68391e39553d7451f0c3f8a7565b59e19fcb608b", size = 13491552, upload-time = "2025-09-19T00:10:13.753Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/66/b2c0af3b684fa80d1b27501a8bdd3d2daa467ea3992a8aa612f5ca17c2db/mypy-1.18.2-cp39-cp39-win_amd64.whl", hash = "sha256:aa5e07ac1a60a253445797e42b8b2963c9675563a94f11291ab40718b016a7a0", size = 9765635, upload-time = "2025-09-19T00:10:30.993Z" },
     { url = "https://files.pythonhosted.org/packages/87/e3/be76d87158ebafa0309946c4a73831974d4d6ab4f4ef40c3b53a385a66fd/mypy-1.18.2-py3-none-any.whl", hash = "sha256:22a1748707dd62b58d2ae53562ffc4d7f8bcc727e8ac7cbc69c053ddc874d47e", size = 2352367, upload-time = "2025-09-19T00:10:15.489Z" },
 ]
 
@@ -2608,52 +2320,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/bd/af0de40a01d5cb4df19318cc018e64666f2b7fa89bffa1ab5b35337aae2c/mysql_connector_python-9.4.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:227dd420c71e6d4788d52d98f298e563f16b6853577e5ade4bd82d644257c812", size = 33516503, upload-time = "2025-07-22T07:58:41.987Z" },
     { url = "https://files.pythonhosted.org/packages/d1/9b/712053216fcbe695e519ecb1035ffd767c2de9f51ccba15078537c99d6fa/mysql_connector_python-9.4.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5163381a312d38122eded2197eb5cd7ccf1a5c5881d4e7a6de10d6ea314d088e", size = 33918904, upload-time = "2025-07-22T07:58:46.796Z" },
     { url = "https://files.pythonhosted.org/packages/64/15/cbd996d425c59811849f3c1d1b1dae089a1ae18c4acd4d8de2b847b772df/mysql_connector_python-9.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:c727cb1f82b40c9aaa7a15ab5cf0a7f87c5d8dce32eab5ff2530a4aa6054e7df", size = 16392566, upload-time = "2025-07-22T07:58:50.223Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/36/b32635b69729f144d45c0cbcd135cfd6c480a62160ac015ca71ebf68fca7/mysql_connector_python-9.4.0-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:20f8154ab5c0ed444f8ef8e5fa91e65215037db102c137b5f995ebfffd309b78", size = 17501675, upload-time = "2025-07-22T07:58:53.049Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/23/65e801f74b3fcc2a6944242d64f0d623af48497e4d9cf55419c2c6d6439b/mysql_connector_python-9.4.0-cp39-cp39-macosx_14_0_x86_64.whl", hash = "sha256:7b8976d89d67c8b0dc452471cb557d9998ed30601fb69a876bf1f0ecaa7954a4", size = 18369579, upload-time = "2025-07-22T07:58:55.995Z" },
-    { url = "https://files.pythonhosted.org/packages/86/e9/dc31eeffe33786016e1370be72f339544ee00034cb702c0b4a3c6f5c1585/mysql_connector_python-9.4.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:4ee4fe1b067e243aae21981e4b9f9d300a3104814b8274033ca8fc7a89b1729e", size = 33506513, upload-time = "2025-07-22T07:58:59.341Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/c7/aa6f4cc2e5e3fb68b5a6bba680429b761e387b8a040cf16a5f17e0b09df6/mysql_connector_python-9.4.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:1c6b95404e80d003cd452e38674e91528e2b3a089fe505c882f813b564e64f9d", size = 33909982, upload-time = "2025-07-22T07:59:02.832Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/a4/b1e2adc65121e7eabed06d09bed87638e7f9a51e9b5dbb1cfb17b58b1181/mysql_connector_python-9.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:a8f820c111335f225d63367307456eb7e10494f87e7a94acded3bb762e55a6d4", size = 16393051, upload-time = "2025-07-22T07:59:05.983Z" },
     { url = "https://files.pythonhosted.org/packages/36/34/b6165e15fd45a8deb00932d8e7d823de7650270873b4044c4db6688e1d8f/mysql_connector_python-9.4.0-py2.py3-none-any.whl", hash = "sha256:56e679169c704dab279b176fab2a9ee32d2c632a866c0f7cd48a8a1e2cf802c4", size = 406574, upload-time = "2025-07-22T07:59:08.394Z" },
-]
-
-[[package]]
-name = "myst-parser"
-version = "3.0.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "docutils", marker = "python_full_version < '3.10'" },
-    { name = "jinja2", marker = "python_full_version < '3.10'" },
-    { name = "markdown-it-py", marker = "python_full_version < '3.10'" },
-    { name = "mdit-py-plugins", version = "0.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyyaml", marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/49/64/e2f13dac02f599980798c01156393b781aec983b52a6e4057ee58f07c43a/myst_parser-3.0.1.tar.gz", hash = "sha256:88f0cb406cb363b077d176b51c476f62d60604d68a8dcdf4832e080441301a87", size = 92392, upload-time = "2024-04-28T20:22:42.116Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/de/21aa8394f16add8f7427f0a1326ccd2b3a2a8a3245c9252bc5ac034c6155/myst_parser-3.0.1-py3-none-any.whl", hash = "sha256:6457aaa33a5d474aca678b8ead9b3dc298e89c68e67012e73146ea6fd54babf1", size = 83163, upload-time = "2024-04-28T20:22:39.985Z" },
 ]
 
 [[package]]
 name = "myst-parser"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "docutils", marker = "python_full_version >= '3.10'" },
-    { name = "jinja2", marker = "python_full_version >= '3.10'" },
-    { name = "markdown-it-py", marker = "python_full_version >= '3.10'" },
-    { name = "mdit-py-plugins", version = "0.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "docutils" },
+    { name = "jinja2" },
+    { name = "markdown-it-py" },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
@@ -2681,65 +2361,10 @@ wheels = [
 
 [[package]]
 name = "numpy"
-version = "2.0.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/75/10dd1f8116a8b796cb2c737b674e02d02e80454bda953fa7e65d8c12b016/numpy-2.0.2.tar.gz", hash = "sha256:883c987dee1880e2a864ab0dc9892292582510604156762362d9326444636e78", size = 18902015, upload-time = "2024-08-26T20:19:40.945Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/91/3495b3237510f79f5d81f2508f9f13fea78ebfdf07538fc7444badda173d/numpy-2.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:51129a29dbe56f9ca83438b706e2e69a39892b5eda6cedcb6b0c9fdc9b0d3ece", size = 21165245, upload-time = "2024-08-26T20:04:14.625Z" },
-    { url = "https://files.pythonhosted.org/packages/05/33/26178c7d437a87082d11019292dce6d3fe6f0e9026b7b2309cbf3e489b1d/numpy-2.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f15975dfec0cf2239224d80e32c3170b1d168335eaedee69da84fbe9f1f9cd04", size = 13738540, upload-time = "2024-08-26T20:04:36.784Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/31/cc46e13bf07644efc7a4bf68df2df5fb2a1a88d0cd0da9ddc84dc0033e51/numpy-2.0.2-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:8c5713284ce4e282544c68d1c3b2c7161d38c256d2eefc93c1d683cf47683e66", size = 5300623, upload-time = "2024-08-26T20:04:46.491Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/16/7bfcebf27bb4f9d7ec67332ffebee4d1bf085c84246552d52dbb548600e7/numpy-2.0.2-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:becfae3ddd30736fe1889a37f1f580e245ba79a5855bff5f2a29cb3ccc22dd7b", size = 6901774, upload-time = "2024-08-26T20:04:58.173Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/a3/561c531c0e8bf082c5bef509d00d56f82e0ea7e1e3e3a7fc8fa78742a6e5/numpy-2.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2da5960c3cf0df7eafefd806d4e612c5e19358de82cb3c343631188991566ccd", size = 13907081, upload-time = "2024-08-26T20:05:19.098Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/66/f7177ab331876200ac7563a580140643d1179c8b4b6a6b0fc9838de2a9b8/numpy-2.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:496f71341824ed9f3d2fd36cf3ac57ae2e0165c143b55c3a035ee219413f3318", size = 19523451, upload-time = "2024-08-26T20:05:47.479Z" },
-    { url = "https://files.pythonhosted.org/packages/25/7f/0b209498009ad6453e4efc2c65bcdf0ae08a182b2b7877d7ab38a92dc542/numpy-2.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a61ec659f68ae254e4d237816e33171497e978140353c0c2038d46e63282d0c8", size = 19927572, upload-time = "2024-08-26T20:06:17.137Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/df/2619393b1e1b565cd2d4c4403bdd979621e2c4dea1f8532754b2598ed63b/numpy-2.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d731a1c6116ba289c1e9ee714b08a8ff882944d4ad631fd411106a30f083c326", size = 14400722, upload-time = "2024-08-26T20:06:39.16Z" },
-    { url = "https://files.pythonhosted.org/packages/22/ad/77e921b9f256d5da36424ffb711ae79ca3f451ff8489eeca544d0701d74a/numpy-2.0.2-cp310-cp310-win32.whl", hash = "sha256:984d96121c9f9616cd33fbd0618b7f08e0cfc9600a7ee1d6fd9b239186d19d97", size = 6472170, upload-time = "2024-08-26T20:06:50.361Z" },
-    { url = "https://files.pythonhosted.org/packages/10/05/3442317535028bc29cf0c0dd4c191a4481e8376e9f0db6bcf29703cadae6/numpy-2.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:c7b0be4ef08607dd04da4092faee0b86607f111d5ae68036f16cc787e250a131", size = 15905558, upload-time = "2024-08-26T20:07:13.881Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/cf/034500fb83041aa0286e0fb16e7c76e5c8b67c0711bb6e9e9737a717d5fe/numpy-2.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:49ca4decb342d66018b01932139c0961a8f9ddc7589611158cb3c27cbcf76448", size = 21169137, upload-time = "2024-08-26T20:07:45.345Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/d9/32de45561811a4b87fbdee23b5797394e3d1504b4a7cf40c10199848893e/numpy-2.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:11a76c372d1d37437857280aa142086476136a8c0f373b2e648ab2c8f18fb195", size = 13703552, upload-time = "2024-08-26T20:08:06.666Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/ca/2f384720020c7b244d22508cb7ab23d95f179fcfff33c31a6eeba8d6c512/numpy-2.0.2-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:807ec44583fd708a21d4a11d94aedf2f4f3c3719035c76a2bbe1fe8e217bdc57", size = 5298957, upload-time = "2024-08-26T20:08:15.83Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/78/a3e4f9fb6aa4e6fdca0c5428e8ba039408514388cf62d89651aade838269/numpy-2.0.2-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8cafab480740e22f8d833acefed5cc87ce276f4ece12fdaa2e8903db2f82897a", size = 6905573, upload-time = "2024-08-26T20:08:27.185Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/72/cfc3a1beb2caf4efc9d0b38a15fe34025230da27e1c08cc2eb9bfb1c7231/numpy-2.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a15f476a45e6e5a3a79d8a14e62161d27ad897381fecfa4a09ed5322f2085669", size = 13914330, upload-time = "2024-08-26T20:08:48.058Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/a8/c17acf65a931ce551fee11b72e8de63bf7e8a6f0e21add4c937c83563538/numpy-2.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13e689d772146140a252c3a28501da66dfecd77490b498b168b501835041f951", size = 19534895, upload-time = "2024-08-26T20:09:16.536Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/86/8767f3d54f6ae0165749f84648da9dcc8cd78ab65d415494962c86fac80f/numpy-2.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9ea91dfb7c3d1c56a0e55657c0afb38cf1eeae4544c208dc465c3c9f3a7c09f9", size = 19937253, upload-time = "2024-08-26T20:09:46.263Z" },
-    { url = "https://files.pythonhosted.org/packages/df/87/f76450e6e1c14e5bb1eae6836478b1028e096fd02e85c1c37674606ab752/numpy-2.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c1c9307701fec8f3f7a1e6711f9089c06e6284b3afbbcd259f7791282d660a15", size = 14414074, upload-time = "2024-08-26T20:10:08.483Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/ca/0f0f328e1e59f73754f06e1adfb909de43726d4f24c6a3f8805f34f2b0fa/numpy-2.0.2-cp311-cp311-win32.whl", hash = "sha256:a392a68bd329eafac5817e5aefeb39038c48b671afd242710b451e76090e81f4", size = 6470640, upload-time = "2024-08-26T20:10:19.732Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/57/3a3f14d3a759dcf9bf6e9eda905794726b758819df4663f217d658a58695/numpy-2.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:286cd40ce2b7d652a6f22efdfc6d1edf879440e53e76a75955bc0c826c7e64dc", size = 15910230, upload-time = "2024-08-26T20:10:43.413Z" },
-    { url = "https://files.pythonhosted.org/packages/45/40/2e117be60ec50d98fa08c2f8c48e09b3edea93cfcabd5a9ff6925d54b1c2/numpy-2.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:df55d490dea7934f330006d0f81e8551ba6010a5bf035a249ef61a94f21c500b", size = 20895803, upload-time = "2024-08-26T20:11:13.916Z" },
-    { url = "https://files.pythonhosted.org/packages/46/92/1b8b8dee833f53cef3e0a3f69b2374467789e0bb7399689582314df02651/numpy-2.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8df823f570d9adf0978347d1f926b2a867d5608f434a7cff7f7908c6570dcf5e", size = 13471835, upload-time = "2024-08-26T20:11:34.779Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/19/e2793bde475f1edaea6945be141aef6c8b4c669b90c90a300a8954d08f0a/numpy-2.0.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9a92ae5c14811e390f3767053ff54eaee3bf84576d99a2456391401323f4ec2c", size = 5038499, upload-time = "2024-08-26T20:11:43.902Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/ff/ddf6dac2ff0dd50a7327bcdba45cb0264d0e96bb44d33324853f781a8f3c/numpy-2.0.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:a842d573724391493a97a62ebbb8e731f8a5dcc5d285dfc99141ca15a3302d0c", size = 6633497, upload-time = "2024-08-26T20:11:55.09Z" },
-    { url = "https://files.pythonhosted.org/packages/72/21/67f36eac8e2d2cd652a2e69595a54128297cdcb1ff3931cfc87838874bd4/numpy-2.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c05e238064fc0610c840d1cf6a13bf63d7e391717d247f1bf0318172e759e692", size = 13621158, upload-time = "2024-08-26T20:12:14.95Z" },
-    { url = "https://files.pythonhosted.org/packages/39/68/e9f1126d757653496dbc096cb429014347a36b228f5a991dae2c6b6cfd40/numpy-2.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0123ffdaa88fa4ab64835dcbde75dcdf89c453c922f18dced6e27c90d1d0ec5a", size = 19236173, upload-time = "2024-08-26T20:12:44.049Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/e9/1f5333281e4ebf483ba1c888b1d61ba7e78d7e910fdd8e6499667041cc35/numpy-2.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:96a55f64139912d61de9137f11bf39a55ec8faec288c75a54f93dfd39f7eb40c", size = 19634174, upload-time = "2024-08-26T20:13:13.634Z" },
-    { url = "https://files.pythonhosted.org/packages/71/af/a469674070c8d8408384e3012e064299f7a2de540738a8e414dcfd639996/numpy-2.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ec9852fb39354b5a45a80bdab5ac02dd02b15f44b3804e9f00c556bf24b4bded", size = 14099701, upload-time = "2024-08-26T20:13:34.851Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/3d/08ea9f239d0e0e939b6ca52ad403c84a2bce1bde301a8eb4888c1c1543f1/numpy-2.0.2-cp312-cp312-win32.whl", hash = "sha256:671bec6496f83202ed2d3c8fdc486a8fc86942f2e69ff0e986140339a63bcbe5", size = 6174313, upload-time = "2024-08-26T20:13:45.653Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/b5/4ac39baebf1fdb2e72585c8352c56d063b6126be9fc95bd2bb5ef5770c20/numpy-2.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:cfd41e13fdc257aa5778496b8caa5e856dc4896d4ccf01841daee1d96465467a", size = 15606179, upload-time = "2024-08-26T20:14:08.786Z" },
-    { url = "https://files.pythonhosted.org/packages/43/c1/41c8f6df3162b0c6ffd4437d729115704bd43363de0090c7f913cfbc2d89/numpy-2.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9059e10581ce4093f735ed23f3b9d283b9d517ff46009ddd485f1747eb22653c", size = 21169942, upload-time = "2024-08-26T20:14:40.108Z" },
-    { url = "https://files.pythonhosted.org/packages/39/bc/fd298f308dcd232b56a4031fd6ddf11c43f9917fbc937e53762f7b5a3bb1/numpy-2.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:423e89b23490805d2a5a96fe40ec507407b8ee786d66f7328be214f9679df6dd", size = 13711512, upload-time = "2024-08-26T20:15:00.985Z" },
-    { url = "https://files.pythonhosted.org/packages/96/ff/06d1aa3eeb1c614eda245c1ba4fb88c483bee6520d361641331872ac4b82/numpy-2.0.2-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:2b2955fa6f11907cf7a70dab0d0755159bca87755e831e47932367fc8f2f2d0b", size = 5306976, upload-time = "2024-08-26T20:15:10.876Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/98/121996dcfb10a6087a05e54453e28e58694a7db62c5a5a29cee14c6e047b/numpy-2.0.2-cp39-cp39-macosx_14_0_x86_64.whl", hash = "sha256:97032a27bd9d8988b9a97a8c4d2c9f2c15a81f61e2f21404d7e8ef00cb5be729", size = 6906494, upload-time = "2024-08-26T20:15:22.055Z" },
-    { url = "https://files.pythonhosted.org/packages/15/31/9dffc70da6b9bbf7968f6551967fc21156207366272c2a40b4ed6008dc9b/numpy-2.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e795a8be3ddbac43274f18588329c72939870a16cae810c2b73461c40718ab1", size = 13912596, upload-time = "2024-08-26T20:15:42.452Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/14/78635daab4b07c0930c919d451b8bf8c164774e6a3413aed04a6d95758ce/numpy-2.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f26b258c385842546006213344c50655ff1555a9338e2e5e02a0756dc3e803dd", size = 19526099, upload-time = "2024-08-26T20:16:11.048Z" },
-    { url = "https://files.pythonhosted.org/packages/26/4c/0eeca4614003077f68bfe7aac8b7496f04221865b3a5e7cb230c9d055afd/numpy-2.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5fec9451a7789926bcf7c2b8d187292c9f93ea30284802a0ab3f5be8ab36865d", size = 19932823, upload-time = "2024-08-26T20:16:40.171Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/46/ea25b98b13dccaebddf1a803f8c748680d972e00507cd9bc6dcdb5aa2ac1/numpy-2.0.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9189427407d88ff25ecf8f12469d4d39d35bee1db5d39fc5c168c6f088a6956d", size = 14404424, upload-time = "2024-08-26T20:17:02.604Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/a6/177dd88d95ecf07e722d21008b1b40e681a929eb9e329684d449c36586b2/numpy-2.0.2-cp39-cp39-win32.whl", hash = "sha256:905d16e0c60200656500c95b6b8dca5d109e23cb24abc701d41c02d74c6b3afa", size = 6476809, upload-time = "2024-08-26T20:17:13.553Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/2b/7fc9f4e7ae5b507c1a3a21f0f15ed03e794c1242ea8a242ac158beb56034/numpy-2.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:a3f4ab0caa7f053f6797fcd4e1e25caee367db3112ef2b6ef82d749530768c73", size = 15911314, upload-time = "2024-08-26T20:17:36.72Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/3b/df5a870ac6a3be3a86856ce195ef42eec7ae50d2a202be1f5a4b3b340e14/numpy-2.0.2-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:7f0a0c6f12e07fa94133c8a67404322845220c06a9e80e85999afe727f7438b8", size = 21025288, upload-time = "2024-08-26T20:18:07.732Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/97/51af92f18d6f6f2d9ad8b482a99fb74e142d71372da5d834b3a2747a446e/numpy-2.0.2-pp39-pypy39_pp73-macosx_14_0_x86_64.whl", hash = "sha256:312950fdd060354350ed123c0e25a71327d3711584beaef30cdaa93320c392d4", size = 6762793, upload-time = "2024-08-26T20:18:19.125Z" },
-    { url = "https://files.pythonhosted.org/packages/12/46/de1fbd0c1b5ccaa7f9a005b66761533e2f6a3e560096682683a223631fe9/numpy-2.0.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26df23238872200f63518dd2aa984cfca675d82469535dc7162dc2ee52d9dd5c", size = 19334885, upload-time = "2024-08-26T20:18:47.237Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/dc/d330a6faefd92b446ec0f0dfea4c3207bb1fef3c4771d19cf4543efd2c78/numpy-2.0.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:a46288ec55ebbd58947d31d72be2c63cbf839f0a63b49cb755022310792a3385", size = 15828784, upload-time = "2024-08-26T20:19:11.19Z" },
-]
-
-[[package]]
-name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.10.*'",
+    "python_full_version < '3.11'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
@@ -2959,19 +2584,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/74/3269a3a58347e0b019742d888612c4b765293c9c75efa44e144b1e884c0d/obstore-0.8.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:329038c9645d6d1741e77fe1a53e28a14b1a5c1461cfe4086082ad39ebabf981", size = 3687307, upload-time = "2025-09-16T15:34:14.501Z" },
     { url = "https://files.pythonhosted.org/packages/01/f9/4fd4819ad6a49d2f462a45be453561f4caebded0dc40112deeffc34b89b1/obstore-0.8.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:1e4df99b369790c97c752d126b286dc86484ea49bff5782843a265221406566f", size = 3776076, upload-time = "2025-09-16T15:34:16.207Z" },
     { url = "https://files.pythonhosted.org/packages/14/dd/7c4f958fa0b9fc4778fb3d232e38b37db8c6b260f641022fbba48b049d7e/obstore-0.8.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9e1c65c65e20cc990414a8a9af88209b1bbc0dd9521b5f6b0293c60e19439bb7", size = 3947445, upload-time = "2025-09-16T15:34:17.423Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/25/e50fcd26ad42aec68dcf0b328041c9ae5ee62b25a035d7d6f881647372c5/obstore-0.8.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:2ca19d5310ba2736a3052d756e682cc1aafbcc4069e62c05b7222b7d8434b543", size = 3624240, upload-time = "2025-09-16T15:34:18.702Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/86/b370512250c1e145f9d5c192144452976ab4ef71a4679fbbd1bb3c3223be/obstore-0.8.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e5f3df9b64c683e288fa1e47fac237c6a1e1021e7c8cadcc75f1bcb3098e824d", size = 3357769, upload-time = "2025-09-16T15:34:19.826Z" },
-    { url = "https://files.pythonhosted.org/packages/74/2a/72287ef76b9e21df7ba3f2183c23a336eb1f664771bdf8b3372f542ac0f5/obstore-0.8.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0cd293ace46ee175b50e21c0d8c94f606de6cd68f2f199877c55fe8837c585a5", size = 3456380, upload-time = "2025-09-16T15:34:21.001Z" },
-    { url = "https://files.pythonhosted.org/packages/55/3f/fc57774211926123e8b40e9fa01c433b5587969371003cbdba7b5fc0a4df/obstore-0.8.2-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f5a39750feedf5b95b4f62bacaded0b95a53be047d9462d6b24dc8f8b6fc6ec8", size = 3689375, upload-time = "2025-09-16T15:34:22.302Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/81/e9adc1751f846f5f485d7b8f639290d3fe7cc875d95631704d4dba4720c3/obstore-0.8.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cb76517cca57f6ee9d74be18074a1c0f5ff0e62b4c6e1e0f893993dda93ebbfc", size = 3960873, upload-time = "2025-09-16T15:34:23.488Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/bd/6ba0842505c5e3a77f9175f3e08408ba7df67a7c5e0e51fe566f216a70c3/obstore-0.8.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7cd653932bbb7afe611786388cdb403a4b19b13205e0e43d8b0e4890e0accfd0", size = 3927698, upload-time = "2025-09-16T15:34:24.744Z" },
-    { url = "https://files.pythonhosted.org/packages/74/e1/d02e330e29f71767756921b1790bb9fb068c5e466001ebc10b846c525658/obstore-0.8.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4952d69843bb78c73c9a81258f448003f74ff7b298a60899f015788db98a1cd1", size = 3770826, upload-time = "2025-09-16T15:34:25.934Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/fb/987ed1f6e5d05211a691f7f011b0109baffe763f960572b7d10718cb92ab/obstore-0.8.2-cp39-cp39-manylinux_2_24_aarch64.whl", hash = "sha256:2e3cd6d0822888b7e79c92c1258997289ebf0224598aad8f46ada17405666852", size = 3536530, upload-time = "2025-09-16T15:34:27.16Z" },
-    { url = "https://files.pythonhosted.org/packages/58/1f/87c1d8a2ae978262f5ce8cea5714dff565c6251001f8f50bfa3b17fe5472/obstore-0.8.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:feb4a6e5a3f2d323b3f61356d4ef99dd3f430aaacdaf5607ced5f857d992d2d4", size = 3699687, upload-time = "2025-09-16T15:34:28.62Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/d7/1f6012f030af83b977939bd6121468388283170b539d4fa54a9537c471dc/obstore-0.8.2-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:61e29fd6a27df284027c23dc49851dbeeacb2d40cb3d945bd3d6ec6cb0650450", size = 3682807, upload-time = "2025-09-16T15:34:29.993Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/80/5d41bcaa12e77d36cb805fc1a2401b26c967e00133b5d87d17c99a86aa5b/obstore-0.8.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:8f9e18ff6c32997bd9a9fd636a98439bcbd3f44f13bae350243eacfb75803161", size = 3767014, upload-time = "2025-09-16T15:34:31.246Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/c7/28119d6da47cb5a49fb93e4639ffa134257654a59b1677f663cda688b9f7/obstore-0.8.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:6ebc814302485d453b61df956c09662ebb33471684add5bbc321de7ba265b723", size = 3942657, upload-time = "2025-09-16T15:34:32.642Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/0a/f0fd85dc7fb627d16ad52e7408339b95ae34ea1a5ba3dfbb0e5c18bdd227/obstore-0.8.2-cp39-cp39-win_amd64.whl", hash = "sha256:36478c16fd7c7f880f28ece352251eec1fc6f6b69dbf2b78cec9754eb80a4b41", size = 3969143, upload-time = "2025-09-16T15:34:33.897Z" },
     { url = "https://files.pythonhosted.org/packages/c3/37/14bae1f5bf4369027abc5315cdba2428ad4c16e2fd3bd5d35b7ee584aa0c/obstore-0.8.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:6ea04118980a9c22fc8581225ff4507b6a161baf8949d728d96e68326ebaab59", size = 3624857, upload-time = "2025-09-16T15:34:35.601Z" },
     { url = "https://files.pythonhosted.org/packages/1a/c4/8cba91629aa20479ba86a57c2c2b3bc0a54fc6a31a4594014213603efae6/obstore-0.8.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5f33a7570b6001b54252260fbec18c3f6d21e25d3ec57e9b6c5e7330e8290eb2", size = 3355999, upload-time = "2025-09-16T15:34:36.954Z" },
     { url = "https://files.pythonhosted.org/packages/f2/10/3e40557d6d9c38c5a0f7bac1508209b9dbb8c4da918ddfa9326ba9a1de3f/obstore-0.8.2-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:11fa78dfb749edcf5a041cd6db20eae95b3e8b09dfdd9b38d14939da40e7c115", size = 3457322, upload-time = "2025-09-16T15:34:38.143Z" },
@@ -3061,11 +2673,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/56/0eef985b490e7018f501dc39af12c0023360f18e3b9b0ae14809e95487e8/oracledb-3.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d450dcada7711007a9a8a2770f81b54c24ba1e1d2456643c3fae7a2ff26b3a29", size = 2458312, upload-time = "2025-07-29T22:35:06.725Z" },
     { url = "https://files.pythonhosted.org/packages/69/ed/83f786041a9ab8aee157156ce2526b332e603086f1ec2dfa3e8553c8204b/oracledb-3.3.0-cp314-cp314-win32.whl", hash = "sha256:b19ca41b3344dc77c53f74d31e0ca442734314593c4bec578a62efebdb1b59d7", size = 1469071, upload-time = "2025-07-29T22:35:08.76Z" },
     { url = "https://files.pythonhosted.org/packages/59/78/9627eb1630cb60b070889fce71b90e81ed276f678a1c4dfe2dccefab73f3/oracledb-3.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:a410dcf69b18ea607f3aed5cb4ecdebeb7bfb5f86e746c09a864c0f5bd563279", size = 1823668, upload-time = "2025-07-29T22:35:10.612Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/ae/5e44576e568395692f3819539137239b6b8ab13ee7ff072b8c64c296b203/oracledb-3.3.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2615f4f516a574fdf18e5aadca809bc90ac6ab37889d0293a9192c695fe07cd9", size = 3916715, upload-time = "2025-07-29T22:35:12.866Z" },
-    { url = "https://files.pythonhosted.org/packages/02/0b/9d80aa547b97122005143a45abb5a8c8ee4d6d14fba781f4c9d1f3e07b76/oracledb-3.3.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ed608fee4e87319618be200d2befcdd17fa534e16f20cf60df6e9cbbfeadf58e", size = 2414025, upload-time = "2025-07-29T22:35:15.241Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/fc/d674acbcda75ed3302155b9d11f5890655f1e9577fed15afac43f36d6bfb/oracledb-3.3.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:35f6df7bec55314f56d4d87a53a1d5f6a0ded9ee106bc9346a5a4d4fe64aa667", size = 2602944, upload-time = "2025-07-29T22:35:17.024Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/54/0a9818a7f348ebd1ea89467b8ce11338815b5cab6bb9fa25ca13d75a444c/oracledb-3.3.0-cp39-cp39-win32.whl", hash = "sha256:0434f4ed7ded88120487b2ed3a13c37f89fc62b283960a72ddc051293e971244", size = 1488390, upload-time = "2025-07-29T22:35:18.62Z" },
-    { url = "https://files.pythonhosted.org/packages/46/32/0e3084c846d12b70146e2f82031a3f17b6488bd15b6889f8cbbdabea3d46/oracledb-3.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:4c0e77e8dd1315f05f3d98d1f08df45f7bedd99612caccf315bb754cb768d692", size = 1830820, upload-time = "2025-07-29T22:35:20.624Z" },
 ]
 
 [[package]]
@@ -3143,19 +2750,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/09/17d9d2b60592890ff7382e591aa1d9afb202a266b180c3d4049b1ec70e4a/orjson-3.11.3-cp314-cp314-win32.whl", hash = "sha256:0c6d7328c200c349e3a4c6d8c83e0a5ad029bdc2d417f234152bf34842d0fc8d", size = 136266, upload-time = "2025-08-26T17:46:13.853Z" },
     { url = "https://files.pythonhosted.org/packages/15/58/358f6846410a6b4958b74734727e582ed971e13d335d6c7ce3e47730493e/orjson-3.11.3-cp314-cp314-win_amd64.whl", hash = "sha256:317bbe2c069bbc757b1a2e4105b64aacd3bc78279b66a6b9e51e846e4809f804", size = 131351, upload-time = "2025-08-26T17:46:15.27Z" },
     { url = "https://files.pythonhosted.org/packages/28/01/d6b274a0635be0468d4dbd9cafe80c47105937a0d42434e805e67cd2ed8b/orjson-3.11.3-cp314-cp314-win_arm64.whl", hash = "sha256:e8f6a7a27d7b7bec81bd5924163e9af03d49bbb63013f107b48eb5d16db711bc", size = 125985, upload-time = "2025-08-26T17:46:16.67Z" },
-    { url = "https://files.pythonhosted.org/packages/99/a6/18d88ccf8e5d8f711310eba9b4f6562f4aa9d594258efdc4dcf8c1550090/orjson-3.11.3-cp39-cp39-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:56afaf1e9b02302ba636151cfc49929c1bb66b98794291afd0e5f20fecaf757c", size = 238221, upload-time = "2025-08-26T17:46:18.113Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/18/e210365a17bf984c89db40c8be65da164b4ce6a866a2a0ae1d6407c2630b/orjson-3.11.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:913f629adef31d2d350d41c051ce7e33cf0fd06a5d1cb28d49b1899b23b903aa", size = 123209, upload-time = "2025-08-26T17:46:19.688Z" },
-    { url = "https://files.pythonhosted.org/packages/26/43/6b3f8ec15fa910726ed94bd2e618f86313ad1cae7c3c8c6b9b8a3a161814/orjson-3.11.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e0a23b41f8f98b4e61150a03f83e4f0d566880fe53519d445a962929a4d21045", size = 127881, upload-time = "2025-08-26T17:46:21.502Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/ed/f41d2406355ce67efdd4ab504732b27bea37b7dbdab3eb86314fe764f1b9/orjson-3.11.3-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3d721fee37380a44f9d9ce6c701b3960239f4fb3d5ceea7f31cbd43882edaa2f", size = 130306, upload-time = "2025-08-26T17:46:22.914Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/a1/1be02950f92c82e64602d3d284bd76d9fc82a6b92c9ce2a387e57a825a11/orjson-3.11.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:73b92a5b69f31b1a58c0c7e31080aeaec49c6e01b9522e71ff38d08f15aa56de", size = 132383, upload-time = "2025-08-26T17:46:24.33Z" },
-    { url = "https://files.pythonhosted.org/packages/39/49/46766ac00c68192b516a15ffc44c2a9789ca3468b8dc8a500422d99bf0dd/orjson-3.11.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d2489b241c19582b3f1430cc5d732caefc1aaf378d97e7fb95b9e56bed11725f", size = 135159, upload-time = "2025-08-26T17:46:25.741Z" },
-    { url = "https://files.pythonhosted.org/packages/47/e1/27fd5e7600fdd82996329d48ee56f6e9e9ae4d31eadbc7f93fd2ff0d8214/orjson-3.11.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5189a5dab8b0312eadaf9d58d3049b6a52c454256493a557405e77a3d67ab7f", size = 132690, upload-time = "2025-08-26T17:46:27.271Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/21/f57ef08799a68c36ef96fe561101afeef735caa80814636b2e18c234e405/orjson-3.11.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9d8787bdfbb65a85ea76d0e96a3b1bed7bf0fbcb16d40408dc1172ad784a49d2", size = 131086, upload-time = "2025-08-26T17:46:33.067Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/84/a3a24306a9dc482e929232c65f5b8c69188136edd6005441d8cc4754f7ea/orjson-3.11.3-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:8e531abd745f51f8035e207e75e049553a86823d189a51809c078412cefb399a", size = 403884, upload-time = "2025-08-26T17:46:34.55Z" },
-    { url = "https://files.pythonhosted.org/packages/11/98/fdae5b2c28bc358e6868e54c8eca7398c93d6a511f0436b61436ad1b04dc/orjson-3.11.3-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:8ab962931015f170b97a3dd7bd933399c1bae8ed8ad0fb2a7151a5654b6941c7", size = 145837, upload-time = "2025-08-26T17:46:36.46Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/a9/2fe5cd69ed231f3ed88b1ad36a6957e3d2c876eb4b2c6b17b8ae0a6681fc/orjson-3.11.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:124d5ba71fee9c9902c4a7baa9425e663f7f0aecf73d31d54fe3dd357d62c1a7", size = 135325, upload-time = "2025-08-26T17:46:38.03Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/a4/7d4c8aefb45f6c8d7d527d84559a3a7e394b9fd1d424a2b5bcaf75fa68e7/orjson-3.11.3-cp39-cp39-win32.whl", hash = "sha256:22724d80ee5a815a44fc76274bb7ba2e7464f5564aacb6ecddaa9970a83e3225", size = 136184, upload-time = "2025-08-26T17:46:39.542Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/1f/1d6a24d22001e96c0afcf1806b6eabee1109aebd2ef20ec6698f6a6012d7/orjson-3.11.3-cp39-cp39-win_amd64.whl", hash = "sha256:215c595c792a87d4407cb72dd5e0f6ee8e694ceeb7f9102b533c5a9bf2a916bb", size = 131373, upload-time = "2025-08-26T17:46:41.227Z" },
 ]
 
 [[package]]
@@ -3172,8 +2766,7 @@ name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "python-dateutil" },
     { name = "pytz" },
@@ -3228,13 +2821,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/1e/1bac1a839d12e6a82ec6cb40cda2edde64a2013a66963293696bbf31fbbb/pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5", size = 12121582, upload-time = "2025-09-29T23:30:43.391Z" },
     { url = "https://files.pythonhosted.org/packages/44/91/483de934193e12a3b1d6ae7c8645d083ff88dec75f46e827562f1e4b4da6/pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788", size = 12699963, upload-time = "2025-09-29T23:31:10.009Z" },
     { url = "https://files.pythonhosted.org/packages/70/44/5191d2e4026f86a2a109053e194d3ba7a31a2d10a9c2348368c63ed4e85a/pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87", size = 13202175, upload-time = "2025-09-29T23:31:59.173Z" },
-    { url = "https://files.pythonhosted.org/packages/56/b4/52eeb530a99e2a4c55ffcd352772b599ed4473a0f892d127f4147cf0f88e/pandas-2.3.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c503ba5216814e295f40711470446bc3fd00f0faea8a086cbc688808e26f92a2", size = 11567720, upload-time = "2025-09-29T23:33:06.209Z" },
-    { url = "https://files.pythonhosted.org/packages/48/4a/2d8b67632a021bced649ba940455ed441ca854e57d6e7658a6024587b083/pandas-2.3.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a637c5cdfa04b6d6e2ecedcb81fc52ffb0fd78ce2ebccc9ea964df9f658de8c8", size = 10810302, upload-time = "2025-09-29T23:33:35.846Z" },
-    { url = "https://files.pythonhosted.org/packages/13/e6/d2465010ee0569a245c975dc6967b801887068bc893e908239b1f4b6c1ac/pandas-2.3.3-cp39-cp39-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:854d00d556406bffe66a4c0802f334c9ad5a96b4f1f868adf036a21b11ef13ff", size = 12154874, upload-time = "2025-09-29T23:33:49.939Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/18/aae8c0aa69a386a3255940e9317f793808ea79d0a525a97a903366bb2569/pandas-2.3.3-cp39-cp39-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf1f8a81d04ca90e32a0aceb819d34dbd378a98bf923b6398b9a3ec0bf44de29", size = 12790141, upload-time = "2025-09-29T23:34:05.655Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/26/617f98de789de00c2a444fbe6301bb19e66556ac78cff933d2c98f62f2b4/pandas-2.3.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:23ebd657a4d38268c7dfbdf089fbc31ea709d82e4923c5ffd4fbd5747133ce73", size = 13208697, upload-time = "2025-09-29T23:34:21.835Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/fb/25709afa4552042bd0e15717c75e9b4a2294c3dc4f7e6ea50f03c5136600/pandas-2.3.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:5554c929ccc317d41a5e3d1234f3be588248e61f08a74dd17c9eabb535777dc9", size = 13879233, upload-time = "2025-09-29T23:34:35.079Z" },
-    { url = "https://files.pythonhosted.org/packages/98/af/7be05277859a7bc399da8ba68b88c96b27b48740b6cf49688899c6eb4176/pandas-2.3.3-cp39-cp39-win_amd64.whl", hash = "sha256:d3e28b3e83862ccf4d85ff19cf8c20b2ae7e503881711ff2d534dc8f761131aa", size = 11359119, upload-time = "2025-09-29T23:34:46.339Z" },
 ]
 
 [[package]]
@@ -3251,8 +2837,7 @@ name = "pgvector"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/43/9a0fb552ab4fd980680c2037962e331820f67585df740bedc4a2b50faf20/pgvector-0.4.1.tar.gz", hash = "sha256:83d3a1c044ff0c2f1e95d13dfb625beb0b65506cfec0941bfe81fd0ad44f4003", size = 30646, upload-time = "2025-04-26T18:56:37.151Z" }
@@ -3440,22 +3025,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/35/91/9cb56efbb428b006bb85db28591e40b7736847b8331d43fe335acf95f6c8/propcache-0.3.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4445542398bd0b5d32df908031cb1b30d43ac848e20470a878b770ec2dcc6330", size = 265778, upload-time = "2025-06-09T22:55:36.45Z" },
     { url = "https://files.pythonhosted.org/packages/9a/4c/b0fe775a2bdd01e176b14b574be679d84fc83958335790f7c9a686c1f468/propcache-0.3.2-cp313-cp313t-win32.whl", hash = "sha256:f86e5d7cd03afb3a1db8e9f9f6eff15794e79e791350ac48a8c924e6f439f394", size = 41175, upload-time = "2025-06-09T22:55:38.436Z" },
     { url = "https://files.pythonhosted.org/packages/a4/ff/47f08595e3d9b5e149c150f88d9714574f1a7cbd89fe2817158a952674bf/propcache-0.3.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9704bedf6e7cbe3c65eca4379a9b53ee6a83749f047808cbb5044d40d7d72198", size = 44857, upload-time = "2025-06-09T22:55:39.687Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/39/8ea9bcfaaff16fd0b0fc901ee522e24c9ec44b4ca0229cfffb8066a06959/propcache-0.3.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a7fad897f14d92086d6b03fdd2eb844777b0c4d7ec5e3bac0fbae2ab0602bbe5", size = 74678, upload-time = "2025-06-09T22:55:41.227Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/85/cab84c86966e1d354cf90cdc4ba52f32f99a5bca92a1529d666d957d7686/propcache-0.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1f43837d4ca000243fd7fd6301947d7cb93360d03cd08369969450cc6b2ce3b4", size = 43829, upload-time = "2025-06-09T22:55:42.417Z" },
-    { url = "https://files.pythonhosted.org/packages/23/f7/9cb719749152d8b26d63801b3220ce2d3931312b2744d2b3a088b0ee9947/propcache-0.3.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:261df2e9474a5949c46e962065d88eb9b96ce0f2bd30e9d3136bcde84befd8f2", size = 43729, upload-time = "2025-06-09T22:55:43.651Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/a2/0b2b5a210ff311260002a315f6f9531b65a36064dfb804655432b2f7d3e3/propcache-0.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e514326b79e51f0a177daab1052bc164d9d9e54133797a3a58d24c9c87a3fe6d", size = 204483, upload-time = "2025-06-09T22:55:45.327Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e0/7aff5de0c535f783b0c8be5bdb750c305c1961d69fbb136939926e155d98/propcache-0.3.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d4a996adb6904f85894570301939afeee65f072b4fd265ed7e569e8d9058e4ec", size = 217425, upload-time = "2025-06-09T22:55:46.729Z" },
-    { url = "https://files.pythonhosted.org/packages/92/1d/65fa889eb3b2a7d6e4ed3c2b568a9cb8817547a1450b572de7bf24872800/propcache-0.3.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:76cace5d6b2a54e55b137669b30f31aa15977eeed390c7cbfb1dafa8dfe9a701", size = 214723, upload-time = "2025-06-09T22:55:48.342Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/e2/eecf6989870988dfd731de408a6fa366e853d361a06c2133b5878ce821ad/propcache-0.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31248e44b81d59d6addbb182c4720f90b44e1efdc19f58112a3c3a1615fb47ef", size = 200166, upload-time = "2025-06-09T22:55:49.775Z" },
-    { url = "https://files.pythonhosted.org/packages/12/06/c32be4950967f18f77489268488c7cdc78cbfc65a8ba8101b15e526b83dc/propcache-0.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abb7fa19dbf88d3857363e0493b999b8011eea856b846305d8c0512dfdf8fbb1", size = 194004, upload-time = "2025-06-09T22:55:51.335Z" },
-    { url = "https://files.pythonhosted.org/packages/46/6c/17b521a6b3b7cbe277a4064ff0aa9129dd8c89f425a5a9b6b4dd51cc3ff4/propcache-0.3.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:d81ac3ae39d38588ad0549e321e6f773a4e7cc68e7751524a22885d5bbadf886", size = 203075, upload-time = "2025-06-09T22:55:52.681Z" },
-    { url = "https://files.pythonhosted.org/packages/62/cb/3bdba2b736b3e45bc0e40f4370f745b3e711d439ffbffe3ae416393eece9/propcache-0.3.2-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:cc2782eb0f7a16462285b6f8394bbbd0e1ee5f928034e941ffc444012224171b", size = 195407, upload-time = "2025-06-09T22:55:54.048Z" },
-    { url = "https://files.pythonhosted.org/packages/29/bd/760c5c6a60a4a2c55a421bc34a25ba3919d49dee411ddb9d1493bb51d46e/propcache-0.3.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:db429c19a6c7e8a1c320e6a13c99799450f411b02251fb1b75e6217cf4a14fcb", size = 196045, upload-time = "2025-06-09T22:55:55.485Z" },
-    { url = "https://files.pythonhosted.org/packages/76/58/ced2757a46f55b8c84358d6ab8de4faf57cba831c51e823654da7144b13a/propcache-0.3.2-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:21d8759141a9e00a681d35a1f160892a36fb6caa715ba0b832f7747da48fb6ea", size = 208432, upload-time = "2025-06-09T22:55:56.884Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/ec/d98ea8d5a4d8fe0e372033f5254eddf3254344c0c5dc6c49ab84349e4733/propcache-0.3.2-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:2ca6d378f09adb13837614ad2754fa8afaee330254f404299611bce41a8438cb", size = 210100, upload-time = "2025-06-09T22:55:58.498Z" },
-    { url = "https://files.pythonhosted.org/packages/56/84/b6d8a7ecf3f62d7dd09d9d10bbf89fad6837970ef868b35b5ffa0d24d9de/propcache-0.3.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:34a624af06c048946709f4278b4176470073deda88d91342665d95f7c6270fbe", size = 200712, upload-time = "2025-06-09T22:55:59.906Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/32/889f4903ddfe4a9dc61da71ee58b763758cf2d608fe1decede06e6467f8d/propcache-0.3.2-cp39-cp39-win32.whl", hash = "sha256:4ba3fef1c30f306b1c274ce0b8baaa2c3cdd91f645c48f06394068f37d3837a1", size = 38187, upload-time = "2025-06-09T22:56:01.212Z" },
-    { url = "https://files.pythonhosted.org/packages/67/74/d666795fb9ba1dc139d30de64f3b6fd1ff9c9d3d96ccfdb992cd715ce5d2/propcache-0.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:7a2368eed65fc69a7a7a40b27f22e85e7627b74216f0846b04ba5c116e191ec9", size = 42025, upload-time = "2025-06-09T22:56:02.875Z" },
     { url = "https://files.pythonhosted.org/packages/cc/35/cc0aaecf278bb4575b8555f2b137de5ab821595ddae9da9d3cd1da4072c7/propcache-0.3.2-py3-none-any.whl", hash = "sha256:98f1ec44fb675f5052cccc8e609c46ed23a35a1cfd18545ad4e29002d858a43f", size = 12663, upload-time = "2025-06-09T22:56:04.484Z" },
 ]
 
@@ -3482,8 +3051,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/10/56/a8a3f4e7190837139e68c7002ec749190a163af3e330f65d90309145a210/protobuf-6.32.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8c7e6eb619ffdf105ee4ab76af5a68b60a9d0f66da3ea12d1640e6d8dab7281", size = 426454, upload-time = "2025-09-11T21:38:34.076Z" },
     { url = "https://files.pythonhosted.org/packages/3f/be/8dd0a927c559b37d7a6c8ab79034fd167dcc1f851595f2e641ad62be8643/protobuf-6.32.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:2f5b80a49e1eb7b86d85fcd23fe92df154b9730a725c3b38c4e43b9d77018bf4", size = 322874, upload-time = "2025-09-11T21:38:35.509Z" },
     { url = "https://files.pythonhosted.org/packages/5c/f6/88d77011b605ef979aace37b7703e4eefad066f7e84d935e5a696515c2dd/protobuf-6.32.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:b1864818300c297265c83a4982fd3169f97122c299f56a56e2445c3698d34710", size = 322013, upload-time = "2025-09-11T21:38:37.017Z" },
-    { url = "https://files.pythonhosted.org/packages/05/9d/d6f1a8b6657296920c58f6b85f7bca55fa27e3ca7fc5914604d89cd0250b/protobuf-6.32.1-cp39-cp39-win32.whl", hash = "sha256:68ff170bac18c8178f130d1ccb94700cf72852298e016a2443bdb9502279e5f1", size = 424505, upload-time = "2025-09-11T21:38:38.415Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/cd/891bd2d23558f52392a5687b2406a741e2e28d629524c88aade457029acd/protobuf-6.32.1-cp39-cp39-win_amd64.whl", hash = "sha256:d0975d0b2f3e6957111aa3935d08a0eb7e006b1505d825f862a1fffc8348e122", size = 435825, upload-time = "2025-09-11T21:38:39.773Z" },
     { url = "https://files.pythonhosted.org/packages/97/b7/15cc7d93443d6c6a84626ae3258a91f4c6ac8c0edd5df35ea7658f71b79c/protobuf-6.32.1-py3-none-any.whl", hash = "sha256:2601b779fc7d32a866c6b4404f9d42a3f67c5b9f3f15b4db3cccabe06b95c346", size = 169289, upload-time = "2025-09-11T21:38:41.234Z" },
 ]
 
@@ -3541,18 +3108,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/50/bf/c7b5082c3709c3fa2c08d09971b012979a9d879f0a5ed22c7995c94ef95a/psqlpy-0.11.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b633ae41fd5d1295655a338c595af3f020722af312c3b541b53d1caa6882afe8", size = 5063961, upload-time = "2025-08-14T17:22:00.005Z" },
     { url = "https://files.pythonhosted.org/packages/74/6b/48089ae018f9d2fef0d8859248ef33c6b0d04299f73a554ef3a7680a2673/psqlpy-0.11.6-cp313-cp313-win32.whl", hash = "sha256:6aca8c34509c25e49c651ec59b7e164ea45a63111c0c11bdadc222c8ca714eed", size = 3351887, upload-time = "2025-08-14T17:22:01.422Z" },
     { url = "https://files.pythonhosted.org/packages/f1/74/868413b3be5b07a5b6dae9d73f71718ebb99844e0f072912490ef6f7696a/psqlpy-0.11.6-cp313-cp313-win_amd64.whl", hash = "sha256:8e601faf0e7cf771fa118e89487c805a53271185aea63025b18914feb982ee4a", size = 3767978, upload-time = "2025-08-14T17:22:02.793Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/ff/96d672cb6d62b593ec6d2a53072663b72f8b4cc7c782d9b16e63a23d1f8e/psqlpy-0.11.6-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:3a36263ac9ed535cb066dd9ffa75eba7c2a3d622ebadf1ee90a1adaf33e1c3dd", size = 4310264, upload-time = "2025-08-14T17:22:04.118Z" },
-    { url = "https://files.pythonhosted.org/packages/df/33/8011fc5457c94d7462f667a20a6959f44d3a96ae3f6f9c697974265b3590/psqlpy-0.11.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:efa42516e911ed9c76ab054fd061d2456f89f20d55807d645a9ad47571234b57", size = 4518025, upload-time = "2025-08-14T17:22:05.529Z" },
-    { url = "https://files.pythonhosted.org/packages/95/50/63dccb212fda68b16a9d5169d306ac38d3efdba1b8b6cf74a2cd26979b61/psqlpy-0.11.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5eaaa658b6204103ad7f03dbc762baed3803de9303d94eac551ac05c57758423", size = 5043163, upload-time = "2025-08-14T17:22:06.914Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/12/7900a705a990d7192f45ebf619affbf7dec4db54f3732a9a1616ee542f8a/psqlpy-0.11.6-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:392a763fc2c992d1e45c89a184d3de87189a9f247995d3e16f0871f67a67b781", size = 4299937, upload-time = "2025-08-14T17:22:08.351Z" },
-    { url = "https://files.pythonhosted.org/packages/25/01/621c0d19c863019760a45e95f2e88dc007b12aaf6d8ee49f2957923ce218/psqlpy-0.11.6-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ff00b4c53f6f188f48ea8d58f63f8699c623bb6ee302c99bf559f61bc78ca5b8", size = 4926194, upload-time = "2025-08-14T17:22:09.983Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/d5/343a6a0f3fa88ab2da42bb4b539d46e68c88f4912865e5963f05afee25d9/psqlpy-0.11.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d079161fdaf4e3d2c336309161cc8a1f60bda03562872c479e805f2ccf5e7ea0", size = 5042997, upload-time = "2025-08-14T17:22:11.648Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/83/32b399b3a2eecafa06afd5eec465f5abbeff90aa175ae98d9dde4079ea0b/psqlpy-0.11.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7afa10100009833a40fbc92993ce200d46081293472f6b68aefeafba206517b5", size = 4700624, upload-time = "2025-08-14T17:22:13.156Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/bd/841b47e7f2b08021c2cf42788c6a669e2e3ea2cb09cbe0e58b6ba7c76cfb/psqlpy-0.11.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:295df1f589e65e285e2cad23b4000572f083a563dd5a3ddd043de3a9e9027ab0", size = 4929964, upload-time = "2025-08-14T17:22:14.839Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/c7/9a7f39a74bd2f16f980b599f61c3afd55e245706f4d6d682e7621598c03e/psqlpy-0.11.6-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1ea482e2b4df2b7f5393c35f64927c4fc0ecaf57455f41127cdc78307bbb2320", size = 4958544, upload-time = "2025-08-14T17:22:16.471Z" },
-    { url = "https://files.pythonhosted.org/packages/be/bc/a3186ce50e3fe76814c9cd1dc8267eb2d79015292ff346691c62e47379d7/psqlpy-0.11.6-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:f231871393ff627fdb36607b8d4113bf901e3838bf573003ace6177260db61d4", size = 5069641, upload-time = "2025-08-14T17:22:17.969Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/1c/d1d1b84a52949bb91f5a1c5208120b61b165fa24faafb8150709c241dae8/psqlpy-0.11.6-cp39-cp39-win32.whl", hash = "sha256:008407cac3591a7cdf45250727df2aaffe1e077aa40d0d5ef858998078c93c5f", size = 3352566, upload-time = "2025-08-14T17:22:19.526Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/01/5572e1e647971f0d4db0278256d57ea8ed80f57bddba9b14bd937ae9a9ae/psqlpy-0.11.6-cp39-cp39-win_amd64.whl", hash = "sha256:b6dad4f42b00b34b540cc487e923e181726b887074093e3cdea21d51fc67e3a7", size = 3761797, upload-time = "2025-08-14T17:22:21.09Z" },
     { url = "https://files.pythonhosted.org/packages/60/98/f29b17f931ea17ef673c8a2ac817901e663b2db102660a4902997859c2c2/psqlpy-0.11.6-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:80ed664f40b259f65c5983e529fd32212ffcb5caa5cddb8ed899f3939547c5c7", size = 4303600, upload-time = "2025-08-14T17:22:22.579Z" },
     { url = "https://files.pythonhosted.org/packages/f1/05/bd23d3c2a3254640f5205e71b41dbd8279b6dcb211d3a0834edc9e560ef5/psqlpy-0.11.6-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b01cc82cf9af3b5237d8059cdfcf41fce656d300f768e948c20358ce94774862", size = 4503850, upload-time = "2025-08-14T17:22:24.408Z" },
     { url = "https://files.pythonhosted.org/packages/94/7f/bcce7a63bc0fca8a43bf81abae97c6cc262c582b4a420252e1eb51c9fb41/psqlpy-0.11.6-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4d2eb9dcb0a7f60d045bbe8061b8318b7718a4093eac9cd65fd3c00ebf1544b4", size = 5041335, upload-time = "2025-08-14T17:22:25.843Z" },
@@ -3573,16 +3128,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/52/a13570a371a9f268ded0ee6c2534ea3655878bccea905c1149a351f1ab6b/psqlpy-0.11.6-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0c63c9a41ec6a6abde2c7b9dcb271c08896259911e4268124bfdd632f2c7435", size = 4933316, upload-time = "2025-08-14T17:22:49.418Z" },
     { url = "https://files.pythonhosted.org/packages/11/c4/3c51b817ebc8b8344cc27d68c3d2fec00e0291ce9350acd2a5e16144706c/psqlpy-0.11.6-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:33768b71afde498211f271f5ea0c430ed8ddfdc7ee5f541de4761222d8633c3f", size = 4956086, upload-time = "2025-08-14T17:22:51.008Z" },
     { url = "https://files.pythonhosted.org/packages/b9/bc/2f6e5ba5ca7890c56bfe59b95536557f15ddc17171234edda342e53415c7/psqlpy-0.11.6-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:820fbeac25919fb463de3a50594ee12cd434fa539e483adfda87404dfa602b73", size = 5073593, upload-time = "2025-08-14T17:22:52.906Z" },
-    { url = "https://files.pythonhosted.org/packages/da/28/de38383c0c01643515df8a067db96b1be03a9f08d273865fa089b61c9a27/psqlpy-0.11.6-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:713ab646c6eb4a79bb012fceddc8261d8945f973a4e569ed66bd75efea538145", size = 4303717, upload-time = "2025-08-14T17:22:54.818Z" },
-    { url = "https://files.pythonhosted.org/packages/66/01/82f4d27a6b34b1e451a584d42f7a3cc59cdafa8fa4e4a19fe5ff06d46cd0/psqlpy-0.11.6-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:c5edca9a74a5321049fd26317941fe997a7f860ee5c18fa1210ac57849b1fa50", size = 4502218, upload-time = "2025-08-14T17:22:56.401Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/38/1fee83a44052ce338838839574fc6247b73809093d8ec1045e01943a8898/psqlpy-0.11.6-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3751b11b9852204d9d7f9a4a0013885e50b1efe9c519705ea3d48681c517dd9a", size = 5042449, upload-time = "2025-08-14T17:22:58.149Z" },
-    { url = "https://files.pythonhosted.org/packages/30/92/2d7822567f94221205057ba6c31b5e300dc092a2774574b14e340185ce3a/psqlpy-0.11.6-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a218444193d30305088fb10b5f914454213d30ce72ec1fbc2d704955611a5d6f", size = 4294799, upload-time = "2025-08-14T17:22:59.711Z" },
-    { url = "https://files.pythonhosted.org/packages/26/41/8f62d6fee34d829000e9c7b6ded565af6e477bf8acc5d86c05be85cc0db3/psqlpy-0.11.6-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:726ff110b1165ad500f8f815710d6c74e2f80f96f8e6837e01fe0a0e5d70584a", size = 4921904, upload-time = "2025-08-14T17:23:01.226Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/f7/7e0250d752b3a9e80546ab80083c3c1fb783cda41af0a8ab4292a795e455/psqlpy-0.11.6-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f84052981060673020c9b0fe0531df067df079350b9155a600f310915f738b27", size = 5044055, upload-time = "2025-08-14T17:23:02.871Z" },
-    { url = "https://files.pythonhosted.org/packages/af/b6/a73c0627d2b522929762fa471df25da15b174a61930fca6bf3ee9e46e3e8/psqlpy-0.11.6-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3607ba741ada381bb672618c0fe2cc8e0c4bc559cdd444d17c9079947ad94fa8", size = 4684160, upload-time = "2025-08-14T17:23:04.702Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/d7/d76c863875b0e7385879a0502d2f67f848bc5f94da9634633966d467f0cb/psqlpy-0.11.6-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e0ee9c153fb7500da1d717faecd28d99994cb8419dbe0be4b89e8821b4e9291", size = 4934082, upload-time = "2025-08-14T17:23:06.524Z" },
-    { url = "https://files.pythonhosted.org/packages/23/40/613fe3a2139e131e84d138ff9e05ff6194790a8fe402bc0e801b3abb8b42/psqlpy-0.11.6-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:f06cd4e031364c9faa41be8481bcce2876eb7ba1b1b769aa0edb05af17af3b1b", size = 4954714, upload-time = "2025-08-14T17:23:08.176Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/04/3abf261a6ad16c92c1b14ae0858ae349c3836820e8aae0d507094fa127df/psqlpy-0.11.6-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:d4a128962d01a82a9e0447e4626916d2f1ae9722d0c7898009d8c2a6e0d0ea2b", size = 5073280, upload-time = "2025-08-14T17:23:09.706Z" },
 ]
 
 [[package]]
@@ -3672,15 +3217,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/8c/9446e3a84187220a98657ef778518f9b44eba55b1f6c3e8300d229ec9930/psycopg_binary-3.2.10-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1f6982609b8ff8fcd67299b67cd5787da1876f3bb28fedd547262cfa8ddedf94", size = 3535121, upload-time = "2025-09-08T09:11:53.887Z" },
     { url = "https://files.pythonhosted.org/packages/b4/e1/f0382c956bfaa951a0dbd4d5a354acf093ef7e5219996958143dfd2bf37d/psycopg_binary-3.2.10-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bf30dcf6aaaa8d4779a20d2158bdf81cc8e84ce8eee595d748a7671c70c7b890", size = 3584235, upload-time = "2025-09-08T09:12:01.118Z" },
     { url = "https://files.pythonhosted.org/packages/5a/dd/464bd739bacb3b745a1c93bc15f20f0b1e27f0a64ec693367794b398673b/psycopg_binary-3.2.10-cp314-cp314-win_amd64.whl", hash = "sha256:d5c6a66a76022af41970bf19f51bc6bf87bd10165783dd1d40484bfd87d6b382", size = 2973554, upload-time = "2025-09-08T09:12:05.884Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/c0/f9fefea225c49b9c4528ce17d93f91d4687a7e619f4cd19818a0481e4066/psycopg_binary-3.2.10-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0738320a8d405f98743227ff70ed8fac9670870289435f4861dc640cef4a61d3", size = 3996466, upload-time = "2025-09-08T09:12:50.418Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/a9/505a7558ed4f0aaa1373f307a7f21cba480ef99063107e8809e0e45c73d1/psycopg_binary-3.2.10-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:89440355d1b163b11dc661ae64a5667578aab1b80bbf71ced90693d88e9863e1", size = 4067930, upload-time = "2025-09-08T09:12:54.225Z" },
-    { url = "https://files.pythonhosted.org/packages/36/d1/b08bba8a017a24dfdd3844d5e1b080bba30fddb6b8d71316387772bcbdd3/psycopg_binary-3.2.10-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3234605839e7d7584bd0a20716395eba34d368a5099dafe7896c943facac98fc", size = 4627622, upload-time = "2025-09-08T09:13:05.429Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/27/e4cf67d8e9f9e045ef445832b1dcc6ed6173184d80740e40a7f35c57fa27/psycopg_binary-3.2.10-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:725843fd444075cc6c9989f5b25ca83ac68d8d70b58e1f476fbb4096975e43cc", size = 4722794, upload-time = "2025-09-08T09:13:11.155Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/3b/31f7629360d2c36c0bba8897dafdc7482d71170f601bc79358fb3f099f88/psycopg_binary-3.2.10-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:447afc326cbc95ed67c0cd27606c0f81fa933b830061e096dbd37e08501cb3de", size = 4407119, upload-time = "2025-09-08T09:13:16.477Z" },
-    { url = "https://files.pythonhosted.org/packages/03/84/9610a633b33d685269318a92428619097d1a9fc0832ee6c4fd3d6ab75fb8/psycopg_binary-3.2.10-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:5334a61a00ccb722f0b28789e265c7a273cfd10d5a1ed6bf062686fbb71e7032", size = 3880897, upload-time = "2025-09-08T09:13:20.716Z" },
-    { url = "https://files.pythonhosted.org/packages/af/0d/af7ba9bcb035454d19f88992a5cdd03313500a78f55d47f474b561ecf996/psycopg_binary-3.2.10-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:183a59cbdcd7e156669577fd73a9e917b1ee664e620f1e31ae138d24c7714693", size = 3563882, upload-time = "2025-09-08T09:13:25.919Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/b2/b6ba55c253208f03271b2c3d890fe5cbb8ef8f54551e6579a76f3978188f/psycopg_binary-3.2.10-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:8fa2efaf5e2f8c289a185c91c80a624a8f97aa17fbedcbc68f373d089b332afd", size = 3604543, upload-time = "2025-09-08T09:13:31.075Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/3d/90ac8893003ed16eb2709d755bd8c53eb6330fc7f34774df166b2e00eed4/psycopg_binary-3.2.10-cp39-cp39-win_amd64.whl", hash = "sha256:6220d6efd6e2df7b67d70ed60d653106cd3b70c5cb8cbe4e9f0a142a5db14015", size = 2888394, upload-time = "2025-09-08T09:13:35.73Z" },
 ]
 
 [[package]]
@@ -3736,13 +3272,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/f9/4ee798dc902533159250fb4321267730bc0a107d8c6889e07c3add4fe3a5/pyarrow-21.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fc0d2f88b81dcf3ccf9a6ae17f89183762c8a94a5bdcfa09e05cfe413acf0503", size = 43276625, upload-time = "2025-07-18T00:56:48.002Z" },
     { url = "https://files.pythonhosted.org/packages/5a/da/e02544d6997037a4b0d22d8e5f66bc9315c3671371a8b18c79ade1cefe14/pyarrow-21.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6299449adf89df38537837487a4f8d3bd91ec94354fdd2a7d30bc11c48ef6e79", size = 44951890, upload-time = "2025-07-18T00:56:52.568Z" },
     { url = "https://files.pythonhosted.org/packages/e5/4e/519c1bc1876625fe6b71e9a28287c43ec2f20f73c658b9ae1d485c0c206e/pyarrow-21.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:222c39e2c70113543982c6b34f3077962b44fca38c0bd9e68bb6781534425c10", size = 26371006, upload-time = "2025-07-18T00:56:56.379Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/cc/ce4939f4b316457a083dc5718b3982801e8c33f921b3c98e7a93b7c7491f/pyarrow-21.0.0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:a7f6524e3747e35f80744537c78e7302cd41deee8baa668d56d55f77d9c464b3", size = 31211248, upload-time = "2025-07-18T00:56:59.7Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/c2/7a860931420d73985e2f340f06516b21740c15b28d24a0e99a900bb27d2b/pyarrow-21.0.0-cp39-cp39-macosx_12_0_x86_64.whl", hash = "sha256:203003786c9fd253ebcafa44b03c06983c9c8d06c3145e37f1b76a1f317aeae1", size = 32676896, upload-time = "2025-07-18T00:57:03.884Z" },
-    { url = "https://files.pythonhosted.org/packages/68/a8/197f989b9a75e59b4ca0db6a13c56f19a0ad8a298c68da9cc28145e0bb97/pyarrow-21.0.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:3b4d97e297741796fead24867a8dabf86c87e4584ccc03167e4a811f50fdf74d", size = 41067862, upload-time = "2025-07-18T00:57:07.587Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/82/6ecfa89487b35aa21accb014b64e0a6b814cc860d5e3170287bf5135c7d8/pyarrow-21.0.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:898afce396b80fdda05e3086b4256f8677c671f7b1d27a6976fa011d3fd0a86e", size = 42747508, upload-time = "2025-07-18T00:57:13.917Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/b7/ba252f399bbf3addc731e8643c05532cf32e74cebb5e32f8f7409bc243cf/pyarrow-21.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:067c66ca29aaedae08218569a114e413b26e742171f526e828e1064fcdec13f4", size = 43345293, upload-time = "2025-07-18T00:57:19.828Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0a/a20819795bd702b9486f536a8eeb70a6aa64046fce32071c19ec8230dbaa/pyarrow-21.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:0c4e75d13eb76295a49e0ea056eb18dbd87d81450bfeb8afa19a7e5a75ae2ad7", size = 45060670, upload-time = "2025-07-18T00:57:24.477Z" },
-    { url = "https://files.pythonhosted.org/packages/10/15/6b30e77872012bbfe8265d42a01d5b3c17ef0ac0f2fae531ad91b6a6c02e/pyarrow-21.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:cdc4c17afda4dab2a9c0b79148a43a7f4e1094916b3e18d8975bfd6d6d52241f", size = 26227521, upload-time = "2025-07-18T00:57:29.119Z" },
 ]
 
 [[package]]
@@ -3820,11 +3349,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/5e/63f5cbde2342b7f70a39e591dbe75d9809d6338ce0b07c10406f1a140cdc/pycryptodome-3.23.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14e15c081e912c4b0d75632acd8382dfce45b258667aa3c67caf7a4d4c13f630", size = 1664461, upload-time = "2025-05-17T17:21:25.225Z" },
     { url = "https://files.pythonhosted.org/packages/d6/92/608fbdad566ebe499297a86aae5f2a5263818ceeecd16733006f1600403c/pycryptodome-3.23.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a7fc76bf273353dc7e5207d172b83f569540fc9a28d63171061c42e361d22353", size = 1702440, upload-time = "2025-05-17T17:21:27.991Z" },
     { url = "https://files.pythonhosted.org/packages/d1/92/2eadd1341abd2989cce2e2740b4423608ee2014acb8110438244ee97d7ff/pycryptodome-3.23.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:45c69ad715ca1a94f778215a11e66b7ff989d792a4d63b68dc586a1da1392ff5", size = 1803005, upload-time = "2025-05-17T17:21:31.37Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/c4/6925ad41576d3e84f03aaf9a0411667af861f9fa2c87553c7dd5bde01518/pycryptodome-3.23.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:865d83c906b0fc6a59b510deceee656b6bc1c4fa0d82176e2b77e97a420a996a", size = 1623768, upload-time = "2025-05-17T17:21:33.418Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/14/d6c6a3098ddf2624068f041c5639be5092ad4ae1a411842369fd56765994/pycryptodome-3.23.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:89d4d56153efc4d81defe8b65fd0821ef8b2d5ddf8ed19df31ba2f00872b8002", size = 1672070, upload-time = "2025-05-17T17:21:35.565Z" },
-    { url = "https://files.pythonhosted.org/packages/20/89/5d29c8f178fea7c92fd20d22f9ddd532a5e3ac71c574d555d2362aaa832a/pycryptodome-3.23.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e3f2d0aaf8080bda0587d58fc9fe4766e012441e2eed4269a77de6aea981c8be", size = 1664359, upload-time = "2025-05-17T17:21:37.551Z" },
-    { url = "https://files.pythonhosted.org/packages/38/bc/a287d41b4421ad50eafb02313137d0276d6aeffab90a91e2b08f64140852/pycryptodome-3.23.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:64093fc334c1eccfd3933c134c4457c34eaca235eeae49d69449dc4728079339", size = 1702359, upload-time = "2025-05-17T17:21:39.827Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/62/2392b7879f4d2c1bfa20815720b89d464687877851716936b9609959c201/pycryptodome-3.23.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:ce64e84a962b63a47a592690bdc16a7eaf709d2c2697ababf24a0def566899a6", size = 1802461, upload-time = "2025-05-17T17:21:41.722Z" },
 ]
 
 [[package]]
@@ -3909,19 +3433,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162, upload-time = "2025-04-23T18:32:20.188Z" },
     { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560, upload-time = "2025-04-23T18:32:22.354Z" },
     { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777, upload-time = "2025-04-23T18:32:25.088Z" },
-    { url = "https://files.pythonhosted.org/packages/53/ea/bbe9095cdd771987d13c82d104a9c8559ae9aec1e29f139e286fd2e9256e/pydantic_core-2.33.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:a2b911a5b90e0374d03813674bf0a5fbbb7741570dcd4b4e85a2e48d17def29d", size = 2028677, upload-time = "2025-04-23T18:32:27.227Z" },
-    { url = "https://files.pythonhosted.org/packages/49/1d/4ac5ed228078737d457a609013e8f7edc64adc37b91d619ea965758369e5/pydantic_core-2.33.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6fa6dfc3e4d1f734a34710f391ae822e0a8eb8559a85c6979e14e65ee6ba2954", size = 1864735, upload-time = "2025-04-23T18:32:29.019Z" },
-    { url = "https://files.pythonhosted.org/packages/23/9a/2e70d6388d7cda488ae38f57bc2f7b03ee442fbcf0d75d848304ac7e405b/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c54c939ee22dc8e2d545da79fc5381f1c020d6d3141d3bd747eab59164dc89fb", size = 1898467, upload-time = "2025-04-23T18:32:31.119Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/2e/1568934feb43370c1ffb78a77f0baaa5a8b6897513e7a91051af707ffdc4/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:53a57d2ed685940a504248187d5685e49eb5eef0f696853647bf37c418c538f7", size = 1983041, upload-time = "2025-04-23T18:32:33.655Z" },
-    { url = "https://files.pythonhosted.org/packages/01/1a/1a1118f38ab64eac2f6269eb8c120ab915be30e387bb561e3af904b12499/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:09fb9dd6571aacd023fe6aaca316bd01cf60ab27240d7eb39ebd66a3a15293b4", size = 2136503, upload-time = "2025-04-23T18:32:35.519Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/da/44754d1d7ae0f22d6d3ce6c6b1486fc07ac2c524ed8f6eca636e2e1ee49b/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0e6116757f7959a712db11f3e9c0a99ade00a5bbedae83cb801985aa154f071b", size = 2736079, upload-time = "2025-04-23T18:32:37.659Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/98/f43cd89172220ec5aa86654967b22d862146bc4d736b1350b4c41e7c9c03/pydantic_core-2.33.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d55ab81c57b8ff8548c3e4947f119551253f4e3787a7bbc0b6b3ca47498a9d3", size = 2006508, upload-time = "2025-04-23T18:32:39.637Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/cc/f77e8e242171d2158309f830f7d5d07e0531b756106f36bc18712dc439df/pydantic_core-2.33.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c20c462aa4434b33a2661701b861604913f912254e441ab8d78d30485736115a", size = 2113693, upload-time = "2025-04-23T18:32:41.818Z" },
-    { url = "https://files.pythonhosted.org/packages/54/7a/7be6a7bd43e0a47c147ba7fbf124fe8aaf1200bc587da925509641113b2d/pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:44857c3227d3fb5e753d5fe4a3420d6376fa594b07b621e220cd93703fe21782", size = 2074224, upload-time = "2025-04-23T18:32:44.033Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/07/31cf8fadffbb03be1cb520850e00a8490c0927ec456e8293cafda0726184/pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_armv7l.whl", hash = "sha256:eb9b459ca4df0e5c87deb59d37377461a538852765293f9e6ee834f0435a93b9", size = 2245403, upload-time = "2025-04-23T18:32:45.836Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/8d/bbaf4c6721b668d44f01861f297eb01c9b35f612f6b8e14173cb204e6240/pydantic_core-2.33.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9fcd347d2cc5c23b06de6d3b7b8275be558a0c90549495c699e379a80bf8379e", size = 2242331, upload-time = "2025-04-23T18:32:47.618Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/93/3cc157026bca8f5006250e74515119fcaa6d6858aceee8f67ab6dc548c16/pydantic_core-2.33.2-cp39-cp39-win32.whl", hash = "sha256:83aa99b1285bc8f038941ddf598501a86f1536789740991d7d8756e34f1e74d9", size = 1910571, upload-time = "2025-04-23T18:32:49.401Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/90/7edc3b2a0d9f0dda8806c04e511a67b0b7a41d2187e2003673a996fb4310/pydantic_core-2.33.2-cp39-cp39-win_amd64.whl", hash = "sha256:f481959862f57f29601ccced557cc2e817bce7533ab8e01a797a48b49c9692b3", size = 1956504, upload-time = "2025-04-23T18:32:51.287Z" },
     { url = "https://files.pythonhosted.org/packages/30/68/373d55e58b7e83ce371691f6eaa7175e3a24b956c44628eb25d7da007917/pydantic_core-2.33.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5c4aa4e82353f65e548c476b37e64189783aa5384903bfea4f41580f255fddfa", size = 2023982, upload-time = "2025-04-23T18:32:53.14Z" },
     { url = "https://files.pythonhosted.org/packages/a4/16/145f54ac08c96a63d8ed6442f9dec17b2773d19920b627b18d4f10a061ea/pydantic_core-2.33.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d946c8bf0d5c24bf4fe333af284c59a19358aa3ec18cb3dc4370080da1e8ad29", size = 1858412, upload-time = "2025-04-23T18:32:55.52Z" },
     { url = "https://files.pythonhosted.org/packages/41/b1/c6dc6c3e2de4516c0bb2c46f6a373b91b5660312342a0cf5826e38ad82fa/pydantic_core-2.33.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87b31b6846e361ef83fedb187bb5b4372d0da3f7e28d85415efa92d6125d6e6d", size = 1892749, upload-time = "2025-04-23T18:32:57.546Z" },
@@ -3940,15 +3451,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/e9/1f7efbe20d0b2b10f6718944b5d8ece9152390904f29a78e68d4e7961159/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:de4b83bb311557e439b9e186f733f6c645b9417c84e2eb8203f3f820a4b988bf", size = 2239013, upload-time = "2025-04-23T18:33:26.621Z" },
     { url = "https://files.pythonhosted.org/packages/3c/b2/5309c905a93811524a49b4e031e9851a6b00ff0fb668794472ea7746b448/pydantic_core-2.33.2-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:82f68293f055f51b51ea42fafc74b6aad03e70e191799430b90c13d643059ebb", size = 2238715, upload-time = "2025-04-23T18:33:28.656Z" },
     { url = "https://files.pythonhosted.org/packages/32/56/8a7ca5d2cd2cda1d245d34b1c9a942920a718082ae8e54e5f3e5a58b7add/pydantic_core-2.33.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:329467cecfb529c925cf2bbd4d60d2c509bc2fb52a20c1045bf09bb70971a9c1", size = 2066757, upload-time = "2025-04-23T18:33:30.645Z" },
-    { url = "https://files.pythonhosted.org/packages/08/98/dbf3fdfabaf81cda5622154fda78ea9965ac467e3239078e0dcd6df159e7/pydantic_core-2.33.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:87acbfcf8e90ca885206e98359d7dca4bcbb35abdc0ff66672a293e1d7a19101", size = 2024034, upload-time = "2025-04-23T18:33:32.843Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/99/7810aa9256e7f2ccd492590f86b79d370df1e9292f1f80b000b6a75bd2fb/pydantic_core-2.33.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:7f92c15cd1e97d4b12acd1cc9004fa092578acfa57b67ad5e43a197175d01a64", size = 1858578, upload-time = "2025-04-23T18:33:34.912Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/60/bc06fa9027c7006cc6dd21e48dbf39076dc39d9abbaf718a1604973a9670/pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d3f26877a748dc4251cfcfda9dfb5f13fcb034f5308388066bcfe9031b63ae7d", size = 1892858, upload-time = "2025-04-23T18:33:36.933Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/40/9d03997d9518816c68b4dfccb88969756b9146031b61cd37f781c74c9b6a/pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac89aea9af8cd672fa7b510e7b8c33b0bba9a43186680550ccf23020f32d535", size = 2068498, upload-time = "2025-04-23T18:33:38.997Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/62/d490198d05d2d86672dc269f52579cad7261ced64c2df213d5c16e0aecb1/pydantic_core-2.33.2-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:970919794d126ba8645f3837ab6046fb4e72bbc057b3709144066204c19a455d", size = 2108428, upload-time = "2025-04-23T18:33:41.18Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/ec/4cd215534fd10b8549015f12ea650a1a973da20ce46430b68fc3185573e8/pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:3eb3fe62804e8f859c49ed20a8451342de53ed764150cb14ca71357c765dc2a6", size = 2069854, upload-time = "2025-04-23T18:33:43.446Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/1a/abbd63d47e1d9b0d632fee6bb15785d0889c8a6e0a6c3b5a8e28ac1ec5d2/pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:3abcd9392a36025e3bd55f9bd38d908bd17962cc49bc6da8e7e96285336e2bca", size = 2237859, upload-time = "2025-04-23T18:33:45.56Z" },
-    { url = "https://files.pythonhosted.org/packages/80/1c/fa883643429908b1c90598fd2642af8839efd1d835b65af1f75fba4d94fe/pydantic_core-2.33.2-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:3a1c81334778f9e3af2f8aeb7a960736e5cab1dfebfb26aabca09afd2906c039", size = 2239059, upload-time = "2025-04-23T18:33:47.735Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/29/3cade8a924a61f60ccfa10842f75eb12787e1440e2b8660ceffeb26685e7/pydantic_core-2.33.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2807668ba86cb38c6817ad9bc66215ab8584d1d304030ce4f0887336f28a5e27", size = 2066661, upload-time = "2025-04-23T18:33:49.995Z" },
 ]
 
 [[package]]
@@ -4037,14 +3539,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/38/a9/d4cdbaa63a271e88380d1a99b749c99d6b5be1c4800777a9f9d4a0832f11/pymssql-2.3.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:37c16bc48a2ca88f1719bac6d2ebbbe7e2b821749bc1d04284975f1628300f13", size = 3463013, upload-time = "2025-07-11T01:03:46.275Z" },
     { url = "https://files.pythonhosted.org/packages/b0/29/ecacbacf81a5d8c186da77a1fe4f5cc948caf192f15371ead3bf7c95be65/pymssql-2.3.7-cp313-cp313-win32.whl", hash = "sha256:ef769e7c9427cb97143e61c70ec594834bf1954b0f89285b448bb2e3b7e8c2a3", size = 1306860, upload-time = "2025-07-11T01:03:48.26Z" },
     { url = "https://files.pythonhosted.org/packages/a3/9e/913aec491c17ccdd60603fd98661c993cd74e13526e62f0e07d3d489fa5a/pymssql-2.3.7-cp313-cp313-win_amd64.whl", hash = "sha256:ee3fdfe37e40ead646a622af3a8b405f6aa8d6f48e9b7a412a47dcf3be8b703e", size = 1988939, upload-time = "2025-07-11T01:03:49.33Z" },
-    { url = "https://files.pythonhosted.org/packages/99/eb/563b579c00357b5fae7a66bf12a9eea53cf9b06db7f80499834e7c3f62a2/pymssql-2.3.7-cp39-cp39-macosx_13_0_x86_64.whl", hash = "sha256:616c8c21cda7f78894fcb2f11172edc41564191f125d8aa5205df3ed0709d3db", size = 2918269, upload-time = "2025-07-11T01:03:50.812Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/53/a2d970e22c0ae544ddc64aa57126fab27d928b2d553c8ef8bc3ffe26bd02/pymssql-2.3.7-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:e69d840bf5cd3abd4e88c80ccb219095b332b107a780e26a578e051b6648e415", size = 3133283, upload-time = "2025-07-11T01:03:51.884Z" },
-    { url = "https://files.pythonhosted.org/packages/59/2a/fb3d3552a1129cd8f9bf94fccb4b49fb14d4eea2b8f89c07fdf65ebcb80a/pymssql-2.3.7-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba85c3ceb3fbcb1d7d75ecd556a6ec7d88fc97c2c703136c5c63119f7b14b4f9", size = 2452323, upload-time = "2025-07-11T01:03:53Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/08/9014f383f15806f6c98a0ac27c85a79c953cb22e47ca6b794361a70935b8/pymssql-2.3.7-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6706cdfca15b62a96c6ab5f48faa087b991c6d070b49b5a797ba93f11a84ffd9", size = 2796267, upload-time = "2025-07-11T01:03:54.146Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/13/157f9e7b428cb7136b0797014fdcce01d2ec509fe83d3a6be330cde8bcee/pymssql-2.3.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:6d01d0c3382d5d05c4c2993e01834013fb1a612e0eb1b3c1a884c194b5e2a5e5", size = 3694244, upload-time = "2025-07-11T01:03:55.28Z" },
-    { url = "https://files.pythonhosted.org/packages/67/a3/fab88703eb7b0bc41bfa04f7809b030f13712c78c39f2e0a768bd705b747/pymssql-2.3.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:b83222b3e13f9a688c7c251f9d5a4106b60728a7935a07ad5e9fc1d5e1c5093a", size = 3442465, upload-time = "2025-07-11T01:03:56.413Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/7e/70bbc0df77a40eacaf710d7d13c6e15a7475f9615b094d82b4f331abda09/pymssql-2.3.7-cp39-cp39-win32.whl", hash = "sha256:da059513444680080d22ba2e252384877391025da07355d50683ebe7f6c88027", size = 1323669, upload-time = "2025-07-11T01:03:57.61Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/a8/8a197cecb132b6949d835ecebd92b5333dbe6e5a1e9b30032b382d74c627/pymssql-2.3.7-cp39-cp39-win_amd64.whl", hash = "sha256:208c5a195fdeb4962a7c28f97a70b1f44a6487e74055f797ae519e88c196dbb1", size = 2004712, upload-time = "2025-07-11T01:03:58.859Z" },
 ]
 
 [[package]]
@@ -4086,12 +3580,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/35/1c7efd4665e7983169d20175014f68578e0edfcbc4602b0bafcefa522c4a/pyodbc-5.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eaf42c4bd323b8fd01f1cd900cca2d09232155f9b8f0b9bcd0be66763588ce64", size = 353025, upload-time = "2024-10-16T01:39:55.124Z" },
     { url = "https://files.pythonhosted.org/packages/6d/c9/736d07fa33572abdc50d858fd9e527d2c8281f3acbb90dff4999a3662edd/pyodbc-5.2.0-cp313-cp313-win32.whl", hash = "sha256:207f16b7e9bf09c591616429ebf2b47127e879aad21167ac15158910dc9bbcda", size = 63052, upload-time = "2024-10-16T01:39:56.565Z" },
     { url = "https://files.pythonhosted.org/packages/73/2a/3219c8b7fa3788fc9f27b5fc2244017223cf070e5ab370f71c519adf9120/pyodbc-5.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:96d3127f28c0dacf18da7ae009cd48eac532d3dcc718a334b86a3c65f6a5ef5c", size = 69486, upload-time = "2024-10-16T01:39:57.57Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/1a/bec4dd9f65a7c0c1a75641119351f0f402c721bbcea3c4eb684868259467/pyodbc-5.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9e8f4ee2c523bbe85124540ffad62a3b62ae481f012e390ef93e0602b6302e5e", size = 72440, upload-time = "2024-10-16T01:40:05.42Z" },
-    { url = "https://files.pythonhosted.org/packages/df/2f/62cce82e4547dc8c4ac3174403e24ed31bdb10bb69ad30e1bb362b960877/pyodbc-5.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:057b8ede91b21d9f0ef58210d1ca1aad704e641ca68ac6b02f109d86b61d7402", size = 71902, upload-time = "2024-10-16T01:40:06.379Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/1a/54d9595f0471c15b1de4766ec3436763aeef980740d484d629afa778c506/pyodbc-5.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f0ecbc7067467df95c9b8bd38fb2682c4a13a3402d77dccaddf1e145cea8cc0", size = 329596, upload-time = "2024-10-16T01:40:07.948Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/3a/88bc3bb8c15aefaf98bfadd51dae2fe492486daeb04911d8cf0a6d8dd884/pyodbc-5.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26b7f8324fa01c09fe4843ad8adb0b131299ef263a1fb9e63830c9cd1d5c45e4", size = 333575, upload-time = "2024-10-16T01:40:09.898Z" },
-    { url = "https://files.pythonhosted.org/packages/60/75/aedf6d10f66b22302dc3f0181cbef0cc5789f2c2a658343f10ae72f51190/pyodbc-5.2.0-cp39-cp39-win32.whl", hash = "sha256:600ef6f562f609f5612ffaa8a93827249150aa3030c867937c87b24a1608967e", size = 62379, upload-time = "2024-10-16T01:40:11.412Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/9c/b1e367b07904a52f22b8707979bcbda1b5a6056c46e67e0a66241d8138aa/pyodbc-5.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:b77556349746fb90416a48bd114cd7323f7e2559a4b263dada935f9b406ba59b", size = 68951, upload-time = "2024-10-16T01:40:12.374Z" },
 ]
 
 [[package]]
@@ -4275,9 +3763,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
     { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
-    { url = "https://files.pythonhosted.org/packages/59/42/b86689aac0cdaee7ae1c58d464b0ff04ca909c19bb6502d4973cdd9f9544/pywin32-311-cp39-cp39-win32.whl", hash = "sha256:aba8f82d551a942cb20d4a83413ccbac30790b50efb89a75e4f586ac0bb8056b", size = 8760837, upload-time = "2025-07-14T20:12:59.59Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/8a/1403d0353f8c5a2f0829d2b1c4becbf9da2f0a4d040886404fc4a5431e4d/pywin32-311-cp39-cp39-win_amd64.whl", hash = "sha256:e0c4cfb0621281fe40387df582097fd796e80430597cb9944f0ae70447bacd91", size = 9590187, upload-time = "2025-07-14T20:13:01.419Z" },
-    { url = "https://files.pythonhosted.org/packages/60/22/e0e8d802f124772cec9c75430b01a212f86f9de7546bda715e54140d5aeb/pywin32-311-cp39-cp39-win_arm64.whl", hash = "sha256:62ea666235135fee79bb154e695f3ff67370afefd71bd7fea7512fc70ef31e3d", size = 8778162, upload-time = "2025-07-14T20:13:03.544Z" },
 ]
 
 [[package]]
@@ -4342,15 +3827,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/62/67fc8e68a75f738c9200422bf65693fb79a4cd0dc5b23310e5202e978090/pyyaml-6.0.3-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:b865addae83924361678b652338317d1bd7e79b1f4596f96b96c77a5a34b34da", size = 184450, upload-time = "2025-09-25T21:33:00.618Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/92/861f152ce87c452b11b9d0977952259aa7df792d71c1053365cc7b09cc08/pyyaml-6.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c3355370a2c156cffb25e876646f149d5d68f5e0a3ce86a5084dd0b64a994917", size = 174319, upload-time = "2025-09-25T21:33:02.086Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/cd/f0cfc8c74f8a030017a2b9c771b7f47e5dd702c3e28e5b2071374bda2948/pyyaml-6.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c5677e12444c15717b902a5798264fa7909e41153cdf9ef7ad571b704a63dd9", size = 737631, upload-time = "2025-09-25T21:33:03.25Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/b2/18f2bd28cd2055a79a46c9b0895c0b3d987ce40ee471cecf58a1a0199805/pyyaml-6.0.3-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ed875a24292240029e4483f9d4a4b8a1ae08843b9c54f43fcc11e404532a8a5", size = 836795, upload-time = "2025-09-25T21:33:05.014Z" },
-    { url = "https://files.pythonhosted.org/packages/73/b9/793686b2d54b531203c160ef12bec60228a0109c79bae6c1277961026770/pyyaml-6.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a", size = 750767, upload-time = "2025-09-25T21:33:06.398Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/86/a137b39a611def2ed78b0e66ce2fe13ee701a07c07aebe55c340ed2a050e/pyyaml-6.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fa160448684b4e94d80416c0fa4aac48967a969efe22931448d853ada8baf926", size = 727982, upload-time = "2025-09-25T21:33:08.708Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/62/71c27c94f457cf4418ef8ccc71735324c549f7e3ea9d34aba50874563561/pyyaml-6.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:27c0abcb4a5dac13684a37f76e701e054692a9b2d3064b70f5e4eb54810553d7", size = 755677, upload-time = "2025-09-25T21:33:09.876Z" },
-    { url = "https://files.pythonhosted.org/packages/29/3d/6f5e0d58bd924fb0d06c3a6bad00effbdae2de5adb5cda5648006ffbd8d3/pyyaml-6.0.3-cp39-cp39-win32.whl", hash = "sha256:1ebe39cb5fc479422b83de611d14e2c0d3bb2a18bbcb01f229ab3cfbd8fee7a0", size = 142592, upload-time = "2025-09-25T21:33:10.983Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/0c/25113e0b5e103d7f1490c0e947e303fe4a696c10b501dea7a9f49d4e876c/pyyaml-6.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:2e71d11abed7344e42a8849600193d15b6def118602c4c176f748e4583246007", size = 158777, upload-time = "2025-09-25T21:33:15.55Z" },
 ]
 
 [[package]]
@@ -4373,8 +3849,7 @@ dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
     { name = "idna" },
-    { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
@@ -4399,8 +3874,7 @@ name = "rich-click"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "click" },
     { name = "rich" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
@@ -4492,16 +3966,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/fa/3234f913fe9a6525a7b97c6dad1f51e72b917e6872e051a5e2ffd8b16fbb/ruamel.yaml.clib-0.2.14-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:70eda7703b8126f5e52fcf276e6c0f40b0d314674f896fc58c47b0aef2b9ae83", size = 137970, upload-time = "2025-09-22T19:51:09.472Z" },
     { url = "https://files.pythonhosted.org/packages/ef/ec/4edbf17ac2c87fa0845dd366ef8d5852b96eb58fcd65fc1ecf5fe27b4641/ruamel.yaml.clib-0.2.14-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a0cb71ccc6ef9ce36eecb6272c81afdc2f565950cdcec33ae8e6cd8f7fc86f27", size = 739639, upload-time = "2025-09-22T19:51:10.566Z" },
     { url = "https://files.pythonhosted.org/packages/15/18/b0e1fafe59051de9e79cdd431863b03593ecfa8341c110affad7c8121efc/ruamel.yaml.clib-0.2.14-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7cb9ad1d525d40f7d87b6df7c0ff916a66bc52cb61b66ac1b2a16d0c1b07640", size = 764456, upload-time = "2025-09-22T19:51:11.736Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/a0/e709dc2f58054049cd154319a7d37917689785b12ec43ea2df47ea5344ef/ruamel.yaml.clib-0.2.14-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:18c041b28f3456ddef1f1951d4492dbebe0f8114157c1b3c981a4611c2020792", size = 270636, upload-time = "2025-09-23T14:24:17.855Z" },
-    { url = "https://files.pythonhosted.org/packages/18/81/491c9e394976e10682a596f2b785ba7066db525cc17f267005ae8ca33c73/ruamel.yaml.clib-0.2.14-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:d8354515ab62f95a07deaf7f845886cc50e2f345ceab240a3d2d09a9f7d77853", size = 137954, upload-time = "2025-09-22T19:51:12.851Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/a5/c6d1c767e051bbc00146a93132bf199b3e6ec2c219131b9d3e19eff428f3/ruamel.yaml.clib-0.2.14-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:275f938692013a3883edbd848edde6d9f26825d65c9a2eb1db8baa1adc96a05d", size = 636162, upload-time = "2025-09-22T19:51:16.823Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/6f/4746e2e8f60b3489b6cd6fad96a8e2aaa0cf7dd6760de3daad1a6e9f5789/ruamel.yaml.clib-0.2.14-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:16a60d69f4057ad9a92f3444e2367c08490daed6428291aa16cefb445c29b0e9", size = 723934, upload-time = "2025-09-22T19:51:13.948Z" },
-    { url = "https://files.pythonhosted.org/packages/26/47/5446e8cea2f6b5391fba653196f38b3f14030c1c324bd9aa67f1773d24ec/ruamel.yaml.clib-0.2.14-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ac5ff9425d8acb8f59ac5b96bcb7fd3d272dc92d96a7c730025928ffcc88a7a", size = 686265, upload-time = "2025-09-22T19:51:15.142Z" },
-    { url = "https://files.pythonhosted.org/packages/52/d7/344d7b3010b6a01af97431bdf89056abb2d8bd704d0f3430e7b50232cce4/ruamel.yaml.clib-0.2.14-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:e1d1735d97fd8a48473af048739379975651fab186f8a25a9f683534e6904179", size = 693042, upload-time = "2025-09-23T18:42:53.238Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/d5/a0f2cce1b6cfa9bf1921b8a19ebceafc7a9b3c27882e5af5a07ae080b1bd/ruamel.yaml.clib-0.2.14-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:83bbd8354f6abb3fdfb922d1ed47ad8d1db3ea72b0523dac8d07cdacfe1c0fcf", size = 706110, upload-time = "2025-09-22T19:51:18.467Z" },
-    { url = "https://files.pythonhosted.org/packages/42/cd/85b422d24ee2096eaf6faa360c95ef9bdb59097d19b9624cebce4dd9bc2a/ruamel.yaml.clib-0.2.14-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:808c7190a0fe7ae7014c42f73897cf8e9ef14ff3aa533450e51b1e72ec5239ad", size = 725028, upload-time = "2025-09-22T19:51:19.782Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/ac/99e6e0ea2584f84f447069d0187fe411e9b5deb7e3ddecda25001cfc7a95/ruamel.yaml.clib-0.2.14-cp39-cp39-win32.whl", hash = "sha256:6d5472f63a31b042aadf5ed28dd3ef0523da49ac17f0463e10fda9c4a2773352", size = 100915, upload-time = "2025-09-22T19:51:21.764Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/8d/846e43369658958c99d959bb7774136fff9210f9017d91a4277818ceafbf/ruamel.yaml.clib-0.2.14-cp39-cp39-win_amd64.whl", hash = "sha256:8dd3c2cc49caa7a8d64b67146462aed6723a0495e44bf0aa0a2e94beaa8432f6", size = 118706, upload-time = "2025-09-22T19:51:20.878Z" },
 ]
 
 [[package]]
@@ -4559,8 +4023,7 @@ version = "2025.9.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pygments-styles" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/00/f3/36435b8e126b0a2cd7efa346cb366f25769094425fa0b145ab6991d20829/shibuya-2025.9.25.tar.gz", hash = "sha256:03131beb0f8e31cf4f501a4b744cd9c3f387cf23696259476d141b9ca976156b", size = 81798, upload-time = "2025-09-25T02:54:18.744Z" }
@@ -4582,8 +4045,7 @@ name = "slotscheck"
 version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "click" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4b/57/6fcb8df11e7c76eb87b23bfa931408e47f051c6161749c531b4060a45516/slotscheck-0.19.1.tar.gz", hash = "sha256:6146b7747f8db335a00a66b782f86011b74b995f61746dc5b36a9e77d5326013", size = 16050, upload-time = "2024-10-19T13:30:53.369Z" }
@@ -4620,61 +4082,29 @@ wheels = [
 
 [[package]]
 name = "sphinx"
-version = "7.4.7"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "alabaster", version = "0.7.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "babel", marker = "python_full_version < '3.10'" },
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version < '3.10'" },
-    { name = "imagesize", marker = "python_full_version < '3.10'" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
-    { name = "jinja2", marker = "python_full_version < '3.10'" },
-    { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "pygments", marker = "python_full_version < '3.10'" },
-    { name = "requests", marker = "python_full_version < '3.10'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.10'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.10'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.10'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.10'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.10'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.10'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.10'" },
-    { name = "tomli", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/be/50e50cb4f2eff47df05673d361095cafd95521d2a22521b920c67a372dcb/sphinx-7.4.7.tar.gz", hash = "sha256:242f92a7ea7e6c5b406fdc2615413890ba9f699114a9c09192d7dfead2ee9cfe", size = 8067911, upload-time = "2024-07-20T14:46:56.059Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/ef/153f6803c5d5f8917dbb7f7fcf6d34a871ede3296fa89c2c703f5f8a6c8e/sphinx-7.4.7-py3-none-any.whl", hash = "sha256:c2419e2135d11f1951cd994d6eb18a1835bd8fdd8429f9ca375dc1f3281bd239", size = 3401624, upload-time = "2024-07-20T14:46:52.142Z" },
-]
-
-[[package]]
-name = "sphinx"
 version = "8.1.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.10.*'",
+    "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "babel", marker = "python_full_version == '3.10.*'" },
-    { name = "colorama", marker = "python_full_version == '3.10.*' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version == '3.10.*'" },
-    { name = "imagesize", marker = "python_full_version == '3.10.*'" },
-    { name = "jinja2", marker = "python_full_version == '3.10.*'" },
-    { name = "packaging", marker = "python_full_version == '3.10.*'" },
-    { name = "pygments", marker = "python_full_version == '3.10.*'" },
-    { name = "requests", marker = "python_full_version == '3.10.*'" },
-    { name = "snowballstemmer", marker = "python_full_version == '3.10.*'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.10.*'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.10.*'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.10.*'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.10.*'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.10.*'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.10.*'" },
-    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+    { name = "alabaster", marker = "python_full_version < '3.11'" },
+    { name = "babel", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version < '3.11'" },
+    { name = "imagesize", marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "requests", marker = "python_full_version < '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -4692,7 +4122,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster", version = "1.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "alabaster", marker = "python_full_version >= '3.11'" },
     { name = "babel", marker = "python_full_version >= '3.11'" },
     { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
     { name = "docutils", marker = "python_full_version >= '3.11'" },
@@ -4720,13 +4150,11 @@ name = "sphinx-autobuild"
 version = "2024.10.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.10.*'",
-    "python_full_version < '3.10'",
+    "python_full_version < '3.11'",
 ]
 dependencies = [
     { name = "colorama", marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "starlette", marker = "python_full_version < '3.11'" },
     { name = "uvicorn", marker = "python_full_version < '3.11'" },
     { name = "watchfiles", marker = "python_full_version < '3.11'" },
@@ -4762,28 +4190,13 @@ wheels = [
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/74/cd/03e7b917230dc057922130a79ba0240df1693bfd76727ea33fae84b39138/sphinx_autodoc_typehints-2.3.0.tar.gz", hash = "sha256:535c78ed2d6a1bad393ba9f3dfa2602cf424e2631ee207263e07874c38fde084", size = 40709, upload-time = "2024-08-29T16:25:48.343Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/f3/e0a4ce49da4b6f4e4ce84b3c39a0677831884cb9d8a87ccbf1e9e56e53ac/sphinx_autodoc_typehints-2.3.0-py3-none-any.whl", hash = "sha256:3098e2c6d0ba99eacd013eb06861acc9b51c6e595be86ab05c08ee5506ac0c67", size = 19836, upload-time = "2024-08-29T16:25:46.707Z" },
-]
-
-[[package]]
-name = "sphinx-autodoc-typehints"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.10.*'",
+    "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/f0/43c6a5ff3e7b08a8c3b32f81b859f1b518ccc31e45f22e2b41ced38be7b9/sphinx_autodoc_typehints-3.0.1.tar.gz", hash = "sha256:b9b40dd15dee54f6f810c924f863f9cf1c54f9f3265c495140ea01be7f44fa55", size = 36282, upload-time = "2025-01-16T18:25:30.958Z" }
 wheels = [
@@ -4810,36 +4223,12 @@ wheels = [
 
 [[package]]
 name = "sphinx-click"
-version = "6.0.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "docutils", marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/db/0a/5b1e8d0579dbb4ca8114e456ca4a68020bfe8e15c7001f3856be4929ab83/sphinx_click-6.0.0.tar.gz", hash = "sha256:f5d664321dc0c6622ff019f1e1c84e58ce0cecfddeb510e004cf60c2a3ab465b", size = 29574, upload-time = "2024-05-15T14:49:17.044Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/d7/8621c4726ad3f788a1db4c0c409044b16edc563f5c9542807b3724037555/sphinx_click-6.0.0-py3-none-any.whl", hash = "sha256:1e0a3c83bcb7c55497751b19d07ebe56b5d7b85eb76dd399cf9061b497adc317", size = 9922, upload-time = "2024-05-15T14:49:15.768Z" },
-]
-
-[[package]]
-name = "sphinx-click"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "docutils", marker = "python_full_version >= '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "click" },
+    { name = "docutils" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/4b/c433ea57136eac0ccb8d76d33355783f1e6e77f1f13dc7d8f15dba2dc024/sphinx_click-6.1.0.tar.gz", hash = "sha256:c702e0751c1a0b6ad649e4f7faebd0dc09a3cc7ca3b50f959698383772f50eef", size = 26855, upload-time = "2025-09-11T11:05:45.53Z" }
@@ -4852,8 +4241,7 @@ name = "sphinx-copybutton"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
@@ -4866,8 +4254,7 @@ name = "sphinx-design"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/69/b34e0cb5336f09c6866d53b4a19d76c227cdec1bbc7ac4de63ca7d58c9c7/sphinx_design-0.6.1.tar.gz", hash = "sha256:b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632", size = 2193689, upload-time = "2024-08-02T13:48:44.277Z" }
@@ -4895,48 +4282,23 @@ version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/21/62d3a58ff7bd02bbb9245a63d1f0d2e0455522a11a78951d16088569fca8/sphinx-paramlinks-0.6.0.tar.gz", hash = "sha256:746a0816860aa3fff5d8d746efcbec4deead421f152687411db1d613d29f915e", size = 12363, upload-time = "2023-08-11T16:09:28.604Z" }
 
 [[package]]
 name = "sphinx-prompt"
-version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "docutils", marker = "python_full_version < '3.10'" },
-    { name = "pygments", marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/fb/7a07b8df1ca2418147a6b13e3f6b445071f2565198b45efa631d0d6ef0cd/sphinx_prompt-1.8.0.tar.gz", hash = "sha256:47482f86fcec29662fdfd23e7c04ef03582714195d01f5d565403320084372ed", size = 5121, upload-time = "2023-09-14T12:46:13.449Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/49/f890a2668b7cbf375f5528b549c8d36dd2e801b0fbb7b2b5ef65663ecb6c/sphinx_prompt-1.8.0-py3-none-any.whl", hash = "sha256:369ecc633f0711886f9b3a078c83264245be1adf46abeeb9b88b5519e4b51007", size = 7298, upload-time = "2023-09-14T12:46:12.373Z" },
-]
-
-[[package]]
-name = "sphinx-prompt"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 dependencies = [
-    { name = "certifi", marker = "python_full_version >= '3.10'" },
-    { name = "docutils", marker = "python_full_version >= '3.10'" },
-    { name = "idna", marker = "python_full_version >= '3.10'" },
-    { name = "pygments", marker = "python_full_version >= '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "certifi" },
+    { name = "docutils" },
+    { name = "idna" },
+    { name = "pygments" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/34/fe/ac4e24f35b5148b31ac717ae7dcc7a2f7ec56eb729e22c7252ed8ad2d9a5/sphinx_prompt-1.9.0.tar.gz", hash = "sha256:471b3c6d466dce780a9b167d9541865fd4e9a80ed46e31b06a52a0529ae995a1", size = 5340, upload-time = "2024-08-07T15:46:51.428Z" }
 wheels = [
@@ -4950,8 +4312,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
     { name = "pygments" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/27/32/ab475e252dc2b704e82a91141fa404cdd8901a5cf34958fd22afacebfccd/sphinx-tabs-3.4.5.tar.gz", hash = "sha256:ba9d0c1e3e37aaadd4b5678449eb08176770e0fc227e769b6ce747df3ceea531", size = 16070, upload-time = "2024-01-21T12:13:39.392Z" }
@@ -4966,8 +4327,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
     { name = "setuptools" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "wheel" },
 ]
@@ -4991,15 +4351,12 @@ dependencies = [
     { name = "filelock" },
     { name = "html5lib" },
     { name = "ruamel-yaml" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "sphinx-autodoc-typehints", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx-autodoc-typehints", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx-autodoc-typehints", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx-autodoc-typehints", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-jinja2-compat" },
-    { name = "sphinx-prompt", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx-prompt", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "sphinx-prompt" },
     { name = "sphinx-tabs" },
     { name = "tabulate" },
     { name = "typing-extensions" },
@@ -5051,8 +4408,7 @@ version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/97/69/bf039237ad260073e8c02f820b3e00dc34f3a2de20aff7861e6b19d2f8c5/sphinxcontrib_mermaid-1.0.0.tar.gz", hash = "sha256:2e8ab67d3e1e2816663f9347d026a8dee4a858acdd4ad32dd1c808893db88146", size = 15153, upload-time = "2024-10-12T16:33:03.863Z" }
@@ -5120,14 +4476,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/85/29d216002d4593c2ce1c0ec2cec46dda77bfbcd221e24caa6e85eff53d89/sqlalchemy-2.0.43-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9df7126fd9db49e3a5a3999442cc67e9ee8971f3cb9644250107d7296cb2a164", size = 3219363, upload-time = "2025-08-11T15:56:39.11Z" },
     { url = "https://files.pythonhosted.org/packages/b6/e4/bd78b01919c524f190b4905d47e7630bf4130b9f48fd971ae1c6225b6f6a/sqlalchemy-2.0.43-cp313-cp313-win32.whl", hash = "sha256:7f1ac7828857fcedb0361b48b9ac4821469f7694089d15550bbcf9ab22564a1d", size = 2096718, upload-time = "2025-08-11T15:55:05.349Z" },
     { url = "https://files.pythonhosted.org/packages/ac/a5/ca2f07a2a201f9497de1928f787926613db6307992fe5cda97624eb07c2f/sqlalchemy-2.0.43-cp313-cp313-win_amd64.whl", hash = "sha256:971ba928fcde01869361f504fcff3b7143b47d30de188b11c6357c0505824197", size = 2123200, upload-time = "2025-08-11T15:55:07.932Z" },
-    { url = "https://files.pythonhosted.org/packages/92/95/ddb5acf74a71e0fa4f9410c7d8555f169204ae054a49693b3cd31d0bf504/sqlalchemy-2.0.43-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ceb5c832cc30663aeaf5e39657712f4c4241ad1f638d487ef7216258f6d41fe7", size = 2136445, upload-time = "2025-08-12T17:29:06.145Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/d4/7d7ea7dfbc1ddb0aa54dd63a686cd43842192b8e1bfb5315bb052925f704/sqlalchemy-2.0.43-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:11f43c39b4b2ec755573952bbcc58d976779d482f6f832d7f33a8d869ae891bf", size = 2126411, upload-time = "2025-08-12T17:29:08.138Z" },
-    { url = "https://files.pythonhosted.org/packages/07/bd/123ba09bec14112de10e49d8835e6561feb24fd34131099d98d28d34f106/sqlalchemy-2.0.43-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:413391b2239db55be14fa4223034d7e13325a1812c8396ecd4f2c08696d5ccad", size = 3221776, upload-time = "2025-08-11T16:00:30.938Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/35/553e45d5b91b15980c13e1dbcd7591f49047589843fff903c086d7985afb/sqlalchemy-2.0.43-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c379e37b08c6c527181a397212346be39319fb64323741d23e46abd97a400d34", size = 3221665, upload-time = "2025-08-12T17:29:11.307Z" },
-    { url = "https://files.pythonhosted.org/packages/07/4d/ff03e516087251da99bd879b5fdb2c697ff20295c836318dda988e12ec19/sqlalchemy-2.0.43-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:03d73ab2a37d9e40dec4984d1813d7878e01dbdc742448d44a7341b7a9f408c7", size = 3160067, upload-time = "2025-08-11T16:00:33.148Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/88/cbc7caa186ecdc5dea013e9ccc00d78b93a6638dc39656a42369a9536458/sqlalchemy-2.0.43-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:8cee08f15d9e238ede42e9bbc1d6e7158d0ca4f176e4eab21f88ac819ae3bd7b", size = 3184462, upload-time = "2025-08-12T17:29:14.919Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/69/f8bbd43080b6fa75cb44ff3a1cc99aaae538dd0ade1a58206912b2565d72/sqlalchemy-2.0.43-cp39-cp39-win32.whl", hash = "sha256:b3edaec7e8b6dc5cd94523c6df4f294014df67097c8217a89929c99975811414", size = 2104031, upload-time = "2025-08-11T15:48:56.453Z" },
-    { url = "https://files.pythonhosted.org/packages/36/39/2ec1b0e7a4f44d833d924e7bfca8054c72e37eb73f4d02795d16d8b0230a/sqlalchemy-2.0.43-cp39-cp39-win_amd64.whl", hash = "sha256:227119ce0a89e762ecd882dc661e0aa677a690c914e358f0dd8932a2e8b2765b", size = 2128007, upload-time = "2025-08-11T15:48:57.872Z" },
     { url = "https://files.pythonhosted.org/packages/b8/d9/13bdde6521f322861fab67473cec4b1cc8999f3871953531cf61945fad92/sqlalchemy-2.0.43-py3-none-any.whl", hash = "sha256:1681c21dd2ccee222c2fe0bef671d1aef7c504087c9c4e800371cfcc8ac966fc", size = 1924759, upload-time = "2025-08-11T15:39:53.024Z" },
 ]
 
@@ -5196,16 +4544,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/7f/62e27243b014cb5cf116653b0122902b1a6f44af7d9d0094b366a5a846f2/sqlglotrs-0.6.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:014887e055ec0fdf0186446885be09cd0c6a48fbf604b58abaa9abd8e8f11f5a", size = 362053, upload-time = "2025-09-03T09:27:26.403Z" },
     { url = "https://files.pythonhosted.org/packages/55/80/678cd8bbf49fa9c5523adac1ca1815f84e1a1ebb52cf3dc9812c808ac375/sqlglotrs-0.6.2-cp313-cp313-win32.whl", hash = "sha256:12438b306bcc56e160f5562c1f96abbba0b1c923d7425fbda1bcbfa40116f3e4", size = 183754, upload-time = "2025-09-03T09:28:02.285Z" },
     { url = "https://files.pythonhosted.org/packages/cc/ca/46dad4f7c4d94a7a627add1f4b6ac8d4a6b248b20f54461339767b313afa/sqlglotrs-0.6.2-cp313-cp313-win_amd64.whl", hash = "sha256:40c7cf78ae2a9a5dcf8f18ed7e17947817f0c0e0b82c8cd9339613c746b90280", size = 195711, upload-time = "2025-09-03T09:28:07.204Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/71/3cc061eceb92c3575cad3aa7d89eba036923847374f9698cf47f28b02245/sqlglotrs-0.6.2-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:6e2a02b4e00320798450b433f7443b00070c852c85b628d1b8af3f6be2b7ea0f", size = 316729, upload-time = "2025-09-03T09:27:57.446Z" },
-    { url = "https://files.pythonhosted.org/packages/63/71/baef8445a52164243d048acb4d48c055c936bf61aba35d48525f8f8d2630/sqlglotrs-0.6.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:add0f8ce1dbcc78bbebc5b28bb1fbb79f8c15d97912b8df2ea4d61690661ddc2", size = 301947, upload-time = "2025-09-03T09:27:51.757Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/5c/fde358983f78bdb26063f647459b77f34ac2e646f78ae5f755602ccaee43/sqlglotrs-0.6.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:630e35fbfda11e050b8317410d1098165255aadde334063b769cfa5ce17fa6e7", size = 333337, upload-time = "2025-09-03T09:27:15.89Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/da/de7064147a713fdc9d50e257bc7b50edb36214f0f7203da377b8cecd3efd/sqlglotrs-0.6.2-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f9a02e99141944e95de3bd5ded879e567e0160cb8f8f2b454de3a63505358599", size = 341883, upload-time = "2025-09-03T09:27:21.455Z" },
-    { url = "https://files.pythonhosted.org/packages/73/e4/7dcf1ff14b8c13055ff414763497db8cefe181dacbb9fde9bd1866ba4e4b/sqlglotrs-0.6.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a7b230f7ee600015eb761ef8d61e9c705800187d311c8795899eaef20ef66748", size = 486371, upload-time = "2025-09-03T09:27:33.752Z" },
-    { url = "https://files.pythonhosted.org/packages/31/47/69e8014d71576fa9d0a6e6cdddeec501a077986b17d242b91e3c4825f1f5/sqlglotrs-0.6.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e1fc3569b1832c02a82d56518d972114715f024315d7dffc4721d6b0f3078bdd", size = 366168, upload-time = "2025-09-03T09:27:40.182Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/fd/bbea37fb896c7134cc8939e0396715c3537ad929457ba2e388234b25b09d/sqlglotrs-0.6.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:462ab50b7a9217689f1f403df002f350a5887e64feed72acd3807a475406767b", size = 339085, upload-time = "2025-09-03T09:27:46.446Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/5a/27b6f6756e5fc5236bc379aab8b51a6479cf654ddb322b81cf425434e047/sqlglotrs-0.6.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d5d695739e4adeb703cbd411c4798806d373da6774e939c81c4ba9a9d9e66196", size = 364575, upload-time = "2025-09-03T09:27:27.416Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/c4/e17a1e7ef35ddd7c45e0fef1ab22f26f5be36bee5f9a1f2718b8262ae658/sqlglotrs-0.6.2-cp39-cp39-win32.whl", hash = "sha256:8cb3b3d9ee20ba91bf0c7b34f9974b45172275b9278e458128704f3661ba85ac", size = 184081, upload-time = "2025-09-03T09:28:03.244Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/1a/b77cf199f1c696e511d054b2cfd15c3eb2f5a3228017d4bb99bc4b8dd16f/sqlglotrs-0.6.2-cp39-cp39-win_amd64.whl", hash = "sha256:d9fc7db0404bcf5953e0492c942e8db2630f7503d658745ff3198ea4a265c173", size = 196452, upload-time = "2025-09-03T09:28:08.212Z" },
 ]
 
 [[package]]
@@ -5222,7 +4560,6 @@ name = "sqlspec"
 version = "0.26.0"
 source = { editable = "." }
 dependencies = [
-    { name = "eval-type-backport", marker = "python_full_version < '3.10'" },
     { name = "mypy-extensions" },
     { name = "rich-click" },
     { name = "sqlglot" },
@@ -5356,13 +4693,12 @@ dev = [
     { name = "auto-pytabs", extra = ["sphinx"] },
     { name = "bump-my-version" },
     { name = "coverage" },
-    { name = "dishka", marker = "python_full_version >= '3.10'" },
+    { name = "dishka" },
     { name = "duckdb" },
     { name = "fsspec", extra = ["s3"] },
     { name = "hatch-mypyc" },
     { name = "mypy" },
-    { name = "myst-parser", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "myst-parser" },
     { name = "pgvector" },
     { name = "polars" },
     { name = "pre-commit" },
@@ -5384,16 +4720,13 @@ dev = [
     { name = "ruff" },
     { name = "shibuya" },
     { name = "slotscheck" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-autobuild", version = "2024.10.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx-autobuild", version = "2025.8.25", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "sphinx-autodoc-typehints", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx-autodoc-typehints", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx-autodoc-typehints", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx-autodoc-typehints", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "sphinx-click", version = "6.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx-click", version = "6.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "sphinx-click" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
     { name = "sphinx-paramlinks" },
@@ -5409,19 +4742,15 @@ dev = [
 ]
 doc = [
     { name = "auto-pytabs", extra = ["sphinx"] },
-    { name = "myst-parser", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "myst-parser" },
     { name = "shibuya" },
-    { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-autobuild", version = "2024.10.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx-autobuild", version = "2025.8.25", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "sphinx-autodoc-typehints", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx-autodoc-typehints", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "sphinx-autodoc-typehints", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx-autodoc-typehints", version = "3.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "sphinx-click", version = "6.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sphinx-click", version = "6.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "sphinx-click" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
     { name = "sphinx-paramlinks" },
@@ -5435,7 +4764,7 @@ extras = [
     { name = "adbc-driver-manager" },
     { name = "adbc-driver-postgresql" },
     { name = "adbc-driver-sqlite" },
-    { name = "dishka", marker = "python_full_version >= '3.10'" },
+    { name = "dishka" },
     { name = "fsspec", extra = ["s3"] },
     { name = "pgvector" },
     { name = "polars" },
@@ -5479,7 +4808,6 @@ requires-dist = [
     { name = "attrs", marker = "extra == 'attrs'" },
     { name = "cattrs", marker = "extra == 'attrs'" },
     { name = "duckdb", marker = "extra == 'duckdb'" },
-    { name = "eval-type-backport", marker = "python_full_version < '3.10'" },
     { name = "fastapi", marker = "extra == 'fastapi'" },
     { name = "fastnanoid", marker = "extra == 'nanoid'", specifier = ">=0.4.1" },
     { name = "flask", marker = "extra == 'flask'" },
@@ -5541,7 +4869,7 @@ dev = [
     { name = "auto-pytabs", extras = ["sphinx"], specifier = ">=0.5.0" },
     { name = "bump-my-version" },
     { name = "coverage", specifier = ">=7.6.1" },
-    { name = "dishka", marker = "python_full_version >= '3.10'" },
+    { name = "dishka" },
     { name = "duckdb" },
     { name = "fsspec", extras = ["s3"] },
     { name = "hatch-mypyc" },
@@ -5568,8 +4896,7 @@ dev = [
     { name = "ruff", specifier = ">=0.7.1" },
     { name = "shibuya" },
     { name = "slotscheck", specifier = ">=0.16.5" },
-    { name = "sphinx", marker = "python_full_version < '3.10'", specifier = ">=7.0.0" },
-    { name = "sphinx", marker = "python_full_version >= '3.10'", specifier = ">=8.0.0" },
+    { name = "sphinx" },
     { name = "sphinx-autobuild", specifier = ">=2021.3.14" },
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-click", specifier = ">=6.0.0" },
@@ -5590,8 +4917,7 @@ doc = [
     { name = "auto-pytabs", extras = ["sphinx"], specifier = ">=0.5.0" },
     { name = "myst-parser" },
     { name = "shibuya" },
-    { name = "sphinx", marker = "python_full_version < '3.10'", specifier = ">=7.0.0" },
-    { name = "sphinx", marker = "python_full_version >= '3.10'", specifier = ">=8.0.0" },
+    { name = "sphinx" },
     { name = "sphinx-autobuild", specifier = ">=2021.3.14" },
     { name = "sphinx-autodoc-typehints" },
     { name = "sphinx-click", specifier = ">=6.0.0" },
@@ -5608,7 +4934,7 @@ extras = [
     { name = "adbc-driver-manager" },
     { name = "adbc-driver-postgresql" },
     { name = "adbc-driver-sqlite" },
-    { name = "dishka", marker = "python_full_version >= '3.10'" },
+    { name = "dishka" },
     { name = "fsspec", extras = ["s3"] },
     { name = "pgvector" },
     { name = "polars" },
@@ -5839,27 +5165,8 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "1.26.20"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32", size = 307380, upload-time = "2024-08-29T15:43:11.37Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/cf/8435d5a7159e2a9c83a95896ed596f68cf798005fe107cc655b5c5c14704/urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e", size = 144225, upload-time = "2024-08-29T15:43:08.921Z" },
-]
-
-[[package]]
-name = "urllib3"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version == '3.10.*'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
@@ -5890,13 +5197,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/f2/c10356f7787efa4980993d66ef796787076457df11692e101d99b72c0a77/uuid_utils-0.11.1-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:52e041072a402f1c7bb46bda156bc308adfe63075ac69d16f17fd4e651e016e9", size = 474585, upload-time = "2025-10-02T13:31:54.899Z" },
     { url = "https://files.pythonhosted.org/packages/04/fa/2b76936be180575af4fa8aa992b2f2082d03945e3fd56c5bef7d30336da7/uuid_utils-0.11.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4631774f439926c2488cf77a3b1afaa7ee96b94aae7cff14b7e080d375f3287", size = 330729, upload-time = "2025-10-02T13:31:56.277Z" },
     { url = "https://files.pythonhosted.org/packages/0f/54/2689fd44b1ef5fa045d4fce38977d466f18072a04a63b63739677369613d/uuid_utils-0.11.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:502de88885234f59e1bb4c2756f1369aa14a45f8aca25771c977057a8bbd595a", size = 351930, upload-time = "2025-10-02T13:31:57.872Z" },
-    { url = "https://files.pythonhosted.org/packages/88/53/5d02a025954cb520d46ae7fbf47096a421faa1ddfe0a9477114aeb9410cd/uuid_utils-0.11.1-pp39-pypy39_pp73-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:e6ce277bc8b1c6020908d2fba29c6f018b3c6132865dda8b5ab2da3496ed5270", size = 580730, upload-time = "2025-10-02T13:31:59.578Z" },
-    { url = "https://files.pythonhosted.org/packages/66/8e/a161fad3242124b0565d5383ac8a51d87ee5292350fdfabd23b300a161ae/uuid_utils-0.11.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:a0e04966246e9ef73229eacf3300f53b7491e2cca90bf5c2e724c7ef9ecfa57c", size = 294481, upload-time = "2025-10-02T13:32:01.33Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/b5/65d498e22d62cde1214548bd9ba2f3443bafeebee916bf860b48b872cb90/uuid_utils-0.11.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8df5deed6b1c55aae0a7d8221911ea6f4ef9c03eecf40b2442f605ca1c42e4b4", size = 327635, upload-time = "2025-10-02T13:32:02.777Z" },
-    { url = "https://files.pythonhosted.org/packages/36/e6/8626f55c3ea4312268fff3de459e903eb187aaf773837faca41701405892/uuid_utils-0.11.1-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:34c864e3c098e773eb763ca66450444759ee882413ca76e5c69d57bf689f0cfe", size = 332879, upload-time = "2025-10-02T13:32:04.24Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f8/cb0763df3b4777045f67e15aa54f9a600fdfdd9a317839729da1e5f1fc97/uuid_utils-0.11.1-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:52c8858cbb6a6d6745db75e6e205268378c122890aad5f06367a764ed48a0aa3", size = 475165, upload-time = "2025-10-02T13:32:05.49Z" },
-    { url = "https://files.pythonhosted.org/packages/04/c4/f9b303d6a6be633fb46ebf4c8e825aa0928fe1e6560f36082ae0862e23a0/uuid_utils-0.11.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96e601fde7dc2efa5af6fba79be43cac451184abb7c6b578a274ddce0678b17d", size = 331187, upload-time = "2025-10-02T13:32:06.806Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/b7/0e6a8c36f50925c8d786e6925392a849289c4bfaa0613a23832ad3574929/uuid_utils-0.11.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7dfab8bb7e047bac7baeb1cc06b1570cb1aa611f87962dfe16e198212535bfdc", size = 352623, upload-time = "2025-10-02T13:32:08.45Z" },
 ]
 
 [[package]]
@@ -5904,8 +5204,7 @@ name = "uvicorn"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "click" },
     { name = "h11" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
@@ -6019,18 +5318,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/69/c4/088825b75489cb5b6a761a4542645718893d395d8c530b38734f19da44d2/watchfiles-1.1.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d05686b5487cfa2e2c28ff1aa370ea3e6c5accfe6435944ddea1e10d93872147", size = 452240, upload-time = "2025-06-15T19:06:26.552Z" },
     { url = "https://files.pythonhosted.org/packages/10/8c/22b074814970eeef43b7c44df98c3e9667c1f7bf5b83e0ff0201b0bd43f9/watchfiles-1.1.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d0e10e6f8f6dc5762adee7dece33b722282e1f59aa6a55da5d493a97282fedd8", size = 625607, upload-time = "2025-06-15T19:06:27.606Z" },
     { url = "https://files.pythonhosted.org/packages/32/fa/a4f5c2046385492b2273213ef815bf71a0d4c1943b784fb904e184e30201/watchfiles-1.1.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:af06c863f152005c7592df1d6a7009c836a247c9d8adb78fef8575a5a98699db", size = 623315, upload-time = "2025-06-15T19:06:29.076Z" },
-    { url = "https://files.pythonhosted.org/packages/47/8a/a45db804b9f0740f8408626ab2bca89c3136432e57c4673b50180bf85dd9/watchfiles-1.1.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:865c8e95713744cf5ae261f3067861e9da5f1370ba91fc536431e29b418676fa", size = 406400, upload-time = "2025-06-15T19:06:30.233Z" },
-    { url = "https://files.pythonhosted.org/packages/64/06/a08684f628fb41addd451845aceedc2407dc3d843b4b060a7c4350ddee0c/watchfiles-1.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:42f92befc848bb7a19658f21f3e7bae80d7d005d13891c62c2cd4d4d0abb3433", size = 397920, upload-time = "2025-06-15T19:06:31.315Z" },
-    { url = "https://files.pythonhosted.org/packages/79/e6/e10d5675af653b1b07d4156906858041149ca222edaf8995877f2605ba9e/watchfiles-1.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa0cc8365ab29487eb4f9979fd41b22549853389e22d5de3f134a6796e1b05a4", size = 451196, upload-time = "2025-06-15T19:06:32.435Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/8a/facd6988100cd0f39e89f6c550af80edb28e3a529e1ee662e750663e6b36/watchfiles-1.1.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:90ebb429e933645f3da534c89b29b665e285048973b4d2b6946526888c3eb2c7", size = 458218, upload-time = "2025-06-15T19:06:33.503Z" },
-    { url = "https://files.pythonhosted.org/packages/90/26/34cbcbc4d0f2f8f9cc243007e65d741ae039f7a11ef8ec6e9cd25bee08d1/watchfiles-1.1.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c588c45da9b08ab3da81d08d7987dae6d2a3badd63acdb3e206a42dbfa7cb76f", size = 484851, upload-time = "2025-06-15T19:06:34.541Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/1f/f59faa9fc4b0e36dbcdd28a18c430416443b309d295d8b82e18192d120ad/watchfiles-1.1.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c55b0f9f68590115c25272b06e63f0824f03d4fc7d6deed43d8ad5660cabdbf", size = 599520, upload-time = "2025-06-15T19:06:35.785Z" },
-    { url = "https://files.pythonhosted.org/packages/83/72/3637abecb3bf590529f5154ca000924003e5f4bbb9619744feeaf6f0b70b/watchfiles-1.1.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd17a1e489f02ce9117b0de3c0b1fab1c3e2eedc82311b299ee6b6faf6c23a29", size = 477956, upload-time = "2025-06-15T19:06:36.965Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/f3/d14ffd9acc0c1bd4790378995e320981423263a5d70bd3929e2e0dc87fff/watchfiles-1.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da71945c9ace018d8634822f16cbc2a78323ef6c876b1d34bbf5d5222fd6a72e", size = 453196, upload-time = "2025-06-15T19:06:38.024Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/38/78ad77bd99e20c0fdc82262be571ef114fc0beef9b43db52adb939768c38/watchfiles-1.1.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:51556d5004887045dba3acdd1fdf61dddea2be0a7e18048b5e853dcd37149b86", size = 627479, upload-time = "2025-06-15T19:06:39.442Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/cf/549d50a22fcc83f1017c6427b1c76c053233f91b526f4ad7a45971e70c0b/watchfiles-1.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04e4ed5d1cd3eae68c89bcc1a485a109f39f2fd8de05f705e98af6b5f1861f1f", size = 624414, upload-time = "2025-06-15T19:06:40.859Z" },
-    { url = "https://files.pythonhosted.org/packages/72/de/57d6e40dc9140af71c12f3a9fc2d3efc5529d93981cd4d265d484d7c9148/watchfiles-1.1.0-cp39-cp39-win32.whl", hash = "sha256:c600e85f2ffd9f1035222b1a312aff85fd11ea39baff1d705b9b047aad2ce267", size = 280020, upload-time = "2025-06-15T19:06:41.89Z" },
-    { url = "https://files.pythonhosted.org/packages/88/bb/7d287fc2a762396b128a0fca2dbae29386e0a242b81d1046daf389641db3/watchfiles-1.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:3aba215958d88182e8d2acba0fdaf687745180974946609119953c0e112397dc", size = 292758, upload-time = "2025-06-15T19:06:43.251Z" },
     { url = "https://files.pythonhosted.org/packages/be/7c/a3d7c55cfa377c2f62c4ae3c6502b997186bc5e38156bafcb9b653de9a6d/watchfiles-1.1.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3a6fd40bbb50d24976eb275ccb55cd1951dfb63dbc27cae3066a6ca5f4beabd5", size = 406748, upload-time = "2025-06-15T19:06:44.2Z" },
     { url = "https://files.pythonhosted.org/packages/38/d0/c46f1b2c0ca47f3667b144de6f0515f6d1c670d72f2ca29861cac78abaa1/watchfiles-1.1.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9f811079d2f9795b5d48b55a37aa7773680a5659afe34b54cc1d86590a51507d", size = 398801, upload-time = "2025-06-15T19:06:45.774Z" },
     { url = "https://files.pythonhosted.org/packages/70/9c/9a6a42e97f92eeed77c3485a43ea96723900aefa3ac739a8c73f4bff2cd7/watchfiles-1.1.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a2726d7bfd9f76158c84c10a409b77a320426540df8c35be172444394b17f7ea", size = 451528, upload-time = "2025-06-15T19:06:46.791Z" },
@@ -6039,10 +5326,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/d3/71c2dcf81dc1edcf8af9f4d8d63b1316fb0a2dd90cbfd427e8d9dd584a90/watchfiles-1.1.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:51b81e55d40c4b4aa8658427a3ee7ea847c591ae9e8b81ef94a90b668999353c", size = 398816, upload-time = "2025-06-15T19:06:50.433Z" },
     { url = "https://files.pythonhosted.org/packages/b8/fa/12269467b2fc006f8fce4cd6c3acfa77491dd0777d2a747415f28ccc8c60/watchfiles-1.1.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2bcdc54ea267fe72bfc7d83c041e4eb58d7d8dc6f578dfddb52f037ce62f432", size = 451584, upload-time = "2025-06-15T19:06:51.834Z" },
     { url = "https://files.pythonhosted.org/packages/bd/d3/254cea30f918f489db09d6a8435a7de7047f8cb68584477a515f160541d6/watchfiles-1.1.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:923fec6e5461c42bd7e3fd5ec37492c6f3468be0499bc0707b4bbbc16ac21792", size = 454009, upload-time = "2025-06-15T19:06:52.896Z" },
-    { url = "https://files.pythonhosted.org/packages/48/93/5c96bdb65e7f88f7da40645f34c0a3c317a2931ed82161e93c91e8eddd27/watchfiles-1.1.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7b3443f4ec3ba5aa00b0e9fa90cf31d98321cbff8b925a7c7b84161619870bc9", size = 406640, upload-time = "2025-06-15T19:06:54.868Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/25/09204836e93e1b99cce88802ce87264a1d20610c7a8f6de24def27ad95b1/watchfiles-1.1.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:7049e52167fc75fc3cc418fc13d39a8e520cbb60ca08b47f6cedb85e181d2f2a", size = 398543, upload-time = "2025-06-15T19:06:55.95Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/dc/6f324a6f32c5ab73b54311b5f393a79df34c1584b8d2404cf7e6d780aa5d/watchfiles-1.1.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54062ef956807ba806559b3c3d52105ae1827a0d4ab47b621b31132b6b7e2866", size = 451787, upload-time = "2025-06-15T19:06:56.998Z" },
-    { url = "https://files.pythonhosted.org/packages/45/5d/1d02ef4caa4ec02389e72d5594cdf9c67f1800a7c380baa55063c30c6598/watchfiles-1.1.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a7bd57a1bb02f9d5c398c0c1675384e7ab1dd39da0ca50b7f09af45fa435277", size = 454272, upload-time = "2025-06-15T19:06:58.055Z" },
 ]
 
 [[package]]
@@ -6125,29 +5408,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
-    { url = "https://files.pythonhosted.org/packages/36/db/3fff0bcbe339a6fa6a3b9e3fbc2bfb321ec2f4cd233692272c5a8d6cf801/websockets-15.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5f4c04ead5aed67c8a1a20491d54cdfba5884507a48dd798ecaf13c74c4489f5", size = 175424, upload-time = "2025-03-05T20:02:56.505Z" },
-    { url = "https://files.pythonhosted.org/packages/46/e6/519054c2f477def4165b0ec060ad664ed174e140b0d1cbb9fafa4a54f6db/websockets-15.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:abdc0c6c8c648b4805c5eacd131910d2a7f6455dfd3becab248ef108e89ab16a", size = 173077, upload-time = "2025-03-05T20:02:58.37Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/21/c0712e382df64c93a0d16449ecbf87b647163485ca1cc3f6cbadb36d2b03/websockets-15.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a625e06551975f4b7ea7102bc43895b90742746797e2e14b70ed61c43a90f09b", size = 173324, upload-time = "2025-03-05T20:02:59.773Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/cb/51ba82e59b3a664df54beed8ad95517c1b4dc1a913730e7a7db778f21291/websockets-15.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d591f8de75824cbb7acad4e05d2d710484f15f29d4a915092675ad3456f11770", size = 182094, upload-time = "2025-03-05T20:03:01.827Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/0f/bf3788c03fec679bcdaef787518dbe60d12fe5615a544a6d4cf82f045193/websockets-15.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:47819cea040f31d670cc8d324bb6435c6f133b8c7a19ec3d61634e62f8d8f9eb", size = 181094, upload-time = "2025-03-05T20:03:03.123Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/da/9fb8c21edbc719b66763a571afbaf206cb6d3736d28255a46fc2fe20f902/websockets-15.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac017dd64572e5c3bd01939121e4d16cf30e5d7e110a119399cf3133b63ad054", size = 181397, upload-time = "2025-03-05T20:03:04.443Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/65/65f379525a2719e91d9d90c38fe8b8bc62bd3c702ac651b7278609b696c4/websockets-15.0.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4a9fac8e469d04ce6c25bb2610dc535235bd4aa14996b4e6dbebf5e007eba5ee", size = 181794, upload-time = "2025-03-05T20:03:06.708Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/26/31ac2d08f8e9304d81a1a7ed2851c0300f636019a57cbaa91342015c72cc/websockets-15.0.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:363c6f671b761efcb30608d24925a382497c12c506b51661883c3e22337265ed", size = 181194, upload-time = "2025-03-05T20:03:08.844Z" },
-    { url = "https://files.pythonhosted.org/packages/98/72/1090de20d6c91994cd4b357c3f75a4f25ee231b63e03adea89671cc12a3f/websockets-15.0.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2034693ad3097d5355bfdacfffcbd3ef5694f9718ab7f29c29689a9eae841880", size = 181164, upload-time = "2025-03-05T20:03:10.242Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/37/098f2e1c103ae8ed79b0e77f08d83b0ec0b241cf4b7f2f10edd0126472e1/websockets-15.0.1-cp39-cp39-win32.whl", hash = "sha256:3b1ac0d3e594bf121308112697cf4b32be538fb1444468fb0a6ae4feebc83411", size = 176381, upload-time = "2025-03-05T20:03:12.77Z" },
-    { url = "https://files.pythonhosted.org/packages/75/8b/a32978a3ab42cebb2ebdd5b05df0696a09f4d436ce69def11893afa301f0/websockets-15.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7643a03db5c95c799b89b31c036d5f27eeb4d259c798e878d6937d71832b1e4", size = 176841, upload-time = "2025-03-05T20:03:14.367Z" },
     { url = "https://files.pythonhosted.org/packages/02/9e/d40f779fa16f74d3468357197af8d6ad07e7c5a27ea1ca74ceb38986f77a/websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3", size = 173109, upload-time = "2025-03-05T20:03:17.769Z" },
     { url = "https://files.pythonhosted.org/packages/bc/cd/5b887b8585a593073fd92f7c23ecd3985cd2c3175025a91b0d69b0551372/websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1", size = 173343, upload-time = "2025-03-05T20:03:19.094Z" },
     { url = "https://files.pythonhosted.org/packages/fe/ae/d34f7556890341e900a95acf4886833646306269f899d58ad62f588bf410/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475", size = 174599, upload-time = "2025-03-05T20:03:21.1Z" },
     { url = "https://files.pythonhosted.org/packages/71/e6/5fd43993a87db364ec60fc1d608273a1a465c0caba69176dd160e197ce42/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9", size = 174207, upload-time = "2025-03-05T20:03:23.221Z" },
     { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
     { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/48/4b67623bac4d79beb3a6bb27b803ba75c1bdedc06bd827e465803690a4b2/websockets-15.0.1-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7f493881579c90fc262d9cdbaa05a6b54b3811c2f300766748db79f098db9940", size = 173106, upload-time = "2025-03-05T20:03:29.404Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/f0/adb07514a49fe5728192764e04295be78859e4a537ab8fcc518a3dbb3281/websockets-15.0.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:47b099e1f4fbc95b701b6e85768e1fcdaf1630f3cbe4765fa216596f12310e2e", size = 173339, upload-time = "2025-03-05T20:03:30.755Z" },
-    { url = "https://files.pythonhosted.org/packages/87/28/bd23c6344b18fb43df40d0700f6d3fffcd7cef14a6995b4f976978b52e62/websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67f2b6de947f8c757db2db9c71527933ad0019737ec374a8a6be9a956786aaf9", size = 174597, upload-time = "2025-03-05T20:03:32.247Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/79/ca288495863d0f23a60f546f0905ae8f3ed467ad87f8b6aceb65f4c013e4/websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d08eb4c2b7d6c41da6ca0600c077e93f5adcfd979cd777d747e9ee624556da4b", size = 174205, upload-time = "2025-03-05T20:03:33.731Z" },
-    { url = "https://files.pythonhosted.org/packages/04/e4/120ff3180b0872b1fe6637f6f995bcb009fb5c87d597c1fc21456f50c848/websockets-15.0.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b826973a4a2ae47ba357e4e82fa44a463b8f168e1ca775ac64521442b19e87f", size = 174150, upload-time = "2025-03-05T20:03:35.757Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/c3/30e2f9c539b8da8b1d76f64012f3b19253271a63413b2d3adb94b143407f/websockets-15.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:21c1fa28a6a7e3cbdc171c694398b6df4744613ce9b36b1a498e816787e28123", size = 176877, upload-time = "2025-03-05T20:03:37.199Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]
 
@@ -6238,16 +5504,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
     { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
     { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
-    { url = "https://files.pythonhosted.org/packages/41/be/be9b3b0a461ee3e30278706f3f3759b9b69afeedef7fe686036286c04ac6/wrapt-1.17.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:30ce38e66630599e1193798285706903110d4f057aab3168a34b7fdc85569afc", size = 53485, upload-time = "2025-08-12T05:51:53.11Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/a8/8f61d6b8f526efc8c10e12bf80b4206099fea78ade70427846a37bc9cbea/wrapt-1.17.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:65d1d00fbfb3ea5f20add88bbc0f815150dbbde3b026e6c24759466c8b5a9ef9", size = 38675, upload-time = "2025-08-12T05:51:42.885Z" },
-    { url = "https://files.pythonhosted.org/packages/48/f1/23950c29a25637b74b322f9e425a17cc01a478f6afb35138ecb697f9558d/wrapt-1.17.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a7c06742645f914f26c7f1fa47b8bc4c91d222f76ee20116c43d5ef0912bba2d", size = 38956, upload-time = "2025-08-12T05:52:03.149Z" },
-    { url = "https://files.pythonhosted.org/packages/43/46/dd0791943613885f62619f18ee6107e6133237a6b6ed8a9ecfac339d0b4f/wrapt-1.17.3-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7e18f01b0c3e4a07fe6dfdb00e29049ba17eadbc5e7609a2a3a4af83ab7d710a", size = 81745, upload-time = "2025-08-12T05:52:49.62Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/ec/bb2d19bd1a614cc4f438abac13ae26c57186197920432d2a915183b15a8b/wrapt-1.17.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f5f51a6466667a5a356e6381d362d259125b57f059103dd9fdc8c0cf1d14139", size = 82833, upload-time = "2025-08-12T05:52:27.738Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/eb/66579aea6ad36f07617fedca8e282e49c7c9bab64c63b446cfe4f7f47a49/wrapt-1.17.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:59923aa12d0157f6b82d686c3fd8e1166fa8cdfb3e17b42ce3b6147ff81528df", size = 81889, upload-time = "2025-08-12T05:52:29.023Z" },
-    { url = "https://files.pythonhosted.org/packages/04/9c/a56b5ac0e2473bdc3fb11b22dd69ff423154d63861cf77911cdde5e38fd2/wrapt-1.17.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:46acc57b331e0b3bcb3e1ca3b421d65637915cfcd65eb783cb2f78a511193f9b", size = 81344, upload-time = "2025-08-12T05:52:50.869Z" },
-    { url = "https://files.pythonhosted.org/packages/93/4c/9bd735c42641d81cb58d7bfb142c58f95c833962d15113026705add41a07/wrapt-1.17.3-cp39-cp39-win32.whl", hash = "sha256:3e62d15d3cfa26e3d0788094de7b64efa75f3a53875cdbccdf78547aed547a81", size = 36462, upload-time = "2025-08-12T05:53:19.623Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/ea/0b72f29cb5ebc16eb55c57dc0c98e5de76fc97f435fd407f7d409459c0a6/wrapt-1.17.3-cp39-cp39-win_amd64.whl", hash = "sha256:1f23fa283f51c890eda8e34e4937079114c74b4c81d2b2f1f1d94948f5cc3d7f", size = 38740, upload-time = "2025-08-12T05:53:18.271Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/8b/9eae65fb92321e38dbfec7719b87d840a4b92fde83fd1bbf238c5488d055/wrapt-1.17.3-cp39-cp39-win_arm64.whl", hash = "sha256:24c2ed34dc222ed754247a2702b1e1e89fdbaa4016f324b4b8f1a802d4ffe87f", size = 36806, upload-time = "2025-08-12T05:52:58.765Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
@@ -6347,23 +5603,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/ed/c5fb04869b99b717985e244fd93029c7a8e8febdfcffa06093e32d7d44e7/yarl-1.20.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:88cab98aa4e13e1ade8c141daeedd300a4603b7132819c484841bb7af3edce9e", size = 341709, upload-time = "2025-06-10T00:45:23.221Z" },
     { url = "https://files.pythonhosted.org/packages/24/fd/725b8e73ac2a50e78a4534ac43c6addf5c1c2d65380dd48a9169cc6739a9/yarl-1.20.1-cp313-cp313t-win32.whl", hash = "sha256:b121ff6a7cbd4abc28985b6028235491941b9fe8fe226e6fdc539c977ea1739d", size = 86591, upload-time = "2025-06-10T00:45:25.793Z" },
     { url = "https://files.pythonhosted.org/packages/94/c3/b2e9f38bc3e11191981d57ea08cab2166e74ea770024a646617c9cddd9f6/yarl-1.20.1-cp313-cp313t-win_amd64.whl", hash = "sha256:541d050a355bbbc27e55d906bc91cb6fe42f96c01413dd0f4ed5a5240513874f", size = 93003, upload-time = "2025-06-10T00:45:27.752Z" },
-    { url = "https://files.pythonhosted.org/packages/01/75/0d37402d208d025afa6b5b8eb80e466d267d3fd1927db8e317d29a94a4cb/yarl-1.20.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:e42ba79e2efb6845ebab49c7bf20306c4edf74a0b20fc6b2ccdd1a219d12fad3", size = 134259, upload-time = "2025-06-10T00:45:29.882Z" },
-    { url = "https://files.pythonhosted.org/packages/73/84/1fb6c85ae0cf9901046f07d0ac9eb162f7ce6d95db541130aa542ed377e6/yarl-1.20.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:41493b9b7c312ac448b7f0a42a089dffe1d6e6e981a2d76205801a023ed26a2b", size = 91269, upload-time = "2025-06-10T00:45:32.917Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/9c/eae746b24c4ea29a5accba9a06c197a70fa38a49c7df244e0d3951108861/yarl-1.20.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f5a5928ff5eb13408c62a968ac90d43f8322fd56d87008b8f9dabf3c0f6ee983", size = 89995, upload-time = "2025-06-10T00:45:35.066Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/30/693e71003ec4bc1daf2e4cf7c478c417d0985e0a8e8f00b2230d517876fc/yarl-1.20.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30c41ad5d717b3961b2dd785593b67d386b73feca30522048d37298fee981805", size = 325253, upload-time = "2025-06-10T00:45:37.052Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/a2/5264dbebf90763139aeb0b0b3154763239398400f754ae19a0518b654117/yarl-1.20.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:59febc3969b0781682b469d4aca1a5cab7505a4f7b85acf6db01fa500fa3f6ba", size = 320897, upload-time = "2025-06-10T00:45:39.962Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/17/77c7a89b3c05856489777e922f41db79ab4faf58621886df40d812c7facd/yarl-1.20.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d2b6fb3622b7e5bf7a6e5b679a69326b4279e805ed1699d749739a61d242449e", size = 340696, upload-time = "2025-06-10T00:45:41.915Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/55/28409330b8ef5f2f681f5b478150496ec9cf3309b149dab7ec8ab5cfa3f0/yarl-1.20.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:749d73611db8d26a6281086f859ea7ec08f9c4c56cec864e52028c8b328db723", size = 335064, upload-time = "2025-06-10T00:45:43.893Z" },
-    { url = "https://files.pythonhosted.org/packages/85/58/cb0257cbd4002828ff735f44d3c5b6966c4fd1fc8cc1cd3cd8a143fbc513/yarl-1.20.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9427925776096e664c39e131447aa20ec738bdd77c049c48ea5200db2237e000", size = 327256, upload-time = "2025-06-10T00:45:46.393Z" },
-    { url = "https://files.pythonhosted.org/packages/53/f6/c77960370cfa46f6fb3d6a5a79a49d3abfdb9ef92556badc2dcd2748bc2a/yarl-1.20.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ff70f32aa316393eaf8222d518ce9118148eddb8a53073c2403863b41033eed5", size = 316389, upload-time = "2025-06-10T00:45:48.358Z" },
-    { url = "https://files.pythonhosted.org/packages/64/ab/be0b10b8e029553c10905b6b00c64ecad3ebc8ace44b02293a62579343f6/yarl-1.20.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:c7ddf7a09f38667aea38801da8b8d6bfe81df767d9dfc8c88eb45827b195cd1c", size = 340481, upload-time = "2025-06-10T00:45:50.663Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/c3/3f327bd3905a4916029bf5feb7f86dcf864c7704f099715f62155fb386b2/yarl-1.20.1-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:57edc88517d7fc62b174fcfb2e939fbc486a68315d648d7e74d07fac42cec240", size = 336941, upload-time = "2025-06-10T00:45:52.554Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/42/040bdd5d3b3bb02b4a6ace4ed4075e02f85df964d6e6cb321795d2a6496a/yarl-1.20.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:dab096ce479d5894d62c26ff4f699ec9072269d514b4edd630a393223f45a0ee", size = 339936, upload-time = "2025-06-10T00:45:54.919Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/1c/911867b8e8c7463b84dfdc275e0d99b04b66ad5132b503f184fe76be8ea4/yarl-1.20.1-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:14a85f3bd2d7bb255be7183e5d7d6e70add151a98edf56a770d6140f5d5f4010", size = 360163, upload-time = "2025-06-10T00:45:56.87Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/31/8c389f6c6ca0379b57b2da87f1f126c834777b4931c5ee8427dd65d0ff6b/yarl-1.20.1-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:2c89b5c792685dd9cd3fa9761c1b9f46fc240c2a3265483acc1565769996a3f8", size = 359108, upload-time = "2025-06-10T00:45:58.869Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/09/ae4a649fb3964324c70a3e2b61f45e566d9ffc0affd2b974cbf628957673/yarl-1.20.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:69e9b141de5511021942a6866990aea6d111c9042235de90e08f94cf972ca03d", size = 351875, upload-time = "2025-06-10T00:46:01.45Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/43/bbb4ed4c34d5bb62b48bf957f68cd43f736f79059d4f85225ab1ef80f4b9/yarl-1.20.1-cp39-cp39-win32.whl", hash = "sha256:b5f307337819cdfdbb40193cad84978a029f847b0a357fbe49f712063cfc4f06", size = 82293, upload-time = "2025-06-10T00:46:03.763Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/cd/ce185848a7dba68ea69e932674b5c1a42a1852123584bccc5443120f857c/yarl-1.20.1-cp39-cp39-win_amd64.whl", hash = "sha256:eae7bfe2069f9c1c5b05fc7fe5d612e5bbc089a39309904ee8b829e322dcad00", size = 87385, upload-time = "2025-06-10T00:46:05.655Z" },
     { url = "https://files.pythonhosted.org/packages/b4/2d/2345fce04cfd4bee161bf1e7d9cdc702e3e16109021035dbb24db654a622/yarl-1.20.1-py3-none-any.whl", hash = "sha256:83b8eb083fe4683c6115795d9fc1cfaf2cbbefb19b3a1cb68f6527460f483a77", size = 46542, upload-time = "2025-06-10T00:46:07.521Z" },
 ]
 


### PR DESCRIPTION
Remove support for Python 3.9 and transition type hints to the 3.10+ syntax across the codebase. This enhances type checking and maintains compatibility with newer Python versions.