### PR TITLE
feat: remove `__all__` imports for utils

### DIFF
--- a/sqlspec/utils/__init__.py
+++ b/sqlspec/utils/__init__.py
@@ -5,29 +5,3 @@ fixture loading, logging, module loading (including dependency checking),
 portal pattern for async bridging, singleton patterns, sync/async conversion,
 text processing, and type guards.
 """
-
-from sqlspec.utils import (
-    config_discovery,
-    deprecation,
-    fixtures,
-    logging,
-    module_loader,
-    portal,
-    singleton,
-    sync_tools,
-    text,
-    type_guards,
-)
-
-__all__ = (
-    "config_discovery",
-    "deprecation",
-    "fixtures",
-    "logging",
-    "module_loader",
-    "portal",
-    "singleton",
-    "sync_tools",
-    "text",
-    "type_guards",
-)


### PR DESCRIPTION
Removes the `__all__` dunder from `utils` to prevent optional import leakage when running the build process.