### PR TITLE
fix: handle None/empty edge cases in SearchFilter and Update.set()

### DIFF
--- a/sqlspec/builder/_dml.py
+++ b/sqlspec/builder/_dml.py
@@ -310,6 +310,8 @@ class UpdateSetClauseMixin:
         return placeholder
 
     def set(self, *args: Any, **kwargs: Any) -> Self:
+        if not args and not kwargs:
+            return self
         current_expr = self.get_expression()
         if current_expr is None:
             self.set_expression(exp.Update())

--- a/sqlspec/core/filters.py
+++ b/sqlspec/core/filters.py
@@ -658,7 +658,7 @@ class SearchFilter(StatementFilter):
 
     __slots__ = ("_field_name", "_ignore_case", "_value")
 
-    def __init__(self, field_name: str | set[str], value: str, ignore_case: bool | None = False) -> None:
+    def __init__(self, field_name: str | set[str], value: str | None, ignore_case: bool | None = False) -> None:
         self._field_name = field_name
         self._value = value
         self._ignore_case = ignore_case
@@ -668,7 +668,7 @@ class SearchFilter(StatementFilter):
         return self._field_name
 
     @property
-    def value(self) -> str:
+    def value(self) -> str | None:
         return self._value
 
     @property

--- a/sqlspec/extensions/litestar/providers.py
+++ b/sqlspec/extensions/litestar/providers.py
@@ -226,12 +226,7 @@ def _create_statement_filters(
             ),
         ) -> SearchFilter:
             field_names = set(search_fields.split(",")) if isinstance(search_fields, str) else set(search_fields)
-
-            return SearchFilter(
-                field_name=field_names,
-                value=search_string,  # type: ignore[arg-type]
-                ignore_case=ignore_case or False,
-            )
+            return SearchFilter(field_name=field_names, value=search_string, ignore_case=ignore_case or False)
 
         filters[dep_defaults.SEARCH_FILTER_DEPENDENCY_KEY] = Provide(provide_search_filter, sync_to_thread=False)
 


### PR DESCRIPTION
## Summary

Fixes two related edge-case handling issues where SQLSpec raised errors instead of handling gracefully.

## The Problem

1. **#281**: `SearchFilter` raised `TypeError` when `value=None` was passed (common when no search query param provided)
2. **#279**: `Update.set(**{})` raised `SQLBuilderError` (common with Pydantic/msgspec `exclude_unset=True` patterns)

## The Solution

Handle edge cases at the source rather than requiring defensive checks everywhere:

1. **SearchFilter**: Accept `value: str | None` - the `append_to_statement` method already handles None as no-op
2. **Update.set()**: Return `self` unchanged when called with empty args/kwargs

## Key Changes

- `sqlspec/core/filters.py`: `SearchFilter.__init__` accepts `value: str | None`
- `sqlspec/builder/_dml.py`: `set()` returns early when `not args and not kwargs`
- `sqlspec/extensions/litestar/providers.py`: Removed now-unnecessary `# type: ignore` comment

Closes #281, closes #279