### PR TITLE
refactor: use pg_catalog in postgres data dictionary

### DIFF
--- a/sqlspec/adapters/asyncpg/data_dictionary.py
+++ b/sqlspec/adapters/asyncpg/data_dictionary.py
@@ -117,7 +117,7 @@ class PostgresAsyncDataDictionary(AsyncDataDictionaryBase):
     async def get_columns(
         self, driver: AsyncDriverAdapterBase, table: str, schema: "str | None" = None
     ) -> "list[dict[str, Any]]":
-        """Get column information for a table using information_schema.
+        """Get column information for a table using pg_catalog.
 
         Args:
             driver: AsyncPG driver instance
@@ -130,25 +130,32 @@ class PostgresAsyncDataDictionary(AsyncDataDictionaryBase):
                 - data_type: PostgreSQL data type
                 - is_nullable: Whether column allows NULL (YES/NO)
                 - column_default: Default value if any
+
+        Notes:
+            Uses pg_catalog instead of information_schema to avoid potential
+            issues with PostgreSQL 'name' type in some drivers.
         """
         asyncpg_driver = cast("AsyncpgDriver", driver)
 
-        if schema:
-            sql = f"""
-                SELECT column_name, data_type, is_nullable, column_default
-                FROM information_schema.columns
-                WHERE table_name = '{table}' AND table_schema = '{schema}'
-                ORDER BY ordinal_position
-            """
-        else:
-            sql = f"""
-                SELECT column_name, data_type, is_nullable, column_default
-                FROM information_schema.columns
-                WHERE table_name = '{table}' AND table_schema = 'public'
-                ORDER BY ordinal_position
-            """
+        schema_name = schema or "public"
+        sql = """
+            SELECT
+                a.attname::text AS column_name,
+                pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,
+                CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END AS is_nullable,
+                pg_catalog.pg_get_expr(d.adbin, d.adrelid)::text AS column_default
+            FROM pg_catalog.pg_attribute a
+            JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
+            JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+            LEFT JOIN pg_catalog.pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
+            WHERE c.relname = $1
+                AND n.nspname = $2
+                AND a.attnum > 0
+                AND NOT a.attisdropped
+            ORDER BY a.attnum
+        """
 
-        result = await asyncpg_driver.execute(sql)
+        result = await asyncpg_driver.execute(sql, (table, schema_name))
         return result.data or []
 
     def list_available_features(self) -> "list[str]":

--- a/sqlspec/adapters/psycopg/adk/store.py
+++ b/sqlspec/adapters/psycopg/adk/store.py
@@ -1,6 +1,6 @@
 """Psycopg ADK store for Google Agent Development Kit session/event storage."""
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from psycopg import errors
 from psycopg import sql as pg_sql
@@ -11,8 +11,6 @@ from sqlspec.utils.logging import get_logger
 
 if TYPE_CHECKING:
     from datetime import datetime
-
-    from psycopg.abc import Query
 
     from sqlspec.adapters.psycopg.config import PsycopgAsyncConfig, PsycopgSyncConfig
 

--- a/tests/integration/test_adapters/test_psqlpy/test_migrations.py
+++ b/tests/integration/test_adapters/test_psqlpy/test_migrations.py
@@ -63,7 +63,7 @@ def down():
 
             async with config.provide_session() as driver:
                 result = await driver.execute(
-                    f"SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = '{users_table}'"
+                    f"SELECT c.relname::text AS table_name FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid WHERE n.nspname = 'public' AND c.relname = '{users_table}' AND c.relkind = 'r'"
                 )
                 assert len(result.data) == 1
 
@@ -80,7 +80,7 @@ def down():
 
             async with config.provide_session() as driver:
                 result = await driver.execute(
-                    f"SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = '{users_table}'"
+                    f"SELECT c.relname::text AS table_name FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid WHERE n.nspname = 'public' AND c.relname = '{users_table}' AND c.relkind = 'r'"
                 )
                 assert len(result.data) == 0
         finally:
@@ -157,10 +157,10 @@ def down():
 
             async with config.provide_session() as driver:
                 users_result = await driver.execute(
-                    f"SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = '{users_table}'"
+                    f"SELECT c.relname::text AS table_name FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid WHERE n.nspname = 'public' AND c.relname = '{users_table}' AND c.relkind = 'r'"
                 )
                 posts_result = await driver.execute(
-                    f"SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = '{posts_table}'"
+                    f"SELECT c.relname::text AS table_name FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid WHERE n.nspname = 'public' AND c.relname = '{posts_table}' AND c.relkind = 'r'"
                 )
                 assert len(users_result.data) == 1
                 assert len(posts_result.data) == 1
@@ -177,10 +177,10 @@ def down():
 
             async with config.provide_session() as driver:
                 users_result = await driver.execute(
-                    f"SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = '{users_table}'"
+                    f"SELECT c.relname::text AS table_name FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid WHERE n.nspname = 'public' AND c.relname = '{users_table}' AND c.relkind = 'r'"
                 )
                 posts_result = await driver.execute(
-                    f"SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = '{posts_table}'"
+                    f"SELECT c.relname::text AS table_name FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid WHERE n.nspname = 'public' AND c.relname = '{posts_table}' AND c.relkind = 'r'"
                 )
                 assert len(users_result.data) == 1
                 assert len(posts_result.data) == 0
@@ -189,7 +189,7 @@ def down():
 
             async with config.provide_session() as driver:
                 users_result = await driver.execute(
-                    f"SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name IN ('{users_table}', '{posts_table}')"
+                    f"SELECT c.relname::text AS table_name FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid WHERE n.nspname = 'public' AND c.relname IN ('{users_table}', '{posts_table}') AND c.relkind = 'r'"
                 )
                 assert len(users_result.data) == 0
         finally:


### PR DESCRIPTION
Switch PostgreSQL queries to use pg_catalog for improved compatibility.