### PR TITLE
fix: add TypedDict support to driver method overloads

### DIFF
--- a/sqlspec/__init__.py
+++ b/sqlspec/__init__.py
@@ -41,9 +41,9 @@ from sqlspec.typing import (
     ModelT,
     PoolT,
     RowT,
+    SchemaT,
     StatementParameters,
     SupportedSchemaModel,
-    TypedDictT,
 )
 from sqlspec.utils.logging import suppress_erroneous_sqlglot_log_messages
 
@@ -81,6 +81,7 @@ __all__ = (
     "SQLFileLoader",
     "SQLResult",
     "SQLSpec",
+    "SchemaT",
     "Select",
     "Statement",
     "StatementConfig",
@@ -88,7 +89,6 @@ __all__ = (
     "SupportedSchemaModel",
     "SyncDatabaseConfig",
     "SyncDriverAdapterBase",
-    "TypedDictT",
     "Update",
     "__version__",
     "adapters",

--- a/sqlspec/driver/_async.py
+++ b/sqlspec/driver/_async.py
@@ -1,7 +1,7 @@
 """Asynchronous driver protocol implementation."""
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Final, NoReturn, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, Final, NoReturn, TypeVar, overload
 
 from sqlspec.core import SQL, Statement
 from sqlspec.driver._common import CommonDriverAttributesMixin, DataDictionaryMixin, ExecutionResult, VersionInfo
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
     from sqlspec.builder import QueryBuilder
     from sqlspec.core import SQLResult, StatementConfig, StatementFilter
-    from sqlspec.typing import ModelDTOT, StatementParameters, TypedDictT
+    from sqlspec.typing import SchemaT, StatementParameters
 
 _LOGGER_NAME: Final[str] = "sqlspec"
 logger = get_logger(_LOGGER_NAME)
@@ -228,21 +228,10 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, To
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[ModelDTOT]",
+        schema_type: "type[SchemaT]",
         statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "ModelDTOT": ...
-
-    @overload
-    async def select_one(
-        self,
-        statement: "Statement | QueryBuilder",
-        /,
-        *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[TypedDictT]",
-        statement_config: "StatementConfig | None" = None,
-        **kwargs: Any,
-    ) -> "TypedDictT": ...
+    ) -> "SchemaT": ...
 
     @overload
     async def select_one(
@@ -260,10 +249,10 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, To
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[ModelDTOT | TypedDictT] | None" = None,
+        schema_type: "type[Any] | None" = None,
         statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "dict[str, Any] | ModelDTOT | TypedDictT":
+    ) -> Any:
         """Execute a select statement and return exactly one row.
 
         Raises an exception if no rows or more than one row is returned.
@@ -284,21 +273,10 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, To
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[ModelDTOT]",
+        schema_type: "type[SchemaT]",
         statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "ModelDTOT | None": ...
-
-    @overload
-    async def select_one_or_none(
-        self,
-        statement: "Statement | QueryBuilder",
-        /,
-        *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[TypedDictT]",
-        statement_config: "StatementConfig | None" = None,
-        **kwargs: Any,
-    ) -> "TypedDictT | None": ...
+    ) -> "SchemaT | None": ...
 
     @overload
     async def select_one_or_none(
@@ -316,10 +294,10 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, To
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[ModelDTOT | TypedDictT] | None" = None,
+        schema_type: "type[Any] | None" = None,
         statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "dict[str, Any] | ModelDTOT | TypedDictT | None":
+    ) -> Any:
         """Execute a select statement and return at most one row.
 
         Returns None if no rows are found.
@@ -333,10 +311,7 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, To
         if data_len > 1:
             self._raise_expected_at_most_one_row(data_len)
         first_row = data[0]
-        return cast(
-            "dict[str, Any] | ModelDTOT | None",
-            self.to_schema(first_row, schema_type=schema_type) if schema_type else first_row,
-        )
+        return self.to_schema(first_row, schema_type=schema_type) if schema_type else first_row
 
     @overload
     async def select(
@@ -344,21 +319,10 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, To
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[ModelDTOT]",
+        schema_type: "type[SchemaT]",
         statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "list[ModelDTOT]": ...
-
-    @overload
-    async def select(
-        self,
-        statement: "Statement | QueryBuilder",
-        /,
-        *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[TypedDictT]",
-        statement_config: "StatementConfig | None" = None,
-        **kwargs: Any,
-    ) -> "list[TypedDictT]": ...
+    ) -> "list[SchemaT]": ...
 
     @overload
     async def select(
@@ -376,15 +340,13 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, To
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[ModelDTOT | TypedDictT] | None" = None,
+        schema_type: "type[Any] | None" = None,
         statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "list[dict[str, Any]] | list[ModelDTOT] | list[TypedDictT]":
+    ) -> Any:
         """Execute a select statement and return all rows."""
         result = await self.execute(statement, *parameters, statement_config=statement_config, **kwargs)
-        return cast(
-            "list[dict[str, Any]] | list[ModelDTOT]", self.to_schema(result.get_data(), schema_type=schema_type)
-        )
+        return self.to_schema(result.get_data(), schema_type=schema_type)
 
     async def select_value(
         self,
@@ -454,21 +416,10 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, To
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[ModelDTOT]",
+        schema_type: "type[SchemaT]",
         statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "tuple[list[ModelDTOT], int]": ...
-
-    @overload
-    async def select_with_total(
-        self,
-        statement: "Statement | QueryBuilder",
-        /,
-        *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[TypedDictT]",
-        statement_config: "StatementConfig | None" = None,
-        **kwargs: Any,
-    ) -> "tuple[list[TypedDictT], int]": ...
+    ) -> "tuple[list[SchemaT], int]": ...
 
     @overload
     async def select_with_total(
@@ -486,10 +437,10 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, To
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[ModelDTOT | TypedDictT] | None" = None,
+        schema_type: "type[Any] | None" = None,
         statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "tuple[list[dict[str, Any]] | list[ModelDTOT] | list[TypedDictT], int]":
+    ) -> Any:
         """Execute a select statement and return both the data and total count.
 
         This method is designed for pagination scenarios where you need both

--- a/sqlspec/driver/_sync.py
+++ b/sqlspec/driver/_sync.py
@@ -1,7 +1,7 @@
 """Synchronous driver protocol implementation."""
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Final, NoReturn, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, Final, NoReturn, TypeVar, overload
 
 from sqlspec.core import SQL
 from sqlspec.driver._common import CommonDriverAttributesMixin, DataDictionaryMixin, ExecutionResult, VersionInfo
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
     from sqlspec.builder import QueryBuilder
     from sqlspec.core import SQLResult, Statement, StatementConfig, StatementFilter
-    from sqlspec.typing import ModelDTOT, StatementParameters, TypedDictT
+    from sqlspec.typing import SchemaT, StatementParameters
 
 _LOGGER_NAME: Final[str] = "sqlspec"
 logger = get_logger(_LOGGER_NAME)
@@ -228,21 +228,10 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToS
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[ModelDTOT]",
+        schema_type: "type[SchemaT]",
         statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "ModelDTOT": ...
-
-    @overload
-    def select_one(
-        self,
-        statement: "Statement | QueryBuilder",
-        /,
-        *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[TypedDictT]",
-        statement_config: "StatementConfig | None" = None,
-        **kwargs: Any,
-    ) -> "TypedDictT": ...
+    ) -> "SchemaT": ...
 
     @overload
     def select_one(
@@ -260,10 +249,10 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToS
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[ModelDTOT | TypedDictT] | None" = None,
+        schema_type: "type[Any] | None" = None,
         statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "dict[str, Any] | ModelDTOT | TypedDictT":
+    ) -> Any:
         """Execute a select statement and return exactly one row.
 
         Raises an exception if no rows or more than one row is returned.
@@ -284,21 +273,10 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToS
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[ModelDTOT]",
+        schema_type: "type[SchemaT]",
         statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "ModelDTOT | None": ...
-
-    @overload
-    def select_one_or_none(
-        self,
-        statement: "Statement | QueryBuilder",
-        /,
-        *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[TypedDictT]",
-        statement_config: "StatementConfig | None" = None,
-        **kwargs: Any,
-    ) -> "TypedDictT | None": ...
+    ) -> "SchemaT | None": ...
 
     @overload
     def select_one_or_none(
@@ -316,10 +294,10 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToS
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[ModelDTOT | TypedDictT] | None" = None,
+        schema_type: "type[Any] | None" = None,
         statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "dict[str, Any] | ModelDTOT | TypedDictT | None":
+    ) -> Any:
         """Execute a select statement and return at most one row.
 
         Returns None if no rows are found.
@@ -333,10 +311,7 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToS
         if data_len > 1:
             self._raise_expected_at_most_one_row(data_len)
         first_row = data[0]
-        return cast(
-            "dict[str, Any] | ModelDTOT | None",
-            self.to_schema(first_row, schema_type=schema_type) if schema_type else first_row,
-        )
+        return self.to_schema(first_row, schema_type=schema_type) if schema_type else first_row
 
     @overload
     def select(
@@ -344,21 +319,10 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToS
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[ModelDTOT]",
+        schema_type: "type[SchemaT]",
         statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "list[ModelDTOT]": ...
-
-    @overload
-    def select(
-        self,
-        statement: "Statement | QueryBuilder",
-        /,
-        *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[TypedDictT]",
-        statement_config: "StatementConfig | None" = None,
-        **kwargs: Any,
-    ) -> "list[TypedDictT]": ...
+    ) -> "list[SchemaT]": ...
 
     @overload
     def select(
@@ -376,15 +340,13 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToS
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[ModelDTOT | TypedDictT] | None" = None,
+        schema_type: "type[Any] | None" = None,
         statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "list[dict[str, Any]] | list[ModelDTOT] | list[TypedDictT]":
+    ) -> Any:
         """Execute a select statement and return all rows."""
         result = self.execute(statement, *parameters, statement_config=statement_config, **kwargs)
-        return cast(
-            "list[dict[str, Any]] | list[ModelDTOT]", self.to_schema(result.get_data(), schema_type=schema_type)
-        )
+        return self.to_schema(result.get_data(), schema_type=schema_type)
 
     def select_value(
         self,
@@ -455,21 +417,10 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToS
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[ModelDTOT]",
+        schema_type: "type[SchemaT]",
         statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "tuple[list[ModelDTOT], int]": ...
-
-    @overload
-    def select_with_total(
-        self,
-        statement: "Statement | QueryBuilder",
-        /,
-        *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[TypedDictT]",
-        statement_config: "StatementConfig | None" = None,
-        **kwargs: Any,
-    ) -> "tuple[list[TypedDictT], int]": ...
+    ) -> "tuple[list[SchemaT], int]": ...
 
     @overload
     def select_with_total(
@@ -487,10 +438,10 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin, SQLTranslatorMixin, ToS
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[ModelDTOT | TypedDictT] | None" = None,
+        schema_type: "type[Any] | None" = None,
         statement_config: "StatementConfig | None" = None,
         **kwargs: Any,
-    ) -> "tuple[list[dict[str, Any]] | list[ModelDTOT] | list[TypedDictT], int]":
+    ) -> Any:
         """Execute a select statement and return both the data and total count.
 
         This method is designed for pagination scenarios where you need both

--- a/sqlspec/typing.py
+++ b/sqlspec/typing.py
@@ -99,11 +99,11 @@ ModelT = TypeVar("ModelT", bound="DictLike | StructStub | BaseModelStub | Datacl
 :class:`DictLike` | :class:`msgspec.Struct` | :class:`pydantic.BaseModel` | :class:`DataclassProtocol` | :class:`AttrsInstance`
 """
 RowT = TypeVar("RowT", bound="dict[str, Any]")
-TypedDictT = TypeVar("TypedDictT")
-"""Type variable for TypedDict types.
+SchemaT = TypeVar("SchemaT")
+"""Type variable for schema types (models, TypedDict, dataclasses, etc.).
 
-Unbounded TypeVar specifically for TypedDict support since TypedDict is a special
-typing form and cannot be unified with regular class types in type[...] contexts.
+Unbounded TypeVar for use with schema_type parameter in driver methods.
+Supports all schema types including TypedDict which cannot be bounded to a class hierarchy.
 """
 
 
@@ -132,6 +132,9 @@ ModelDTOT = TypeVar("ModelDTOT", bound="SupportedSchemaModel")
 """Type variable for model DTOs.
 
 :class:`msgspec.Struct`|:class:`pydantic.BaseModel`
+
+.. deprecated:: 0.27.0
+    Use :class:`SchemaT` instead. This TypeVar will be removed in a future version.
 """
 PydanticOrMsgspecT = SupportedSchemaModel
 """Type alias for pydantic or msgspec models.
@@ -245,6 +248,7 @@ __all__ = (
     "PoolT_co",
     "PydanticOrMsgspecT",
     "RowT",
+    "SchemaT",
     "Span",
     "StatementParameters",
     "Status",
@@ -254,7 +258,6 @@ __all__ = (
     "Tracer",
     "TupleRow",
     "TypeAdapter",
-    "TypedDictT",
     "UnsetType",
     "aiosql",
     "attrs_asdict",


### PR DESCRIPTION
## Summary
- Adds TypedDict support to all driver methods (select, select_one, select_one_or_none, select_with_total)
- Introduces SchemaT TypeVar in typing.py for unified schema type handling
- Fixes Pyright type checking errors when using TypedDict classes with schema_type parameter

## Root Cause
TypedDict is a special typing form (not a real runtime class) that cannot be used in `type[Union[...]]` contexts. Mypy treats `type[...]` as invariant and doesn't support union parameters like `type[ModelDTOT | TypedDictT]`.
 
## Type Safety
Callers retain precise types from overloads:
```python
class ProductSearch(TypedDict):
    id: int
    name: str
    similarity_score: float

# Type checker infers: list[ProductSearch]
results = await driver.select(
    "SELECT id, name, similarity FROM products",
    schema_type=ProductSearch,
)
```

## Technical Details
**Why not keep separate ModelDTOT and TypedDictT?**
- Mypy doesn't support `type[Union[TypeVar1, TypeVar2]]` in implementation signatures
- Using `type[ModelDTOT | TypedDictT]` causes invariance errors
- Single unbounded TypeVar avoids union-in-type issues entirely

**Why use Any return?**
- Implementation must be broader than overloads for mypy to accept it
- Type checkers use overloads for call-site inference, not implementation signature
- This is the standard pattern in typed Python libraries for conditional return types