### PR TITLE
ci: remove --keep-going on building doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ docs-serve: docs-clean                             ## Serve documentation locall
 .PHONY: docs
 docs: docs-clean                                   ## Build documentation
 	@echo "${INFO} Building documentation... 📝"
-	@PYTHONWARNINGS="ignore::FutureWarning" uv run sphinx-build -M html docs docs/_build/ -E -a -j 1 -W --keep-going
+	@PYTHONWARNINGS="ignore::FutureWarning" uv run sphinx-build -M html docs docs/_build/ -E -a -j 1 -W
 	@echo "${OK} Documentation built successfully"
 
 .PHONY: docs-linkcheck


### PR DESCRIPTION
 Remove ``--keep-going`` on building doc,causing CI to succeed when the doc was not actually building properly
