### PR TITLE
fix(events): use extension_config pattern for events configuration

### DIFF
--- a/docs/guides/adapters/asyncpg.md
+++ b/docs/guides/adapters/asyncpg.md
@@ -241,17 +241,15 @@ For comprehensive examples and migration guides, see:
 
 ## Event Channels
 
-- AsyncPG enables native LISTEN/NOTIFY support automatically by setting
-  `driver_features["events_backend"] = "listen_notify"` during config
-  construction. Call `spec.event_channel(config)` to obtain a channel—no
-  migrations are required.
+- AsyncPG defaults to native LISTEN/NOTIFY support (`backend="listen_notify"`).
+  Call `spec.event_channel(config)` to obtain a channel—no migrations required.
 - Publishing uses `connection.notify()` under the hood; consumers rely on
   `connection.add_listener()` with dedicated connections so the shared pool
   stays available for transactional work.
-- For durability and retries, set `driver_features["events_backend"] =
-  "listen_notify_durable"` and include the `events` extension migrations.
+- For durability and retries, set `extension_config={"events": {"backend": "listen_notify_durable"}}`
+  and include the `events` extension migrations.
 - Force the durable queue fallback (for deterministic testing or multi-tenant
-  workloads) by overriding `driver_features["events_backend"] = "table_queue"`
+  workloads) by setting `extension_config={"events": {"backend": "table_queue"}}`
   and including the `events` migrations.
 
 ## Common Issues

--- a/docs/guides/adapters/oracledb.md
+++ b/docs/guides/adapters/oracledb.md
@@ -902,9 +902,9 @@ For comprehensive examples and migration guides, see:
 
 ## Event Channels
 
-- Set `driver_features["events_backend"] = "advanced_queue"` to enable native
+- Set `extension_config={"events": {"backend": "advanced_queue"}}` to enable native
   Advanced Queuing support. Event publishing uses `connection.queue()` and
-  inherits the AQ options surfaced via `extension_config["events"]`
+  inherits the AQ options from `extension_config["events"]`
   (`aq_queue`, `aq_wait_seconds`, `aq_visibility`).
 - AQ requires DBA-provisioned queues plus enqueue/dequeue privileges. When the
   driver detects missing privileges it logs a warning and falls back to the

--- a/docs/guides/adapters/psqlpy.md
+++ b/docs/guides/adapters/psqlpy.md
@@ -254,16 +254,15 @@ For comprehensive examples and migration guides, see:
 
 ## Event Channels
 
-- Psqlpy enables native LISTEN/NOTIFY by default
-  (`driver_features["events_backend"] = "listen_notify"`). Call
-  `spec.event_channel(config)` to publish or consume without migrations.
+- Psqlpy defaults to native LISTEN/NOTIFY support (`backend="listen_notify"`).
+  Call `spec.event_channel(config)` to obtain a channel—no migrations required.
 - Native listeners use the `Listener` API and a dedicated connection so the
   shared pool remains available for normal queries.
-- For durability and retries, set `driver_features["events_backend"] =
-  "listen_notify_durable"` and include the `events` extension migrations.
-- The queue-only fallback remains available by setting
-  `driver_features["events_backend"] = "table_queue"` alongside the
-  `events` migrations.
+- For durability and retries, set `extension_config={"events": {"backend": "listen_notify_durable"}}`
+  and include the `events` extension migrations.
+- Force the durable queue fallback (for deterministic testing or multi-tenant
+  workloads) by setting `extension_config={"events": {"backend": "table_queue"}}`
+  and including the `events` migrations.
 
 ## Best Practices
 

--- a/docs/guides/adapters/psycopg.md
+++ b/docs/guides/adapters/psycopg.md
@@ -133,16 +133,15 @@ For comprehensive examples and migration guides, see:
 
 ## Event Channels
 
-- Psycopg enables native LISTEN/NOTIFY support by default
-  (`driver_features["events_backend"] = "listen_notify"`). Call
-  `spec.event_channel(config)` to publish or consume without migrations.
-- Listeners run on dedicated connections so the pool remains available for
-  transactional work.
-- For durability and retries, set `driver_features["events_backend"] =
-  "listen_notify_durable"` and include the `events` extension migrations.
-- The queue-only fallback remains available by setting
-  `driver_features["events_backend"] = "table_queue"` alongside the
-  `events` migrations.
+- Psycopg defaults to native LISTEN/NOTIFY support (`backend="listen_notify"`).
+  Call `spec.event_channel(config)` to obtain a channel—no migrations required.
+- Publishing uses `connection.notify()` under the hood; consumers rely on
+  dedicated connections so the shared pool stays available for transactional work.
+- For durability and retries, set `extension_config={"events": {"backend": "listen_notify_durable"}}`
+  and include the `events` extension migrations.
+- Force the durable queue fallback (for deterministic testing or multi-tenant
+  workloads) by setting `extension_config={"events": {"backend": "table_queue"}}`
+  and including the `events` migrations.
 
 ## Common Issues
 

--- a/sqlspec/adapters/adbc/config.py
+++ b/sqlspec/adapters/adbc/config.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 
 from typing_extensions import NotRequired
 
@@ -141,8 +141,6 @@ class AdbcDriverFeatures(TypedDict):
     enable_cast_detection: NotRequired[bool]
     strict_type_coercion: NotRequired[bool]
     arrow_extension_types: NotRequired[bool]
-    enable_events: NotRequired[bool]
-    events_backend: NotRequired[Literal["table_queue"]]
 
 
 __all__ = ("AdbcConfig", "AdbcConnectionParams", "AdbcDriverFeatures")
@@ -204,10 +202,6 @@ class AdbcConfig(NoPoolSyncConfig[AdbcConnection, AdbcDriver]):
         processed_driver_features.setdefault("enable_cast_detection", True)
         processed_driver_features.setdefault("strict_type_coercion", False)
         processed_driver_features.setdefault("arrow_extension_types", True)
-
-        # Auto-detect events support based on extension_config
-        processed_driver_features.setdefault("enable_events", "events" in (extension_config or {}))
-        processed_driver_features.setdefault("events_backend", "table_queue")
 
         if json_serializer is not None:
             statement_config = _apply_json_serializer_to_statement_config(statement_config, json_serializer)

--- a/sqlspec/adapters/aiosqlite/config.py
+++ b/sqlspec/adapters/aiosqlite/config.py
@@ -1,7 +1,7 @@
 """Aiosqlite database configuration."""
 
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
 
 from typing_extensions import NotRequired
 
@@ -82,8 +82,6 @@ class AiosqliteDriverFeatures(TypedDict):
     enable_custom_adapters: NotRequired[bool]
     json_serializer: "NotRequired[Callable[[Any], str]]"
     json_deserializer: "NotRequired[Callable[[str], Any]]"
-    enable_events: NotRequired[bool]
-    events_backend: NotRequired[Literal["table_queue"]]
 
 
 class AiosqliteConfig(AsyncDatabaseConfig["AiosqliteConnection", AiosqliteConnectionPool, AiosqliteDriver]):
@@ -144,10 +142,6 @@ class AiosqliteConfig(AsyncDatabaseConfig["AiosqliteConnection", AiosqliteConnec
         processed_driver_features.setdefault("enable_custom_adapters", True)
         json_serializer = processed_driver_features.setdefault("json_serializer", to_json)
         json_deserializer = processed_driver_features.setdefault("json_deserializer", from_json)
-
-        # Auto-detect events support based on extension_config
-        processed_driver_features.setdefault("enable_events", "events" in (extension_config or {}))
-        processed_driver_features.setdefault("events_backend", "table_queue")
 
         base_statement_config = statement_config or aiosqlite_statement_config
         if json_serializer is not None:

--- a/sqlspec/adapters/asyncmy/config.py
+++ b/sqlspec/adapters/asyncmy/config.py
@@ -2,7 +2,7 @@
 
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
 
 import asyncmy
 from asyncmy.cursors import Cursor, DictCursor  # pyright: ignore
@@ -90,8 +90,6 @@ class AsyncmyDriverFeatures(TypedDict):
 
     json_serializer: NotRequired["Callable[[Any], str]"]
     json_deserializer: NotRequired["Callable[[str], Any]"]
-    enable_events: NotRequired[bool]
-    events_backend: NotRequired[Literal["table_queue"]]
 
 
 class AsyncmyConfig(AsyncDatabaseConfig[AsyncmyConnection, "AsyncmyPool", AsyncmyDriver]):  # pyright: ignore
@@ -143,10 +141,6 @@ class AsyncmyConfig(AsyncDatabaseConfig[AsyncmyConnection, "AsyncmyPool", Asyncm
         processed_driver_features: dict[str, Any] = dict(driver_features) if driver_features else {}
         serializer = processed_driver_features.setdefault("json_serializer", to_json)
         deserializer = processed_driver_features.setdefault("json_deserializer", from_json)
-
-        # Auto-detect events support based on extension_config
-        processed_driver_features.setdefault("enable_events", "events" in (extension_config or {}))
-        processed_driver_features.setdefault("events_backend", "table_queue")
 
         base_statement_config = statement_config or build_asyncmy_statement_config(
             json_serializer=serializer, json_deserializer=deserializer

--- a/sqlspec/adapters/asyncpg/config.py
+++ b/sqlspec/adapters/asyncpg/config.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
 
 from asyncpg import Connection, Record
 from asyncpg import create_pool as asyncpg_create_pool
@@ -143,8 +143,6 @@ class AsyncpgDriverFeatures(TypedDict):
     alloydb_instance_uri: NotRequired[str]
     alloydb_enable_iam_auth: NotRequired[bool]
     alloydb_ip_type: NotRequired[str]
-    enable_events: NotRequired[bool]
-    events_backend: NotRequired[Literal["listen_notify", "table_queue", "listen_notify_durable"]]
 
 
 class AsyncpgConfig(AsyncDatabaseConfig[AsyncpgConnection, "Pool[Record]", AsyncpgDriver]):
@@ -196,10 +194,6 @@ class AsyncpgConfig(AsyncDatabaseConfig[AsyncpgConnection, "Pool[Record]", Async
         features_dict.setdefault("enable_pgvector", PGVECTOR_INSTALLED)
         features_dict.setdefault("enable_cloud_sql", False)
         features_dict.setdefault("enable_alloydb", False)
-
-        # Auto-detect events support based on extension_config
-        features_dict.setdefault("enable_events", "events" in (extension_config or {}))
-        features_dict.setdefault("events_backend", "listen_notify")
 
         base_statement_config = statement_config or build_asyncpg_statement_config(
             json_serializer=serializer, json_deserializer=deserializer

--- a/sqlspec/adapters/bigquery/config.py
+++ b/sqlspec/adapters/bigquery/config.py
@@ -1,7 +1,7 @@
 """BigQuery database configuration."""
 
 import contextlib
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
 
 from google.cloud.bigquery import LoadJobConfig, QueryJobConfig
 from typing_extensions import NotRequired
@@ -99,8 +99,6 @@ class BigQueryDriverFeatures(TypedDict):
     on_connection_create: NotRequired["Callable[[Any], None]"]
     json_serializer: NotRequired["Callable[[Any], str]"]
     enable_uuid_conversion: NotRequired[bool]
-    enable_events: NotRequired[bool]
-    events_backend: NotRequired[Literal["table_queue"]]
 
 
 __all__ = ("BigQueryConfig", "BigQueryConnectionParams", "BigQueryDriverFeatures")
@@ -154,10 +152,6 @@ class BigQueryConfig(NoPoolSyncConfig[BigQueryConnection, BigQueryDriver]):
         user_connection_hook = processed_driver_features.pop("on_connection_create", None)
         processed_driver_features.setdefault("enable_uuid_conversion", True)
         serializer = processed_driver_features.setdefault("json_serializer", to_json)
-
-        # Auto-detect events support based on extension_config
-        processed_driver_features.setdefault("enable_events", "events" in (extension_config or {}))
-        processed_driver_features.setdefault("events_backend", "table_queue")
 
         self._connection_instance: BigQueryConnection | None = processed_driver_features.get("connection_instance")
 

--- a/sqlspec/adapters/duckdb/config.py
+++ b/sqlspec/adapters/duckdb/config.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Sequence
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 
 from typing_extensions import NotRequired
 
@@ -159,8 +159,6 @@ class DuckDBDriverFeatures(TypedDict):
     json_serializer: NotRequired["Callable[[Any], str]"]
     enable_uuid_conversion: NotRequired[bool]
     extension_flags: NotRequired[dict[str, Any]]
-    enable_events: NotRequired[bool]
-    events_backend: NotRequired[Literal["table_queue"]]
 
 
 class DuckDBConfig(SyncDatabaseConfig[DuckDBConnection, DuckDBConnectionPool, DuckDBDriver]):
@@ -260,10 +258,6 @@ class DuckDBConfig(SyncDatabaseConfig[DuckDBConnection, DuckDBConnectionPool, Du
         )
         processed_features.setdefault("enable_uuid_conversion", True)
         serializer = processed_features.setdefault("json_serializer", to_json)
-
-        # Auto-detect events support based on extension_config
-        processed_features.setdefault("enable_events", "events" in (extension_config or {}))
-        processed_features.setdefault("events_backend", "table_queue")
 
         if extension_flags:
             existing_flags = cast("dict[str, Any]", processed_features.get("extension_flags", {}))

--- a/sqlspec/adapters/oracledb/config.py
+++ b/sqlspec/adapters/oracledb/config.py
@@ -2,7 +2,7 @@
 
 import contextlib
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 
 import oracledb
 from typing_extensions import NotRequired
@@ -117,8 +117,6 @@ class OracleDriverFeatures(TypedDict):
     enable_numpy_vectors: NotRequired[bool]
     enable_lowercase_column_names: NotRequired[bool]
     enable_uuid_binary: NotRequired[bool]
-    enable_events: NotRequired[bool]
-    events_backend: NotRequired[Literal["advanced_queue", "table_queue"]]
 
 
 class OracleSyncConfig(SyncDatabaseConfig[OracleSyncConnection, "OracleSyncConnectionPool", OracleSyncDriver]):
@@ -170,10 +168,6 @@ class OracleSyncConfig(SyncDatabaseConfig[OracleSyncConnection, "OracleSyncConne
         processed_driver_features.setdefault("enable_numpy_vectors", NUMPY_INSTALLED)
         processed_driver_features.setdefault("enable_lowercase_column_names", True)
         processed_driver_features.setdefault("enable_uuid_binary", True)
-
-        # Auto-detect events support based on extension_config
-        processed_driver_features.setdefault("enable_events", "events" in (extension_config or {}))
-        processed_driver_features.setdefault("events_backend", "table_queue")
 
         super().__init__(
             connection_config=processed_connection_config,
@@ -353,10 +347,6 @@ class OracleAsyncConfig(AsyncDatabaseConfig[OracleAsyncConnection, "OracleAsyncC
         processed_driver_features.setdefault("enable_numpy_vectors", NUMPY_INSTALLED)
         processed_driver_features.setdefault("enable_lowercase_column_names", True)
         processed_driver_features.setdefault("enable_uuid_binary", True)
-
-        # Auto-detect events support based on extension_config
-        processed_driver_features.setdefault("enable_events", "events" in (extension_config or {}))
-        processed_driver_features.setdefault("events_backend", "table_queue")
 
         super().__init__(
             connection_config=processed_connection_config,

--- a/sqlspec/adapters/psqlpy/config.py
+++ b/sqlspec/adapters/psqlpy/config.py
@@ -2,7 +2,7 @@
 
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 
 from psqlpy import ConnectionPool
 from typing_extensions import NotRequired
@@ -102,8 +102,6 @@ class PsqlpyDriverFeatures(TypedDict):
     enable_pgvector: NotRequired[bool]
     json_serializer: NotRequired["Callable[[Any], str]"]
     json_deserializer: NotRequired["Callable[[str], Any]"]
-    enable_events: NotRequired[bool]
-    events_backend: NotRequired[Literal["listen_notify", "table_queue", "listen_notify_durable"]]
 
 
 __all__ = ("PsqlpyConfig", "PsqlpyConnectionParams", "PsqlpyCursor", "PsqlpyDriverFeatures", "PsqlpyPoolParams")
@@ -155,10 +153,6 @@ class PsqlpyConfig(AsyncDatabaseConfig[PsqlpyConnection, ConnectionPool, PsqlpyD
         serializer_callable = to_json if serializer is None else cast("Callable[[Any], str]", serializer)
         processed_driver_features.setdefault("json_serializer", serializer_callable)
         processed_driver_features.setdefault("enable_pgvector", PGVECTOR_INSTALLED)
-
-        # Auto-detect events support based on extension_config
-        processed_driver_features.setdefault("enable_events", "events" in (extension_config or {}))
-        processed_driver_features.setdefault("events_backend", "listen_notify")
 
         super().__init__(
             connection_config=processed_connection_config,

--- a/sqlspec/adapters/psycopg/config.py
+++ b/sqlspec/adapters/psycopg/config.py
@@ -2,7 +2,7 @@
 
 import contextlib
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 
 from psycopg.rows import dict_row
 from psycopg_pool import AsyncConnectionPool, ConnectionPool
@@ -94,8 +94,6 @@ class PsycopgDriverFeatures(TypedDict):
     enable_pgvector: NotRequired[bool]
     json_serializer: NotRequired["Callable[[Any], str]"]
     json_deserializer: NotRequired["Callable[[str], Any]"]
-    enable_events: NotRequired[bool]
-    events_backend: NotRequired[Literal["listen_notify", "table_queue", "listen_notify_durable"]]
 
 
 __all__ = (
@@ -154,10 +152,6 @@ class PsycopgSyncConfig(SyncDatabaseConfig[PsycopgSyncConnection, ConnectionPool
         serializer = cast("Callable[[Any], str]", processed_driver_features.get("json_serializer", to_json))
         processed_driver_features.setdefault("json_serializer", serializer)
         processed_driver_features.setdefault("enable_pgvector", PGVECTOR_INSTALLED)
-
-        # Auto-detect events support based on extension_config
-        processed_driver_features.setdefault("enable_events", "events" in (extension_config or {}))
-        processed_driver_features.setdefault("events_backend", "listen_notify")
 
         super().__init__(
             connection_config=processed_connection_config,
@@ -351,10 +345,6 @@ class PsycopgAsyncConfig(AsyncDatabaseConfig[PsycopgAsyncConnection, AsyncConnec
         serializer = cast("Callable[[Any], str]", processed_driver_features.get("json_serializer", to_json))
         processed_driver_features.setdefault("json_serializer", serializer)
         processed_driver_features.setdefault("enable_pgvector", PGVECTOR_INSTALLED)
-
-        # Auto-detect events support based on extension_config
-        processed_driver_features.setdefault("enable_events", "events" in (extension_config or {}))
-        processed_driver_features.setdefault("events_backend", "listen_notify")
 
         super().__init__(
             connection_config=processed_connection_config,

--- a/sqlspec/adapters/spanner/config.py
+++ b/sqlspec/adapters/spanner/config.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 
 from google.cloud.spanner_v1 import Client
 from google.cloud.spanner_v1.pool import AbstractSessionPool, FixedSizePool
@@ -66,8 +66,6 @@ class SpannerDriverFeatures(TypedDict):
     json_serializer: "NotRequired[Callable[[Any], str]]"
     json_deserializer: "NotRequired[Callable[[str], Any]]"
     session_labels: "NotRequired[dict[str, str]]"
-    enable_events: "NotRequired[bool]"
-    events_backend: "NotRequired[Literal['table_queue']]"
 
 
 class SpannerSyncConfig(SyncDatabaseConfig["SpannerConnection", "AbstractSessionPool", SpannerSyncDriver]):
@@ -109,11 +107,6 @@ class SpannerSyncConfig(SyncDatabaseConfig["SpannerConnection", "AbstractSession
         features.setdefault("enable_uuid_conversion", True)
         features.setdefault("json_serializer", to_json)
         features.setdefault("json_deserializer", from_json)
-        events_configured = extension_config is not None and "events" in extension_config
-        if "enable_events" not in features:
-            features["enable_events"] = events_configured
-        if "events_backend" not in features:
-            features["events_backend"] = "table_queue"
 
         base_statement_config = statement_config or spanner_statement_config
 

--- a/sqlspec/adapters/sqlite/config.py
+++ b/sqlspec/adapters/sqlite/config.py
@@ -2,7 +2,7 @@
 
 import uuid
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
 
 from typing_extensions import NotRequired
 
@@ -61,8 +61,6 @@ class SqliteDriverFeatures(TypedDict):
     enable_custom_adapters: NotRequired[bool]
     json_serializer: "NotRequired[Callable[[Any], str]]"
     json_deserializer: "NotRequired[Callable[[str], Any]]"
-    enable_events: NotRequired[bool]
-    events_backend: NotRequired[Literal["table_queue"]]
 
 
 __all__ = ("SqliteConfig", "SqliteConnectionParams", "SqliteDriverFeatures")
@@ -123,10 +121,6 @@ class SqliteConfig(SyncDatabaseConfig[SqliteConnection, SqliteConnectionPool, Sq
         processed_driver_features.setdefault("enable_custom_adapters", True)
         json_serializer = processed_driver_features.setdefault("json_serializer", to_json)
         json_deserializer = processed_driver_features.setdefault("json_deserializer", from_json)
-
-        # Auto-detect events support based on extension_config
-        processed_driver_features.setdefault("enable_events", "events" in (extension_config or {}))
-        processed_driver_features.setdefault("events_backend", "table_queue")
 
         base_statement_config = statement_config or sqlite_statement_config
         if json_serializer is not None:

--- a/sqlspec/extensions/litestar/store.py
+++ b/sqlspec/extensions/litestar/store.py
@@ -76,12 +76,19 @@ class BaseSQLSpecStore(ABC, Generic[ConfigT]):
 
         Returns:
             Table name for the session store.
+
+        Notes:
+            Accepts ``session_table: True`` for default name or a string for custom name.
         """
+        default_name = "litestar_session"
         if hasattr(self._config, "extension_config"):
             extension_config = cast("dict[str, dict[str, Any]]", self._config.extension_config)  # pyright: ignore
             litestar_config: dict[str, Any] = extension_config.get("litestar", {})
-            return str(litestar_config.get("session_table", "litestar_session"))
-        return "litestar_session"
+            session_table = litestar_config.get("session_table", default_name)
+            if session_table is True:
+                return default_name
+            return str(session_table)
+        return default_name
 
     @property
     def config(self) -> ConfigT:

--- a/tests/integration/test_adapters/test_asyncpg/test_extensions/test_events_listen_notify.py
+++ b/tests/integration/test_adapters/test_asyncpg/test_extensions/test_events_listen_notify.py
@@ -23,8 +23,7 @@ async def test_asyncpg_listen_notify_publish_and_ack(postgres_service: "Any") ->
     """AsyncPG adapter publishes and acknowledges LISTEN/NOTIFY events."""
 
     config = AsyncpgConfig(
-        connection_config={"dsn": _dsn(postgres_service)},
-        driver_features={"events_backend": "listen_notify", "enable_events": True},
+        connection_config={"dsn": _dsn(postgres_service)}, extension_config={"events": {"backend": "listen_notify"}}
     )
 
     spec = SQLSpec()
@@ -49,8 +48,7 @@ async def test_asyncpg_listen_notify_message_delivery(postgres_service: "Any") -
     """AsyncPG adapter delivers NOTIFY payloads via EventChannel listener."""
 
     config = AsyncpgConfig(
-        connection_config={"dsn": _dsn(postgres_service)},
-        driver_features={"events_backend": "listen_notify", "enable_events": True},
+        connection_config={"dsn": _dsn(postgres_service)}, extension_config={"events": {"backend": "listen_notify"}}
     )
 
     spec = SQLSpec()
@@ -94,8 +92,7 @@ async def test_asyncpg_hybrid_listen_notify_durable(postgres_service: "Any", tmp
     config = AsyncpgConfig(
         connection_config={"dsn": _dsn(postgres_service)},
         migration_config={"script_location": str(migrations), "include_extensions": ["events"]},
-        driver_features={"events_backend": "listen_notify_durable", "enable_events": True},
-        extension_config={"events": {}},
+        extension_config={"events": {"backend": "listen_notify_durable"}},
     )
 
     await AsyncMigrationCommands(config).upgrade()
@@ -138,8 +135,7 @@ async def test_asyncpg_listen_notify_metadata(postgres_service: "Any") -> None:
     """AsyncPG adapter preserves metadata in LISTEN/NOTIFY events."""
 
     config = AsyncpgConfig(
-        connection_config={"dsn": _dsn(postgres_service)},
-        driver_features={"events_backend": "listen_notify", "enable_events": True},
+        connection_config={"dsn": _dsn(postgres_service)}, extension_config={"events": {"backend": "listen_notify"}}
     )
 
     spec = SQLSpec()

--- a/tests/integration/test_adapters/test_psqlpy/test_extensions/test_events.py
+++ b/tests/integration/test_adapters/test_psqlpy/test_extensions/test_events.py
@@ -28,7 +28,7 @@ async def test_psqlpy_event_channel_queue_fallback(tmp_path, postgres_service: P
     config = PsqlpyConfig(
         connection_config={"dsn": dsn, "max_db_pool_size": 4},
         migration_config={"script_location": str(migrations_dir), "include_extensions": ["events"]},
-        driver_features={"events_backend": "table_queue", "enable_events": True},
+        extension_config={"events": {"backend": "table_queue"}},
     )
 
     commands = AsyncMigrationCommands(config)

--- a/tests/integration/test_adapters/test_psqlpy/test_extensions/test_events_listen_notify.py
+++ b/tests/integration/test_adapters/test_psqlpy/test_extensions/test_events_listen_notify.py
@@ -22,8 +22,7 @@ async def test_psqlpy_listen_notify_native(postgres_service: "Any") -> None:
     """Native LISTEN/NOTIFY path delivers payloads."""
 
     config = PsqlpyConfig(
-        connection_config={"dsn": _dsn(postgres_service)},
-        driver_features={"events_backend": "listen_notify", "enable_events": True},
+        connection_config={"dsn": _dsn(postgres_service)}, extension_config={"events": {"backend": "listen_notify"}}
     )
 
     spec = SQLSpec()
@@ -67,8 +66,7 @@ async def test_psqlpy_listen_notify_hybrid(postgres_service: "Any", tmp_path) ->
     config = PsqlpyConfig(
         connection_config={"dsn": _dsn(postgres_service)},
         migration_config={"script_location": str(migrations), "include_extensions": ["events"]},
-        driver_features={"events_backend": "listen_notify_durable", "enable_events": True},
-        extension_config={"events": {}},
+        extension_config={"events": {"backend": "listen_notify_durable"}},
     )
 
     await AsyncMigrationCommands(config).upgrade()

--- a/tests/integration/test_adapters/test_psycopg/test_extensions/test_events.py
+++ b/tests/integration/test_adapters/test_psycopg/test_extensions/test_events.py
@@ -27,7 +27,7 @@ def test_psycopg_sync_event_channel_queue_fallback(tmp_path, postgres_service: P
     config = PsycopgSyncConfig(
         connection_config={"conninfo": _build_conninfo(postgres_service)},
         migration_config={"script_location": str(migrations_dir), "include_extensions": ["events"]},
-        driver_features={"events_backend": "table_queue", "enable_events": True},
+        extension_config={"events": {"backend": "table_queue"}},
     )
 
     commands = SyncMigrationCommands(config)
@@ -67,7 +67,7 @@ async def test_psycopg_async_event_channel_queue_fallback(tmp_path, postgres_ser
     config = PsycopgAsyncConfig(
         connection_config={"conninfo": _build_conninfo(postgres_service)},
         migration_config={"script_location": str(migrations_dir), "include_extensions": ["events"]},
-        driver_features={"events_backend": "table_queue", "enable_events": True},
+        extension_config={"events": {"backend": "table_queue"}},
     )
 
     commands = AsyncMigrationCommands(config)

--- a/tests/integration/test_adapters/test_psycopg/test_extensions/test_events_listen_notify.py
+++ b/tests/integration/test_adapters/test_psycopg/test_extensions/test_events_listen_notify.py
@@ -23,7 +23,7 @@ def test_psycopg_sync_listen_notify(postgres_service: "Any") -> None:
 
     config = PsycopgSyncConfig(
         connection_config={"conninfo": _conninfo(postgres_service)},
-        driver_features={"events_backend": "listen_notify", "enable_events": True},
+        extension_config={"events": {"backend": "listen_notify"}},
     )
 
     spec = SQLSpec()
@@ -54,7 +54,7 @@ async def test_psycopg_async_listen_notify(postgres_service: "Any") -> None:
 
     config = PsycopgAsyncConfig(
         connection_config={"conninfo": _conninfo(postgres_service)},
-        driver_features={"events_backend": "listen_notify", "enable_events": True},
+        extension_config={"events": {"backend": "listen_notify"}},
     )
 
     spec = SQLSpec()
@@ -90,8 +90,7 @@ def test_psycopg_sync_hybrid_listen_notify_durable(postgres_service: "Any", tmp_
     config = PsycopgSyncConfig(
         connection_config={"conninfo": _conninfo(postgres_service)},
         migration_config={"script_location": str(migrations), "include_extensions": ["events"]},
-        driver_features={"events_backend": "listen_notify_durable", "enable_events": True},
-        extension_config={"events": {}},
+        extension_config={"events": {"backend": "listen_notify_durable"}},
     )
 
     SyncMigrationCommands(config).upgrade()
@@ -126,8 +125,7 @@ async def test_psycopg_async_hybrid_listen_notify_durable(postgres_service: "Any
     config = PsycopgAsyncConfig(
         connection_config={"conninfo": _conninfo(postgres_service)},
         migration_config={"script_location": str(migrations), "include_extensions": ["events"]},
-        driver_features={"events_backend": "listen_notify_durable", "enable_events": True},
-        extension_config={"events": {}},
+        extension_config={"events": {"backend": "listen_notify_durable"}},
     )
 
     await AsyncMigrationCommands(config).upgrade()

--- a/tests/integration/test_extensions/test_events/test_oracle_aq.py
+++ b/tests/integration/test_extensions/test_events/test_oracle_aq.py
@@ -24,8 +24,7 @@ def oracle_aq_config(oracle_23ai_service: OracleService) -> Generator[OracleSync
             "user": oracle_23ai_service.user,
             "password": oracle_23ai_service.password,
         },
-        driver_features={"events_backend": "advanced_queue", "enable_events": True},
-        extension_config={"events": {}},
+        extension_config={"events": {"backend": "advanced_queue"}},
     )
 
     queue_table = "SQLSPEC_EVENTS_QUEUE_TABLE"

--- a/tests/unit/test_extensions/test_events/test_channel.py
+++ b/tests/unit/test_extensions/test_events/test_channel.py
@@ -124,7 +124,7 @@ def test_event_channel_backend_fallback(tmp_path) -> None:
     config = SqliteConfig(
         connection_config={"database": str(db_path)},
         migration_config={"script_location": str(migrations_dir), "include_extensions": ["events"]},
-        driver_features={"events_backend": "advanced_queue"},
+        extension_config={"events": {"backend": "advanced_queue"}},
     )
 
     commands = SyncMigrationCommands(config)

--- a/tests/unit/test_extensions/test_events/test_channel_extended.py
+++ b/tests/unit/test_extensions/test_events/test_channel_extended.py
@@ -62,7 +62,7 @@ def test_event_channel_backend_fallback_warning(tmp_path) -> None:
     """EventChannel falls back to table_queue for unavailable backends."""
     config = SqliteConfig(
         connection_config={"database": str(tmp_path / "test.db")},
-        driver_features={"events_backend": "nonexistent_backend"},
+        extension_config={"events": {"backend": "nonexistent_backend"}},
     )
     channel = SyncEventChannel(config)
 

--- a/tests/unit/test_extensions/test_events/test_events_config.py
+++ b/tests/unit/test_extensions/test_events/test_events_config.py
@@ -1,4 +1,4 @@
-"""Configuration-related tests for the events extension."""
+"""Configuration-related tests for extension auto-migration inclusion."""
 
 from sqlspec.adapters.sqlite import SqliteConfig
 
@@ -22,9 +22,136 @@ def test_events_extension_preserves_existing_includes(tmp_path) -> None:
 
     config = SqliteConfig(
         connection_config={"database": str(tmp_path / "events_existing.db")},
-        migration_config={"include_extensions": ["litestar"]},
+        migration_config={"include_extensions": ["custom"]},
         extension_config={"events": {}},
     )
 
     include_extensions = config.migration_config.get("include_extensions")
-    assert include_extensions == ["litestar", "events"]
+    assert include_extensions == ["custom", "events"]
+
+
+def test_exclude_extensions_prevents_auto_inclusion(tmp_path) -> None:
+    """exclude_extensions prevents auto-inclusion of events migrations."""
+
+    config = SqliteConfig(
+        connection_config={"database": str(tmp_path / "events_skip.db")},
+        migration_config={"script_location": "migrations", "exclude_extensions": ["events"]},
+        extension_config={"events": {"backend": "listen_notify"}},
+    )
+
+    include_extensions = config.migration_config.get("include_extensions")
+    assert include_extensions is None or "events" not in include_extensions
+
+
+def test_litestar_with_session_table_true_auto_includes_migrations(tmp_path) -> None:
+    """Litestar with session_table=True auto-includes migrations."""
+
+    config = SqliteConfig(
+        connection_config={"database": str(tmp_path / "litestar.db")},
+        migration_config={"script_location": "migrations"},
+        extension_config={"litestar": {"session_table": True}},
+    )
+
+    include_extensions = config.migration_config.get("include_extensions")
+    assert include_extensions is not None
+    assert "litestar" in include_extensions
+
+
+def test_litestar_with_session_table_string_auto_includes_migrations(tmp_path) -> None:
+    """Litestar with session_table as string auto-includes migrations."""
+
+    config = SqliteConfig(
+        connection_config={"database": str(tmp_path / "litestar_custom.db")},
+        migration_config={"script_location": "migrations"},
+        extension_config={"litestar": {"session_table": "my_sessions"}},
+    )
+
+    include_extensions = config.migration_config.get("include_extensions")
+    assert include_extensions is not None
+    assert "litestar" in include_extensions
+
+
+def test_litestar_without_session_table_no_migrations(tmp_path) -> None:
+    """Litestar without session_table does NOT auto-include migrations."""
+
+    config = SqliteConfig(
+        connection_config={"database": str(tmp_path / "litestar_di.db")},
+        migration_config={"script_location": "migrations"},
+        extension_config={"litestar": {"session_key": "db"}},  # Just DI config, no session storage
+    )
+
+    include_extensions = config.migration_config.get("include_extensions")
+    assert include_extensions is None or "litestar" not in include_extensions
+
+
+def test_adk_extension_auto_includes_migrations(tmp_path) -> None:
+    """Configs with adk settings auto-include extension migrations."""
+
+    config = SqliteConfig(
+        connection_config={"database": str(tmp_path / "adk.db")},
+        migration_config={"script_location": "migrations"},
+        extension_config={"adk": {"session_table": "adk_sessions"}},
+    )
+
+    include_extensions = config.migration_config.get("include_extensions")
+    assert include_extensions is not None
+    assert "adk" in include_extensions
+
+
+def test_multiple_extensions_auto_include_migrations(tmp_path) -> None:
+    """Multiple extensions with settings all get auto-included."""
+
+    config = SqliteConfig(
+        connection_config={"database": str(tmp_path / "multi.db")},
+        migration_config={"script_location": "migrations"},
+        extension_config={
+            "litestar": {"session_table": True},  # Needs session_table for migrations
+            "adk": {},
+            "events": {"backend": "table_queue"},
+        },
+    )
+
+    include_extensions = config.migration_config.get("include_extensions")
+    assert include_extensions is not None
+    assert "litestar" in include_extensions
+    assert "adk" in include_extensions
+    assert "events" in include_extensions
+
+
+def test_exclude_extensions_partial(tmp_path) -> None:
+    """exclude_extensions only excludes specified extensions."""
+
+    config = SqliteConfig(
+        connection_config={"database": str(tmp_path / "partial.db")},
+        migration_config={"script_location": "migrations", "exclude_extensions": ["events"]},
+        extension_config={"litestar": {"session_table": True}, "events": {"backend": "listen_notify"}},
+    )
+
+    include_extensions = config.migration_config.get("include_extensions")
+    assert include_extensions is not None
+    assert "litestar" in include_extensions
+    assert "events" not in include_extensions
+
+
+def test_no_auto_include_without_extension_config(tmp_path) -> None:
+    """Extensions not in extension_config are not auto-included."""
+
+    config = SqliteConfig(
+        connection_config={"database": str(tmp_path / "empty.db")}, migration_config={"script_location": "migrations"}
+    )
+
+    include_extensions = config.migration_config.get("include_extensions")
+    assert include_extensions is None
+
+
+def test_observability_extensions_no_migrations(tmp_path) -> None:
+    """Observability extensions (otel, prometheus) don't have migrations."""
+
+    config = SqliteConfig(
+        connection_config={"database": str(tmp_path / "otel.db")},
+        migration_config={"script_location": "migrations"},
+        extension_config={"otel": {"enabled": True}, "prometheus": {"enabled": True}},
+    )
+
+    include_extensions = config.migration_config.get("include_extensions")
+    assert include_extensions is None


### PR DESCRIPTION
## Summary

Moves events configuration from `driver_features` to `extension_config` pattern, consistent with other extensions (litestar, adk, starlette, flask). Also adds consistent auto-migration inclusion for all extensions with `exclude_extensions` opt-out.

## The Problem

The Event Channels PR (#291) incorrectly used `driver_features` for events configuration instead of the standard `extension_config` pattern used by other extensions. This breaks consistency and makes the API confusing.

## The Solution

- Move events configuration to `extension_config["events"]` pattern
- Add `exclude_extensions` to `MigrationConfig` for opting out of auto-inclusion
- Auto-include extension migrations based on settings:
  - **litestar**: only when `session_table` is set (`True` or custom name)
  - **adk**: when any adk settings present  
  - **events**: when any events settings present
- Add `session_table` field to `LitestarConfig` (`bool | str`)

## Key Features

- Consistent `extension_config` pattern across all extensions
- Smart auto-migration inclusion based on actual usage
- `exclude_extensions` for opting out (e.g., ephemeral `listen_notify` backend)
- Litestar migrations only included when session storage is needed
- Backwards compatible for users already using `extension_config`