### PR TITLE
fix: update example tests to use unique table names for isolation

### DIFF
--- a/docs/examples/quickstart/quickstart_4.py
+++ b/docs/examples/quickstart/quickstart_4.py
@@ -25,11 +25,11 @@ async def test_quickstart_4() -> None:
     async with db_manager.provide_session(db) as session:
         await session.execute(
             """
-            CREATE TABLE if not exists users (id INTEGER, name TEXT, email TEXT)
+            CREATE TABLE if not exists qs4_users (id INTEGER, name TEXT, email TEXT)
             """
         )
-        await session.execute("INSERT INTO users VALUES (?, ?, ?)", 100, "Alice", "alice@example.com")
-        user = await session.select_one("SELECT * FROM users WHERE id = ?", 100, schema_type=User)
+        await session.execute("INSERT INTO qs4_users VALUES (?, ?, ?)", 100, "Alice", "alice@example.com")
+        user = await session.select_one("SELECT * FROM qs4_users WHERE id = ?", 100, schema_type=User)
         print(f"User: {user.name}")
     # end-example
 

--- a/docs/examples/quickstart/quickstart_5.py
+++ b/docs/examples/quickstart/quickstart_5.py
@@ -34,16 +34,16 @@ async def test_quickstart_5() -> None:
     async def seed_users(session: Any) -> None:
         await session.execute(
             """
-            CREATE TABLE IF NOT EXISTS users (
+            CREATE TABLE IF NOT EXISTS qs5_users (
                 id INTEGER PRIMARY KEY,
                 name TEXT NOT NULL,
                 email TEXT NOT NULL
             )
             """
         )
-        await session.execute("TRUNCATE TABLE users")
+        await session.execute("TRUNCATE TABLE qs5_users")
         await session.execute(
-            "INSERT INTO users (id, name, email) VALUES ($1, $2, $3)", 1, "Alice", "alice@example.com"
+            "INSERT INTO qs5_users (id, name, email) VALUES ($1, $2, $3)", 1, "Alice", "alice@example.com"
         )
 
     db_manager = SQLSpec()
@@ -51,7 +51,7 @@ async def test_quickstart_5() -> None:
 
     async with db_manager.provide_session(db) as session:
         await seed_users(session)
-        user = await session.select_one("SELECT * FROM users WHERE id = $1", 1, schema_type=User)
+        user = await session.select_one("SELECT * FROM qs5_users WHERE id = $1", 1, schema_type=User)
         print(f"User: {user.name}")
     # end-example
 

--- a/docs/examples/quickstart/quickstart_7.py
+++ b/docs/examples/quickstart/quickstart_7.py
@@ -13,7 +13,7 @@ def test_quickstart_7() -> None:
         session.begin()
         session.execute(
             """
-            CREATE TABLE IF NOT EXISTS users (
+            CREATE TABLE IF NOT EXISTS qs7_users (
                 id INTEGER PRIMARY KEY,
                 name TEXT NOT NULL
             )
@@ -21,26 +21,26 @@ def test_quickstart_7() -> None:
         )
         session.execute(
             """
-            CREATE TABLE IF NOT EXISTS orders (
+            CREATE TABLE IF NOT EXISTS qs7_orders (
                 id INTEGER PRIMARY KEY,
                 user_name TEXT NOT NULL
             )
             """
         )
-        session.execute("DELETE FROM users")
-        session.execute("DELETE FROM orders")
-        session.execute("INSERT INTO users (name) VALUES (?)", "Alice")
-        session.execute("INSERT INTO orders (user_name) VALUES (?)", "Alice")
+        session.execute("DELETE FROM qs7_users")
+        session.execute("DELETE FROM qs7_orders")
+        session.execute("INSERT INTO qs7_users (name) VALUES (?)", "Alice")
+        session.execute("INSERT INTO qs7_orders (user_name) VALUES (?)", "Alice")
         session.commit()
 
     with db_manager.provide_session(db) as session:
         session.begin()
-        session.execute("INSERT INTO users (name) VALUES (?)", "Bob")
+        session.execute("INSERT INTO qs7_users (name) VALUES (?)", "Bob")
         session.rollback()
 
     with db_manager.provide_session(db) as session:
-        alice = session.select_one_or_none("SELECT * FROM users WHERE name = ?", "Alice")
-        bob = session.select_one_or_none("SELECT * FROM users WHERE name = ?", "Bob")
+        alice = session.select_one_or_none("SELECT * FROM qs7_users WHERE name = ?", "Alice")
+        bob = session.select_one_or_none("SELECT * FROM qs7_users WHERE name = ?", "Bob")
     # end-example
 
     assert alice is not None

--- a/docs/examples/quickstart/quickstart_8.py
+++ b/docs/examples/quickstart/quickstart_8.py
@@ -6,7 +6,7 @@ def test_quickstart_8() -> None:
     from sqlspec import SQLSpec, sql
     from sqlspec.adapters.sqlite import SqliteConfig
 
-    query = sql.select("id", "name", "email").from_("users").where("age > ?").order_by("name")
+    query = sql.select("id", "name", "email").from_("qs8_users").where("age > ?").order_by("name")
 
     db_manager = SQLSpec()
     db = db_manager.add_config(SqliteConfig(pool_config={"database": ":memory:"}))
@@ -14,10 +14,10 @@ def test_quickstart_8() -> None:
     with db_manager.provide_session(db) as session:
         session.execute(
             """
-            CREATE TABLE users (id INTEGER, name TEXT, email TEXT, age INTEGER)
+            CREATE TABLE qs8_users (id INTEGER, name TEXT, email TEXT, age INTEGER)
             """
         )
-        session.execute("INSERT INTO users VALUES (?, ?, ?, ?)", 1, "Alice", "alice@example.com", 30)
+        session.execute("INSERT INTO qs8_users VALUES (?, ?, ?, ?)", 1, "Alice", "alice@example.com", 30)
         results = session.select(query, 25)
         print(results)
     # end-example

--- a/docs/examples/usage/usage_drivers_and_querying_2.py
+++ b/docs/examples/usage/usage_drivers_and_querying_2.py
@@ -18,7 +18,7 @@ async def test_example_2_importable(postgres_service: PostgresService) -> None:
     db = spec.add_config(AsyncpgConfig(pool_config={"dsn": dsn, "min_size": 10, "max_size": 20}))
     async with spec.provide_session(db) as session:
         create_table_query = """
-        CREATE TABLE IF NOT EXISTS users (
+        CREATE TABLE IF NOT EXISTS usage2_users (
             id SERIAL PRIMARY KEY,
             name VARCHAR(100),
             email VARCHAR(100) UNIQUE
@@ -27,12 +27,12 @@ async def test_example_2_importable(postgres_service: PostgresService) -> None:
         await session.execute(create_table_query)
         # Insert with RETURNING
         result = await session.execute(
-            "INSERT INTO users (name, email) VALUES ($1, $2) RETURNING id", "Gretta", "gretta@example.com"
+            "INSERT INTO usage2_users (name, email) VALUES ($1, $2) RETURNING id", "Gretta", "gretta@example.com"
         )
         new_id = result.scalar()
         print(f"Inserted user with ID: {new_id}")
         # Basic query
-        result = await session.execute("SELECT * FROM users WHERE id = $1", 1)
+        result = await session.execute("SELECT * FROM usage2_users WHERE id = $1", 1)
         user = result.one()
         print(f"User: {user}")
     # end-example

--- a/docs/examples/usage/usage_drivers_and_querying_3.py
+++ b/docs/examples/usage/usage_drivers_and_querying_3.py
@@ -22,7 +22,7 @@ def test_example_3_sync(postgres_service: PostgresService) -> None:
 
     with spec.provide_session(db) as session:
         create_table_query = """
-        CREATE TABLE IF NOT EXISTS users (
+        CREATE TABLE IF NOT EXISTS usage3_users (
             id SERIAL PRIMARY KEY,
             name VARCHAR(100),
             email VARCHAR(100) UNIQUE
@@ -30,8 +30,10 @@ def test_example_3_sync(postgres_service: PostgresService) -> None:
         """
         session.execute(create_table_query)
         # Insert with RETURNING
-        session.execute("INSERT INTO users (name, email) VALUES (%s, %s) RETURNING id", "Jane", "jane@example.com")
-        session.execute("SELECT * FROM users")
+        session.execute(
+            "INSERT INTO usage3_users (name, email) VALUES (%s, %s) RETURNING id", "Jane", "jane@example.com"
+        )
+        session.execute("SELECT * FROM usage3_users")
     # end-example
 
     spec.close_pool(db)

--- a/docs/examples/usage/usage_drivers_and_querying_4.py
+++ b/docs/examples/usage/usage_drivers_and_querying_4.py
@@ -22,7 +22,7 @@ async def test_example_4_async(postgres_service: PostgresService) -> None:
 
     async with spec.provide_session(db) as session:
         create_table_query = """
-        CREATE TABLE IF NOT EXISTS users (
+        CREATE TABLE IF NOT EXISTS usage4_users (
             id SERIAL PRIMARY KEY,
             name VARCHAR(100),
             email VARCHAR(100) UNIQUE
@@ -31,9 +31,9 @@ async def test_example_4_async(postgres_service: PostgresService) -> None:
         await session.execute(create_table_query)
         # Insert with RETURNING
         await session.execute(
-            "INSERT INTO users (name, email) VALUES (%s, %s) RETURNING id", "Bill", "bill@example.com"
+            "INSERT INTO usage4_users (name, email) VALUES (%s, %s) RETURNING id", "Bill", "bill@example.com"
         )
-        await session.execute("SELECT * FROM users")
+        await session.execute("SELECT * FROM usage4_users")
     # end-example
 
     await spec.close_pool(db)

--- a/docs/examples/usage/usage_drivers_and_querying_5.py
+++ b/docs/examples/usage/usage_drivers_and_querying_5.py
@@ -18,13 +18,15 @@ async def test_example_5_construct_config(postgres_service: PostgresService) -> 
     config = PsqlpyConfig(pool_config={"dsn": dsn})
     assert config is not None
     async with spec.provide_session(config) as session:
-        create_table_query = """CREATE TABLE IF NOT EXISTS users (
+        create_table_query = """CREATE TABLE IF NOT EXISTS usage5_users (
             id SERIAL PRIMARY KEY,
             name VARCHAR(100),
             email VARCHAR(100) UNIQUE
         );        """
         await session.execute(create_table_query)
         # Insert with RETURNING
-        await session.execute("INSERT INTO users (name, email) VALUES ($1, $2) RETURNING id", "Bob", "bob@example.com")
-        await session.execute("SELECT * FROM users WHERE id = $1", 1)
+        await session.execute(
+            "INSERT INTO usage5_users (name, email) VALUES ($1, $2) RETURNING id", "Bob", "bob@example.com"
+        )
+        await session.execute("SELECT * FROM usage5_users WHERE id = $1", 1)
     # end-example

--- a/docs/examples/usage/usage_drivers_and_querying_6.py
+++ b/docs/examples/usage/usage_drivers_and_querying_6.py
@@ -17,16 +17,16 @@ def test_example_6_sqlite_config() -> None:
     with spec.provide_session(config) as session:
         # Create table
         session.execute("""
-           CREATE TABLE IF NOT EXISTS users (
+           CREATE TABLE IF NOT EXISTS usage6_users (
                id INTEGER PRIMARY KEY,
                name TEXT NOT NULL
            )
        """)
 
         # Insert with parameters
-        session.execute("INSERT INTO users (name) VALUES (?)", "Alice")
+        session.execute("INSERT INTO usage6_users (name) VALUES (?)", "Alice")
 
         # Query
-        result = session.execute("SELECT * FROM users")
+        result = session.execute("SELECT * FROM usage6_users")
         result.all()
     # end-example

--- a/docs/examples/usage/usage_drivers_and_querying_8.py
+++ b/docs/examples/usage/usage_drivers_and_querying_8.py
@@ -13,11 +13,11 @@ async def test_example_8_aiosqlite_config() -> None:
     spec = SQLSpec()
 
     async with spec.provide_session(config) as session:
-        create_table_query = """CREATE TABLE IF NOT EXISTS users (
+        create_table_query = """CREATE TABLE IF NOT EXISTS usage8_users (
            id INTEGER PRIMARY KEY AUTOINCREMENT,
            name TEXT NOT NULL
        );"""
         await session.execute(create_table_query)
-        await session.execute("INSERT INTO users (name) VALUES (?)", "Bob")
-        await session.execute("SELECT * FROM users")
+        await session.execute("INSERT INTO usage8_users (name) VALUES (?)", "Bob")
+        await session.execute("SELECT * FROM usage8_users")
     # end-example

--- a/docs/examples/usage/usage_drivers_and_querying_9.py
+++ b/docs/examples/usage/usage_drivers_and_querying_9.py
@@ -26,7 +26,7 @@ async def test_example_9_asyncmy_config(mysql_service: MySQLService) -> None:
     )
 
     async with spec.provide_session(config) as session:
-        create_table_query = """CREATE TABLE IF NOT EXISTS users (
+        create_table_query = """CREATE TABLE IF NOT EXISTS usage9_users (
            id INT PRIMARY KEY,
            name VARCHAR(100),
            email VARCHAR(100)
@@ -34,8 +34,8 @@ async def test_example_9_asyncmy_config(mysql_service: MySQLService) -> None:
         await session.execute(create_table_query)
         # insert a user
         await session.execute(
-            "INSERT INTO users (id, name, email) VALUES (%s, %s, %s)", (1, "John Doe", "john.doe@example.com")
+            "INSERT INTO usage9_users (id, name, email) VALUES (%s, %s, %s)", (1, "John Doe", "john.doe@example.com")
         )
         # query the user
-        await session.execute("SELECT * FROM users WHERE id = %s", 1)
+        await session.execute("SELECT * FROM usage9_users WHERE id = %s", 1)
     # end-example


### PR DESCRIPTION
Update example tests to use unique table names for better isolation during testing. This change prevents conflicts between tests that may run concurrently.

