### PR TITLE
fix(observability): explicitly initialize LifecycleDispatcher guard attributes

### DIFF
--- a/sqlspec/observability/_dispatcher.py
+++ b/sqlspec/observability/_dispatcher.py
@@ -37,9 +37,31 @@ GUARD_ATTRS = tuple(f"has_{name[3:]}" for name in EVENT_ATTRS)
 class LifecycleDispatcher:
     """Dispatches lifecycle hooks with guard flags and diagnostics counters."""
 
-    __slots__ = ("_hooks", "_counters", *GUARD_ATTRS)
+    __slots__ = (
+        "_counters",
+        "_hooks",
+        "has_connection_create",
+        "has_connection_destroy",
+        "has_error",
+        "has_pool_create",
+        "has_pool_destroy",
+        "has_query_complete",
+        "has_query_start",
+        "has_session_end",
+        "has_session_start",
+    )
 
     def __init__(self, hooks: "dict[str, Iterable[Any]] | None" = None) -> None:
+        self.has_pool_create = False
+        self.has_pool_destroy = False
+        self.has_connection_create = False
+        self.has_connection_destroy = False
+        self.has_session_start = False
+        self.has_session_end = False
+        self.has_query_start = False
+        self.has_query_complete = False
+        self.has_error = False
+
         normalized: dict[LifecycleEvent, tuple[Any, ...]] = {}
         for event_name, guard_attr in zip(EVENT_ATTRS, GUARD_ATTRS, strict=False):
             callables = hooks.get(event_name) if hooks else None

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -216,6 +216,25 @@ def test_observability_config_merge_combines_hooks_and_observers() -> None:
     assert observer_called == []  # observers run via runtime, dispatcher unaffected
 
 
+def test_lifecycle_dispatcher_guard_attributes_always_accessible() -> None:
+    """All guard attributes should be accessible even with no hooks (mypyc compatibility)."""
+
+    dispatcher = LifecycleDispatcher(None)
+    assert dispatcher.has_pool_create is False
+    assert dispatcher.has_pool_destroy is False
+    assert dispatcher.has_connection_create is False
+    assert dispatcher.has_connection_destroy is False
+    assert dispatcher.has_session_start is False
+    assert dispatcher.has_session_end is False
+    assert dispatcher.has_query_start is False
+    assert dispatcher.has_query_complete is False
+    assert dispatcher.has_error is False
+
+    dispatcher_with_hooks = LifecycleDispatcher(cast("dict[str, Iterable[Any]]", {"on_query_start": [lambda ctx: ctx]}))
+    assert dispatcher_with_hooks.has_query_start is True
+    assert dispatcher_with_hooks.has_pool_create is False
+
+
 def test_lifecycle_dispatcher_counts_events() -> None:
     """Lifecycle dispatcher should count emitted events for diagnostics."""
 


### PR DESCRIPTION
## Summary

Fixes `AttributeError: 'LifecycleDispatcher' object has no attribute 'has_pool_create'` when SQLSpec is installed with mypyc compilation enabled. 

## The Problem

- `LifecycleDispatcher` used dynamic `__slots__` with tuple unpacking (`*GUARD_ATTRS`)
- When compiled with mypyc, `getattr()` calls on dynamically created slot attributes failed
- This caused crashes when using non-pooling adapters (ADBC, BigQuery) with mypyc builds
- Error only manifested in production builds with `HATCH_BUILD_HOOKS_ENABLE=1`

## The Solution

Explicitly define and initialize all guard attributes:

```python
__slots__ = (
    "_hooks",
    "_counters",
    "has_pool_create",
    "has_pool_destroy",
    # ... all guard attributes listed explicitly
)

def __init__(self, hooks):
    # Initialize all guards to False first
    self.has_pool_create = False
    self.has_pool_destroy = False
    # ... then set correct values via setattr()
```

## Key Features

- All guard attributes explicitly listed in `__slots__` (no tuple unpacking)
- All attributes initialized to `False` before dynamic assignment
- Maintains backward compatibility with existing code
- No performance impact on runtime behavior

## Testing

- Added test `test_lifecycle_dispatcher_guard_attributes_always_accessible()` 
- Validates all guard attributes accessible even with no hooks
- Tested with ADBC and BigQuery (non-pooling adapters)
- All existing observability tests pass