### PR TITLE
fix(aiosqlite): use unique URI per config for in-memory database isolation

### DIFF
--- a/sqlspec/adapters/aiosqlite/config.py
+++ b/sqlspec/adapters/aiosqlite/config.py
@@ -1,5 +1,6 @@
 """Aiosqlite database configuration."""
 
+import uuid
 from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
 
 from mypy_extensions import mypyc_attr
@@ -178,7 +179,7 @@ class AiosqliteConfig(AsyncDatabaseConfig["AiosqliteConnection", AiosqliteConnec
         config_dict: dict[str, Any] = dict(connection_config) if connection_config else {}
 
         if "database" not in config_dict or config_dict["database"] == ":memory:":
-            config_dict["database"] = "file::memory:?cache=shared"
+            config_dict["database"] = f"file:memory_{uuid.uuid4().hex}?mode=memory&cache=shared"
             config_dict["uri"] = True
         elif "database" in config_dict:
             database_path = str(config_dict["database"])

--- a/tests/integration/adapters/aiosqlite/test_connection.py
+++ b/tests/integration/adapters/aiosqlite/test_connection.py
@@ -227,7 +227,9 @@ async def test_config_memory_database_conversion() -> None:
 
     try:
         connection_config = build_connection_config(config.connection_config)
-        assert connection_config["database"] == "file::memory:?cache=shared"
+        assert (
+            connection_config["database"].startswith("file:memory_") and "mode=memory" in connection_config["database"]
+        )
         assert connection_config.get("uri") is True
 
         async with config.provide_session() as driver:
@@ -246,7 +248,9 @@ async def test_config_default_database() -> None:
 
     try:
         connection_config = build_connection_config(config.connection_config)
-        assert connection_config["database"] == "file::memory:?cache=shared"
+        assert (
+            connection_config["database"].startswith("file:memory_") and "mode=memory" in connection_config["database"]
+        )
         assert connection_config.get("uri") is True
 
         async with config.provide_session() as driver:

--- a/tests/integration/adapters/aiosqlite/test_pooling.py
+++ b/tests/integration/adapters/aiosqlite/test_pooling.py
@@ -60,7 +60,8 @@ async def test_regular_memory_auto_converted_pooling() -> None:
     config = AiosqliteConfig(connection_config={"database": ":memory:", "pool_min_size": 5, "pool_max_size": 10})
 
     try:
-        assert build_connection_config(config.connection_config)["database"] == "file::memory:?cache=shared"
+        db_uri = build_connection_config(config.connection_config)["database"]
+        assert db_uri.startswith("file:memory_") and "mode=memory" in db_uri and "cache=shared" in db_uri
 
         async with config.provide_session() as session1:
             await session1.execute("DROP TABLE IF EXISTS converted_test")
@@ -188,3 +189,68 @@ async def test_pool_concurrent_access(aiosqlite_config_file: AiosqliteConfig) ->
 
         await verify_session.execute("DROP TABLE IF EXISTS concurrent_test")
         await verify_session.commit()
+
+
+async def test_sequential_configs_isolated_databases() -> None:
+    """Regression test for #360: sequential configs must not share state.
+
+    Two AiosqliteConfig instances created with default settings must have
+    completely isolated in-memory databases.
+    """
+    config1 = AiosqliteConfig()
+    config2 = AiosqliteConfig()
+    try:
+        # Create a table in config1's database
+        async with config1.provide_session() as session1:
+            await session1.execute_script("""
+                CREATE TABLE isolation_test (
+                    id INTEGER PRIMARY KEY,
+                    value TEXT
+                )
+            """)
+            await session1.commit()
+
+        # config2 must NOT see the table from config1
+        async with config2.provide_session() as session2:
+            result = await session2.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='isolation_test'"
+            )
+            assert isinstance(result, SQLResult)
+            assert result.data is not None
+            assert len(result.data) == 0, (
+                "Table 'isolation_test' from config1 leaked into config2's database. See issue #360."
+            )
+    finally:
+        await config1.close_pool()
+        await config2.close_pool()
+
+
+async def test_same_config_pool_shares_database() -> None:
+    """Verify that connections within the same config share the database.
+
+    This ensures the fix for #360 doesn't break legitimate pooling.
+    """
+    config = AiosqliteConfig()
+    try:
+        async with config.provide_session() as session1:
+            await session1.execute_script("""
+                CREATE TABLE pool_share_test (
+                    id INTEGER PRIMARY KEY,
+                    value TEXT
+                );
+                INSERT INTO pool_share_test (value) VALUES ('shared');
+            """)
+            await session1.commit()
+
+        # A second session from the SAME config must see the table
+        async with config.provide_session() as session2:
+            result = await session2.execute("SELECT value FROM pool_share_test")
+            assert isinstance(result, SQLResult)
+            assert result.data is not None
+            assert len(result.data) == 1
+            assert result.get_data()[0]["value"] == "shared"
+
+            await session2.execute("DROP TABLE pool_share_test")
+            await session2.commit()
+    finally:
+        await config.close_pool()


### PR DESCRIPTION
## Summary

Each `AiosqliteConfig` with a default or `:memory:` database now gets a unique URI (`file:memory_{uuid4}?mode=memory&cache=shared`), preventing state leakage between independent config instances while preserving shared cache within the same pool.

Previously all default configs shared `file::memory:?cache=shared`, causing "table already exists" errors when using sequential configs.

Closes #360.