### PR TITLE
fix: simplify `get_next` function by using `anext` for async iteration

### DIFF
--- a/sqlspec/utils/sync_tools.py
+++ b/sqlspec/utils/sync_tools.py
@@ -271,16 +271,7 @@ async def get_next(iterable: Any, default: Any = NO_VALUE, *args: Any) -> Any:  
 
     Returns:
         The next value of the iterable.
-
-    Raises:
-        StopAsyncIteration: The iterable given is not async.
     """
-    has_default = bool(not isinstance(default, NoValue))
-    try:
-        return await iterable.__anext__()
-
-    except StopAsyncIteration as exc:
-        if has_default:
-            return default
-
-        raise StopAsyncIteration from exc
+    if isinstance(default, NoValue):
+        return await anext(iterable)
+    return await anext(iterable, default)


### PR DESCRIPTION
The previous implementation was using an implementation that was originally 3.9 compatible.  There was no `anext` in 3.9.  There's also a segfault that's been occurring and moving to `anext` solves it.