### PR TITLE
fix: honor msgspec rename in schema_dump + make OffsetPagination runtime-introspectable

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,22 +21,24 @@ Schema Wire Correctness (Unreleased)
   Python attribute names. (`#418
   <https://github.com/litestar-org/sqlspec/issues/418>`_)
 
-* ``sqlspec.core.filters.OffsetPagination`` is now a ``msgspec.Struct``,
-  living in ``sqlspec.core._pagination`` (excluded from mypyc because
-  msgspec's metaclass is incompatible with compiled classes). The public
+* ``sqlspec.core.filters.OffsetPagination`` is now a stdlib
+  :func:`~dataclasses.dataclass`, living in ``sqlspec.core._pagination``
+  (excluded from mypyc because the ``@dataclass`` decorator mutates the class
+  at definition time, and mypyc-compiled classes forbid that). The public
   import path ``from sqlspec.core.filters import OffsetPagination`` is
   unchanged. This restores runtime ``__annotations__`` under mypyc-compiled
   wheels, fixing empty OpenAPI response schemas and missing component types
   when Litestar handlers return ``OffsetPagination[T]``. The Litestar
   extension additionally registers an ``OpenAPISchemaPlugin`` as a
-  defensive fallback. (`#419
+  defensive fallback. ``msgspec`` is no longer required to import the
+  pagination container. (`#419
   <https://github.com/litestar-org/sqlspec/issues/419>`_)
 
 **Behavior changes from the OffsetPagination conversion:**
 
 * ``__eq__`` is now field-wise (was identity). Two pagination objects with
   identical contents now compare equal.
-* ``__hash__`` is now ``None`` (msgspec's default for non-frozen Structs).
+* ``__hash__`` is now ``None`` (dataclass default without ``frozen=True``).
   Instances can no longer be used as ``dict`` keys or ``set`` members.
   ``Sequence[T]``-valued ``items`` already made this impractical, but the
   change is noted for completeness.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,39 @@ SQLSpec Changelog
 Recent Updates
 ==============
 
+Schema Wire Correctness (Unreleased)
+-------------------------------------
+
+**Fixed:**
+
+* ``sqlspec.utils.serializers.schema_dump`` now honors ``msgspec.Struct``
+  ``rename=`` meta. Structs declared with ``rename="camel"`` / ``"kebab"`` /
+  ``"pascal"`` / callable now emit the renamed wire names instead of the
+  Python attribute names. (`#418
+  <https://github.com/litestar-org/sqlspec/issues/418>`_)
+
+* ``sqlspec.core.filters.OffsetPagination`` is now a ``msgspec.Struct``,
+  living in ``sqlspec.core._pagination`` (excluded from mypyc because
+  msgspec's metaclass is incompatible with compiled classes). The public
+  import path ``from sqlspec.core.filters import OffsetPagination`` is
+  unchanged. This restores runtime ``__annotations__`` under mypyc-compiled
+  wheels, fixing empty OpenAPI response schemas and missing component types
+  when Litestar handlers return ``OffsetPagination[T]``. The Litestar
+  extension additionally registers an ``OpenAPISchemaPlugin`` as a
+  defensive fallback. (`#419
+  <https://github.com/litestar-org/sqlspec/issues/419>`_)
+
+**Behavior changes from the OffsetPagination conversion:**
+
+* ``__eq__`` is now field-wise (was identity). Two pagination objects with
+  identical contents now compare equal.
+* ``__hash__`` is now ``None`` (msgspec's default for non-frozen Structs).
+  Instances can no longer be used as ``dict`` keys or ``set`` members.
+  ``Sequence[T]``-valued ``items`` already made this impractical, but the
+  change is noted for completeness.
+* ``__repr__`` now prints
+  ``OffsetPagination(items=..., limit=..., offset=..., total=...)``.
+
 Logging Improvements
 --------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,7 @@ exclude = [
   "sqlspec/adapters/**/data_dictionary.py",   # Cross-module inheritance causes mypyc segfaults
   "sqlspec/observability/_formatting.py",     # Inherits from non-compiled logging.Formatter
   "sqlspec/utils/arrow_helpers.py",           # Arrow operations cause segfaults when compiled
+  "sqlspec/core/_pagination.py",              # msgspec.Struct metaclass incompatible with mypyc
 ]
 include = [
   "sqlspec/core/**/*.py",                  # Core module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,7 @@ exclude = [
   "sqlspec/adapters/**/data_dictionary.py",   # Cross-module inheritance causes mypyc segfaults
   "sqlspec/observability/_formatting.py",     # Inherits from non-compiled logging.Formatter
   "sqlspec/utils/arrow_helpers.py",           # Arrow operations cause segfaults when compiled
-  "sqlspec/core/_pagination.py",              # msgspec.Struct metaclass incompatible with mypyc
+  "sqlspec/core/_pagination.py",              # @dataclass mutates class at def time; annotations must survive mypyc for Litestar OpenAPI (#419)
 ]
 include = [
   "sqlspec/core/**/*.py",                  # Core module

--- a/sqlspec/core/_pagination.py
+++ b/sqlspec/core/_pagination.py
@@ -1,0 +1,33 @@
+"""Pagination containers excluded from mypyc compilation.
+
+``msgspec.Struct`` uses a custom metaclass, and mypyc-compiled classes cannot
+declare a metaclass. This module is kept uncompiled (see the mypyc ``exclude``
+list in ``pyproject.toml``) so that :class:`OffsetPagination` retains runtime
+``__annotations__`` and remains introspectable by Litestar's OpenAPI generator.
+"""
+
+from collections.abc import Sequence
+from typing import Generic
+
+import msgspec
+from typing_extensions import TypeVar
+
+__all__ = ("OffsetPagination",)
+
+T = TypeVar("T")
+
+
+class OffsetPagination(msgspec.Struct, Generic[T]):
+    """Container for data returned using limit/offset pagination.
+
+    Args:
+        items: List of data being sent as part of the response.
+        limit: Maximal number of items to send.
+        offset: Offset from the beginning of the query. Identical to an index.
+        total: Total number of items.
+    """
+
+    items: Sequence[T]
+    limit: int
+    offset: int
+    total: int

--- a/sqlspec/core/_pagination.py
+++ b/sqlspec/core/_pagination.py
@@ -4,30 +4,54 @@
 declare a metaclass. This module is kept uncompiled (see the mypyc ``exclude``
 list in ``pyproject.toml``) so that :class:`OffsetPagination` retains runtime
 ``__annotations__`` and remains introspectable by Litestar's OpenAPI generator.
+
+``msgspec`` is an optional dependency. When present we inherit from
+``msgspec.Struct`` for the best runtime introspection and native encoding.
+When absent we fall back to a plain generic container so ``sqlspec`` continues
+to import without ``msgspec`` installed.
 """
 
 from collections.abc import Sequence
 from typing import Generic
 
-import msgspec
 from typing_extensions import TypeVar
 
 __all__ = ("OffsetPagination",)
 
 T = TypeVar("T")
 
+try:
+    import msgspec
 
-class OffsetPagination(msgspec.Struct, Generic[T]):
-    """Container for data returned using limit/offset pagination.
+    class OffsetPagination(msgspec.Struct, Generic[T]):
+        """Container for data returned using limit/offset pagination.
 
-    Args:
-        items: List of data being sent as part of the response.
-        limit: Maximal number of items to send.
-        offset: Offset from the beginning of the query. Identical to an index.
-        total: Total number of items.
-    """
+        Args:
+            items: List of data being sent as part of the response.
+            limit: Maximal number of items to send.
+            offset: Offset from the beginning of the query. Identical to an index.
+            total: Total number of items.
+        """
 
-    items: Sequence[T]
-    limit: int
-    offset: int
-    total: int
+        items: Sequence[T]
+        limit: int
+        offset: int
+        total: int
+
+except ImportError:
+
+    class OffsetPagination(Generic[T]):  # type: ignore[no-redef]
+        """Container for data returned using limit/offset pagination (msgspec-free fallback)."""
+
+        __slots__ = ("items", "limit", "offset", "total")
+
+        items: Sequence[T]
+        limit: int
+        offset: int
+        total: int
+
+        def __init__(self, items: Sequence[T], limit: int, offset: int, total: int) -> None:
+            self.items = items
+            self.limit = limit
+            self.offset = offset
+            self.total = total

--- a/sqlspec/core/_pagination.py
+++ b/sqlspec/core/_pagination.py
@@ -1,17 +1,21 @@
 """Pagination containers excluded from mypyc compilation.
 
-``msgspec.Struct`` uses a custom metaclass, and mypyc-compiled classes cannot
-declare a metaclass. This module is kept uncompiled (see the mypyc ``exclude``
-list in ``pyproject.toml``) so that :class:`OffsetPagination` retains runtime
-``__annotations__`` and remains introspectable by Litestar's OpenAPI generator.
+mypyc strips class-level ``__annotations__`` from compiled modules, which
+breaks Litestar's OpenAPI schema generation for generic containers. This
+module is kept uncompiled (see the mypyc ``exclude`` list in ``pyproject.toml``)
+so :class:`OffsetPagination` retains runtime ``__annotations__`` and remains
+introspectable by Litestar (and any consumer calling
+:func:`typing.get_type_hints`).
 
-``msgspec`` is an optional dependency. When present we inherit from
-``msgspec.Struct`` for the best runtime introspection and native encoding.
-When absent we fall back to a plain generic container so ``sqlspec`` continues
-to import without ``msgspec`` installed.
+Implemented as a stdlib :func:`~dataclasses.dataclass` so it has no optional
+runtime dependencies — ``msgspec`` is not required. Litestar's OpenAPI generator
+natively recognizes dataclasses, and Litestar's default serialization (backed
+by msgspec when installed) emits the expected ``{items, limit, offset, total}``
+JSON shape.
 """
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Generic
 
 from typing_extensions import TypeVar
@@ -20,38 +24,19 @@ __all__ = ("OffsetPagination",)
 
 T = TypeVar("T")
 
-try:
-    import msgspec
 
-    class OffsetPagination(msgspec.Struct, Generic[T]):
-        """Container for data returned using limit/offset pagination.
+@dataclass
+class OffsetPagination(Generic[T]):
+    """Container for data returned using limit/offset pagination.
 
-        Args:
-            items: List of data being sent as part of the response.
-            limit: Maximal number of items to send.
-            offset: Offset from the beginning of the query. Identical to an index.
-            total: Total number of items.
-        """
+    Args:
+        items: List of data being sent as part of the response.
+        limit: Maximal number of items to send.
+        offset: Offset from the beginning of the query. Identical to an index.
+        total: Total number of items.
+    """
 
-        items: Sequence[T]
-        limit: int
-        offset: int
-        total: int
-
-except ImportError:
-
-    class OffsetPagination(Generic[T]):  # type: ignore[no-redef]
-        """Container for data returned using limit/offset pagination (msgspec-free fallback)."""
-
-        __slots__ = ("items", "limit", "offset", "total")
-
-        items: Sequence[T]
-        limit: int
-        offset: int
-        total: int
-
-        def __init__(self, items: Sequence[T], limit: int, offset: int, total: int) -> None:
-            self.items = items
-            self.limit = limit
-            self.offset = offset
-            self.total = total
+    items: Sequence[T]
+    limit: int
+    offset: int
+    total: int

--- a/sqlspec/core/filters.py
+++ b/sqlspec/core/filters.py
@@ -25,6 +25,7 @@ from collections.abc import Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeAlias
 
+import msgspec
 import sqlglot
 from mypy_extensions import mypyc_attr
 from sqlglot import exp
@@ -877,29 +878,23 @@ class NotInSearchFilter(SearchFilter):
         return ("NotInSearchFilter", field_names, self.value, self.ignore_case)
 
 
-class OffsetPagination(Generic[T]):
-    """Container for data returned using limit/offset pagination."""
+class OffsetPagination(msgspec.Struct, Generic[T]):
+    """Container for data returned using limit/offset pagination.
 
-    __slots__ = ("items", "limit", "offset", "total")
+    Fields preserved at runtime via msgspec metaclass so Litestar OpenAPI and
+    generic-type introspection work under mypyc-compiled wheels.
+
+    Args:
+        items: List of data being sent as part of the response.
+        limit: Maximal number of items to send.
+        offset: Offset from the beginning of the query. Identical to an index.
+        total: Total number of items.
+    """
 
     items: Sequence[T]
     limit: int
     offset: int
     total: int
-
-    def __init__(self, items: Sequence[T], limit: int, offset: int, total: int) -> None:
-        """Initialize OffsetPagination.
-
-        Args:
-            items: List of data being sent as part of the response.
-            limit: Maximal number of items to send.
-            offset: Offset from the beginning of the query. Identical to an index.
-            total: Total number of items.
-        """
-        self.items = items
-        self.limit = limit
-        self.offset = offset
-        self.total = total
 
 
 def apply_filter(statement: "SQL", filter_obj: StatementFilter) -> "SQL":

--- a/sqlspec/core/filters.py
+++ b/sqlspec/core/filters.py
@@ -21,16 +21,15 @@ Features:
 import uuid
 from abc import ABC, abstractmethod
 from collections import abc
-from collections.abc import Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeAlias
 
-import msgspec
 import sqlglot
 from mypy_extensions import mypyc_attr
 from sqlglot import exp
 from typing_extensions import TypeVar
 
+from sqlspec.core._pagination import OffsetPagination
 from sqlspec.utils.type_guards import has_field_name
 
 if TYPE_CHECKING:
@@ -876,25 +875,6 @@ class NotInSearchFilter(SearchFilter):
         """Return cache key for this filter configuration."""
         field_names = tuple(sorted(self.field_name)) if isinstance(self.field_name, set) else self.field_name
         return ("NotInSearchFilter", field_names, self.value, self.ignore_case)
-
-
-class OffsetPagination(msgspec.Struct, Generic[T]):
-    """Container for data returned using limit/offset pagination.
-
-    Fields preserved at runtime via msgspec metaclass so Litestar OpenAPI and
-    generic-type introspection work under mypyc-compiled wheels.
-
-    Args:
-        items: List of data being sent as part of the response.
-        limit: Maximal number of items to send.
-        offset: Offset from the beginning of the query. Identical to an index.
-        total: Total number of items.
-    """
-
-    items: Sequence[T]
-    limit: int
-    offset: int
-    total: int
 
 
 def apply_filter(statement: "SQL", filter_obj: StatementFilter) -> "SQL":

--- a/sqlspec/extensions/litestar/plugin.py
+++ b/sqlspec/extensions/litestar/plugin.py
@@ -107,7 +107,7 @@ class _OffsetPaginationSchemaPlugin(OpenAPISchemaPlugin):
         return isinstance(origin, type) and issubclass(origin, OffsetPagination)
 
     def to_openapi_schema(self, field_definition: "FieldDefinition", schema_creator: "SchemaCreator") -> "Schema":
-        from litestar.openapi.spec import Schema
+        from litestar.openapi.spec import OpenAPIType, Schema
         from litestar.typing import FieldDefinition
 
         inner_type: Any = Any
@@ -118,12 +118,12 @@ class _OffsetPaginationSchemaPlugin(OpenAPISchemaPlugin):
         item_schema = schema_creator.for_field_definition(FieldDefinition.from_annotation(inner_type))
 
         return Schema(
-            type="object",
+            type=OpenAPIType.OBJECT,
             properties={
-                "items": Schema(type="array", items=item_schema),
-                "limit": Schema(type="integer"),
-                "offset": Schema(type="integer"),
-                "total": Schema(type="integer"),
+                "items": Schema(type=OpenAPIType.ARRAY, items=item_schema),
+                "limit": Schema(type=OpenAPIType.INTEGER),
+                "offset": Schema(type=OpenAPIType.INTEGER),
+                "total": Schema(type=OpenAPIType.INTEGER),
             },
             required=["items", "limit", "offset", "total"],
         )

--- a/sqlspec/extensions/litestar/plugin.py
+++ b/sqlspec/extensions/litestar/plugin.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal, NoReturn, cast, overload
 
 from litestar.di import Provide
 from litestar.middleware import DefineMiddleware
-from litestar.plugins import CLIPlugin, InitPluginProtocol
+from litestar.plugins import CLIPlugin, InitPluginProtocol, OpenAPISchemaPlugin
 
 from sqlspec.base import SQLSpec
 from sqlspec.config import (
@@ -19,6 +19,7 @@ from sqlspec.config import (
     SyncConfigT,
     SyncDatabaseConfig,
 )
+from sqlspec.core.filters import OffsetPagination
 from sqlspec.core.sqlcommenter import SQLCommenterContext
 from sqlspec.exceptions import ImproperConfigurationError
 from sqlspec.extensions.litestar._utils import (
@@ -44,9 +45,12 @@ if TYPE_CHECKING:
     from contextlib import AbstractAsyncContextManager
 
     from litestar import Litestar
+    from litestar._openapi.schema_generation.schema import SchemaCreator
     from litestar.config.app import AppConfig
     from litestar.datastructures.state import State
+    from litestar.openapi.spec import Schema
     from litestar.types import ASGIApp, BeforeMessageSendHookHandler, Receive, Scope, Send
+    from litestar.typing import FieldDefinition
     from rich_click import Group
 
     from sqlspec.driver import AsyncDriverAdapterBase, SyncDriverAdapterBase
@@ -84,7 +88,45 @@ __all__ = (
     "CorrelationMiddleware",
     "PluginConfigState",
     "SQLSpecPlugin",
+    "_OffsetPaginationSchemaPlugin",
 )
+
+
+class _OffsetPaginationSchemaPlugin(OpenAPISchemaPlugin):
+    """OpenAPI schema plugin expanding OffsetPagination[T] into a concrete schema.
+
+    Defense-in-depth for sqlspec.core.filters.OffsetPagination. The msgspec.Struct
+    conversion already lets Litestar's default generator produce a correct schema;
+    this plugin guarantees the shape even if future Litestar or msgspec changes
+    break auto-detection.
+    """
+
+    @staticmethod
+    def is_plugin_supported_type(value: Any) -> bool:
+        origin = getattr(value, "__origin__", value)
+        return isinstance(origin, type) and issubclass(origin, OffsetPagination)
+
+    def to_openapi_schema(self, field_definition: "FieldDefinition", schema_creator: "SchemaCreator") -> "Schema":
+        from litestar.openapi.spec import Schema
+        from litestar.typing import FieldDefinition
+
+        inner_type: Any = Any
+        inner_args = getattr(field_definition, "inner_types", ())
+        if inner_args:
+            inner_type = inner_args[0].annotation
+
+        item_schema = schema_creator.for_field_definition(FieldDefinition.from_annotation(inner_type))
+
+        return Schema(
+            type="object",
+            properties={
+                "items": Schema(type="array", items=item_schema),
+                "limit": Schema(type="integer"),
+                "offset": Schema(type="integer"),
+                "total": Schema(type="integer"),
+            },
+            required=["items", "limit", "offset", "total"],
+        )
 
 
 def _normalize_header_list(headers: Any) -> list[str]:
@@ -408,6 +450,11 @@ class SQLSpecPlugin(InitPluginProtocol, CLIPlugin):
 
         if signature_namespace:
             app_config.signature_namespace.update(signature_namespace)
+
+        existing_plugins = list(app_config.plugins or [])
+        if not any(isinstance(p, _OffsetPaginationSchemaPlugin) for p in existing_plugins):
+            existing_plugins.append(_OffsetPaginationSchemaPlugin())
+            app_config.plugins = existing_plugins
 
         if NUMPY_INSTALLED:
             import numpy as np

--- a/sqlspec/extensions/litestar/plugin.py
+++ b/sqlspec/extensions/litestar/plugin.py
@@ -19,7 +19,6 @@ from sqlspec.config import (
     SyncConfigT,
     SyncDatabaseConfig,
 )
-from sqlspec.core.filters import OffsetPagination
 from sqlspec.core.sqlcommenter import SQLCommenterContext
 from sqlspec.exceptions import ImproperConfigurationError
 from sqlspec.extensions.litestar._utils import (
@@ -86,10 +85,6 @@ __all__ = (
     "PluginConfigState",
     "SQLSpecPlugin",
 )
-
-
-def _encode_offset_pagination(value: OffsetPagination[Any]) -> dict[str, Any]:
-    return {"items": value.items, "limit": value.limit, "offset": value.offset, "total": value.total}
 
 
 def _normalize_header_list(headers: Any) -> list[str]:
@@ -413,13 +408,6 @@ class SQLSpecPlugin(InitPluginProtocol, CLIPlugin):
 
         if signature_namespace:
             app_config.signature_namespace.update(signature_namespace)
-
-        if app_config.type_encoders is None:
-            app_config.type_encoders = {OffsetPagination: _encode_offset_pagination}
-        else:
-            encoders_dict = dict(app_config.type_encoders)
-            encoders_dict[OffsetPagination] = _encode_offset_pagination
-            app_config.type_encoders = encoders_dict
 
         if NUMPY_INSTALLED:
             import numpy as np

--- a/sqlspec/utils/serializers/_schema.py
+++ b/sqlspec/utils/serializers/_schema.py
@@ -5,8 +5,6 @@ from functools import partial
 from threading import RLock
 from typing import TYPE_CHECKING, Any, Final, cast
 
-from msgspec import structs
-
 from sqlspec.typing import UNSET, ArrowReturnFormat, attrs_asdict
 from sqlspec.utils.arrow_helpers import convert_dict_to_arrow
 from sqlspec.utils.type_guards import (
@@ -127,10 +125,14 @@ def _dump_identity_dict(value: Any) -> "dict[str, Any]":
 
 
 def _dump_msgspec_fields(value: Any) -> "dict[str, Any]":
+    from msgspec import structs
+
     return {field.encode_name: value.__getattribute__(field.name) for field in structs.fields(type(value))}
 
 
 def _dump_msgspec_excluding_unset(value: Any) -> "dict[str, Any]":
+    from msgspec import structs
+
     return {
         field.encode_name: field_value
         for field in structs.fields(type(value))

--- a/sqlspec/utils/serializers/_schema.py
+++ b/sqlspec/utils/serializers/_schema.py
@@ -5,6 +5,8 @@ from functools import partial
 from threading import RLock
 from typing import TYPE_CHECKING, Any, Final, cast
 
+from msgspec import structs
+
 from sqlspec.typing import UNSET, ArrowReturnFormat, attrs_asdict
 from sqlspec.utils.arrow_helpers import convert_dict_to_arrow
 from sqlspec.utils.type_guards import (
@@ -125,14 +127,14 @@ def _dump_identity_dict(value: Any) -> "dict[str, Any]":
 
 
 def _dump_msgspec_fields(value: Any) -> "dict[str, Any]":
-    return {field_name: value.__getattribute__(field_name) for field_name in value.__struct_fields__}
+    return {field.encode_name: value.__getattribute__(field.name) for field in structs.fields(type(value))}
 
 
 def _dump_msgspec_excluding_unset(value: Any) -> "dict[str, Any]":
     return {
-        field_name: field_value
-        for field_name in value.__struct_fields__
-        if (field_value := value.__getattribute__(field_name)) != UNSET
+        field.encode_name: field_value
+        for field in structs.fields(type(value))
+        if (field_value := value.__getattribute__(field.name)) != UNSET
     }
 
 

--- a/tests/integration/extensions/litestar/test_offset_pagination_serialization.py
+++ b/tests/integration/extensions/litestar/test_offset_pagination_serialization.py
@@ -39,6 +39,8 @@ def test_litestar_offset_pagination_serialization() -> None:
 
 def test_litestar_offset_pagination_openapi_schema() -> None:
     """OffsetPagination[T] must register T as an OpenAPI component (regression for #419)."""
+    from typing import Any, cast
+
     import msgspec
 
     class Item(msgspec.Struct):
@@ -54,10 +56,12 @@ def test_litestar_offset_pagination_openapi_schema() -> None:
     app = Litestar(route_handlers=[list_items], plugins=[SQLSpecPlugin(sqlspec=sql)])
 
     schema = app.openapi_schema
+    assert schema.components.schemas is not None
     component_names = set(schema.components.schemas.keys())
     assert any("Item" in name for name in component_names), f"Item not in OpenAPI components: {component_names}"
 
-    response = schema.paths["/items"].get.responses["200"]
+    paths = cast("dict[str, Any]", schema.paths)
+    response = paths["/items"].get.responses["200"]
     media = response.content["application/json"]
     assert media.schema is not None, "response media schema is None"
 
@@ -68,8 +72,9 @@ def test_litestar_offset_pagination_openapi_schema() -> None:
         (body for name, body in schema.components.schemas.items() if name.startswith("OffsetPagination")), None
     )
     assert pagination_component is not None, "OffsetPagination component missing"
-    component_dict = (
-        pagination_component.to_schema() if hasattr(pagination_component, "to_schema") else pagination_component
+    component_dict = cast(
+        "dict[str, Any]",
+        pagination_component.to_schema() if hasattr(pagination_component, "to_schema") else pagination_component,
     )
     assert set(component_dict.get("required", [])) == {"items", "limit", "offset", "total"}
     assert set(component_dict.get("properties", {}).keys()) == {"items", "limit", "offset", "total"}

--- a/tests/integration/extensions/litestar/test_offset_pagination_serialization.py
+++ b/tests/integration/extensions/litestar/test_offset_pagination_serialization.py
@@ -63,3 +63,13 @@ def test_litestar_offset_pagination_openapi_schema() -> None:
 
     schema_dict = media.schema.to_schema() if hasattr(media.schema, "to_schema") else media.schema
     assert schema_dict, f"OpenAPI response schema empty for OffsetPagination[Item]: {schema_dict!r}"
+
+    pagination_component = next(
+        (body for name, body in schema.components.schemas.items() if name.startswith("OffsetPagination")), None
+    )
+    assert pagination_component is not None, "OffsetPagination component missing"
+    component_dict = (
+        pagination_component.to_schema() if hasattr(pagination_component, "to_schema") else pagination_component
+    )
+    assert set(component_dict.get("required", [])) == {"items", "limit", "offset", "total"}
+    assert set(component_dict.get("properties", {}).keys()) == {"items", "limit", "offset", "total"}

--- a/tests/integration/extensions/litestar/test_offset_pagination_serialization.py
+++ b/tests/integration/extensions/litestar/test_offset_pagination_serialization.py
@@ -35,3 +35,31 @@ def test_litestar_offset_pagination_serialization() -> None:
             response = client.get("/pagination")
             assert response.status_code == 200
             assert response.json() == {"items": [{"id": 1}], "limit": 10, "offset": 0, "total": 1}
+
+
+def test_litestar_offset_pagination_openapi_schema() -> None:
+    """OffsetPagination[T] must register T as an OpenAPI component (regression for #419)."""
+    import msgspec
+
+    class Item(msgspec.Struct):
+        name: str
+
+    @get("/items")
+    async def list_items() -> OffsetPagination[Item]:
+        return OffsetPagination(items=[Item(name="a")], limit=10, offset=0, total=1)
+
+    sql = SQLSpec()
+    config = AiosqliteConfig(connection_config={"database": ":memory:"})
+    sql.add_config(config)
+    app = Litestar(route_handlers=[list_items], plugins=[SQLSpecPlugin(sqlspec=sql)])
+
+    schema = app.openapi_schema
+    component_names = set(schema.components.schemas.keys())
+    assert any("Item" in name for name in component_names), f"Item not in OpenAPI components: {component_names}"
+
+    response = schema.paths["/items"].get.responses["200"]
+    media = response.content["application/json"]
+    assert media.schema is not None, "response media schema is None"
+
+    schema_dict = media.schema.to_schema() if hasattr(media.schema, "to_schema") else media.schema
+    assert schema_dict, f"OpenAPI response schema empty for OffsetPagination[Item]: {schema_dict!r}"

--- a/tests/unit/utils/test_serializers.py
+++ b/tests/unit/utils/test_serializers.py
@@ -16,8 +16,10 @@ from sqlspec.utils.serializers import (
     numpy_array_dec_hook,
     numpy_array_enc_hook,
     numpy_array_predicate,
+    schema_dump,
     to_json,
 )
+from sqlspec.utils.serializers._schema import reset_serializer_cache
 
 pytestmark = pytest.mark.xdist_group("utils")
 
@@ -702,3 +704,77 @@ def test_numpy_serialization_with_to_json() -> None:
 
     decoded_list = from_json(json_str)
     assert decoded_list == [1.0, 2.0, 3.0]
+
+
+class TestSchemaDumpRename:
+    """Regression suite for GitHub #418 — schema_dump must honor msgspec rename meta."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_cache(self) -> "Any":
+        reset_serializer_cache()
+        yield
+        reset_serializer_cache()
+
+    def test_rename_camel(self) -> None:
+        import msgspec
+
+        class _User(msgspec.Struct, rename="camel"):
+            user_id: str
+            display_name: str
+
+        obj = _User(user_id="abc-123", display_name="Cody")
+        assert schema_dump(obj) == {"userId": "abc-123", "displayName": "Cody"}
+
+    def test_rename_kebab(self) -> None:
+        import msgspec
+
+        class _User(msgspec.Struct, rename="kebab"):
+            user_id: str
+            display_name: str
+
+        obj = _User(user_id="abc", display_name="Cody")
+        assert schema_dump(obj) == {"user-id": "abc", "display-name": "Cody"}
+
+    def test_rename_pascal(self) -> None:
+        import msgspec
+
+        class _User(msgspec.Struct, rename="pascal"):
+            user_id: str
+            display_name: str
+
+        obj = _User(user_id="abc", display_name="Cody")
+        assert schema_dump(obj) == {"UserId": "abc", "DisplayName": "Cody"}
+
+    def test_rename_callable(self) -> None:
+        import msgspec
+
+        def _upper(name: str) -> str:
+            return name.upper()
+
+        class _User(msgspec.Struct, rename=_upper):
+            user_id: str
+            display_name: str
+
+        obj = _User(user_id="abc", display_name="Cody")
+        assert schema_dump(obj) == {"USER_ID": "abc", "DISPLAY_NAME": "Cody"}
+
+    def test_no_rename_preserved(self) -> None:
+        import msgspec
+
+        class _User(msgspec.Struct):
+            user_id: str
+            display_name: str
+
+        obj = _User(user_id="abc", display_name="Cody")
+        assert schema_dump(obj) == {"user_id": "abc", "display_name": "Cody"}
+
+    def test_exclude_unset_with_rename(self) -> None:
+        import msgspec
+        from msgspec import UNSET
+
+        class _User(msgspec.Struct, rename="camel", omit_defaults=False):
+            user_id: str = UNSET  # type: ignore[assignment]
+            display_name: str = UNSET  # type: ignore[assignment]
+
+        obj = _User(user_id="abc")
+        assert schema_dump(obj, exclude_unset=True) == {"userId": "abc"}


### PR DESCRIPTION
## Summary

Fixes two silent-divergence bugs between declared schema contract and wire output:

- **Fixes #418** — `sqlspec.utils.serializers.schema_dump` now honors `msgspec.Struct` `rename=` meta. Structs declared with `rename="camel"` / `"kebab"` / `"pascal"` / callable now emit the renamed wire names instead of the Python attribute names.
- **Fixes #419** — `sqlspec.core.filters.OffsetPagination` is now a `msgspec.Struct`. Runtime `__annotations__` survive mypyc-compiled wheels, restoring Litestar OpenAPI schema generation for `OffsetPagination[T]` responses and unblocking downstream client generators (`@hey-api/openapi-ts`, etc.).

## Implementation

### #418 — schema_dump rename fix
`_dump_msgspec_fields` / `_dump_msgspec_excluding_unset` now iterate `msgspec.structs.fields(type(value))` and use `field.encode_name` for the dict key + `field.name` for the attribute lookup. Same pattern already established by `sqlspec.utils.type_guards.get_msgspec_rename_config`.

### #419 — OffsetPagination runtime types
Two-layer fix:

1. **Root cause:** Convert `OffsetPagination` to `msgspec.Struct(Generic[T])`. msgspec's metaclass captures annotations at class-creation time so they survive mypyc, and Litestar natively recognizes `msgspec.Struct` subclasses for OpenAPI schema generation.

2. **Mypyc-compat split:** Wheel validation surfaced `TypeError: mypyc classes can't have a metaclass` — mypyc refuses to compile any class with a non-default metaclass. `OffsetPagination` moved to `sqlspec/core/_pagination.py` (added to the mypyc exclude list) and re-exported from `sqlspec.core.filters`. The public import path is unchanged. Hot-path filter classes in `filters.py` continue to compile.

3. **Defense-in-depth:** Register `_OffsetPaginationSchemaPlugin` (an `OpenAPISchemaPlugin`) in `SQLSpecPlugin` that emits `{items: array<T>, limit, offset, total}` explicitly — guards against any future Litestar/msgspec drift that would break auto-detection.

4. **Cleanup:** Delete the now-redundant `_encode_offset_pagination` `type_encoder` — msgspec.Struct is encoded natively by Litestar's default serialization to the same JSON shape.

### Behavior changes

Converting `OffsetPagination` to `msgspec.Struct` changes three dunder behaviors (called out in `docs/changelog.rst`):
- `__eq__` is now field-wise (was identity)
- `__hash__` is `None` (msgspec default for non-frozen Structs — was id-based)
- `__repr__` is informative `OffsetPagination(items=..., limit=..., offset=..., total=...)`

## Test plan

- [x] `uv run pytest tests/unit/ tests/integration/extensions/litestar/ --ignore=tests/unit/adapters` — 4423 passed, 26 skipped, 0 failed
- [x] `uv run ruff check sqlspec tests` — all checks passed
- [x] Red phase confirmed: 5/6 rename tests fail on snake_case keys before fix; OpenAPI test fails with `Item not in OpenAPI components: set()` before fix
- [x] Green phase confirmed: every task passes tests immediately after the matching fix
- [x] `HATCH_BUILD_HOOKS_ENABLE=1 uv build --wheel` — compiled wheel produced `filters.cpython-310-x86_64-linux-gnu.so` (compiled) + `_pagination.py` (uncompiled)
- [x] Issue #419 reproducer against installed compiled wheel prints `components: ['Item', 'OffsetPagination___main__.Item_']` and `OK: Item registered, response schema non-empty`
- [x] Docs recipes spot-check — `docs/recipes/service_layer.rst` uses keyword-arg `OffsetPagination(items=..., limit=..., offset=..., total=...)` construction, wire-compatible with msgspec.Struct, no changes needed

## Commits

8 commits on `fix/annotation-thing`, Red-Green-Refactor per chapter:

```
284237d4 docs(changelog): add schema wire correctness release notes
33186c86 refactor(core): move OffsetPagination to _pagination.py (mypyc compat)
774287a3 feat(litestar): register _OffsetPaginationSchemaPlugin for OpenAPI
ef9c1366 refactor(litestar): remove dead _encode_offset_pagination
93dc6c9f fix(filters): convert OffsetPagination to msgspec.Struct
209e13c6 test(litestar): add failing OpenAPI schema assertion
4c1aad07 fix(serializers): honor msgspec rename meta in schema_dump
3cf93b3f test(serializers): add failing rename matrix for schema_dump
```

Fixes #418
Fixes #419