### PR TITLE
fix: python template triple quote formatting

### DIFF
--- a/sqlspec/migrations/templates.py
+++ b/sqlspec/migrations/templates.py
@@ -221,12 +221,12 @@ _DEFAULT_PY_TEMPLATE = PythonTemplateDefinition(
     body=(
         "def up(context: object | None = None) -> str | Iterable[str]:\n"
         '    """Apply the migration (upgrade)."""\n'
-        '    return "\n'
+        '    return """\n'
         "    CREATE TABLE example (\n"
         "        id INTEGER PRIMARY KEY,\n"
         "        name TEXT NOT NULL\n"
         "    );\n"
-        '    "\n\n'
+        '    """\n\n'
         "def down(context: object | None = None) -> str | Iterable[str]:\n"
         '    """Reverse the migration."""\n'
         '    return "DROP TABLE example;"'


### PR DESCRIPTION
## Description

The Python default migration template uses double quotes for the upgrade statement, which is multiline and therefore invalid syntax. This replaces the start and end quotes with triple quotes instead. This fixes a syntactical error which would block auto-formatting the migration on creation.

