### PR TITLE
fix(oracledb): add BLOB support and use byte-length thresholds for LOB coercion

### DIFF
--- a/sqlspec/adapters/oracledb/core.py
+++ b/sqlspec/adapters/oracledb/core.py
@@ -46,8 +46,8 @@ __all__ = (
     "build_profile",
     "build_statement_config",
     "build_truncate_statement",
-    "coerce_large_string_parameters_async",
-    "coerce_large_string_parameters_sync",
+    "coerce_large_parameters_async",
+    "coerce_large_parameters_sync",
     "collect_async_rows",
     "collect_sync_rows",
     "create_mapped_exception",
@@ -184,49 +184,61 @@ def normalize_execute_many_parameters_async(parameters: Any) -> Any:
     return parameters
 
 
-def coerce_large_string_parameters_sync(connection: Any, parameters: Any, *, lob_type: Any, threshold: int) -> Any:
-    """Coerce large string parameters into CLOBs.
+def coerce_large_parameters_sync(
+    connection: Any, parameters: Any, *, clob_type: Any, blob_type: Any, varchar2_byte_limit: int, raw_byte_limit: int
+) -> Any:
+    """Coerce large string/bytes parameters into CLOBs/BLOBs.
+
+    Strings whose UTF-8 encoding exceeds ``varchar2_byte_limit`` are bound as
+    CLOBs.  Bytes values longer than ``raw_byte_limit`` are bound as BLOBs.
 
     Args:
         connection: Oracle database connection.
         parameters: Prepared parameters payload.
-        lob_type: Oracle CLOB type.
-        threshold: String length threshold for CLOB conversion.
+        clob_type: Oracle CLOB DB type (``oracledb.DB_TYPE_CLOB``).
+        blob_type: Oracle BLOB DB type (``oracledb.DB_TYPE_BLOB``).
+        varchar2_byte_limit: Byte-length threshold for CLOB conversion.
+        raw_byte_limit: Byte-length threshold for BLOB conversion.
 
     Returns:
-        Parameters payload with large strings converted to CLOBs.
+        Parameters payload with large values converted to LOBs.
     """
     if not parameters or not isinstance(parameters, dict):
         return parameters
     for param_name, param_value in parameters.items():
-        if isinstance(param_value, str) and len(param_value) > threshold:
-            clob = connection.createlob(lob_type)
-            clob.write(param_value)
-            parameters[param_name] = clob
+        if isinstance(param_value, str) and len(param_value.encode("utf-8")) > varchar2_byte_limit:
+            parameters[param_name] = connection.createlob(clob_type, param_value)
+        elif isinstance(param_value, (bytes, bytearray)) and len(param_value) > raw_byte_limit:
+            parameters[param_name] = connection.createlob(blob_type, bytes(param_value))
     return parameters
 
 
-async def coerce_large_string_parameters_async(
-    connection: Any, parameters: Any, *, lob_type: Any, threshold: int
+async def coerce_large_parameters_async(
+    connection: Any, parameters: Any, *, clob_type: Any, blob_type: Any, varchar2_byte_limit: int, raw_byte_limit: int
 ) -> Any:
-    """Coerce large string parameters into CLOBs for async Oracle drivers.
+    """Coerce large string/bytes parameters into CLOBs/BLOBs for async Oracle drivers.
+
+    Strings whose UTF-8 encoding exceeds ``varchar2_byte_limit`` are bound as
+    CLOBs.  Bytes values longer than ``raw_byte_limit`` are bound as BLOBs.
 
     Args:
         connection: Oracle database connection.
         parameters: Prepared parameters payload.
-        lob_type: Oracle CLOB type.
-        threshold: String length threshold for CLOB conversion.
+        clob_type: Oracle CLOB DB type (``oracledb.DB_TYPE_CLOB``).
+        blob_type: Oracle BLOB DB type (``oracledb.DB_TYPE_BLOB``).
+        varchar2_byte_limit: Byte-length threshold for CLOB conversion.
+        raw_byte_limit: Byte-length threshold for BLOB conversion.
 
     Returns:
-        Parameters payload with large strings converted to CLOBs.
+        Parameters payload with large values converted to LOBs.
     """
     if not parameters or not isinstance(parameters, dict):
         return parameters
     for param_name, param_value in parameters.items():
-        if isinstance(param_value, str) and len(param_value) > threshold:
-            clob = await connection.createlob(lob_type)
-            await clob.write(param_value)
-            parameters[param_name] = clob
+        if isinstance(param_value, str) and len(param_value.encode("utf-8")) > varchar2_byte_limit:
+            parameters[param_name] = await connection.createlob(clob_type, param_value)
+        elif isinstance(param_value, (bytes, bytearray)) and len(param_value) > raw_byte_limit:
+            parameters[param_name] = await connection.createlob(blob_type, bytes(param_value))
     return parameters
 
 

--- a/sqlspec/adapters/oracledb/driver.py
+++ b/sqlspec/adapters/oracledb/driver.py
@@ -19,8 +19,8 @@ from sqlspec.adapters.oracledb.core import (
     build_insert_statement,
     build_pipeline_stack_result,
     build_truncate_statement,
-    coerce_large_string_parameters_async,
-    coerce_large_string_parameters_sync,
+    coerce_large_parameters_async,
+    coerce_large_parameters_sync,
     collect_async_rows,
     collect_sync_rows,
     create_mapped_exception,
@@ -69,7 +69,9 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 # Oracle-specific constants
-LARGE_STRING_THRESHOLD = 4000  # Threshold for large string parameters to avoid ORA-01704
+# Oracle SQL-context limits (in bytes)
+ORACLE_VARCHAR2_BYTE_LIMIT = 4000  # VARCHAR2 max in SQL context
+ORACLE_RAW_BYTE_LIMIT = 2000  # RAW max in SQL context
 
 __all__ = (
     "OracleAsyncDriver",
@@ -373,8 +375,13 @@ class OracleSyncDriver(OraclePipelineMixin, SyncDriverAdapterBase):
         """
         sql, prepared_parameters = self._get_compiled_sql(statement, self.statement_config)
 
-        prepared_parameters = coerce_large_string_parameters_sync(
-            self.connection, prepared_parameters, lob_type=oracledb.DB_TYPE_CLOB, threshold=LARGE_STRING_THRESHOLD
+        prepared_parameters = coerce_large_parameters_sync(
+            self.connection,
+            prepared_parameters,
+            clob_type=oracledb.DB_TYPE_CLOB,
+            blob_type=oracledb.DB_TYPE_BLOB,
+            varchar2_byte_limit=ORACLE_VARCHAR2_BYTE_LIMIT,
+            raw_byte_limit=ORACLE_RAW_BYTE_LIMIT,
         )
         prepared_parameters = cast("list[Any] | tuple[Any, ...] | dict[Any, Any] | None", prepared_parameters)
 
@@ -864,8 +871,13 @@ class OracleAsyncDriver(OraclePipelineMixin, AsyncDriverAdapterBase):
         """
         sql, prepared_parameters = self._get_compiled_sql(statement, self.statement_config)
 
-        prepared_parameters = await coerce_large_string_parameters_async(
-            self.connection, prepared_parameters, lob_type=oracledb.DB_TYPE_CLOB, threshold=LARGE_STRING_THRESHOLD
+        prepared_parameters = await coerce_large_parameters_async(
+            self.connection,
+            prepared_parameters,
+            clob_type=oracledb.DB_TYPE_CLOB,
+            blob_type=oracledb.DB_TYPE_BLOB,
+            varchar2_byte_limit=ORACLE_VARCHAR2_BYTE_LIMIT,
+            raw_byte_limit=ORACLE_RAW_BYTE_LIMIT,
         )
         prepared_parameters = cast("list[Any] | tuple[Any, ...] | dict[Any, Any] | None", prepared_parameters)
 

--- a/tests/unit/adapters/test_oracledb/test_lob_coercion.py
+++ b/tests/unit/adapters/test_oracledb/test_lob_coercion.py
@@ -1,0 +1,226 @@
+"""Unit tests for Oracle LOB parameter coercion."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from sqlspec.adapters.oracledb.core import coerce_large_parameters_async, coerce_large_parameters_sync
+
+# --- Fixtures ---
+
+CLOB_TYPE = "DB_TYPE_CLOB"
+BLOB_TYPE = "DB_TYPE_BLOB"
+VARCHAR2_LIMIT = 4000
+RAW_LIMIT = 2000
+
+
+@pytest.fixture
+def sync_connection() -> MagicMock:
+    conn = MagicMock()
+    conn.createlob.return_value = MagicMock(name="LOB")
+    return conn
+
+
+@pytest.fixture
+def async_connection() -> AsyncMock:
+    conn = AsyncMock()
+    conn.createlob.return_value = MagicMock(name="LOB")
+    return conn
+
+
+# --- Sync Tests ---
+
+
+class TestCoerceLargeParametersSync:
+    def test_none_parameters_passthrough(self, sync_connection: MagicMock) -> None:
+        result = coerce_large_parameters_sync(
+            sync_connection,
+            None,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        assert result is None
+
+    def test_list_parameters_passthrough(self, sync_connection: MagicMock) -> None:
+        params = ["a", "b"]
+        result = coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        assert result is params  # unchanged
+
+    def test_string_under_threshold_no_coercion(self, sync_connection: MagicMock) -> None:
+        params = {"name": "x" * 100}
+        coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        sync_connection.createlob.assert_not_called()
+        assert params["name"] == "x" * 100
+
+    def test_string_exactly_at_threshold_no_coercion(self, sync_connection: MagicMock) -> None:
+        params = {"name": "a" * 4000}  # exactly 4000 bytes (ASCII)
+        coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        sync_connection.createlob.assert_not_called()
+
+    def test_string_over_threshold_becomes_clob(self, sync_connection: MagicMock) -> None:
+        params = {"content": "a" * 4001}
+        coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        sync_connection.createlob.assert_called_once_with(CLOB_TYPE, "a" * 4001)
+        assert params["content"] is sync_connection.createlob.return_value
+
+    def test_multibyte_string_under_charcount_but_over_bytecount(self, sync_connection: MagicMock) -> None:
+        """A string with 2000 CJK chars = 6000 UTF-8 bytes > 4000 byte limit."""
+        # Each CJK character is 3 bytes in UTF-8
+        value = "\u4e00" * 2000  # 2000 chars, 6000 bytes
+        assert len(value) == 2000
+        assert len(value.encode("utf-8")) == 6000
+        params = {"content": value}
+        coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        sync_connection.createlob.assert_called_once_with(CLOB_TYPE, value)
+
+    def test_bytes_under_threshold_no_coercion(self, sync_connection: MagicMock) -> None:
+        params = {"data": b"\x00" * 100}
+        coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        sync_connection.createlob.assert_not_called()
+
+    def test_bytes_over_threshold_becomes_blob(self, sync_connection: MagicMock) -> None:
+        params = {"data": b"\x00" * 2001}
+        coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        sync_connection.createlob.assert_called_once_with(BLOB_TYPE, b"\x00" * 2001)
+
+    def test_bytearray_over_threshold_becomes_blob(self, sync_connection: MagicMock) -> None:
+        params = {"data": bytearray(b"\x01" * 2001)}
+        coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        sync_connection.createlob.assert_called_once()
+
+    def test_mixed_parameters(self, sync_connection: MagicMock) -> None:
+        params = {
+            "small_str": "hello",
+            "big_str": "x" * 5000,
+            "small_bytes": b"\x00" * 100,
+            "big_bytes": b"\xff" * 3000,
+            "number": 42,
+        }
+        coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        assert params["small_str"] == "hello"
+        assert params["big_str"] is sync_connection.createlob.return_value
+        assert params["small_bytes"] == b"\x00" * 100
+        assert params["number"] == 42
+        assert sync_connection.createlob.call_count == 2
+
+
+# --- Async Tests ---
+
+
+class TestCoerceLargeParametersAsync:
+    @pytest.mark.anyio
+    async def test_none_parameters_passthrough(self, async_connection: AsyncMock) -> None:
+        result = await coerce_large_parameters_async(
+            async_connection,
+            None,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_string_over_threshold_becomes_clob(self, async_connection: AsyncMock) -> None:
+        params = {"content": "a" * 4001}
+        await coerce_large_parameters_async(
+            async_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        async_connection.createlob.assert_called_once_with(CLOB_TYPE, "a" * 4001)
+
+    @pytest.mark.anyio
+    async def test_bytes_over_threshold_becomes_blob(self, async_connection: AsyncMock) -> None:
+        params = {"data": b"\x00" * 2001}
+        await coerce_large_parameters_async(
+            async_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        async_connection.createlob.assert_called_once_with(BLOB_TYPE, b"\x00" * 2001)
+
+    @pytest.mark.anyio
+    async def test_multibyte_string_byte_threshold(self, async_connection: AsyncMock) -> None:
+        value = "\u4e00" * 2000  # 6000 bytes
+        params = {"content": value}
+        await coerce_large_parameters_async(
+            async_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        async_connection.createlob.assert_called_once_with(CLOB_TYPE, value)


### PR DESCRIPTION
## Summary

- Rename `coerce_large_string_parameters_*` to `coerce_large_parameters_*` with expanded scope
- Add BLOB support for `bytes`/`bytearray` exceeding RAW limit (2000 bytes)
- Use UTF-8 byte-length (`len(value.encode("utf-8"))`) for CLOB threshold instead of char-length, fixing multibyte string handling
- Use single-call `createlob(type, data)` API instead of two-step `createlob()` + `write()`
- Replace `LARGE_STRING_THRESHOLD` with `ORACLE_VARCHAR2_BYTE_LIMIT` (4000) and `ORACLE_RAW_BYTE_LIMIT` (2000)

Closes #377.