### PR TITLE
docs: fix documentation with VectorDistance reference + flask

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -155,6 +155,7 @@ autodoc_mock_imports = [
     "adbc_driver_sqlite",
     "adbc_driver_flightsql",
     "google.cloud.bigquery",
+    "flask",
 ]
 
 autosummary_generate = False

--- a/docs/reference/builder/expressions.rst
+++ b/docs/reference/builder/expressions.rst
@@ -52,9 +52,7 @@ Expression Wrappers
 Vector Expressions
 ==================
 
-.. autoclass:: VectorDistance
-   :members:
-   :show-inheritance:
+.. autofunction:: VectorDistance
 
 Base Classes
 ============

--- a/docs/reference/dialects.rst
+++ b/docs/reference/dialects.rst
@@ -88,8 +88,7 @@ Spanner
 Expression Types
 ================
 
-.. autoclass:: sqlspec.dialects.postgres.pgvector.VectorDistance
-   :members:
+.. autofunction:: sqlspec.builder.VectorDistance
    :no-index:
 
 .. autoclass:: sqlspec.dialects.postgres.paradedb.SearchOperator


### PR DESCRIPTION
This fix the doc building issue with VectorDistance + missing flask in sphinx configuration