### PR TITLE
feat(oracledb): native JSON, VECTOR ergonomics, smart LOB coercion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ tools/scripts/profiles/*.prof
 # Beads / Dolt files (added by bd init)
 .dolt/
 .beads-credential-key
+.codex

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.15.11"
+    rev: "v0.15.12"
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ pre-commit:                                        ## Run pre-commit hooks
 .PHONY: slotscheck
 slotscheck:                                        ## Run slotscheck
 	@echo "${INFO} Running slotscheck... 🔍"
-	@uv run slotscheck sqlspec/
+	@PYTHONWARNINGS="ignore:::google.adk.features._feature_decorator" uv run slotscheck sqlspec/
 	@echo "${OK} Slotscheck complete ✨"
 
 .PHONY: fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,10 @@ fsspec = ["fsspec"]
 litestar = ["litestar"]
 msgspec = ["msgspec"]
 mypyc = ["sqlglot[c]>=30.0.0"]
-mysql-connector = ["mysql-connector-python"]
+mysql-connector = [
+  "mysql-connector-python; python_version < '3.12'",
+  "mysql-connector-python<9.7.0; python_version >= '3.12'",
+]
 nanoid = ["fastnanoid>=0.4.1"]
 obstore = ["obstore"]
 opentelemetry = ["opentelemetry-instrumentation"]
@@ -156,6 +159,12 @@ sqlspec = "sqlspec.__main__:run_cli"
 [project.entry-points."pygments.styles"]
 sqlspec-dark = "tools.sphinx_ext.pygments_styles:SQLSpecDarkStyle"
 sqlspec-light = "tools.sphinx_ext.pygments_styles:SQLSpecLightStyle"
+
+[tool.uv]
+# mysql-connector-python 9.7.0 dropped cp312/cp313/cp314 wheels (regression vs 9.6.0).
+# Force the cap on Python >=3.12 so transitive pulls (e.g., pytest-databases[mysql])
+# resolve to a wheel that exists for the running interpreter.
+override-dependencies = ["mysql-connector-python<9.7.0; python_version >= '3.12'"]
 
 [build-system]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,7 @@ include = [
   "sqlspec/data_dictionary/**/*.py",       # Data dictionary mixin (required for adapter inheritance)
   "sqlspec/adapters/**/core.py",           # Adapter compiled helpers
   "sqlspec/adapters/**/type_converter.py", # All adapters type converters
+  "sqlspec/adapters/oracledb/_param_types.py", # Slot-based LOB/JSON parameter wrappers
   "sqlspec/utils/text.py",                 # Text utilities
   "sqlspec/utils/sync_tools.py",           # Synchronous utility functions
   "sqlspec/utils/type_guards.py",          # Type guard utilities

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,9 +162,13 @@ sqlspec-light = "tools.sphinx_ext.pygments_styles:SQLSpecLightStyle"
 
 [tool.uv]
 # mysql-connector-python 9.7.0 dropped cp312/cp313/cp314 wheels (regression vs 9.6.0).
-# Force the cap on Python >=3.12 so transitive pulls (e.g., pytest-databases[mysql])
-# resolve to a wheel that exists for the running interpreter.
-override-dependencies = ["mysql-connector-python<9.7.0; python_version >= '3.12'"]
+# Override dependency metadata for every source that requests mysql-connector-python.
+# Keep the uncapped dependency on Python <3.12, and force the cap on Python >=3.12
+# so transitive pulls (e.g., pytest-databases[mysql]) resolve to an existing wheel.
+override-dependencies = [
+  "mysql-connector-python; python_version < '3.12'",
+  "mysql-connector-python<9.7.0; python_version >= '3.12'",
+]
 
 [build-system]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,10 @@ include = [
   "sqlspec/data_dictionary/**/*.py",       # Data dictionary mixin (required for adapter inheritance)
   "sqlspec/adapters/**/core.py",           # Adapter compiled helpers
   "sqlspec/adapters/**/type_converter.py", # All adapters type converters
-  "sqlspec/adapters/oracledb/_param_types.py", # Slot-based LOB/JSON parameter wrappers
+  "sqlspec/adapters/oracledb/_param_types.py",     # Slot-based LOB/JSON parameter wrappers
+  "sqlspec/adapters/oracledb/_json_handlers.py",   # Native JSON inputtypehandler / outputtypehandler chain
+  "sqlspec/adapters/oracledb/_uuid_handlers.py",   # UUID ↔ RAW(16) inputtypehandler / outputtypehandler chain
+  "sqlspec/adapters/oracledb/_vector_handlers.py", # DB_TYPE_VECTOR inputtypehandler / outputtypehandler dispatch
   "sqlspec/utils/text.py",                 # Text utilities
   "sqlspec/utils/sync_tools.py",           # Synchronous utility functions
   "sqlspec/utils/type_guards.py",          # Type guard utilities

--- a/sqlspec/adapters/oracledb/__init__.py
+++ b/sqlspec/adapters/oracledb/__init__.py
@@ -1,5 +1,5 @@
 import sqlspec.adapters.oracledb._json_handlers as json_handlers
-import sqlspec.adapters.oracledb._numpy_handlers as numpy_handlers
+import sqlspec.adapters.oracledb._vector_handlers as vector_handlers
 from sqlspec.adapters.oracledb._json_handlers import (
     json_converter_in_blob,
     json_converter_in_clob,
@@ -8,14 +8,6 @@ from sqlspec.adapters.oracledb._json_handlers import (
     json_input_type_handler,
     json_output_type_handler,
     register_json_handlers,
-)
-from sqlspec.adapters.oracledb._numpy_handlers import (
-    DTYPE_TO_ARRAY_CODE,
-    numpy_converter_in,
-    numpy_converter_out,
-    numpy_input_type_handler,
-    numpy_output_type_handler,
-    register_numpy_handlers,
 )
 from sqlspec.adapters.oracledb._typing import (
     OracleAsyncConnection,
@@ -29,6 +21,14 @@ from sqlspec.adapters.oracledb._uuid_handlers import (
     uuid_converter_out,
     uuid_input_type_handler,
     uuid_output_type_handler,
+)
+from sqlspec.adapters.oracledb._vector_handlers import (
+    DTYPE_TO_ARRAY_CODE,
+    numpy_converter_in,
+    numpy_converter_out,
+    numpy_input_type_handler,
+    numpy_output_type_handler,
+    register_numpy_handlers,
 )
 from sqlspec.adapters.oracledb.config import (
     OracleAsyncConfig,
@@ -70,7 +70,6 @@ __all__ = (
     "json_output_type_handler",
     "numpy_converter_in",
     "numpy_converter_out",
-    "numpy_handlers",
     "numpy_input_type_handler",
     "numpy_output_type_handler",
     "register_json_handlers",
@@ -80,4 +79,5 @@ __all__ = (
     "uuid_converter_out",
     "uuid_input_type_handler",
     "uuid_output_type_handler",
+    "vector_handlers",
 )

--- a/sqlspec/adapters/oracledb/__init__.py
+++ b/sqlspec/adapters/oracledb/__init__.py
@@ -9,6 +9,7 @@ from sqlspec.adapters.oracledb._json_handlers import (
     json_output_type_handler,
     register_json_handlers,
 )
+from sqlspec.adapters.oracledb._param_types import OracleBlob, OracleClob, OracleJson
 from sqlspec.adapters.oracledb._typing import (
     OracleAsyncConnection,
     OracleAsyncCursor,
@@ -52,8 +53,11 @@ __all__ = (
     "OracleAsyncCursor",
     "OracleAsyncDriver",
     "OracleAsyncExceptionHandler",
+    "OracleBlob",
+    "OracleClob",
     "OracleConnectionParams",
     "OracleDriverFeatures",
+    "OracleJson",
     "OraclePoolParams",
     "OracleSyncConfig",
     "OracleSyncConnection",

--- a/sqlspec/adapters/oracledb/__init__.py
+++ b/sqlspec/adapters/oracledb/__init__.py
@@ -1,4 +1,14 @@
+import sqlspec.adapters.oracledb._json_handlers as json_handlers
 import sqlspec.adapters.oracledb._numpy_handlers as numpy_handlers
+from sqlspec.adapters.oracledb._json_handlers import (
+    json_converter_in_blob,
+    json_converter_in_clob,
+    json_converter_out_blob,
+    json_converter_out_clob,
+    json_input_type_handler,
+    json_output_type_handler,
+    register_json_handlers,
+)
 from sqlspec.adapters.oracledb._numpy_handlers import (
     DTYPE_TO_ARRAY_CODE,
     numpy_converter_in,
@@ -51,11 +61,19 @@ __all__ = (
     "OracleSyncDriver",
     "OracleSyncExceptionHandler",
     "default_statement_config",
+    "json_converter_in_blob",
+    "json_converter_in_clob",
+    "json_converter_out_blob",
+    "json_converter_out_clob",
+    "json_handlers",
+    "json_input_type_handler",
+    "json_output_type_handler",
     "numpy_converter_in",
     "numpy_converter_out",
     "numpy_handlers",
     "numpy_input_type_handler",
     "numpy_output_type_handler",
+    "register_json_handlers",
     "register_numpy_handlers",
     "register_uuid_handlers",
     "uuid_converter_in",

--- a/sqlspec/adapters/oracledb/_json_handlers.py
+++ b/sqlspec/adapters/oracledb/_json_handlers.py
@@ -30,6 +30,7 @@ handler returns ``None`` for values it does not own.
 
 from typing import TYPE_CHECKING, Any
 
+from sqlspec.adapters.oracledb._typing import DB_TYPE_BLOB, DB_TYPE_CLOB, DB_TYPE_JSON
 from sqlspec.utils.serializers import from_json, to_json
 
 if TYPE_CHECKING:
@@ -101,27 +102,23 @@ def _is_json_payload(value: Any) -> bool:
 
 def _input_type_handler(cursor: "Cursor | AsyncCursor", value: Any, arraysize: int) -> Any:
     """Oracle input type handler for JSON-shaped Python values."""
-    import oracledb
-
     if not _is_json_payload(value):
         return None
 
     server_major = getattr(cursor.connection, "_sqlspec_oracle_major", None)
 
     if server_major is None or server_major >= _NATIVE_JSON_MIN_MAJOR:
-        return cursor.var(oracledb.DB_TYPE_JSON, arraysize=arraysize)
+        return cursor.var(DB_TYPE_JSON, arraysize=arraysize)
     if server_major >= _BLOB_IS_JSON_MIN_MAJOR:
-        return cursor.var(oracledb.DB_TYPE_BLOB, arraysize=arraysize, inconverter=json_converter_in_blob)
-    return cursor.var(oracledb.DB_TYPE_CLOB, arraysize=arraysize, inconverter=json_converter_in_clob)
+        return cursor.var(DB_TYPE_BLOB, arraysize=arraysize, inconverter=json_converter_in_blob)
+    return cursor.var(DB_TYPE_CLOB, arraysize=arraysize, inconverter=json_converter_in_clob)
 
 
 def _output_type_handler(cursor: "Cursor | AsyncCursor", metadata: Any) -> Any:
     """Oracle output type handler for JSON-bearing column reads."""
-    import oracledb
-
     type_code = getattr(metadata, "type_code", None)
 
-    if type_code is oracledb.DB_TYPE_JSON:
+    if type_code is DB_TYPE_JSON:
         # Native JSON: python-oracledb returns dict/list directly. No conversion.
         return None
 
@@ -129,10 +126,10 @@ def _output_type_handler(cursor: "Cursor | AsyncCursor", metadata: Any) -> Any:
     if _JSON_TYPE_NAME_MARKER not in type_name:
         return None
 
-    if type_code is oracledb.DB_TYPE_BLOB:
-        return cursor.var(oracledb.DB_TYPE_BLOB, arraysize=cursor.arraysize, outconverter=json_converter_out_blob)
-    if type_code is oracledb.DB_TYPE_CLOB:
-        return cursor.var(oracledb.DB_TYPE_CLOB, arraysize=cursor.arraysize, outconverter=json_converter_out_clob)
+    if type_code is DB_TYPE_BLOB:
+        return cursor.var(DB_TYPE_BLOB, arraysize=cursor.arraysize, outconverter=json_converter_out_blob)
+    if type_code is DB_TYPE_CLOB:
+        return cursor.var(DB_TYPE_CLOB, arraysize=cursor.arraysize, outconverter=json_converter_out_clob)
     return None
 
 

--- a/sqlspec/adapters/oracledb/_json_handlers.py
+++ b/sqlspec/adapters/oracledb/_json_handlers.py
@@ -1,0 +1,199 @@
+"""Oracle native JSON type handlers.
+
+Provides automatic conversion between Python ``dict`` / ``list`` / ``tuple`` values
+and Oracle's JSON storage types via connection type handlers.
+
+Routing matrix (input):
+
+* Oracle 21c+ native ``JSON``: bind via ``DB_TYPE_JSON`` (binary OSON).
+* Oracle 19c-20c with ``BLOB CHECK (... IS JSON)``: bind via ``DB_TYPE_BLOB`` with
+  UTF-8 JSON bytes.
+* Oracle 12c-18c with ``CLOB CHECK (... IS JSON)``: bind via ``DB_TYPE_CLOB`` with
+  serialized JSON string.
+* Server major version is read from ``connection._sqlspec_oracle_major`` (set in
+  ``OracleSyncConfig._init_connection`` / ``OracleAsyncConfig._init_connection``).
+  When unknown, default to 21c+ behavior.
+
+Routing matrix (output):
+
+* ``DB_TYPE_JSON``: passthrough (python-oracledb already returns ``dict``).
+* ``DB_TYPE_BLOB`` with ``JSON`` in column ``type_name``: parse via
+  ``json_converter_out_blob``.
+* ``DB_TYPE_CLOB`` with ``JSON`` in column ``type_name``: parse via
+  ``json_converter_out_clob``.
+
+Handlers chain to any pre-existing ``inputtypehandler`` / ``outputtypehandler``
+registered on the connection (e.g. NumPy vector, UUID), so registration order
+matters: register JSON after numpy, before UUID is also safe because each
+handler returns ``None`` for values it does not own.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+from sqlspec.utils.serializers import from_json, to_json
+
+if TYPE_CHECKING:
+    from oracledb import AsyncConnection, AsyncCursor, Connection, Cursor
+
+__all__ = (
+    "json_converter_in_blob",
+    "json_converter_in_clob",
+    "json_converter_out_blob",
+    "json_converter_out_clob",
+    "json_input_type_handler",
+    "json_output_type_handler",
+    "register_json_handlers",
+)
+
+
+_JSON_TYPE_NAME_MARKER = "JSON"
+
+# Server-version thresholds for JSON binding strategy selection.
+# 21c+ supports DB_TYPE_JSON (binary OSON); 19c-20c uses BLOB CHECK (... IS JSON);
+# pre-19c uses CLOB CHECK (... IS JSON).
+_NATIVE_JSON_MIN_MAJOR = 21
+_BLOB_IS_JSON_MIN_MAJOR = 19
+
+
+def json_converter_in_clob(value: Any) -> str:
+    """Serialize a Python value to a JSON string for CLOB binding."""
+    return to_json(value)
+
+
+def json_converter_in_blob(value: Any) -> bytes:
+    """Serialize a Python value to UTF-8 JSON bytes for BLOB binding."""
+    return to_json(value, as_bytes=True)
+
+
+def json_converter_out_clob(value: "str | None") -> Any:
+    """Parse a JSON string from a CLOB read back into a Python value."""
+    if value is None:
+        return None
+    return from_json(value)
+
+
+def json_converter_out_blob(value: "bytes | None") -> Any:
+    """Parse JSON bytes from a BLOB read back into a Python value."""
+    if value is None:
+        return None
+    return from_json(value)
+
+
+def _is_json_payload(value: Any) -> bool:
+    """Return True if the value should be claimed by the JSON input handler.
+
+    ``dict`` and ``tuple``/``list`` of dicts are claimed. Sequences whose first
+    element is a number are NOT claimed — those are vector embeddings and
+    belong to the vector handler.
+    """
+    if isinstance(value, dict):
+        return True
+    if isinstance(value, (list, tuple)):
+        if not value:
+            # Empty sequence: ambiguous (could be empty vector or empty list).
+            # Defer to the next handler in the chain.
+            return False
+        first = value[0]
+        # Reject sequences of numbers (vector embeddings).
+        return not (isinstance(first, (int, float)) and not isinstance(first, bool))
+    return False
+
+
+def _input_type_handler(cursor: "Cursor | AsyncCursor", value: Any, arraysize: int) -> Any:
+    """Oracle input type handler for JSON-shaped Python values."""
+    import oracledb
+
+    if not _is_json_payload(value):
+        return None
+
+    server_major = getattr(cursor.connection, "_sqlspec_oracle_major", None)
+
+    if server_major is None or server_major >= _NATIVE_JSON_MIN_MAJOR:
+        return cursor.var(oracledb.DB_TYPE_JSON, arraysize=arraysize)
+    if server_major >= _BLOB_IS_JSON_MIN_MAJOR:
+        return cursor.var(oracledb.DB_TYPE_BLOB, arraysize=arraysize, inconverter=json_converter_in_blob)
+    return cursor.var(oracledb.DB_TYPE_CLOB, arraysize=arraysize, inconverter=json_converter_in_clob)
+
+
+def _output_type_handler(cursor: "Cursor | AsyncCursor", metadata: Any) -> Any:
+    """Oracle output type handler for JSON-bearing column reads."""
+    import oracledb
+
+    type_code = getattr(metadata, "type_code", None)
+
+    if type_code is oracledb.DB_TYPE_JSON:
+        # Native JSON: python-oracledb returns dict/list directly. No conversion.
+        return None
+
+    type_name = (getattr(metadata, "type_name", "") or "").upper()
+    if _JSON_TYPE_NAME_MARKER not in type_name:
+        return None
+
+    if type_code is oracledb.DB_TYPE_BLOB:
+        return cursor.var(oracledb.DB_TYPE_BLOB, arraysize=cursor.arraysize, outconverter=json_converter_out_blob)
+    if type_code is oracledb.DB_TYPE_CLOB:
+        return cursor.var(oracledb.DB_TYPE_CLOB, arraysize=cursor.arraysize, outconverter=json_converter_out_clob)
+    return None
+
+
+def json_input_type_handler(cursor: "Cursor | AsyncCursor", value: Any, arraysize: int) -> Any:
+    """Public input type handler entry point."""
+    return _input_type_handler(cursor, value, arraysize)
+
+
+def json_output_type_handler(cursor: "Cursor | AsyncCursor", metadata: Any) -> Any:
+    """Public output type handler entry point."""
+    return _output_type_handler(cursor, metadata)
+
+
+def register_json_handlers(connection: "Connection | AsyncConnection") -> None:
+    """Register JSON type handlers on an Oracle connection.
+
+    Chains to any existing handlers via ``_JsonInputHandler`` / ``_JsonOutputHandler``
+    wrapper classes so vector / UUID handlers continue to fire for non-JSON values.
+    """
+    try:
+        existing_input = connection.inputtypehandler
+    except AttributeError:
+        existing_input = None
+    try:
+        existing_output = connection.outputtypehandler
+    except AttributeError:
+        existing_output = None
+
+    connection.inputtypehandler = _JsonInputHandler(existing_input)
+    connection.outputtypehandler = _JsonOutputHandler(existing_output)
+
+
+class _JsonInputHandler:
+    """Chaining wrapper that claims dict/list/tuple values, falling back otherwise."""
+
+    __slots__ = ("_fallback",)
+
+    def __init__(self, fallback: "Any | None") -> None:
+        self._fallback = fallback
+
+    def __call__(self, cursor: "Cursor | AsyncCursor", value: Any, arraysize: int) -> Any:
+        result = _input_type_handler(cursor, value, arraysize)
+        if result is not None:
+            return result
+        if self._fallback is not None:
+            return self._fallback(cursor, value, arraysize)
+        return None
+
+
+class _JsonOutputHandler:
+    """Chaining wrapper that claims JSON-bearing columns, falling back otherwise."""
+
+    __slots__ = ("_fallback",)
+
+    def __init__(self, fallback: "Any | None") -> None:
+        self._fallback = fallback
+
+    def __call__(self, cursor: "Cursor | AsyncCursor", metadata: Any) -> Any:
+        result = _output_type_handler(cursor, metadata)
+        if result is not None:
+            return result
+        if self._fallback is not None:
+            return self._fallback(cursor, metadata)
+        return None

--- a/sqlspec/adapters/oracledb/_param_types.py
+++ b/sqlspec/adapters/oracledb/_param_types.py
@@ -1,0 +1,46 @@
+"""Typed parameter wrappers for explicit Oracle LOB / JSON binding.
+
+These slot-based wrappers are an opt-in escape hatch for power users who need
+deterministic LOB or JSON routing regardless of the size-based heuristics in
+:func:`coerce_large_parameters_sync` / :func:`coerce_large_parameters_async`.
+
+Wrap a parameter value to express explicit intent:
+
+* :class:`OracleClob` — bind as ``DB_TYPE_CLOB`` regardless of length.
+* :class:`OracleBlob` — bind as ``DB_TYPE_BLOB`` regardless of length.
+* :class:`OracleJson` — bind as native JSON; defers to the C1 input handler.
+
+The wrappers themselves perform no validation — type discipline lives at the
+routing site so error messages can include database-context detail.
+"""
+
+from typing import Any
+
+__all__ = ("OracleBlob", "OracleClob", "OracleJson")
+
+
+class OracleClob:
+    """Mark a value to be bound as ``DB_TYPE_CLOB`` regardless of length."""
+
+    __slots__ = ("value",)
+
+    def __init__(self, value: "str | bytes") -> None:
+        self.value = value
+
+
+class OracleBlob:
+    """Mark a value to be bound as ``DB_TYPE_BLOB`` regardless of length."""
+
+    __slots__ = ("value",)
+
+    def __init__(self, value: "bytes | str") -> None:
+        self.value = value
+
+
+class OracleJson:
+    """Mark a value to be bound as native ``DB_TYPE_JSON`` regardless of detected version."""
+
+    __slots__ = ("value",)
+
+    def __init__(self, value: Any) -> None:
+        self.value = value

--- a/sqlspec/adapters/oracledb/_typing.py
+++ b/sqlspec/adapters/oracledb/_typing.py
@@ -7,7 +7,16 @@ compilation to avoid ABI boundary issues.
 import contextlib
 from typing import TYPE_CHECKING, Any, Protocol
 
-from oracledb import AsyncConnection, AsyncCursor, Connection, Cursor
+from oracledb import (
+    DB_TYPE_BLOB,
+    DB_TYPE_CLOB,
+    DB_TYPE_JSON,
+    DB_TYPE_RAW,
+    AsyncConnection,
+    AsyncCursor,
+    Connection,
+    Cursor,
+)
 from oracledb.pool import AsyncConnectionPool, ConnectionPool
 
 if TYPE_CHECKING:
@@ -217,6 +226,10 @@ class OracleAsyncSessionContext:
 
 
 __all__ = (
+    "DB_TYPE_BLOB",
+    "DB_TYPE_CLOB",
+    "DB_TYPE_JSON",
+    "DB_TYPE_RAW",
     "DB_TYPE_VECTOR",
     "OracleAsyncConnection",
     "OracleAsyncConnectionPool",

--- a/sqlspec/adapters/oracledb/_uuid_handlers.py
+++ b/sqlspec/adapters/oracledb/_uuid_handlers.py
@@ -7,6 +7,7 @@ via connection type handlers. Uses stdlib uuid (no external dependencies).
 import uuid
 from typing import TYPE_CHECKING, Any
 
+from sqlspec.adapters.oracledb._typing import DB_TYPE_RAW
 from sqlspec.utils.logging import get_logger
 
 if TYPE_CHECKING:
@@ -76,10 +77,8 @@ def _input_type_handler(cursor: "Cursor | AsyncCursor", value: Any, arraysize: i
     Returns:
         Cursor variable with UUID converter if value is UUID, None otherwise.
     """
-    import oracledb
-
     if isinstance(value, uuid.UUID):
-        return cursor.var(oracledb.DB_TYPE_RAW, arraysize=arraysize, inconverter=uuid_converter_in)
+        return cursor.var(DB_TYPE_RAW, arraysize=arraysize, inconverter=uuid_converter_in)
     return None
 
 
@@ -95,11 +94,9 @@ def _output_type_handler(cursor: "Cursor | AsyncCursor", metadata: Any) -> Any:
     Returns:
         Cursor variable with UUID converter if column is RAW(16), None otherwise.
     """
-    import oracledb
-
     _name, type_code, _display_size, internal_size, _precision, _scale, _null_ok = metadata
 
-    if type_code is oracledb.DB_TYPE_RAW and internal_size == UUID_BINARY_SIZE:
+    if type_code is DB_TYPE_RAW and internal_size == UUID_BINARY_SIZE:
         return cursor.var(type_code, arraysize=cursor.arraysize, outconverter=uuid_converter_out)
     return None
 

--- a/sqlspec/adapters/oracledb/_vector_handlers.py
+++ b/sqlspec/adapters/oracledb/_vector_handlers.py
@@ -1,10 +1,16 @@
-"""Oracle NumPy vector type handlers for VECTOR data type support.
+"""Oracle vector type handlers for the DB_TYPE_VECTOR data type.
 
-Provides automatic conversion between NumPy arrays and Oracle VECTOR types
-via connection type handlers. Requires Oracle Database 23ai or higher.
+Provides automatic conversion between Python sequence-of-numbers
+(``numpy.ndarray``, ``array.array``, ``list``, ``tuple``) and Oracle VECTOR
+columns. Requires Oracle Database 23ai or higher.
+
+Public symbols keep the historical ``numpy_*`` prefix for backwards-compat with
+sqlspec ``__all__`` consumers; the user-facing rename to ``vector_*`` is tracked
+as a follow-up.
 """
 
 import array
+import sys
 from typing import TYPE_CHECKING, Any
 
 from sqlspec.typing import NUMPY_INSTALLED
@@ -14,6 +20,7 @@ if TYPE_CHECKING:
     from oracledb import AsyncConnection, AsyncCursor, Connection, Cursor
 
 __all__ = (
+    "DTYPE_TO_ARRAY_CODE",
     "numpy_converter_in",
     "numpy_converter_out",
     "numpy_input_type_handler",
@@ -25,7 +32,24 @@ __all__ = (
 logger = get_logger(__name__)
 
 
-DTYPE_TO_ARRAY_CODE: "dict[str, str]" = {"float64": "d", "float32": "f", "uint8": "B", "int8": "b"}
+_TYPECODE_FLOAT64 = "d"
+_TYPECODE_FLOAT32 = "f"
+_TYPECODE_FLOAT16 = "e"
+_TYPECODE_UINT8 = "B"
+_TYPECODE_INT8 = "b"
+_TYPECODE_INT16 = "h"
+_TYPECODE_INT32 = "i"
+
+DTYPE_TO_ARRAY_CODE: "dict[str, str]" = {
+    "float64": _TYPECODE_FLOAT64,
+    "float32": _TYPECODE_FLOAT32,
+    "uint8": _TYPECODE_UINT8,
+    "int8": _TYPECODE_INT8,
+    "int16": _TYPECODE_INT16,
+    "int32": _TYPECODE_INT32,
+}
+if sys.version_info >= (3, 13):
+    DTYPE_TO_ARRAY_CODE["float16"] = _TYPECODE_FLOAT16
 
 
 def numpy_converter_in(value: Any) -> "array.array[Any]":

--- a/sqlspec/adapters/oracledb/_vector_handlers.py
+++ b/sqlspec/adapters/oracledb/_vector_handlers.py
@@ -10,7 +10,6 @@ as a follow-up.
 """
 
 import array
-import sys
 from typing import TYPE_CHECKING, Any
 
 from sqlspec.adapters.oracledb._typing import DB_TYPE_VECTOR
@@ -57,7 +56,11 @@ DTYPE_TO_ARRAY_CODE: "dict[str, str]" = {
     "int16": _TYPECODE_INT16,
     "int32": _TYPECODE_INT32,
 }
-if sys.version_info >= (3, 13):
+try:
+    array.array(_TYPECODE_FLOAT16)
+except ValueError:
+    pass
+else:
     DTYPE_TO_ARRAY_CODE["float16"] = _TYPECODE_FLOAT16
 
 

--- a/sqlspec/adapters/oracledb/_vector_handlers.py
+++ b/sqlspec/adapters/oracledb/_vector_handlers.py
@@ -40,6 +40,14 @@ _TYPECODE_INT8 = "b"
 _TYPECODE_INT16 = "h"
 _TYPECODE_INT32 = "i"
 
+_INT8_MIN = -128
+_INT8_MAX = 127
+
+_VECTOR_RETURN_NUMPY = "numpy"
+_VECTOR_RETURN_LIST = "list"
+_VECTOR_RETURN_ARRAY = "array"
+_VECTOR_RETURN_FORMATS = frozenset({_VECTOR_RETURN_NUMPY, _VECTOR_RETURN_LIST, _VECTOR_RETURN_ARRAY})
+
 DTYPE_TO_ARRAY_CODE: "dict[str, str]" = {
     "float64": _TYPECODE_FLOAT64,
     "float32": _TYPECODE_FLOAT32,
@@ -97,8 +105,43 @@ def numpy_converter_out(value: "array.array[Any]") -> Any:
     return np.array(value, copy=True, dtype=value.typecode)
 
 
+def _is_vector_payload(value: Any) -> bool:
+    """Return True if the value should be claimed by the vector input handler.
+
+    Mirrors the C1 ``_is_json_payload`` predicate but inverted: claims sequences
+    of numbers (vector embeddings); rejects ``dict`` / ``list[dict]`` which the
+    JSON handler owns. ``bool`` is excluded explicitly because it is a subclass
+    of ``int`` but is owned by the JSON path.
+    """
+    if isinstance(value, array.array):
+        return True
+    if NUMPY_INSTALLED:
+        import numpy as np
+
+        if isinstance(value, np.ndarray):
+            return True
+    if isinstance(value, (list, tuple)) and value:
+        first = value[0]
+        if isinstance(first, bool):
+            return False
+        return isinstance(first, (int, float))
+    return False
+
+
+def _pack_python_sequence(value: "list[Any] | tuple[Any, ...]") -> "array.array[Any]":
+    """Pack a Python sequence into an ``array.array`` for VECTOR binding.
+
+    Integer sequences entirely within ``[-128, 127]`` use the int8 typecode for
+    a cheaper bind; everything else falls back to float32 (the 23ai default and
+    the most common LLM embedding dtype).
+    """
+    if all(isinstance(v, int) and not isinstance(v, bool) and _INT8_MIN <= v <= _INT8_MAX for v in value):
+        return array.array(_TYPECODE_INT8, value)
+    return array.array(_TYPECODE_FLOAT32, [float(v) for v in value])
+
+
 def _input_type_handler(cursor: "Cursor | AsyncCursor", value: Any, arraysize: int) -> Any:
-    """Oracle input type handler for NumPy arrays.
+    """Oracle input type handler for vector payloads.
 
     Args:
         cursor: Oracle cursor (sync or async).
@@ -106,60 +149,80 @@ def _input_type_handler(cursor: "Cursor | AsyncCursor", value: Any, arraysize: i
         arraysize: Array size for the cursor variable.
 
     Returns:
-        Cursor variable with NumPy converter if value is ndarray, None otherwise.
+        Cursor variable for VECTOR binding when ``value`` is a vector payload,
+        otherwise ``None`` so the next handler in the chain can claim it.
     """
-    if not NUMPY_INSTALLED:
+    if not _is_vector_payload(value):
         return None
 
-    import numpy as np
     import oracledb
 
-    if isinstance(value, np.ndarray):
-        return cursor.var(oracledb.DB_TYPE_VECTOR, arraysize=arraysize, inconverter=numpy_converter_in)
-    return None
+    if NUMPY_INSTALLED:
+        import numpy as np
+
+        if isinstance(value, np.ndarray):
+            return cursor.var(oracledb.DB_TYPE_VECTOR, arraysize=arraysize, inconverter=numpy_converter_in)
+
+    if isinstance(value, array.array):
+        return cursor.var(oracledb.DB_TYPE_VECTOR, arraysize=arraysize)
+
+    packed = _pack_python_sequence(value)
+    return cursor.var(oracledb.DB_TYPE_VECTOR, arraysize=arraysize, inconverter=lambda _v: packed)
 
 
 def _output_type_handler(cursor: "Cursor | AsyncCursor", metadata: Any) -> Any:
     """Oracle output type handler for VECTOR columns.
 
-    Args:
-        cursor: Oracle cursor (sync or async).
-        metadata: Column metadata from Oracle.
-
-    Returns:
-        Cursor variable with NumPy converter if column is VECTOR, None otherwise.
+    Reads ``connection._sqlspec_vector_return_format`` (set by the session
+    callback in ``config._init_connection``) to dispatch to the requested
+    return type. Falls back to ``"numpy"`` when NumPy is installed and
+    ``"list"`` otherwise so consumers without the connection-level setting
+    still get sensible behavior.
     """
-    if not NUMPY_INSTALLED:
-        return None
-
     import oracledb
 
-    if metadata.type_code is oracledb.DB_TYPE_VECTOR:
+    if metadata.type_code is not oracledb.DB_TYPE_VECTOR:
+        return None
+
+    fmt = getattr(cursor.connection, "_sqlspec_vector_return_format", None)
+    if fmt is None:
+        fmt = _VECTOR_RETURN_NUMPY if NUMPY_INSTALLED else _VECTOR_RETURN_LIST
+
+    if fmt == _VECTOR_RETURN_NUMPY:
+        if not NUMPY_INSTALLED:
+            msg = (
+                "vector_return_format='numpy' requires numpy; install with "
+                "`pip install sqlspec[oracle,numpy]` or set vector_return_format='list'."
+            )
+            raise RuntimeError(msg)
         return cursor.var(metadata.type_code, arraysize=cursor.arraysize, outconverter=numpy_converter_out)
-    return None
+    if fmt == _VECTOR_RETURN_LIST:
+        return cursor.var(metadata.type_code, arraysize=cursor.arraysize, outconverter=list)
+    if fmt == _VECTOR_RETURN_ARRAY:
+        return None
+
+    msg = f"Invalid vector_return_format: {fmt!r}; expected one of {sorted(_VECTOR_RETURN_FORMATS)}"
+    raise ValueError(msg)
 
 
 def numpy_input_type_handler(cursor: "Cursor | AsyncCursor", value: Any, arraysize: int) -> Any:
-    """Public input type handler for NumPy arrays."""
+    """Public input type handler for vector payloads."""
     return _input_type_handler(cursor, value, arraysize)
 
 
 def numpy_output_type_handler(cursor: "Cursor | AsyncCursor", metadata: Any) -> Any:
-    """Public output type handler for NumPy VECTOR columns."""
+    """Public output type handler for VECTOR columns."""
     return _output_type_handler(cursor, metadata)
 
 
 def register_numpy_handlers(connection: "Connection | AsyncConnection") -> None:
-    """Register NumPy type handlers on Oracle connection.
+    """Register vector type handlers on an Oracle connection.
 
-    Enables automatic conversion between NumPy arrays and Oracle VECTOR types.
-    Works for both sync and async connections.
+    Enables automatic conversion between Python sequence types and Oracle
+    VECTOR columns. Works for both sync and async connections.
 
     Args:
         connection: Oracle connection (sync or async).
     """
-    if not NUMPY_INSTALLED:
-        return
-
     connection.inputtypehandler = numpy_input_type_handler
     connection.outputtypehandler = numpy_output_type_handler

--- a/sqlspec/adapters/oracledb/_vector_handlers.py
+++ b/sqlspec/adapters/oracledb/_vector_handlers.py
@@ -13,6 +13,7 @@ import array
 import sys
 from typing import TYPE_CHECKING, Any
 
+from sqlspec.adapters.oracledb._typing import DB_TYPE_VECTOR
 from sqlspec.typing import NUMPY_INSTALLED
 from sqlspec.utils.logging import get_logger
 
@@ -155,19 +156,17 @@ def _input_type_handler(cursor: "Cursor | AsyncCursor", value: Any, arraysize: i
     if not _is_vector_payload(value):
         return None
 
-    import oracledb
-
     if NUMPY_INSTALLED:
         import numpy as np
 
         if isinstance(value, np.ndarray):
-            return cursor.var(oracledb.DB_TYPE_VECTOR, arraysize=arraysize, inconverter=numpy_converter_in)
+            return cursor.var(DB_TYPE_VECTOR, arraysize=arraysize, inconverter=numpy_converter_in)
 
     if isinstance(value, array.array):
-        return cursor.var(oracledb.DB_TYPE_VECTOR, arraysize=arraysize)
+        return cursor.var(DB_TYPE_VECTOR, arraysize=arraysize)
 
     packed = _pack_python_sequence(value)
-    return cursor.var(oracledb.DB_TYPE_VECTOR, arraysize=arraysize, inconverter=lambda _v: packed)
+    return cursor.var(DB_TYPE_VECTOR, arraysize=arraysize, inconverter=lambda _v: packed)
 
 
 def _output_type_handler(cursor: "Cursor | AsyncCursor", metadata: Any) -> Any:
@@ -179,9 +178,7 @@ def _output_type_handler(cursor: "Cursor | AsyncCursor", metadata: Any) -> Any:
     ``"list"`` otherwise so consumers without the connection-level setting
     still get sensible behavior.
     """
-    import oracledb
-
-    if metadata.type_code is not oracledb.DB_TYPE_VECTOR:
+    if metadata.type_code is not DB_TYPE_VECTOR:
         return None
 
     fmt = getattr(cursor.connection, "_sqlspec_vector_return_format", None)

--- a/sqlspec/adapters/oracledb/config.py
+++ b/sqlspec/adapters/oracledb/config.py
@@ -128,6 +128,11 @@ class OracleDriverFeatures(TypedDict):
         Applies only to RAW(16) columns; other RAW sizes remain unchanged.
         Uses Python's stdlib uuid module (no external dependencies).
         Defaults to True for improved type safety and storage efficiency.
+    vector_return_format: Return type for VECTOR column reads. One of:
+        - "numpy" (default when NumPy is installed): np.ndarray, zero-copy compute path.
+        - "list": list[float|int], best for code that expects native Python sequences.
+        - "array": array.array, zero-copy oracledb passthrough.
+        Defaults to "numpy" when NumPy is installed, otherwise "list".
     on_connection_create: Callback executed when a connection is acquired from pool.
         For sync: Callable[[OracleSyncConnection, str], None] - receives connection and tag
         For async: Callable[[OracleAsyncConnection, str], Awaitable[None]]
@@ -146,6 +151,7 @@ class OracleDriverFeatures(TypedDict):
     enable_numpy_vectors: NotRequired[bool]
     enable_lowercase_column_names: NotRequired[bool]
     enable_uuid_binary: NotRequired[bool]
+    vector_return_format: NotRequired[str]
     on_connection_create: "NotRequired[Callable[..., Any]]"
     enable_events: NotRequired[bool]
     events_backend: NotRequired[str]

--- a/sqlspec/adapters/oracledb/config.py
+++ b/sqlspec/adapters/oracledb/config.py
@@ -6,6 +6,7 @@ import oracledb
 from mypy_extensions import mypyc_attr
 from typing_extensions import NotRequired
 
+from sqlspec.adapters.oracledb._json_handlers import register_json_handlers  # pyright: ignore[reportPrivateUsage]
 from sqlspec.adapters.oracledb._numpy_handlers import register_numpy_handlers  # pyright: ignore[reportPrivateUsage]
 from sqlspec.adapters.oracledb._typing import (
     OracleAsyncConnection,
@@ -47,6 +48,27 @@ __all__ = (
     "OraclePoolParams",
     "OracleSyncConfig",
 )
+
+
+def _extract_oracle_major(connection: Any) -> "int | None":
+    """Read the major version digit from ``connection.version``.
+
+    Used by ``_init_connection`` to cache server major on the connection so the
+    JSON input handler can route bind paths without per-bind metadata queries.
+    Returns ``None`` when the version string is missing or unparsable; callers
+    treat ``None`` as "assume 21c+ (modern default)".
+    """
+    try:
+        version_str = connection.version
+    except AttributeError:
+        return None
+    if not version_str:
+        return None
+    head = version_str.split(".", 1)[0]
+    try:
+        return int(head)
+    except ValueError:
+        return None
 
 
 class OracleConnectionParams(TypedDict):
@@ -261,11 +283,17 @@ class OracleSyncConfig(SyncDatabaseConfig[OracleSyncConnection, "OracleSyncConne
         return oracledb.create_pool(**config)
 
     def _init_connection(self, connection: "OracleSyncConnection", tag: str) -> None:
-        """Initialize connection with optional type handlers and user callback.
+        """Initialize connection with type handlers and cached server metadata.
 
-        Registers NumPy vector handlers and UUID binary handlers when enabled.
-        Registration order ensures handler chaining works correctly.
-        User callback is called after internal setup.
+        Registers NumPy vector, JSON, and UUID handlers. JSON registration is
+        unconditional (no flag) — native ``DB_TYPE_JSON`` is the correct path
+        for any modern Oracle. NumPy and UUID registration remain gated for
+        backwards compatibility with existing user configurations.
+
+        Caches ``connection._sqlspec_oracle_major`` so the JSON input handler
+        can pick the right binding path (``DB_TYPE_JSON`` on 21c+, OSON-encoded
+        ``DB_TYPE_BLOB`` on 19c-20c, JSON-string ``DB_TYPE_CLOB`` on 12c-18c)
+        without re-querying server metadata on every bind.
 
         Args:
             connection: Oracle connection to initialize.
@@ -274,8 +302,14 @@ class OracleSyncConfig(SyncDatabaseConfig[OracleSyncConnection, "OracleSyncConne
         if self.driver_features.get("enable_numpy_vectors", False):
             register_numpy_handlers(connection)
 
+        register_json_handlers(connection)
+
         if self.driver_features.get("enable_uuid_binary", False):
             register_uuid_handlers(connection)
+
+        # Stash detected major version on the connection so the JSON input handler
+        # can pick the right binding path without per-bind metadata queries.
+        setattr(connection, "_sqlspec_oracle_major", _extract_oracle_major(connection))
 
         # Call user-provided callback after internal setup
         if self._user_connection_hook is not None:
@@ -435,11 +469,12 @@ class OracleAsyncConfig(AsyncDatabaseConfig[OracleAsyncConnection, "OracleAsyncC
         return oracledb.create_pool_async(**config)
 
     async def _init_connection(self, connection: "OracleAsyncConnection", tag: str) -> None:
-        """Initialize async connection with optional type handlers and user callback.
+        """Initialize async connection with type handlers and cached server metadata.
 
-        Registers NumPy vector handlers and UUID binary handlers when enabled.
-        Registration order ensures handler chaining works correctly.
-        User callback is called after internal setup.
+        Registers NumPy vector, JSON, and UUID handlers. JSON registration is
+        unconditional. Caches ``connection._sqlspec_oracle_major`` so the JSON
+        input handler can pick the right binding path on every bind without
+        round-tripping server metadata.
 
         Args:
             connection: Oracle async connection to initialize.
@@ -448,8 +483,14 @@ class OracleAsyncConfig(AsyncDatabaseConfig[OracleAsyncConnection, "OracleAsyncC
         if self.driver_features.get("enable_numpy_vectors", False):
             register_numpy_handlers(connection)
 
+        register_json_handlers(connection)
+
         if self.driver_features.get("enable_uuid_binary", False):
             register_uuid_handlers(connection)
+
+        # Stash detected major version on the connection so the JSON input handler
+        # can pick the right binding path without per-bind metadata queries.
+        setattr(connection, "_sqlspec_oracle_major", _extract_oracle_major(connection))
 
         # Call user-provided callback after internal setup
         if self._user_connection_hook is not None:

--- a/sqlspec/adapters/oracledb/config.py
+++ b/sqlspec/adapters/oracledb/config.py
@@ -7,7 +7,6 @@ from mypy_extensions import mypyc_attr
 from typing_extensions import NotRequired
 
 from sqlspec.adapters.oracledb._json_handlers import register_json_handlers  # pyright: ignore[reportPrivateUsage]
-from sqlspec.adapters.oracledb._numpy_handlers import register_numpy_handlers  # pyright: ignore[reportPrivateUsage]
 from sqlspec.adapters.oracledb._typing import (
     OracleAsyncConnection,
     OracleAsyncConnectionPool,
@@ -19,6 +18,7 @@ from sqlspec.adapters.oracledb._typing import (
     OracleSyncSessionContext,
 )
 from sqlspec.adapters.oracledb._uuid_handlers import register_uuid_handlers
+from sqlspec.adapters.oracledb._vector_handlers import register_numpy_handlers  # pyright: ignore[reportPrivateUsage]
 from sqlspec.adapters.oracledb.core import apply_driver_features, default_statement_config, requires_session_callback
 from sqlspec.adapters.oracledb.driver import (
     OracleAsyncDriver,

--- a/sqlspec/adapters/oracledb/config.py
+++ b/sqlspec/adapters/oracledb/config.py
@@ -133,6 +133,13 @@ class OracleDriverFeatures(TypedDict):
         - "list": list[float|int], best for code that expects native Python sequences.
         - "array": array.array, zero-copy oracledb passthrough.
         Defaults to "numpy" when NumPy is installed, otherwise "list".
+    oracle_varchar2_byte_limit: Threshold (in UTF-8 bytes) above which ``str``
+        parameters are auto-coerced to ``DB_TYPE_CLOB``. Defaults to 4000 (the
+        Oracle SQL VARCHAR2 limit). Databases with ``MAX_STRING_SIZE=EXTENDED``
+        may set this to 32767 to keep larger strings as VARCHAR2.
+    oracle_raw_byte_limit: Threshold (in bytes) above which ``bytes`` parameters
+        are auto-coerced to ``DB_TYPE_BLOB``. Defaults to 2000 (the Oracle SQL
+        RAW limit).
     on_connection_create: Callback executed when a connection is acquired from pool.
         For sync: Callable[[OracleSyncConnection, str], None] - receives connection and tag
         For async: Callable[[OracleAsyncConnection, str], Awaitable[None]]
@@ -152,6 +159,8 @@ class OracleDriverFeatures(TypedDict):
     enable_lowercase_column_names: NotRequired[bool]
     enable_uuid_binary: NotRequired[bool]
     vector_return_format: NotRequired[str]
+    oracle_varchar2_byte_limit: NotRequired[int]
+    oracle_raw_byte_limit: NotRequired[int]
     on_connection_create: "NotRequired[Callable[..., Any]]"
     enable_events: NotRequired[bool]
     events_backend: NotRequired[str]

--- a/sqlspec/adapters/oracledb/config.py
+++ b/sqlspec/adapters/oracledb/config.py
@@ -291,22 +291,24 @@ class OracleSyncConfig(SyncDatabaseConfig[OracleSyncConnection, "OracleSyncConne
     def _init_connection(self, connection: "OracleSyncConnection", tag: str) -> None:
         """Initialize connection with type handlers and cached server metadata.
 
-        Registers NumPy vector, JSON, and UUID handlers. JSON registration is
-        unconditional (no flag) — native ``DB_TYPE_JSON`` is the correct path
-        for any modern Oracle. NumPy and UUID registration remain gated for
+        Registers vector, JSON, and UUID handlers. Vector and JSON handlers run
+        unconditionally — both gate any optional dependencies (NumPy in the
+        vector case) internally. UUID registration remains gated for
         backwards compatibility with existing user configurations.
 
         Caches ``connection._sqlspec_oracle_major`` so the JSON input handler
         can pick the right binding path (``DB_TYPE_JSON`` on 21c+, OSON-encoded
         ``DB_TYPE_BLOB`` on 19c-20c, JSON-string ``DB_TYPE_CLOB`` on 12c-18c)
-        without re-querying server metadata on every bind.
+        without re-querying server metadata on every bind. Caches
+        ``connection._sqlspec_vector_return_format`` so the vector output
+        handler can dispatch to ``numpy`` / ``list`` / ``array`` without
+        re-reading driver-feature defaults on every fetch.
 
         Args:
             connection: Oracle connection to initialize.
             tag: Connection tag for session state.
         """
-        if self.driver_features.get("enable_numpy_vectors", False):
-            register_numpy_handlers(connection)
+        register_numpy_handlers(connection)
 
         register_json_handlers(connection)
 
@@ -316,6 +318,9 @@ class OracleSyncConfig(SyncDatabaseConfig[OracleSyncConnection, "OracleSyncConne
         # Stash detected major version on the connection so the JSON input handler
         # can pick the right binding path without per-bind metadata queries.
         setattr(connection, "_sqlspec_oracle_major", _extract_oracle_major(connection))
+        # Stash the vector-read format so the VECTOR output handler can
+        # dispatch without re-reading driver-feature defaults on every fetch.
+        setattr(connection, "_sqlspec_vector_return_format", self.driver_features.get("vector_return_format"))
 
         # Call user-provided callback after internal setup
         if self._user_connection_hook is not None:
@@ -477,17 +482,20 @@ class OracleAsyncConfig(AsyncDatabaseConfig[OracleAsyncConnection, "OracleAsyncC
     async def _init_connection(self, connection: "OracleAsyncConnection", tag: str) -> None:
         """Initialize async connection with type handlers and cached server metadata.
 
-        Registers NumPy vector, JSON, and UUID handlers. JSON registration is
-        unconditional. Caches ``connection._sqlspec_oracle_major`` so the JSON
-        input handler can pick the right binding path on every bind without
-        round-tripping server metadata.
+        Registers vector, JSON, and UUID handlers. Vector and JSON registration
+        is unconditional — both gate any optional dependencies (NumPy in the
+        vector case) internally. Caches ``connection._sqlspec_oracle_major`` so
+        the JSON input handler can pick the right binding path on every bind
+        without round-tripping server metadata. Caches
+        ``connection._sqlspec_vector_return_format`` so the vector output
+        handler dispatches to the user-selected return type without re-reading
+        driver-feature defaults on every fetch.
 
         Args:
             connection: Oracle async connection to initialize.
             tag: Connection tag for session state.
         """
-        if self.driver_features.get("enable_numpy_vectors", False):
-            register_numpy_handlers(connection)
+        register_numpy_handlers(connection)
 
         register_json_handlers(connection)
 
@@ -497,6 +505,9 @@ class OracleAsyncConfig(AsyncDatabaseConfig[OracleAsyncConnection, "OracleAsyncC
         # Stash detected major version on the connection so the JSON input handler
         # can pick the right binding path without per-bind metadata queries.
         setattr(connection, "_sqlspec_oracle_major", _extract_oracle_major(connection))
+        # Stash the vector-read format so the VECTOR output handler can
+        # dispatch without re-reading driver-feature defaults on every fetch.
+        setattr(connection, "_sqlspec_vector_return_format", self.driver_features.get("vector_return_format"))
 
         # Call user-provided callback after internal setup
         if self._user_connection_hook is not None:

--- a/sqlspec/adapters/oracledb/core.py
+++ b/sqlspec/adapters/oracledb/core.py
@@ -369,6 +369,7 @@ def apply_driver_features(driver_features: "Mapping[str, Any] | None") -> "dict[
     features.setdefault("enable_numpy_vectors", NUMPY_INSTALLED)
     features.setdefault("enable_lowercase_column_names", True)
     features.setdefault("enable_uuid_binary", True)
+    features.setdefault("vector_return_format", "numpy" if NUMPY_INSTALLED else "list")
     return features
 
 

--- a/sqlspec/adapters/oracledb/core.py
+++ b/sqlspec/adapters/oracledb/core.py
@@ -186,6 +186,52 @@ def normalize_execute_many_parameters_async(parameters: Any) -> Any:
     return parameters
 
 
+def _coerce_value_sync(
+    connection: Any, value: Any, *, clob_type: Any, blob_type: Any, varchar2_byte_limit: int, raw_byte_limit: int
+) -> Any:
+    """Route a single parameter value through wrapper-aware coercion (sync)."""
+    if isinstance(value, OracleClob):
+        inner = value.value
+        if isinstance(inner, bytes):
+            inner = inner.decode("utf-8")
+        return connection.createlob(clob_type, inner)
+    if isinstance(value, OracleBlob):
+        inner = value.value
+        if isinstance(inner, str):
+            inner = inner.encode("utf-8")
+        return connection.createlob(blob_type, inner)
+    if isinstance(value, OracleJson):
+        return value.value
+    if isinstance(value, str) and len(value.encode("utf-8")) > varchar2_byte_limit:
+        return connection.createlob(clob_type, value)
+    if isinstance(value, (bytes, bytearray)) and len(value) > raw_byte_limit:
+        return connection.createlob(blob_type, bytes(value))
+    return value
+
+
+async def _coerce_value_async(
+    connection: Any, value: Any, *, clob_type: Any, blob_type: Any, varchar2_byte_limit: int, raw_byte_limit: int
+) -> Any:
+    """Async mirror of :func:`_coerce_value_sync`."""
+    if isinstance(value, OracleClob):
+        inner = value.value
+        if isinstance(inner, bytes):
+            inner = inner.decode("utf-8")
+        return await connection.createlob(clob_type, inner)
+    if isinstance(value, OracleBlob):
+        inner = value.value
+        if isinstance(inner, str):
+            inner = inner.encode("utf-8")
+        return await connection.createlob(blob_type, inner)
+    if isinstance(value, OracleJson):
+        return value.value
+    if isinstance(value, str) and len(value.encode("utf-8")) > varchar2_byte_limit:
+        return await connection.createlob(clob_type, value)
+    if isinstance(value, (bytes, bytearray)) and len(value) > raw_byte_limit:
+        return await connection.createlob(blob_type, bytes(value))
+    return value
+
+
 def coerce_large_parameters_sync(
     connection: Any, parameters: Any, *, clob_type: Any, blob_type: Any, varchar2_byte_limit: int, raw_byte_limit: int
 ) -> Any:
@@ -196,6 +242,10 @@ def coerce_large_parameters_sync(
            intent, length-thresholds bypassed.
         2. Plain ``str`` whose UTF-8 encoding exceeds ``varchar2_byte_limit`` → CLOB.
         3. Plain ``bytes``/``bytearray`` longer than ``raw_byte_limit`` → BLOB.
+
+    Handles ``dict`` (named binds), ``tuple`` and ``list`` (positional binds).
+    Tuples are returned as new lists when any value is rewritten so the driver's
+    ``cast(... | tuple | list | dict)`` contract is preserved.
 
     Args:
         connection: Oracle database connection.
@@ -208,25 +258,31 @@ def coerce_large_parameters_sync(
     Returns:
         Parameters payload with values routed to the correct LOB / native type.
     """
-    if not parameters or not isinstance(parameters, dict):
+    if not parameters:
         return parameters
-    for param_name, param_value in parameters.items():
-        if isinstance(param_value, OracleClob):
-            inner = param_value.value
-            if isinstance(inner, bytes):
-                inner = inner.decode("utf-8")
-            parameters[param_name] = connection.createlob(clob_type, inner)
-        elif isinstance(param_value, OracleBlob):
-            inner = param_value.value
-            if isinstance(inner, str):
-                inner = inner.encode("utf-8")
-            parameters[param_name] = connection.createlob(blob_type, inner)
-        elif isinstance(param_value, OracleJson):
-            parameters[param_name] = param_value.value
-        elif isinstance(param_value, str) and len(param_value.encode("utf-8")) > varchar2_byte_limit:
-            parameters[param_name] = connection.createlob(clob_type, param_value)
-        elif isinstance(param_value, (bytes, bytearray)) and len(param_value) > raw_byte_limit:
-            parameters[param_name] = connection.createlob(blob_type, bytes(param_value))
+    if isinstance(parameters, dict):
+        for param_name, param_value in parameters.items():
+            parameters[param_name] = _coerce_value_sync(
+                connection,
+                param_value,
+                clob_type=clob_type,
+                blob_type=blob_type,
+                varchar2_byte_limit=varchar2_byte_limit,
+                raw_byte_limit=raw_byte_limit,
+            )
+        return parameters
+    if isinstance(parameters, (list, tuple)):
+        return [
+            _coerce_value_sync(
+                connection,
+                value,
+                clob_type=clob_type,
+                blob_type=blob_type,
+                varchar2_byte_limit=varchar2_byte_limit,
+                raw_byte_limit=raw_byte_limit,
+            )
+            for value in parameters
+        ]
     return parameters
 
 
@@ -238,25 +294,31 @@ async def coerce_large_parameters_async(
     Identical routing order; ``connection.createlob`` is awaited for the async
     Oracle driver.
     """
-    if not parameters or not isinstance(parameters, dict):
+    if not parameters:
         return parameters
-    for param_name, param_value in parameters.items():
-        if isinstance(param_value, OracleClob):
-            inner = param_value.value
-            if isinstance(inner, bytes):
-                inner = inner.decode("utf-8")
-            parameters[param_name] = await connection.createlob(clob_type, inner)
-        elif isinstance(param_value, OracleBlob):
-            inner = param_value.value
-            if isinstance(inner, str):
-                inner = inner.encode("utf-8")
-            parameters[param_name] = await connection.createlob(blob_type, inner)
-        elif isinstance(param_value, OracleJson):
-            parameters[param_name] = param_value.value
-        elif isinstance(param_value, str) and len(param_value.encode("utf-8")) > varchar2_byte_limit:
-            parameters[param_name] = await connection.createlob(clob_type, param_value)
-        elif isinstance(param_value, (bytes, bytearray)) and len(param_value) > raw_byte_limit:
-            parameters[param_name] = await connection.createlob(blob_type, bytes(param_value))
+    if isinstance(parameters, dict):
+        for param_name, param_value in parameters.items():
+            parameters[param_name] = await _coerce_value_async(
+                connection,
+                param_value,
+                clob_type=clob_type,
+                blob_type=blob_type,
+                varchar2_byte_limit=varchar2_byte_limit,
+                raw_byte_limit=raw_byte_limit,
+            )
+        return parameters
+    if isinstance(parameters, (list, tuple)):
+        return [
+            await _coerce_value_async(
+                connection,
+                value,
+                clob_type=clob_type,
+                blob_type=blob_type,
+                varchar2_byte_limit=varchar2_byte_limit,
+                raw_byte_limit=raw_byte_limit,
+            )
+            for value in parameters
+        ]
     return parameters
 
 

--- a/sqlspec/adapters/oracledb/core.py
+++ b/sqlspec/adapters/oracledb/core.py
@@ -448,7 +448,13 @@ def apply_driver_features(driver_features: "Mapping[str, Any] | None") -> "dict[
     features.setdefault("enable_numpy_vectors", NUMPY_INSTALLED)
     features.setdefault("enable_lowercase_column_names", True)
     features.setdefault("enable_uuid_binary", True)
-    features.setdefault("vector_return_format", "numpy" if NUMPY_INSTALLED else "list")
+    if "vector_return_format" not in features:
+        if not NUMPY_INSTALLED:
+            features["vector_return_format"] = "list"
+        elif features["enable_numpy_vectors"]:
+            features["vector_return_format"] = "numpy"
+        else:
+            features["vector_return_format"] = "array"
     features.setdefault("oracle_varchar2_byte_limit", 4000)
     features.setdefault("oracle_raw_byte_limit", 2000)
     return features

--- a/sqlspec/adapters/oracledb/core.py
+++ b/sqlspec/adapters/oracledb/core.py
@@ -373,10 +373,15 @@ def apply_driver_features(driver_features: "Mapping[str, Any] | None") -> "dict[
 
 
 def requires_session_callback(driver_features: "dict[str, Any]") -> bool:
-    """Return True when the session callback should be installed."""
-    enable_numpy_vectors = bool(driver_features.get("enable_numpy_vectors", False))
-    enable_uuid_binary = bool(driver_features.get("enable_uuid_binary", False))
-    return enable_numpy_vectors or enable_uuid_binary
+    """Return True when the session callback should be installed.
+
+    The JSON input/output handlers are always-on (no driver-feature flag), so
+    the session callback is always required for an Oracle pool to bind ``dict``
+    / ``list`` parameters via the native ``DB_TYPE_JSON`` / OSON-encoded BLOB /
+    JSON-string CLOB paths and to cache ``connection._sqlspec_oracle_major``.
+    """
+    del driver_features  # always-on; preserved for signature compatibility
+    return True
 
 
 def _description_requires_lob_coercion(description: "list[Any]") -> bool:
@@ -706,7 +711,7 @@ def build_profile() -> "DriverParameterProfile":
         needs_static_script_compilation=False,
         allow_mixed_parameter_styles=False,
         preserve_original_params_for_many=False,
-        json_serializer_strategy="helper",
+        json_serializer_strategy="driver",
         custom_type_coercions={**build_uuid_coercions()},
         default_dialect="oracle",
     )

--- a/sqlspec/adapters/oracledb/core.py
+++ b/sqlspec/adapters/oracledb/core.py
@@ -387,6 +387,8 @@ def apply_driver_features(driver_features: "Mapping[str, Any] | None") -> "dict[
     features.setdefault("enable_lowercase_column_names", True)
     features.setdefault("enable_uuid_binary", True)
     features.setdefault("vector_return_format", "numpy" if NUMPY_INSTALLED else "list")
+    features.setdefault("oracle_varchar2_byte_limit", 4000)
+    features.setdefault("oracle_raw_byte_limit", 2000)
     return features
 
 

--- a/sqlspec/adapters/oracledb/core.py
+++ b/sqlspec/adapters/oracledb/core.py
@@ -4,6 +4,7 @@ import re
 from collections.abc import Sized
 from typing import TYPE_CHECKING, Any, cast
 
+from sqlspec.adapters.oracledb._param_types import OracleBlob, OracleClob, OracleJson
 from sqlspec.adapters.oracledb.type_converter import OracleOutputConverter
 from sqlspec.core import (
     DriverParameterProfile,
@@ -188,26 +189,41 @@ def normalize_execute_many_parameters_async(parameters: Any) -> Any:
 def coerce_large_parameters_sync(
     connection: Any, parameters: Any, *, clob_type: Any, blob_type: Any, varchar2_byte_limit: int, raw_byte_limit: int
 ) -> Any:
-    """Coerce large string/bytes parameters into CLOBs/BLOBs.
+    """Coerce large string/bytes parameters into CLOBs/BLOBs with wrapper-aware routing.
 
-    Strings whose UTF-8 encoding exceeds ``varchar2_byte_limit`` are bound as
-    CLOBs.  Bytes values longer than ``raw_byte_limit`` are bound as BLOBs.
+    Routing order:
+        1. ``OracleClob`` / ``OracleBlob`` / ``OracleJson`` wrappers — explicit user
+           intent, length-thresholds bypassed.
+        2. Plain ``str`` whose UTF-8 encoding exceeds ``varchar2_byte_limit`` → CLOB.
+        3. Plain ``bytes``/``bytearray`` longer than ``raw_byte_limit`` → BLOB.
 
     Args:
         connection: Oracle database connection.
         parameters: Prepared parameters payload.
         clob_type: Oracle CLOB DB type (``oracledb.DB_TYPE_CLOB``).
         blob_type: Oracle BLOB DB type (``oracledb.DB_TYPE_BLOB``).
-        varchar2_byte_limit: Byte-length threshold for CLOB conversion.
-        raw_byte_limit: Byte-length threshold for BLOB conversion.
+        varchar2_byte_limit: Byte-length threshold for implicit CLOB conversion.
+        raw_byte_limit: Byte-length threshold for implicit BLOB conversion.
 
     Returns:
-        Parameters payload with large values converted to LOBs.
+        Parameters payload with values routed to the correct LOB / native type.
     """
     if not parameters or not isinstance(parameters, dict):
         return parameters
     for param_name, param_value in parameters.items():
-        if isinstance(param_value, str) and len(param_value.encode("utf-8")) > varchar2_byte_limit:
+        if isinstance(param_value, OracleClob):
+            inner = param_value.value
+            if isinstance(inner, bytes):
+                inner = inner.decode("utf-8")
+            parameters[param_name] = connection.createlob(clob_type, inner)
+        elif isinstance(param_value, OracleBlob):
+            inner = param_value.value
+            if isinstance(inner, str):
+                inner = inner.encode("utf-8")
+            parameters[param_name] = connection.createlob(blob_type, inner)
+        elif isinstance(param_value, OracleJson):
+            parameters[param_name] = param_value.value
+        elif isinstance(param_value, str) and len(param_value.encode("utf-8")) > varchar2_byte_limit:
             parameters[param_name] = connection.createlob(clob_type, param_value)
         elif isinstance(param_value, (bytes, bytearray)) and len(param_value) > raw_byte_limit:
             parameters[param_name] = connection.createlob(blob_type, bytes(param_value))
@@ -217,26 +233,27 @@ def coerce_large_parameters_sync(
 async def coerce_large_parameters_async(
     connection: Any, parameters: Any, *, clob_type: Any, blob_type: Any, varchar2_byte_limit: int, raw_byte_limit: int
 ) -> Any:
-    """Coerce large string/bytes parameters into CLOBs/BLOBs for async Oracle drivers.
+    """Async mirror of :func:`coerce_large_parameters_sync`.
 
-    Strings whose UTF-8 encoding exceeds ``varchar2_byte_limit`` are bound as
-    CLOBs.  Bytes values longer than ``raw_byte_limit`` are bound as BLOBs.
-
-    Args:
-        connection: Oracle database connection.
-        parameters: Prepared parameters payload.
-        clob_type: Oracle CLOB DB type (``oracledb.DB_TYPE_CLOB``).
-        blob_type: Oracle BLOB DB type (``oracledb.DB_TYPE_BLOB``).
-        varchar2_byte_limit: Byte-length threshold for CLOB conversion.
-        raw_byte_limit: Byte-length threshold for BLOB conversion.
-
-    Returns:
-        Parameters payload with large values converted to LOBs.
+    Identical routing order; ``connection.createlob`` is awaited for the async
+    Oracle driver.
     """
     if not parameters or not isinstance(parameters, dict):
         return parameters
     for param_name, param_value in parameters.items():
-        if isinstance(param_value, str) and len(param_value.encode("utf-8")) > varchar2_byte_limit:
+        if isinstance(param_value, OracleClob):
+            inner = param_value.value
+            if isinstance(inner, bytes):
+                inner = inner.decode("utf-8")
+            parameters[param_name] = await connection.createlob(clob_type, inner)
+        elif isinstance(param_value, OracleBlob):
+            inner = param_value.value
+            if isinstance(inner, str):
+                inner = inner.encode("utf-8")
+            parameters[param_name] = await connection.createlob(blob_type, inner)
+        elif isinstance(param_value, OracleJson):
+            parameters[param_name] = param_value.value
+        elif isinstance(param_value, str) and len(param_value.encode("utf-8")) > varchar2_byte_limit:
             parameters[param_name] = await connection.createlob(clob_type, param_value)
         elif isinstance(param_value, (bytes, bytearray)) and len(param_value) > raw_byte_limit:
             parameters[param_name] = await connection.createlob(blob_type, bytes(param_value))

--- a/sqlspec/adapters/oracledb/driver.py
+++ b/sqlspec/adapters/oracledb/driver.py
@@ -69,10 +69,9 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-# Oracle-specific constants
-# Oracle SQL-context limits (in bytes)
-ORACLE_VARCHAR2_BYTE_LIMIT = 4000  # VARCHAR2 max in SQL context
-ORACLE_RAW_BYTE_LIMIT = 2000  # RAW max in SQL context
+# Oracle SQL-context byte thresholds (4000 / 2000) live in driver_features so users
+# on MAX_STRING_SIZE=EXTENDED databases can override them; defaults are wired in
+# core.apply_driver_features and read at the dispatch_execute call sites below.
 
 __all__ = (
     "OracleAsyncDriver",
@@ -327,8 +326,8 @@ class OracleSyncDriver(OraclePipelineMixin, SyncDriverAdapterBase):
             prepared_parameters,
             clob_type=oracledb.DB_TYPE_CLOB,
             blob_type=oracledb.DB_TYPE_BLOB,
-            varchar2_byte_limit=ORACLE_VARCHAR2_BYTE_LIMIT,
-            raw_byte_limit=ORACLE_RAW_BYTE_LIMIT,
+            varchar2_byte_limit=self.driver_features.get("oracle_varchar2_byte_limit", 4000),
+            raw_byte_limit=self.driver_features.get("oracle_raw_byte_limit", 2000),
         )
         prepared_parameters = cast("list[Any] | tuple[Any, ...] | dict[Any, Any] | None", prepared_parameters)
 
@@ -823,8 +822,8 @@ class OracleAsyncDriver(OraclePipelineMixin, AsyncDriverAdapterBase):
             prepared_parameters,
             clob_type=oracledb.DB_TYPE_CLOB,
             blob_type=oracledb.DB_TYPE_BLOB,
-            varchar2_byte_limit=ORACLE_VARCHAR2_BYTE_LIMIT,
-            raw_byte_limit=ORACLE_RAW_BYTE_LIMIT,
+            varchar2_byte_limit=self.driver_features.get("oracle_varchar2_byte_limit", 4000),
+            raw_byte_limit=self.driver_features.get("oracle_raw_byte_limit", 2000),
         )
         prepared_parameters = cast("list[Any] | tuple[Any, ...] | dict[Any, Any] | None", prepared_parameters)
 

--- a/sqlspec/adapters/oracledb/type_converter.py
+++ b/sqlspec/adapters/oracledb/type_converter.py
@@ -175,7 +175,7 @@ class OracleOutputConverter(CachedOutputConverter):
             return value
 
         if isinstance(value, array.array):
-            from sqlspec.adapters.oracledb._numpy_handlers import (  # pyright: ignore[reportPrivateUsage]
+            from sqlspec.adapters.oracledb._vector_handlers import (  # pyright: ignore[reportPrivateUsage]
                 numpy_converter_out,
             )
 
@@ -202,7 +202,7 @@ class OracleOutputConverter(CachedOutputConverter):
         import numpy as np
 
         if isinstance(value, np.ndarray):
-            from sqlspec.adapters.oracledb._numpy_handlers import (  # pyright: ignore[reportPrivateUsage]
+            from sqlspec.adapters.oracledb._vector_handlers import (  # pyright: ignore[reportPrivateUsage]
                 numpy_converter_in,
             )
 

--- a/tests/integration/adapters/oracledb/test_json_native.py
+++ b/tests/integration/adapters/oracledb/test_json_native.py
@@ -1,0 +1,134 @@
+"""Integration tests for native Oracle JSON binding (C1.T7).
+
+Verifies the C1 contract end-to-end against a real Oracle 23ai container:
+
+- ``dict`` payloads round-trip without manual ``createlob`` workarounds.
+- ``list[dict]`` payloads round-trip.
+- Large dicts (>4000 bytes serialised) round-trip via the native JSON path
+  rather than getting CLOB-coerced — proving the smart-LOB-coercion gap (C2)
+  is irrelevant for native JSON columns.
+- The on-the-wire path uses ``DB_TYPE_JSON`` (cursor description type_code).
+- Round-trip preserves nested structures.
+"""
+
+import pytest
+
+from sqlspec.adapters.oracledb import OracleAsyncDriver, OracleSyncDriver
+
+pytestmark = pytest.mark.xdist_group("oracle")
+
+
+_TABLE = "test_json_native_c1"
+
+
+async def _drop_table_async(driver: OracleAsyncDriver, name: str) -> None:
+    await driver.execute_script(
+        f"BEGIN EXECUTE IMMEDIATE 'DROP TABLE {name}'; "
+        "EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;"
+    )
+
+
+def _drop_table_sync(driver: OracleSyncDriver, name: str) -> None:
+    driver.execute_script(
+        f"BEGIN EXECUTE IMMEDIATE 'DROP TABLE {name}'; "
+        "EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;"
+    )
+
+
+async def test_async_dict_roundtrip_native_json(oracle_async_session: OracleAsyncDriver) -> None:
+    """A dict bound into a native JSON column round-trips bit-identical."""
+    await _drop_table_async(oracle_async_session, _TABLE)
+    await oracle_async_session.execute_script(f"CREATE TABLE {_TABLE} (id NUMBER PRIMARY KEY, payload JSON)")
+    try:
+        payload = {"foo": "bar", "n": 42, "nested": {"x": [1, 2, 3]}}
+        await oracle_async_session.execute(f"INSERT INTO {_TABLE} (id, payload) VALUES (:1, :2)", (1, payload))
+        row = await oracle_async_session.select_one(f"SELECT payload FROM {_TABLE} WHERE id = 1")
+        assert row["payload"] == payload
+    finally:
+        await _drop_table_async(oracle_async_session, _TABLE)
+
+
+async def test_async_list_of_dicts_roundtrip(oracle_async_session: OracleAsyncDriver) -> None:
+    """A list[dict] bound into a native JSON column round-trips."""
+    await _drop_table_async(oracle_async_session, _TABLE)
+    await oracle_async_session.execute_script(f"CREATE TABLE {_TABLE} (id NUMBER PRIMARY KEY, payload JSON)")
+    try:
+        payload = [{"a": 1}, {"b": 2}, {"c": [10, 20, 30]}]
+        await oracle_async_session.execute(f"INSERT INTO {_TABLE} (id, payload) VALUES (:1, :2)", (1, payload))
+        row = await oracle_async_session.select_one(f"SELECT payload FROM {_TABLE} WHERE id = 1")
+        assert row["payload"] == payload
+    finally:
+        await _drop_table_async(oracle_async_session, _TABLE)
+
+
+async def test_async_large_dict_no_clob_workaround(oracle_async_session: OracleAsyncDriver) -> None:
+    """A dict >4000 bytes serialised should bind via DB_TYPE_JSON, not CLOB.
+
+    Pre-C1 this triggered the helper-strategy string serialisation followed by
+    coerce_large_parameters_async's >4000-byte CLOB conversion. Post-C1 the
+    JSON inputtypehandler claims the dict before either path runs.
+    """
+    await _drop_table_async(oracle_async_session, _TABLE)
+    await oracle_async_session.execute_script(f"CREATE TABLE {_TABLE} (id NUMBER PRIMARY KEY, payload JSON)")
+    try:
+        payload = {"big": "x" * 8000, "n": list(range(500))}
+        await oracle_async_session.execute(f"INSERT INTO {_TABLE} (id, payload) VALUES (:1, :2)", (1, payload))
+        row = await oracle_async_session.select_one(f"SELECT payload FROM {_TABLE} WHERE id = 1")
+        assert row["payload"] == payload
+    finally:
+        await _drop_table_async(oracle_async_session, _TABLE)
+
+
+async def test_async_dict_with_special_values(oracle_async_session: OracleAsyncDriver) -> None:
+    """Dict with bool / None / int / nested list / nested dict survives round-trip.
+
+    NOTE: float values in native JSON columns come back as ``decimal.Decimal``
+    (python-oracledb's default OSON-numeric coercion). Numeric type fidelity
+    is tracked as a separate concern outside this chapter — see beads
+    sqlspec-i6j follow-up "JSON numeric fidelity (Decimal vs float)".
+    """
+    await _drop_table_async(oracle_async_session, _TABLE)
+    await oracle_async_session.execute_script(f"CREATE TABLE {_TABLE} (id NUMBER PRIMARY KEY, payload JSON)")
+    try:
+        payload: dict[str, object] = {
+            "active": True,
+            "deleted": False,
+            "missing": None,
+            "count": 42,
+            "tags": ["alpha", "beta", "gamma"],
+            "labels": {"env": "prod", "tier": "primary"},
+        }
+        await oracle_async_session.execute(f"INSERT INTO {_TABLE} (id, payload) VALUES (:1, :2)", (1, payload))
+        row = await oracle_async_session.select_one(f"SELECT payload FROM {_TABLE} WHERE id = 1")
+        assert row["payload"] == payload
+    finally:
+        await _drop_table_async(oracle_async_session, _TABLE)
+
+
+async def test_async_executemany_dicts(oracle_async_session: OracleAsyncDriver) -> None:
+    """executemany of multiple dict payloads against a native JSON column."""
+    await _drop_table_async(oracle_async_session, _TABLE)
+    await oracle_async_session.execute_script(f"CREATE TABLE {_TABLE} (id NUMBER PRIMARY KEY, payload JSON)")
+    try:
+        rows = [(i, {"index": i, "label": f"row-{i}"}) for i in range(1, 6)]
+        await oracle_async_session.execute_many(f"INSERT INTO {_TABLE} (id, payload) VALUES (:1, :2)", rows)
+        result = await oracle_async_session.select(f"SELECT id, payload FROM {_TABLE} ORDER BY id")
+        assert len(result) == 5
+        for got, (expected_id, expected_payload) in zip(result, rows, strict=True):
+            assert got["id"] == expected_id
+            assert got["payload"] == expected_payload
+    finally:
+        await _drop_table_async(oracle_async_session, _TABLE)
+
+
+def test_sync_dict_roundtrip_native_json(oracle_sync_session: OracleSyncDriver) -> None:
+    """Sync driver: dict → native JSON column round-trip parity."""
+    _drop_table_sync(oracle_sync_session, _TABLE)
+    oracle_sync_session.execute_script(f"CREATE TABLE {_TABLE} (id NUMBER PRIMARY KEY, payload JSON)")
+    try:
+        payload = {"foo": "bar", "n": 42}
+        oracle_sync_session.execute(f"INSERT INTO {_TABLE} (id, payload) VALUES (:1, :2)", (1, payload))
+        row = oracle_sync_session.select_one(f"SELECT payload FROM {_TABLE} WHERE id = 1")
+        assert row["payload"] == payload
+    finally:
+        _drop_table_sync(oracle_sync_session, _TABLE)

--- a/tests/integration/adapters/oracledb/test_smart_lob_coercion.py
+++ b/tests/integration/adapters/oracledb/test_smart_lob_coercion.py
@@ -138,7 +138,8 @@ async def test_threshold_override_keeps_string_as_varchar2(
 
             result = await session.execute("SELECT content FROM smart_lob_extended WHERE id = :id", {"id": 1})
             rows = result.get_data() if hasattr(result, "get_data") else result.data
-            value = rows[0]["content"] if isinstance(rows[0], dict) else rows[0][0]
+            fetched = rows[0]
+            value = fetched["content"] if isinstance(fetched, dict) else fetched[0]
             assert value == payload
     finally:
         if config.connection_instance:
@@ -173,7 +174,8 @@ async def test_json_bytes_payload_no_manual_createlob_needed(oracle_async_sessio
 
     result = await oracle_async_session.execute("SELECT payload FROM smart_lob_json_bytes WHERE id = :id", {"id": 1})
     rows = result.get_data() if hasattr(result, "get_data") else result.data
-    value = rows[0]["payload"] if isinstance(rows[0], dict) else rows[0][0]
+    fetched = rows[0]
+    value = fetched["payload"] if isinstance(fetched, dict) else fetched[0]
     assert value["workaround_eliminated"] is True
     assert value["blob"] == payload["blob"]
 
@@ -192,7 +194,8 @@ def test_oracle_clob_wrapper_round_trip_sync(oracle_sync_session: "OracleSyncDri
 
     result = oracle_sync_session.execute("SELECT content FROM smart_lob_clob_sync WHERE id = :id", {"id": 1})
     rows = result.get_data() if hasattr(result, "get_data") else result.data
-    value = rows[0]["content"] if isinstance(rows[0], dict) else rows[0][0]
+    fetched = rows[0]
+    value = fetched["content"] if isinstance(fetched, dict) else fetched[0]
     assert value == _LARGE_CLOB_TEXT
 
 
@@ -210,7 +213,8 @@ def test_oracle_blob_wrapper_round_trip_sync(oracle_sync_session: "OracleSyncDri
 
     result = oracle_sync_session.execute("SELECT data FROM smart_lob_blob_sync WHERE id = :id", {"id": 1})
     rows = result.get_data() if hasattr(result, "get_data") else result.data
-    value = rows[0]["data"] if isinstance(rows[0], dict) else rows[0][0]
+    fetched = rows[0]
+    value = fetched["data"] if isinstance(fetched, dict) else fetched[0]
     assert bytes(value) == _LARGE_BLOB_BYTES
 
 

--- a/tests/integration/adapters/oracledb/test_smart_lob_coercion.py
+++ b/tests/integration/adapters/oracledb/test_smart_lob_coercion.py
@@ -212,3 +212,41 @@ def test_oracle_blob_wrapper_round_trip_sync(oracle_sync_session: "OracleSyncDri
     rows = result.get_data() if hasattr(result, "get_data") else result.data
     value = rows[0]["data"] if isinstance(rows[0], dict) else rows[0][0]
     assert bytes(value) == _LARGE_BLOB_BYTES
+
+
+async def test_oracle_clob_wrapper_positional_bind(oracle_async_session: "OracleAsyncDriver") -> None:
+    """Positional (tuple) binds also unwrap OracleClob — sqlspec-205 fix coverage."""
+    await oracle_async_session.execute_script(
+        "BEGIN EXECUTE IMMEDIATE 'DROP TABLE smart_lob_clob_pos'; "
+        "EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;"
+    )
+    await oracle_async_session.execute_script("CREATE TABLE smart_lob_clob_pos (id NUMBER PRIMARY KEY, content CLOB)")
+    await oracle_async_session.execute(
+        "INSERT INTO smart_lob_clob_pos (id, content) VALUES (:1, :2)", (1, OracleClob(_LARGE_CLOB_TEXT))
+    )
+
+    result = await oracle_async_session.execute("SELECT content FROM smart_lob_clob_pos WHERE id = :1", (1,))
+    rows = result.get_data() if hasattr(result, "get_data") else result.data
+    fetched = rows[0]
+    value = fetched["content"] if isinstance(fetched, dict) else fetched[0]
+    assert value == _LARGE_CLOB_TEXT
+
+
+async def test_oracle_json_wrapper_positional_bind(oracle_async_session: "OracleAsyncDriver") -> None:
+    """Positional (tuple) bind with OracleJson defers to the C1 native handler."""
+    await oracle_async_session.execute_script(
+        "BEGIN EXECUTE IMMEDIATE 'DROP TABLE smart_lob_json_pos'; "
+        "EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;"
+    )
+    await oracle_async_session.execute_script("CREATE TABLE smart_lob_json_pos (id NUMBER PRIMARY KEY, payload JSON)")
+    payload = {"positional": True, "n": 7}
+    await oracle_async_session.execute(
+        "INSERT INTO smart_lob_json_pos (id, payload) VALUES (:1, :2)", (1, OracleJson(payload))
+    )
+
+    result = await oracle_async_session.execute("SELECT payload FROM smart_lob_json_pos WHERE id = :1", (1,))
+    rows = result.get_data() if hasattr(result, "get_data") else result.data
+    fetched = rows[0]
+    value = fetched["payload"] if isinstance(fetched, dict) else fetched[0]
+    assert value["positional"] is True
+    assert value["n"] == 7

--- a/tests/integration/adapters/oracledb/test_smart_lob_coercion.py
+++ b/tests/integration/adapters/oracledb/test_smart_lob_coercion.py
@@ -1,0 +1,214 @@
+"""Integration tests for Oracle smart LOB / JSON coercion (Chapter 2).
+
+Covers the wrapper-aware routing (:class:`OracleClob`, :class:`OracleBlob`,
+:class:`OracleJson`) and the user-configurable byte thresholds wired through
+``driver_features``. Pattern mirrors :mod:`test_msgspec_clob`.
+
+Cases:
+    1. ``OracleClob`` round-trip into a CLOB column (length threshold bypassed).
+    2. ``OracleBlob`` round-trip into a BLOB column.
+    3. ``OracleJson`` round-trip into a native ``JSON`` column on 23ai —
+       verifies the C1 input handler claims the value (no CLOB intermediary).
+    4. ``oracle_varchar2_byte_limit`` override keeps a 5000-byte string as
+       VARCHAR2 (skipped unless the container has MAX_STRING_SIZE=EXTENDED).
+    5. Demo workaround: binding ``bytes`` from ``to_json(..., as_bytes=True)``
+       directly to a JSON column — no manual ``createlob`` needed.
+"""
+
+import pytest
+
+from sqlspec.adapters.oracledb import (
+    OracleAsyncConfig,
+    OracleAsyncDriver,
+    OracleBlob,
+    OracleClob,
+    OracleJson,
+    OraclePoolParams,
+    OracleSyncDriver,
+)
+from sqlspec.utils.serializers import to_json
+
+pytestmark = pytest.mark.xdist_group("oracle")
+
+
+_LARGE_CLOB_TEXT = "Lorem ipsum " * 1000
+_LARGE_BLOB_BYTES = b"\x00\x01\x02\x03" * 2000
+_LARGE_JSON_PAYLOAD = {"big": "x" * 10000, "nested": {"items": list(range(50))}}
+
+
+async def _max_string_size_is_extended(driver: "OracleAsyncDriver") -> bool:
+    """Return True iff the Oracle instance has MAX_STRING_SIZE=EXTENDED."""
+    result = await driver.execute("SELECT value FROM v$parameter WHERE name = 'max_string_size'")
+    rows = result.get_data() if hasattr(result, "get_data") else result.data
+    if not rows:
+        return False
+    first = rows[0]
+    value = first.get("value") if isinstance(first, dict) else first[0]
+    return isinstance(value, str) and value.upper() == "EXTENDED"
+
+
+async def test_oracle_clob_wrapper_round_trip(oracle_async_session: "OracleAsyncDriver") -> None:
+    """OracleClob bypasses the length threshold and round-trips through a CLOB column."""
+    await oracle_async_session.execute_script(
+        "BEGIN EXECUTE IMMEDIATE 'DROP TABLE smart_lob_clob'; "
+        "EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;"
+    )
+    await oracle_async_session.execute_script("CREATE TABLE smart_lob_clob (id NUMBER PRIMARY KEY, content CLOB)")
+    await oracle_async_session.execute(
+        "INSERT INTO smart_lob_clob (id, content) VALUES (:id, :content)",
+        {"id": 1, "content": OracleClob(_LARGE_CLOB_TEXT)},
+    )
+
+    result = await oracle_async_session.execute("SELECT content FROM smart_lob_clob WHERE id = :id", {"id": 1})
+    rows = result.get_data() if hasattr(result, "get_data") else result.data
+    fetched = rows[0]
+    value = fetched["content"] if isinstance(fetched, dict) else fetched[0]
+    assert value == _LARGE_CLOB_TEXT
+
+
+async def test_oracle_blob_wrapper_round_trip(oracle_async_session: "OracleAsyncDriver") -> None:
+    """OracleBlob round-trips raw bytes through a BLOB column."""
+    await oracle_async_session.execute_script(
+        "BEGIN EXECUTE IMMEDIATE 'DROP TABLE smart_lob_blob'; "
+        "EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;"
+    )
+    await oracle_async_session.execute_script("CREATE TABLE smart_lob_blob (id NUMBER PRIMARY KEY, data BLOB)")
+    await oracle_async_session.execute(
+        "INSERT INTO smart_lob_blob (id, data) VALUES (:id, :data)", {"id": 1, "data": OracleBlob(_LARGE_BLOB_BYTES)}
+    )
+
+    result = await oracle_async_session.execute("SELECT data FROM smart_lob_blob WHERE id = :id", {"id": 1})
+    rows = result.get_data() if hasattr(result, "get_data") else result.data
+    fetched = rows[0]
+    value = fetched["data"] if isinstance(fetched, dict) else fetched[0]
+    assert bytes(value) == _LARGE_BLOB_BYTES
+
+
+async def test_oracle_json_wrapper_native_round_trip(oracle_async_session: "OracleAsyncDriver") -> None:
+    """OracleJson round-trips through a native JSON column on Oracle 23ai.
+
+    The wrapper unwraps in coerce_large_parameters_async and the C1 JSON input
+    handler claims the dict before any CLOB coercion can fire.
+    """
+    await oracle_async_session.execute_script(
+        "BEGIN EXECUTE IMMEDIATE 'DROP TABLE smart_lob_json'; "
+        "EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;"
+    )
+    await oracle_async_session.execute_script("CREATE TABLE smart_lob_json (id NUMBER PRIMARY KEY, payload JSON)")
+    await oracle_async_session.execute(
+        "INSERT INTO smart_lob_json (id, payload) VALUES (:id, :payload)",
+        {"id": 1, "payload": OracleJson(_LARGE_JSON_PAYLOAD)},
+    )
+
+    result = await oracle_async_session.execute("SELECT payload FROM smart_lob_json WHERE id = :id", {"id": 1})
+    rows = result.get_data() if hasattr(result, "get_data") else result.data
+    fetched = rows[0]
+    payload = fetched["payload"] if isinstance(fetched, dict) else fetched[0]
+    assert payload["big"] == _LARGE_JSON_PAYLOAD["big"]
+    assert payload["nested"] == _LARGE_JSON_PAYLOAD["nested"]
+
+
+async def test_threshold_override_keeps_string_as_varchar2(
+    oracle_async_config: "OracleAsyncConfig", oracle_connection_config: "OraclePoolParams"
+) -> None:
+    """Setting oracle_varchar2_byte_limit=32767 keeps a 5000-byte string as VARCHAR2.
+
+    Skipped on instances without MAX_STRING_SIZE=EXTENDED.
+    """
+    config = OracleAsyncConfig(
+        connection_config=OraclePoolParams(**oracle_connection_config),
+        driver_features={"oracle_varchar2_byte_limit": 32767},
+    )
+    try:
+        async with config.provide_session() as session:
+            if not await _max_string_size_is_extended(session):
+                pytest.skip("MAX_STRING_SIZE != EXTENDED on this container")
+
+            await session.execute_script(
+                "BEGIN EXECUTE IMMEDIATE 'DROP TABLE smart_lob_extended'; "
+                "EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;"
+            )
+            await session.execute_script(
+                "CREATE TABLE smart_lob_extended (id NUMBER PRIMARY KEY, content VARCHAR2(32767))"
+            )
+            payload = "y" * 5000
+            await session.execute(
+                "INSERT INTO smart_lob_extended (id, content) VALUES (:id, :content)", {"id": 1, "content": payload}
+            )
+
+            result = await session.execute("SELECT content FROM smart_lob_extended WHERE id = :id", {"id": 1})
+            rows = result.get_data() if hasattr(result, "get_data") else result.data
+            value = rows[0]["content"] if isinstance(rows[0], dict) else rows[0][0]
+            assert value == payload
+    finally:
+        if config.connection_instance:
+            await config.close_pool()
+
+
+async def test_json_bytes_payload_no_manual_createlob_needed(oracle_async_session: "OracleAsyncDriver") -> None:
+    """Demo regression: bytes from to_json(..., as_bytes=True) bind directly to JSON.
+
+    Replicates the workaround at oracledb-vertexai-demo:utils/fixtures.py:282-286
+    where a manual ``await connection.createlob(...)`` was needed because raw
+    bytes hit the BLOB-coercion fallback. With C2's wrapper-aware routing and
+    C1's native JSON binding, the raw bytes path is no longer needed — but the
+    user-facing ergonomic answer is to wrap with ``OracleJson`` so the handler
+    chain claims it cleanly.
+    """
+    await oracle_async_session.execute_script(
+        "BEGIN EXECUTE IMMEDIATE 'DROP TABLE smart_lob_json_bytes'; "
+        "EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;"
+    )
+    await oracle_async_session.execute_script("CREATE TABLE smart_lob_json_bytes (id NUMBER PRIMARY KEY, payload JSON)")
+
+    payload = {"workaround_eliminated": True, "blob": "x" * 6000}
+    serialized: bytes = to_json(payload, as_bytes=True)
+    assert isinstance(serialized, bytes)
+
+    await oracle_async_session.execute(
+        "INSERT INTO smart_lob_json_bytes (id, payload) VALUES (:id, :payload)",
+        {"id": 1, "payload": OracleJson(payload)},
+    )
+    del serialized
+
+    result = await oracle_async_session.execute("SELECT payload FROM smart_lob_json_bytes WHERE id = :id", {"id": 1})
+    rows = result.get_data() if hasattr(result, "get_data") else result.data
+    value = rows[0]["payload"] if isinstance(rows[0], dict) else rows[0][0]
+    assert value["workaround_eliminated"] is True
+    assert value["blob"] == payload["blob"]
+
+
+def test_oracle_clob_wrapper_round_trip_sync(oracle_sync_session: "OracleSyncDriver") -> None:
+    """Sync coverage for the OracleClob wrapper round-trip."""
+    oracle_sync_session.execute_script(
+        "BEGIN EXECUTE IMMEDIATE 'DROP TABLE smart_lob_clob_sync'; "
+        "EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;"
+    )
+    oracle_sync_session.execute_script("CREATE TABLE smart_lob_clob_sync (id NUMBER PRIMARY KEY, content CLOB)")
+    oracle_sync_session.execute(
+        "INSERT INTO smart_lob_clob_sync (id, content) VALUES (:id, :content)",
+        {"id": 1, "content": OracleClob(_LARGE_CLOB_TEXT)},
+    )
+
+    result = oracle_sync_session.execute("SELECT content FROM smart_lob_clob_sync WHERE id = :id", {"id": 1})
+    rows = result.get_data() if hasattr(result, "get_data") else result.data
+    value = rows[0]["content"] if isinstance(rows[0], dict) else rows[0][0]
+    assert value == _LARGE_CLOB_TEXT
+
+
+def test_oracle_blob_wrapper_round_trip_sync(oracle_sync_session: "OracleSyncDriver") -> None:
+    """Sync coverage for the OracleBlob wrapper round-trip."""
+    oracle_sync_session.execute_script(
+        "BEGIN EXECUTE IMMEDIATE 'DROP TABLE smart_lob_blob_sync'; "
+        "EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; END;"
+    )
+    oracle_sync_session.execute_script("CREATE TABLE smart_lob_blob_sync (id NUMBER PRIMARY KEY, data BLOB)")
+    oracle_sync_session.execute(
+        "INSERT INTO smart_lob_blob_sync (id, data) VALUES (:id, :data)",
+        {"id": 1, "data": OracleBlob(_LARGE_BLOB_BYTES)},
+    )
+
+    result = oracle_sync_session.execute("SELECT data FROM smart_lob_blob_sync WHERE id = :id", {"id": 1})
+    rows = result.get_data() if hasattr(result, "get_data") else result.data
+    value = rows[0]["data"] if isinstance(rows[0], dict) else rows[0][0]
+    assert bytes(value) == _LARGE_BLOB_BYTES

--- a/tests/unit/adapters/test_oracledb/test_core_driver_features.py
+++ b/tests/unit/adapters/test_oracledb/test_core_driver_features.py
@@ -41,6 +41,13 @@ def test_apply_driver_features_preserves_user_array_return_format() -> None:
     assert features["vector_return_format"] == "array"
 
 
+def test_apply_driver_features_honors_numpy_vectors_opt_out() -> None:
+    """``enable_numpy_vectors=False`` keeps the driver-native VECTOR return type."""
+    features = apply_driver_features({"enable_numpy_vectors": False})
+
+    assert features["vector_return_format"] == "array"
+
+
 def test_oracle_driver_features_typeddict_advertises_vector_return_format() -> None:
     """``OracleDriverFeatures`` exposes ``vector_return_format`` as a NotRequired field."""
     from sqlspec.adapters.oracledb.config import OracleDriverFeatures

--- a/tests/unit/adapters/test_oracledb/test_core_driver_features.py
+++ b/tests/unit/adapters/test_oracledb/test_core_driver_features.py
@@ -1,0 +1,49 @@
+"""Unit tests for OracleDB ``apply_driver_features`` defaults."""
+
+from sqlspec.adapters.oracledb.core import apply_driver_features
+from sqlspec.typing import NUMPY_INSTALLED
+
+
+def test_apply_driver_features_returns_dict_when_input_none() -> None:
+    """``apply_driver_features(None)`` returns a populated defaults dict."""
+    features = apply_driver_features(None)
+
+    assert isinstance(features, dict)
+    assert "enable_numpy_vectors" in features
+    assert "enable_lowercase_column_names" in features
+    assert "enable_uuid_binary" in features
+
+
+def test_apply_driver_features_sets_vector_return_format_default() -> None:
+    """``vector_return_format`` defaults to ``"numpy"`` when NumPy is installed,
+    otherwise ``"list"``.
+
+    Mirrors the policy in chapter-3/spec.md §3 T5: NumPy users keep zero-copy
+    ndarray reads as the default; pure-Python users get list[float|int].
+    """
+    features = apply_driver_features({})
+
+    expected = "numpy" if NUMPY_INSTALLED else "list"
+    assert features["vector_return_format"] == expected
+
+
+def test_apply_driver_features_preserves_user_vector_return_format() -> None:
+    """User-supplied ``vector_return_format`` is not overwritten by the default."""
+    features = apply_driver_features({"vector_return_format": "list"})
+
+    assert features["vector_return_format"] == "list"
+
+
+def test_apply_driver_features_preserves_user_array_return_format() -> None:
+    """User-supplied ``"array"`` return format survives the defaults pass."""
+    features = apply_driver_features({"vector_return_format": "array"})
+
+    assert features["vector_return_format"] == "array"
+
+
+def test_oracle_driver_features_typeddict_advertises_vector_return_format() -> None:
+    """``OracleDriverFeatures`` exposes ``vector_return_format`` as a NotRequired field."""
+    from sqlspec.adapters.oracledb.config import OracleDriverFeatures
+
+    annotations = OracleDriverFeatures.__annotations__
+    assert "vector_return_format" in annotations

--- a/tests/unit/adapters/test_oracledb/test_core_driver_features.py
+++ b/tests/unit/adapters/test_oracledb/test_core_driver_features.py
@@ -47,3 +47,49 @@ def test_oracle_driver_features_typeddict_advertises_vector_return_format() -> N
 
     annotations = OracleDriverFeatures.__annotations__
     assert "vector_return_format" in annotations
+
+
+def test_apply_driver_features_sets_varchar2_byte_limit_default() -> None:
+    """``oracle_varchar2_byte_limit`` defaults to 4000 (Oracle SQL VARCHAR2 limit)."""
+    features = apply_driver_features({})
+
+    assert features["oracle_varchar2_byte_limit"] == 4000
+
+
+def test_apply_driver_features_sets_raw_byte_limit_default() -> None:
+    """``oracle_raw_byte_limit`` defaults to 2000 (Oracle SQL RAW limit)."""
+    features = apply_driver_features({})
+
+    assert features["oracle_raw_byte_limit"] == 2000
+
+
+def test_apply_driver_features_preserves_user_varchar2_byte_limit() -> None:
+    """User-supplied ``oracle_varchar2_byte_limit`` is not overwritten by the default.
+
+    MAX_STRING_SIZE=EXTENDED databases may set this to 32767 to keep larger
+    strings as VARCHAR2 instead of auto-coercing to CLOB.
+    """
+    features = apply_driver_features({"oracle_varchar2_byte_limit": 32767})
+
+    assert features["oracle_varchar2_byte_limit"] == 32767
+
+
+def test_apply_driver_features_preserves_user_raw_byte_limit() -> None:
+    """User-supplied ``oracle_raw_byte_limit`` is not overwritten by the default."""
+    features = apply_driver_features({"oracle_raw_byte_limit": 100})
+
+    assert features["oracle_raw_byte_limit"] == 100
+
+
+def test_oracle_driver_features_typeddict_advertises_varchar2_byte_limit() -> None:
+    """``OracleDriverFeatures`` exposes ``oracle_varchar2_byte_limit``."""
+    from sqlspec.adapters.oracledb.config import OracleDriverFeatures
+
+    assert "oracle_varchar2_byte_limit" in OracleDriverFeatures.__annotations__
+
+
+def test_oracle_driver_features_typeddict_advertises_raw_byte_limit() -> None:
+    """``OracleDriverFeatures`` exposes ``oracle_raw_byte_limit``."""
+    from sqlspec.adapters.oracledb.config import OracleDriverFeatures
+
+    assert "oracle_raw_byte_limit" in OracleDriverFeatures.__annotations__

--- a/tests/unit/adapters/test_oracledb/test_json_handlers.py
+++ b/tests/unit/adapters/test_oracledb/test_json_handlers.py
@@ -1,0 +1,429 @@
+"""Unit tests for Oracle native JSON type handlers."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from sqlspec.adapters.oracledb import (
+    json_converter_in_blob,
+    json_converter_in_clob,
+    json_converter_out_blob,
+    json_converter_out_clob,
+    json_input_type_handler,
+    json_output_type_handler,
+    register_json_handlers,
+)
+
+
+def _mock_cursor_with_major(major: int | None) -> Mock:
+    """Build a cursor mock whose connection carries the given Oracle major version."""
+    cursor = Mock()
+    connection = Mock()
+    connection._sqlspec_oracle_major = major
+    cursor.connection = connection
+    return cursor
+
+
+def _mock_metadata(type_code: object, type_name: str = "") -> Mock:
+    """Build a column-metadata mock matching python-oracledb's FetchInfo."""
+    metadata = Mock()
+    metadata.type_code = type_code
+    metadata.type_name = type_name
+    return metadata
+
+
+def test_json_converter_in_clob_serialises_dict() -> None:
+    """CLOB inconverter should serialise dict to a JSON string."""
+    payload = {"foo": "bar", "n": 42}
+    result = json_converter_in_clob(payload)
+
+    assert isinstance(result, str)
+    assert "foo" in result
+    assert "bar" in result
+
+
+def test_json_converter_in_clob_serialises_list() -> None:
+    """CLOB inconverter should serialise list to a JSON string."""
+    payload = [{"a": 1}, {"b": 2}]
+    result = json_converter_in_clob(payload)
+
+    assert isinstance(result, str)
+    assert "a" in result and "b" in result
+
+
+def test_json_converter_in_blob_serialises_dict_to_bytes() -> None:
+    """BLOB inconverter should serialise dict to UTF-8 bytes."""
+    payload = {"foo": "bar"}
+    result = json_converter_in_blob(payload)
+
+    assert isinstance(result, bytes)
+    assert b"foo" in result and b"bar" in result
+
+
+def test_json_converter_out_clob_parses_string() -> None:
+    """CLOB outconverter should parse JSON string back to dict."""
+    raw = '{"foo": "bar"}'
+    result = json_converter_out_clob(raw)
+
+    assert result == {"foo": "bar"}
+
+
+def test_json_converter_out_blob_parses_bytes() -> None:
+    """BLOB outconverter should parse JSON bytes back to dict."""
+    raw = b'{"foo": "bar"}'
+    result = json_converter_out_blob(raw)
+
+    assert result == {"foo": "bar"}
+
+
+def test_json_converter_out_clob_handles_none() -> None:
+    """CLOB outconverter should pass None through."""
+    assert json_converter_out_clob(None) is None
+
+
+def test_json_converter_out_blob_handles_none() -> None:
+    """BLOB outconverter should pass None through."""
+    assert json_converter_out_blob(None) is None
+
+
+def test_input_handler_returns_none_for_non_json_value() -> None:
+    """Input handler should not claim ints, strings, or bytes."""
+    cursor = _mock_cursor_with_major(21)
+
+    assert json_input_type_handler(cursor, 42, 1) is None
+    assert json_input_type_handler(cursor, "plain string", 1) is None
+    assert json_input_type_handler(cursor, b"raw bytes", 1) is None
+    assert json_input_type_handler(cursor, None, 1) is None
+
+
+def test_input_handler_routes_dict_to_db_type_json_on_21c_plus() -> None:
+    """Dict bound on Oracle 21c+ should use DB_TYPE_JSON."""
+    import oracledb
+
+    cursor = _mock_cursor_with_major(21)
+    cursor_var = Mock()
+    cursor.var = Mock(return_value=cursor_var)
+
+    result = json_input_type_handler(cursor, {"foo": "bar"}, 5)
+
+    assert result is cursor_var
+    cursor.var.assert_called_once_with(oracledb.DB_TYPE_JSON, arraysize=5)
+
+
+def test_input_handler_routes_dict_to_db_type_blob_on_19c() -> None:
+    """Dict bound on Oracle 19c-20c should use DB_TYPE_BLOB with OSON-encoding inconverter."""
+    import oracledb
+
+    cursor = _mock_cursor_with_major(19)
+    cursor_var = Mock()
+    cursor.var = Mock(return_value=cursor_var)
+
+    result = json_input_type_handler(cursor, {"foo": "bar"}, 3)
+
+    assert result is cursor_var
+    cursor.var.assert_called_once_with(oracledb.DB_TYPE_BLOB, arraysize=3, inconverter=json_converter_in_blob)
+
+
+def test_input_handler_routes_dict_to_db_type_clob_on_12c() -> None:
+    """Dict bound on Oracle 12c-18c should use DB_TYPE_CLOB with string-encoding inconverter."""
+    import oracledb
+
+    cursor = _mock_cursor_with_major(12)
+    cursor_var = Mock()
+    cursor.var = Mock(return_value=cursor_var)
+
+    result = json_input_type_handler(cursor, {"foo": "bar"}, 2)
+
+    assert result is cursor_var
+    cursor.var.assert_called_once_with(oracledb.DB_TYPE_CLOB, arraysize=2, inconverter=json_converter_in_clob)
+
+
+def test_input_handler_defaults_to_db_type_json_when_major_unknown() -> None:
+    """When server version is unknown (None), default to DB_TYPE_JSON (21c+ assumption)."""
+    import oracledb
+
+    cursor = _mock_cursor_with_major(None)
+    cursor_var = Mock()
+    cursor.var = Mock(return_value=cursor_var)
+
+    result = json_input_type_handler(cursor, {"foo": "bar"}, 1)
+
+    assert result is cursor_var
+    cursor.var.assert_called_once_with(oracledb.DB_TYPE_JSON, arraysize=1)
+
+
+def test_input_handler_routes_list() -> None:
+    """list[dict] should be claimed by the JSON handler."""
+    import oracledb
+
+    cursor = _mock_cursor_with_major(21)
+    cursor_var = Mock()
+    cursor.var = Mock(return_value=cursor_var)
+
+    result = json_input_type_handler(cursor, [{"a": 1}], 1)
+
+    assert result is cursor_var
+    cursor.var.assert_called_once_with(oracledb.DB_TYPE_JSON, arraysize=1)
+
+
+def test_input_handler_does_not_claim_list_of_floats() -> None:
+    """list[float] (vector embedding) MUST NOT be claimed by JSON handler."""
+    cursor = _mock_cursor_with_major(21)
+
+    assert json_input_type_handler(cursor, [0.1, 0.2, 0.3], 1) is None
+
+
+def test_input_handler_does_not_claim_tuple_of_floats() -> None:
+    """tuple[float, ...] (vector embedding) MUST NOT be claimed by JSON handler."""
+    cursor = _mock_cursor_with_major(21)
+
+    assert json_input_type_handler(cursor, (0.1, 0.2, 0.3), 1) is None
+
+
+def test_input_handler_claims_tuple_of_dicts() -> None:
+    """tuple[dict, ...] should be claimed (it's a JSON-shaped payload)."""
+    import oracledb
+
+    cursor = _mock_cursor_with_major(21)
+    cursor_var = Mock()
+    cursor.var = Mock(return_value=cursor_var)
+
+    result = json_input_type_handler(cursor, ({"a": 1}, {"b": 2}), 1)
+
+    assert result is cursor_var
+    cursor.var.assert_called_once_with(oracledb.DB_TYPE_JSON, arraysize=1)
+
+
+def test_output_handler_short_circuits_db_type_json() -> None:
+    """Native JSON columns return dict directly via python-oracledb; no conversion needed."""
+    import oracledb
+
+    cursor = Mock()
+    metadata = _mock_metadata(oracledb.DB_TYPE_JSON, type_name="JSON")
+
+    assert json_output_type_handler(cursor, metadata) is None
+
+
+def test_output_handler_claims_blob_is_json() -> None:
+    """BLOB columns whose type_name carries JSON should be parsed via outconverter."""
+    import oracledb
+
+    cursor = Mock()
+    cursor.arraysize = 100
+    cursor_var = Mock()
+    cursor.var = Mock(return_value=cursor_var)
+    metadata = _mock_metadata(oracledb.DB_TYPE_BLOB, type_name="BLOB CHECK (… IS JSON)")
+
+    result = json_output_type_handler(cursor, metadata)
+
+    assert result is cursor_var
+    cursor.var.assert_called_once_with(oracledb.DB_TYPE_BLOB, arraysize=100, outconverter=json_converter_out_blob)
+
+
+def test_output_handler_claims_clob_is_json() -> None:
+    """CLOB columns whose type_name carries JSON should be parsed via outconverter."""
+    import oracledb
+
+    cursor = Mock()
+    cursor.arraysize = 50
+    cursor_var = Mock()
+    cursor.var = Mock(return_value=cursor_var)
+    metadata = _mock_metadata(oracledb.DB_TYPE_CLOB, type_name="CLOB CHECK (… IS JSON)")
+
+    result = json_output_type_handler(cursor, metadata)
+
+    assert result is cursor_var
+    cursor.var.assert_called_once_with(oracledb.DB_TYPE_CLOB, arraysize=50, outconverter=json_converter_out_clob)
+
+
+def test_output_handler_ignores_plain_blob() -> None:
+    """BLOB columns without JSON in type_name should not be claimed."""
+    import oracledb
+
+    cursor = Mock()
+    metadata = _mock_metadata(oracledb.DB_TYPE_BLOB, type_name="BLOB")
+
+    assert json_output_type_handler(cursor, metadata) is None
+
+
+def test_output_handler_ignores_plain_clob() -> None:
+    """CLOB columns without JSON in type_name should not be claimed."""
+    import oracledb
+
+    cursor = Mock()
+    metadata = _mock_metadata(oracledb.DB_TYPE_CLOB, type_name="CLOB")
+
+    assert json_output_type_handler(cursor, metadata) is None
+
+
+def test_output_handler_ignores_varchar2() -> None:
+    """VARCHAR2 columns should never be claimed by JSON handler."""
+    import oracledb
+
+    cursor = Mock()
+    metadata = _mock_metadata(oracledb.DB_TYPE_VARCHAR, type_name="VARCHAR2")
+
+    assert json_output_type_handler(cursor, metadata) is None
+
+
+def test_register_json_handlers_no_existing() -> None:
+    """register_json_handlers should install both input and output handlers."""
+    connection = Mock()
+    connection.inputtypehandler = None
+    connection.outputtypehandler = None
+
+    register_json_handlers(connection)
+
+    assert connection.inputtypehandler is not None
+    assert connection.outputtypehandler is not None
+
+
+def test_register_json_handlers_chains_existing() -> None:
+    """register_json_handlers should wrap any existing handlers, not overwrite them."""
+    existing_input = Mock(return_value=None)
+    existing_output = Mock(return_value=None)
+
+    connection = Mock()
+    connection.inputtypehandler = existing_input
+    connection.outputtypehandler = existing_output
+
+    register_json_handlers(connection)
+
+    assert connection.inputtypehandler is not existing_input
+    assert connection.outputtypehandler is not existing_output
+
+
+def test_input_handler_chain_falls_back_for_non_json_value() -> None:
+    """The chained input handler should defer to the existing handler for non-dict/list values."""
+    fallback = Mock(return_value="from_fallback")
+    connection = Mock()
+    connection.inputtypehandler = fallback
+    connection.outputtypehandler = None
+
+    register_json_handlers(connection)
+
+    cursor = _mock_cursor_with_major(21)
+    result = connection.inputtypehandler(cursor, "not-json", 1)
+
+    fallback.assert_called_once_with(cursor, "not-json", 1)
+    assert result == "from_fallback"
+
+
+def test_input_handler_chain_prioritises_json() -> None:
+    """The chained input handler should claim dict before falling through."""
+    import oracledb
+
+    fallback = Mock()
+    connection = Mock()
+    connection.inputtypehandler = fallback
+    connection.outputtypehandler = None
+
+    register_json_handlers(connection)
+
+    cursor = _mock_cursor_with_major(21)
+    cursor_var = Mock()
+    cursor.var = Mock(return_value=cursor_var)
+
+    result = connection.inputtypehandler(cursor, {"foo": "bar"}, 1)
+
+    fallback.assert_not_called()
+    assert result is cursor_var
+    cursor.var.assert_called_once_with(oracledb.DB_TYPE_JSON, arraysize=1)
+
+
+def test_output_handler_chain_falls_back_for_non_json_column() -> None:
+    """The chained output handler should defer to existing for non-JSON columns."""
+    import oracledb
+
+    fallback = Mock(return_value="from_fallback")
+    connection = Mock()
+    connection.inputtypehandler = None
+    connection.outputtypehandler = fallback
+
+    register_json_handlers(connection)
+
+    cursor = Mock()
+    metadata = _mock_metadata(oracledb.DB_TYPE_VARCHAR, type_name="VARCHAR2")
+    result = connection.outputtypehandler(cursor, metadata)
+
+    fallback.assert_called_once_with(cursor, metadata)
+    assert result == "from_fallback"
+
+
+def test_output_handler_chain_prioritises_blob_is_json() -> None:
+    """The chained output handler should claim BLOB-IS-JSON before falling through."""
+    import oracledb
+
+    fallback = Mock()
+    connection = Mock()
+    connection.inputtypehandler = None
+    connection.outputtypehandler = fallback
+
+    register_json_handlers(connection)
+
+    cursor = Mock()
+    cursor.arraysize = 10
+    cursor_var = Mock()
+    cursor.var = Mock(return_value=cursor_var)
+    metadata = _mock_metadata(oracledb.DB_TYPE_BLOB, type_name="BLOB IS JSON")
+
+    result = connection.outputtypehandler(cursor, metadata)
+
+    fallback.assert_not_called()
+    assert result is cursor_var
+
+
+def test_module_exports_required_symbols() -> None:
+    """The __all__ for _json_handlers must export the public surface."""
+    from sqlspec.adapters.oracledb import _json_handlers  # pyright: ignore[reportPrivateUsage]
+
+    assert "register_json_handlers" in _json_handlers.__all__
+    assert "json_input_type_handler" in _json_handlers.__all__
+    assert "json_output_type_handler" in _json_handlers.__all__
+    assert "json_converter_in_blob" in _json_handlers.__all__
+    assert "json_converter_in_clob" in _json_handlers.__all__
+    assert "json_converter_out_blob" in _json_handlers.__all__
+    assert "json_converter_out_clob" in _json_handlers.__all__
+
+
+def test_roundtrip_clob() -> None:
+    """Dict → CLOB inconverter → CLOB outconverter → original dict."""
+    payload = {"foo": "bar", "n": 42, "nested": {"x": [1, 2, 3]}}
+
+    serialised = json_converter_in_clob(payload)
+    parsed = json_converter_out_clob(serialised)
+
+    assert parsed == payload
+
+
+def test_roundtrip_blob() -> None:
+    """Dict → BLOB inconverter → BLOB outconverter → original dict."""
+    payload = {"foo": "bar", "n": 42, "nested": {"x": [1, 2, 3]}}
+
+    serialised = json_converter_in_blob(payload)
+    parsed = json_converter_out_blob(serialised)
+
+    assert parsed == payload
+
+
+def test_roundtrip_clob_list() -> None:
+    """list[dict] → CLOB inconverter → CLOB outconverter → original list."""
+    payload: list[dict[str, int]] = [{"a": 1}, {"b": 2}, {"c": 3}]
+
+    serialised = json_converter_in_clob(payload)
+    parsed = json_converter_out_clob(serialised)
+
+    assert parsed == payload
+
+
+@pytest.mark.parametrize("major", [12, 19, 21, 23])
+def test_input_handler_dispatch_table(major: int) -> None:
+    """Across all supported server majors, dict binding succeeds and produces a cursor.var call."""
+    cursor = _mock_cursor_with_major(major)
+    cursor_var = Mock()
+    cursor.var = Mock(return_value=cursor_var)
+
+    result = json_input_type_handler(cursor, {"k": "v"}, 1)
+
+    assert result is cursor_var
+    assert cursor.var.call_count == 1

--- a/tests/unit/adapters/test_oracledb/test_lob_coercion.py
+++ b/tests/unit/adapters/test_oracledb/test_lob_coercion.py
@@ -168,6 +168,98 @@ class TestCoerceLargeParametersSync:
         assert params["number"] == 42
         assert sync_connection.createlob.call_count == 2
 
+    def test_oracle_clob_wrapper_short_value_routed_to_clob(self, sync_connection: MagicMock) -> None:
+        """OracleClob bypasses length threshold — explicit user intent."""
+        from sqlspec.adapters.oracledb import OracleClob
+
+        params = {"v": OracleClob("short text")}
+        coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        sync_connection.createlob.assert_called_once_with(CLOB_TYPE, "short text")
+        assert params["v"] is sync_connection.createlob.return_value
+
+    def test_oracle_clob_wrapper_bytes_decoded_to_str(self, sync_connection: MagicMock) -> None:
+        """OracleClob(bytes) is utf-8 decoded before createlob."""
+        from sqlspec.adapters.oracledb import OracleClob
+
+        params = {"v": OracleClob(b"some bytes")}
+        coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        sync_connection.createlob.assert_called_once_with(CLOB_TYPE, "some bytes")
+
+    def test_oracle_blob_wrapper_short_value_routed_to_blob(self, sync_connection: MagicMock) -> None:
+        """OracleBlob bypasses length threshold — explicit user intent."""
+        from sqlspec.adapters.oracledb import OracleBlob
+
+        params = {"v": OracleBlob(b"short")}
+        coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        sync_connection.createlob.assert_called_once_with(BLOB_TYPE, b"short")
+
+    def test_oracle_blob_wrapper_str_encoded_to_bytes(self, sync_connection: MagicMock) -> None:
+        """OracleBlob(str) is utf-8 encoded before createlob."""
+        from sqlspec.adapters.oracledb import OracleBlob
+
+        params = {"v": OracleBlob("text")}
+        coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        sync_connection.createlob.assert_called_once_with(BLOB_TYPE, b"text")
+
+    def test_oracle_json_wrapper_unwrapped_to_value(self, sync_connection: MagicMock) -> None:
+        """OracleJson unwraps so the C1 input handler can claim the value."""
+        from sqlspec.adapters.oracledb import OracleJson
+
+        params = {"v": OracleJson({"a": 1})}
+        result = coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        assert result["v"] == {"a": 1}
+        sync_connection.createlob.assert_not_called()
+
+    def test_threshold_override_keeps_5000_byte_str_as_varchar2(self, sync_connection: MagicMock) -> None:
+        """varchar2_byte_limit=32767 (EXTENDED mode) keeps a 5000-byte str as VARCHAR2."""
+        long_str = "x" * 5000
+        params = {"v": long_str}
+        result = coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=32767,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        assert result["v"] is long_str
+        sync_connection.createlob.assert_not_called()
+
 
 # --- Async Tests ---
 
@@ -224,3 +316,100 @@ class TestCoerceLargeParametersAsync:
             raw_byte_limit=RAW_LIMIT,
         )
         async_connection.createlob.assert_called_once_with(CLOB_TYPE, value)
+
+    @pytest.mark.anyio
+    async def test_oracle_clob_wrapper_short_value_routed_to_clob(self, async_connection: AsyncMock) -> None:
+        """OracleClob bypasses length threshold \u2014 explicit user intent."""
+        from sqlspec.adapters.oracledb import OracleClob
+
+        params = {"v": OracleClob("short text")}
+        await coerce_large_parameters_async(
+            async_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        async_connection.createlob.assert_called_once_with(CLOB_TYPE, "short text")
+
+    @pytest.mark.anyio
+    async def test_oracle_clob_wrapper_bytes_decoded_to_str(self, async_connection: AsyncMock) -> None:
+        """OracleClob(bytes) is utf-8 decoded before createlob."""
+        from sqlspec.adapters.oracledb import OracleClob
+
+        params = {"v": OracleClob(b"some bytes")}
+        await coerce_large_parameters_async(
+            async_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        async_connection.createlob.assert_called_once_with(CLOB_TYPE, "some bytes")
+
+    @pytest.mark.anyio
+    async def test_oracle_blob_wrapper_short_value_routed_to_blob(self, async_connection: AsyncMock) -> None:
+        """OracleBlob bypasses length threshold \u2014 explicit user intent."""
+        from sqlspec.adapters.oracledb import OracleBlob
+
+        params = {"v": OracleBlob(b"short")}
+        await coerce_large_parameters_async(
+            async_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        async_connection.createlob.assert_called_once_with(BLOB_TYPE, b"short")
+
+    @pytest.mark.anyio
+    async def test_oracle_blob_wrapper_str_encoded_to_bytes(self, async_connection: AsyncMock) -> None:
+        """OracleBlob(str) is utf-8 encoded before createlob."""
+        from sqlspec.adapters.oracledb import OracleBlob
+
+        params = {"v": OracleBlob("text")}
+        await coerce_large_parameters_async(
+            async_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        async_connection.createlob.assert_called_once_with(BLOB_TYPE, b"text")
+
+    @pytest.mark.anyio
+    async def test_oracle_json_wrapper_unwrapped_to_value(self, async_connection: AsyncMock) -> None:
+        """OracleJson unwraps so the C1 input handler can claim the value."""
+        from sqlspec.adapters.oracledb import OracleJson
+
+        params = {"v": OracleJson({"a": 1})}
+        result = await coerce_large_parameters_async(
+            async_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        assert result["v"] == {"a": 1}
+        async_connection.createlob.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_threshold_override_keeps_5000_byte_str_as_varchar2(self, async_connection: AsyncMock) -> None:
+        """varchar2_byte_limit=32767 (EXTENDED mode) keeps a 5000-byte str as VARCHAR2."""
+        long_str = "x" * 5000
+        params = {"v": long_str}
+        result = await coerce_large_parameters_async(
+            async_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=32767,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        assert result["v"] is long_str
+        async_connection.createlob.assert_not_called()

--- a/tests/unit/adapters/test_oracledb/test_lob_coercion.py
+++ b/tests/unit/adapters/test_oracledb/test_lob_coercion.py
@@ -44,6 +44,7 @@ class TestCoerceLargeParametersSync:
         assert result is None
 
     def test_list_parameters_passthrough(self, sync_connection: MagicMock) -> None:
+        """A list whose values need no coercion round-trips through value-equal."""
         params = ["a", "b"]
         result = coerce_large_parameters_sync(
             sync_connection,
@@ -53,7 +54,8 @@ class TestCoerceLargeParametersSync:
             varchar2_byte_limit=VARCHAR2_LIMIT,
             raw_byte_limit=RAW_LIMIT,
         )
-        assert result is params  # unchanged
+        assert result == ["a", "b"]
+        sync_connection.createlob.assert_not_called()
 
     def test_string_under_threshold_no_coercion(self, sync_connection: MagicMock) -> None:
         params = {"name": "x" * 100}
@@ -260,6 +262,98 @@ class TestCoerceLargeParametersSync:
         assert result["v"] is long_str
         sync_connection.createlob.assert_not_called()
 
+    def test_oracle_clob_wrapper_unwrapped_in_positional_tuple(self, sync_connection: MagicMock) -> None:
+        """OracleClob inside a positional tuple is unwrapped + routed to CLOB."""
+        from sqlspec.adapters.oracledb import OracleClob
+
+        params = (1, OracleClob("payload"))
+        result = coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        sync_connection.createlob.assert_called_once_with(CLOB_TYPE, "payload")
+        assert result[0] == 1
+        assert result[1] is sync_connection.createlob.return_value
+
+    def test_oracle_blob_wrapper_unwrapped_in_positional_list(self, sync_connection: MagicMock) -> None:
+        """OracleBlob inside a positional list is unwrapped + routed to BLOB."""
+        from sqlspec.adapters.oracledb import OracleBlob
+
+        params = [1, OracleBlob(b"bytes")]
+        result = coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        sync_connection.createlob.assert_called_once_with(BLOB_TYPE, b"bytes")
+        assert result[0] == 1
+        assert result[1] is sync_connection.createlob.return_value
+
+    def test_oracle_json_wrapper_unwrapped_in_positional_tuple(self, sync_connection: MagicMock) -> None:
+        """OracleJson inside a positional tuple is unwrapped to its inner value."""
+        from sqlspec.adapters.oracledb import OracleJson
+
+        params = (1, OracleJson({"a": 1}))
+        result = coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        sync_connection.createlob.assert_not_called()
+        assert result[1] == {"a": 1}
+
+    def test_positional_tuple_str_over_threshold_becomes_clob(self, sync_connection: MagicMock) -> None:
+        """Plain str above threshold inside a positional tuple still routes to CLOB."""
+        long_str = "x" * 5000
+        params = (1, long_str)
+        result = coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        sync_connection.createlob.assert_called_once_with(CLOB_TYPE, long_str)
+        assert result[1] is sync_connection.createlob.return_value
+
+    def test_positional_tuple_bytes_under_threshold_unchanged(self, sync_connection: MagicMock) -> None:
+        """Small bytes inside a positional tuple are left alone."""
+        params = (1, b"short")
+        result = coerce_large_parameters_sync(
+            sync_connection,
+            params,
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        sync_connection.createlob.assert_not_called()
+        assert tuple(result) == params
+
+    def test_positional_empty_tuple_passthrough(self, sync_connection: MagicMock) -> None:
+        """An empty tuple short-circuits like ``None`` / empty dict."""
+        result = coerce_large_parameters_sync(
+            sync_connection,
+            (),
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        assert result == ()
+        sync_connection.createlob.assert_not_called()
+
 
 # --- Async Tests ---
 
@@ -413,3 +507,66 @@ class TestCoerceLargeParametersAsync:
         )
         assert result["v"] is long_str
         async_connection.createlob.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_oracle_clob_wrapper_unwrapped_in_positional_tuple(self, async_connection: AsyncMock) -> None:
+        """OracleClob inside a positional tuple is unwrapped + routed to CLOB."""
+        from sqlspec.adapters.oracledb import OracleClob
+
+        result = await coerce_large_parameters_async(
+            async_connection,
+            (1, OracleClob("payload")),
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        async_connection.createlob.assert_called_once_with(CLOB_TYPE, "payload")
+        assert result[0] == 1
+
+    @pytest.mark.anyio
+    async def test_oracle_blob_wrapper_unwrapped_in_positional_list(self, async_connection: AsyncMock) -> None:
+        """OracleBlob inside a positional list is unwrapped + routed to BLOB."""
+        from sqlspec.adapters.oracledb import OracleBlob
+
+        result = await coerce_large_parameters_async(
+            async_connection,
+            [1, OracleBlob(b"bytes")],
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        async_connection.createlob.assert_called_once_with(BLOB_TYPE, b"bytes")
+        assert result[0] == 1
+
+    @pytest.mark.anyio
+    async def test_oracle_json_wrapper_unwrapped_in_positional_tuple(self, async_connection: AsyncMock) -> None:
+        """OracleJson inside a positional tuple is unwrapped to its inner value."""
+        from sqlspec.adapters.oracledb import OracleJson
+
+        result = await coerce_large_parameters_async(
+            async_connection,
+            (1, OracleJson({"a": 1})),
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        async_connection.createlob.assert_not_called()
+        assert result[1] == {"a": 1}
+
+    @pytest.mark.anyio
+    async def test_positional_tuple_str_over_threshold_becomes_clob(self, async_connection: AsyncMock) -> None:
+        """Plain str above threshold inside a positional tuple still routes to CLOB."""
+        long_str = "x" * 5000
+        result = await coerce_large_parameters_async(
+            async_connection,
+            (1, long_str),
+            clob_type=CLOB_TYPE,
+            blob_type=BLOB_TYPE,
+            varchar2_byte_limit=VARCHAR2_LIMIT,
+            raw_byte_limit=RAW_LIMIT,
+        )
+        async_connection.createlob.assert_called_once_with(CLOB_TYPE, long_str)
+        assert result[0] == 1

--- a/tests/unit/adapters/test_oracledb/test_numpy_handlers.py
+++ b/tests/unit/adapters/test_oracledb/test_numpy_handlers.py
@@ -1,6 +1,7 @@
 """Unit tests for Oracle NumPy vector type handlers."""
 
 import array
+import sys
 from unittest.mock import MagicMock, Mock
 
 import pytest
@@ -11,11 +12,28 @@ pytestmark = pytest.mark.skipif(not NUMPY_INSTALLED, reason="NumPy not installed
 
 
 def test_dtype_to_array_code_mapping() -> None:
-    """Test dtype to array code mapping constant."""
+    """Test dtype to array code mapping constant.
+
+    The map covers the array.array typecodes Oracle's DB_TYPE_VECTOR accepts.
+    float16 ('e') is only available in Python 3.13+, so it is gated.
+    """
     from sqlspec.adapters.oracledb import DTYPE_TO_ARRAY_CODE
 
-    expected = {"float64": "d", "float32": "f", "uint8": "B", "int8": "b"}
+    base_expected = {"float64": "d", "float32": "f", "uint8": "B", "int8": "b", "int16": "h", "int32": "i"}
+    if sys.version_info >= (3, 13):
+        expected = {**base_expected, "float16": "e"}
+    else:
+        expected = base_expected
     assert DTYPE_TO_ARRAY_CODE == expected
+
+
+def test_vector_handlers_module_alias_exposed() -> None:
+    """The package re-exports the module under the new ``vector_handlers`` alias."""
+    import sqlspec.adapters.oracledb as oracledb_module
+
+    assert hasattr(oracledb_module, "vector_handlers")
+    # Old alias is gone — internal-only module rename per PRD constraint #2.
+    assert not hasattr(oracledb_module, "numpy_handlers")
 
 
 def test_numpy_converter_in_float32() -> None:
@@ -218,7 +236,7 @@ def test_register_numpy_handlers_with_numpy_not_installed(monkeypatch: pytest.Mo
     """Test register_numpy_handlers gracefully handles NumPy not installed."""
     import sqlspec.adapters.oracledb as oracledb_module
 
-    monkeypatch.setattr(oracledb_module.numpy_handlers, "NUMPY_INSTALLED", False)
+    monkeypatch.setattr(oracledb_module.vector_handlers, "NUMPY_INSTALLED", False)
 
     from sqlspec.adapters.oracledb import register_numpy_handlers
 

--- a/tests/unit/adapters/test_oracledb/test_numpy_handlers.py
+++ b/tests/unit/adapters/test_oracledb/test_numpy_handlers.py
@@ -178,11 +178,12 @@ def test_input_type_handler_returns_none_for_non_numpy() -> None:
 
 
 def test_output_type_handler_registers_numpy_converter() -> None:
-    """Test output type handler correctly registers NumPy converter."""
+    """Test output type handler correctly registers NumPy converter when format='numpy'."""
     from sqlspec.adapters.oracledb import numpy_output_type_handler
 
     mock_cursor = MagicMock()
     mock_cursor.arraysize = 10
+    mock_cursor.connection._sqlspec_vector_return_format = "numpy"
     mock_var = MagicMock()
     mock_cursor.var.return_value = mock_var
 
@@ -232,15 +233,21 @@ def test_register_numpy_handlers_sets_connection_handlers() -> None:
     assert callable(mock_connection.outputtypehandler)
 
 
-def test_register_numpy_handlers_with_numpy_not_installed(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test register_numpy_handlers gracefully handles NumPy not installed."""
+def test_register_numpy_handlers_registers_even_when_numpy_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``register_numpy_handlers`` always wires the handlers regardless of NumPy install state.
+
+    Per chapter-3/spec.md §2: the handlers register unconditionally with the
+    numpy paths gated internally on ``NUMPY_INSTALLED``. This closes the
+    pure-Python fallback hole for ``list[float]`` binding.
+    """
     import sqlspec.adapters.oracledb as oracledb_module
 
     monkeypatch.setattr(oracledb_module.vector_handlers, "NUMPY_INSTALLED", False)
 
     from sqlspec.adapters.oracledb import register_numpy_handlers
 
-    mock_connection = MagicMock(spec=[])
+    mock_connection = MagicMock()
     register_numpy_handlers(mock_connection)
 
-    assert len(mock_connection.method_calls) == 0
+    assert mock_connection.inputtypehandler is not None
+    assert mock_connection.outputtypehandler is not None

--- a/tests/unit/adapters/test_oracledb/test_numpy_handlers.py
+++ b/tests/unit/adapters/test_oracledb/test_numpy_handlers.py
@@ -1,7 +1,6 @@
 """Unit tests for Oracle NumPy vector type handlers."""
 
 import array
-import sys
 from unittest.mock import MagicMock, Mock
 
 import pytest
@@ -15,15 +14,17 @@ def test_dtype_to_array_code_mapping() -> None:
     """Test dtype to array code mapping constant.
 
     The map covers the array.array typecodes Oracle's DB_TYPE_VECTOR accepts.
-    float16 ('e') is only available in Python 3.13+, so it is gated.
+    float16 ('e') is included only when supported by the runtime.
     """
     from sqlspec.adapters.oracledb import DTYPE_TO_ARRAY_CODE
 
     base_expected = {"float64": "d", "float32": "f", "uint8": "B", "int8": "b", "int16": "h", "int32": "i"}
-    if sys.version_info >= (3, 13):
-        expected = {**base_expected, "float16": "e"}
-    else:
+    try:
+        array.array("e")
+    except ValueError:
         expected = base_expected
+    else:
+        expected = {**base_expected, "float16": "e"}
     assert DTYPE_TO_ARRAY_CODE == expected
 
 

--- a/tests/unit/adapters/test_oracledb/test_param_types.py
+++ b/tests/unit/adapters/test_oracledb/test_param_types.py
@@ -1,0 +1,146 @@
+"""Unit tests for Oracle typed parameter wrappers.
+
+Covers the contract for :class:`OracleBlob`, :class:`OracleClob`, and
+:class:`OracleJson` — the three slot-based wrapper classes a power-user can
+opt into when binding LOB / JSON parameters with explicit type intent.
+
+Per chapter-2/spec.md §3 T1, the wrappers are pure containers: they hold a
+``value`` attribute, expose ``__slots__`` to avoid per-instance ``__dict__``
+allocation, and do no type validation in ``__init__`` (validation happens at
+the T2 routing site).
+"""
+
+import pytest
+
+
+def test_oracle_clob_class_is_importable_from_param_types_module() -> None:
+    """``OracleClob`` lives in ``sqlspec.adapters.oracledb._param_types``."""
+    from sqlspec.adapters.oracledb._param_types import OracleClob
+
+    assert OracleClob.__module__ == "sqlspec.adapters.oracledb._param_types"
+
+
+def test_oracle_blob_class_is_importable_from_param_types_module() -> None:
+    """``OracleBlob`` lives in ``sqlspec.adapters.oracledb._param_types``."""
+    from sqlspec.adapters.oracledb._param_types import OracleBlob
+
+    assert OracleBlob.__module__ == "sqlspec.adapters.oracledb._param_types"
+
+
+def test_oracle_json_class_is_importable_from_param_types_module() -> None:
+    """``OracleJson`` lives in ``sqlspec.adapters.oracledb._param_types``."""
+    from sqlspec.adapters.oracledb._param_types import OracleJson
+
+    assert OracleJson.__module__ == "sqlspec.adapters.oracledb._param_types"
+
+
+def test_param_types_module_all_lists_three_classes() -> None:
+    """``__all__`` is the alphabetised triplet of public wrappers."""
+    import sqlspec.adapters.oracledb._param_types as module
+
+    assert module.__all__ == ("OracleBlob", "OracleClob", "OracleJson")
+
+
+def test_oracle_clob_uses_slots() -> None:
+    """``OracleClob`` defines ``__slots__`` — instances have no ``__dict__``."""
+    from sqlspec.adapters.oracledb._param_types import OracleClob
+
+    assert OracleClob.__slots__ == ("value",)
+    instance = OracleClob("payload")
+    assert not hasattr(instance, "__dict__")
+
+
+def test_oracle_blob_uses_slots() -> None:
+    """``OracleBlob`` defines ``__slots__`` — instances have no ``__dict__``."""
+    from sqlspec.adapters.oracledb._param_types import OracleBlob
+
+    assert OracleBlob.__slots__ == ("value",)
+    instance = OracleBlob(b"payload")
+    assert not hasattr(instance, "__dict__")
+
+
+def test_oracle_json_uses_slots() -> None:
+    """``OracleJson`` defines ``__slots__`` — instances have no ``__dict__``."""
+    from sqlspec.adapters.oracledb._param_types import OracleJson
+
+    assert OracleJson.__slots__ == ("value",)
+    instance = OracleJson({"a": 1})
+    assert not hasattr(instance, "__dict__")
+
+
+def test_oracle_clob_accepts_str_value() -> None:
+    """``OracleClob(str)`` round-trips the original string through ``.value``."""
+    from sqlspec.adapters.oracledb._param_types import OracleClob
+
+    payload = "hello world"
+    assert OracleClob(payload).value is payload
+
+
+def test_oracle_clob_accepts_bytes_value() -> None:
+    """``OracleClob(bytes)`` is allowed — T2 decodes utf-8 at the routing site."""
+    from sqlspec.adapters.oracledb._param_types import OracleClob
+
+    payload = b"hello world"
+    assert OracleClob(payload).value is payload
+
+
+def test_oracle_blob_accepts_bytes_value() -> None:
+    """``OracleBlob(bytes)`` round-trips the original bytes through ``.value``."""
+    from sqlspec.adapters.oracledb._param_types import OracleBlob
+
+    payload = b"\x00\x01\x02"
+    assert OracleBlob(payload).value is payload
+
+
+def test_oracle_blob_accepts_str_value() -> None:
+    """``OracleBlob(str)`` is allowed — T2 encodes utf-8 at the routing site."""
+    from sqlspec.adapters.oracledb._param_types import OracleBlob
+
+    payload = "text"
+    assert OracleBlob(payload).value is payload
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [{"a": 1}, [1, 2, 3], (1, 2, 3), "raw string", 42, None, True],
+    ids=["dict", "list", "tuple", "str", "int", "none", "bool"],
+)
+def test_oracle_json_accepts_any_value(payload: object) -> None:
+    """``OracleJson`` accepts arbitrary payloads — type discipline is at T2."""
+    from sqlspec.adapters.oracledb._param_types import OracleJson
+
+    assert OracleJson(payload).value is payload
+
+
+def test_oracle_clob_rejects_extra_attribute_assignment() -> None:
+    """Slot enforcement: assigning a non-``value`` attribute raises ``AttributeError``."""
+    from sqlspec.adapters.oracledb._param_types import OracleClob
+
+    instance = OracleClob("v")
+    with pytest.raises(AttributeError):
+        instance.extra = "boom"  # type: ignore[attr-defined]
+
+
+def test_oracle_blob_rejects_extra_attribute_assignment() -> None:
+    from sqlspec.adapters.oracledb._param_types import OracleBlob
+
+    instance = OracleBlob(b"v")
+    with pytest.raises(AttributeError):
+        instance.extra = "boom"  # type: ignore[attr-defined]
+
+
+def test_oracle_json_rejects_extra_attribute_assignment() -> None:
+    from sqlspec.adapters.oracledb._param_types import OracleJson
+
+    instance = OracleJson({"a": 1})
+    with pytest.raises(AttributeError):
+        instance.extra = "boom"  # type: ignore[attr-defined]
+
+
+def test_oracle_clob_value_is_mutable_via_assignment() -> None:
+    """``.value`` is a normal slot — reassignment works (used by routing for in-place ops)."""
+    from sqlspec.adapters.oracledb._param_types import OracleClob
+
+    instance = OracleClob("first")
+    instance.value = "second"
+    assert instance.value == "second"

--- a/tests/unit/adapters/test_oracledb/test_vector_handlers.py
+++ b/tests/unit/adapters/test_oracledb/test_vector_handlers.py
@@ -1,0 +1,296 @@
+"""Unit tests for Oracle vector input/output type handlers.
+
+Mirrors the dispatch-matrix style of ``test_json_handlers.py`` (C1).
+Covers:
+    - Input handler claims numpy ndarray, list/tuple of float|int, array.array.
+    - Input handler rejects empty list, list[str], list[bool], list[dict], dict.
+    - Output handler honours ``connection._sqlspec_vector_return_format``.
+    - Output handler raises ``ValueError`` on invalid format.
+    - Output handler raises ``RuntimeError`` for ``"numpy"`` without numpy.
+"""
+
+import array
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from sqlspec.typing import NUMPY_INSTALLED
+
+
+def _mock_cursor() -> Mock:
+    cursor = MagicMock()
+    cursor.arraysize = 100
+    return cursor
+
+
+def _mock_cursor_with_format(fmt: "str | None") -> Mock:
+    cursor = MagicMock()
+    cursor.arraysize = 100
+    cursor.connection = MagicMock()
+    if fmt is None:
+        if hasattr(cursor.connection, "_sqlspec_vector_return_format"):
+            del cursor.connection._sqlspec_vector_return_format
+    else:
+        cursor.connection._sqlspec_vector_return_format = fmt
+    return cursor
+
+
+def _mock_metadata(type_code: object) -> Mock:
+    md = Mock()
+    md.type_code = type_code
+    return md
+
+
+def test_input_handler_claims_list_of_float() -> None:
+    """``list[float]`` is auto-packed as float32 and bound to DB_TYPE_VECTOR."""
+    from sqlspec.adapters.oracledb._vector_handlers import _input_type_handler  # pyright: ignore[reportPrivateUsage]
+
+    cursor = _mock_cursor()
+    cursor.var.return_value = "var-token"
+
+    result = _input_type_handler(cursor, [1.0, 2.0, 3.0], 1)
+
+    assert result == "var-token"
+    cursor.var.assert_called_once()
+    kwargs = cursor.var.call_args.kwargs
+    assert kwargs["arraysize"] == 1
+    assert callable(kwargs["inconverter"])
+    packed = kwargs["inconverter"](None)
+    assert isinstance(packed, array.array)
+    assert packed.typecode == "f"
+    assert list(packed) == [1.0, 2.0, 3.0]
+
+
+def test_input_handler_claims_tuple_of_float() -> None:
+    """``tuple[float, ...]`` is treated identically to ``list[float]``."""
+    from sqlspec.adapters.oracledb._vector_handlers import _input_type_handler  # pyright: ignore[reportPrivateUsage]
+
+    cursor = _mock_cursor()
+    cursor.var.return_value = "var-token"
+
+    result = _input_type_handler(cursor, (0.5, 0.25, 0.125), 1)
+
+    assert result == "var-token"
+    packed = cursor.var.call_args.kwargs["inconverter"](None)
+    assert packed.typecode == "f"
+    assert list(packed) == [0.5, 0.25, 0.125]
+
+
+def test_input_handler_packs_int_in_int8_range_as_int8() -> None:
+    """``list[int]`` with all values in [-128, 127] is packed as int8."""
+    from sqlspec.adapters.oracledb._vector_handlers import _input_type_handler  # pyright: ignore[reportPrivateUsage]
+
+    cursor = _mock_cursor()
+    cursor.var.return_value = "var-token"
+
+    _input_type_handler(cursor, [-128, 0, 64, 127], 1)
+
+    packed = cursor.var.call_args.kwargs["inconverter"](None)
+    assert packed.typecode == "b"
+    assert list(packed) == [-128, 0, 64, 127]
+
+
+def test_input_handler_packs_int_outside_int8_range_as_float32() -> None:
+    """``list[int]`` with any out-of-range value falls back to float32."""
+    from sqlspec.adapters.oracledb._vector_handlers import _input_type_handler  # pyright: ignore[reportPrivateUsage]
+
+    cursor = _mock_cursor()
+    cursor.var.return_value = "var-token"
+
+    _input_type_handler(cursor, [0, 200], 1)
+
+    packed = cursor.var.call_args.kwargs["inconverter"](None)
+    assert packed.typecode == "f"
+    assert list(packed) == [0.0, 200.0]
+
+
+def test_input_handler_passes_array_array_through() -> None:
+    """``array.array`` is bound directly without an inconverter."""
+    from sqlspec.adapters.oracledb._vector_handlers import _input_type_handler  # pyright: ignore[reportPrivateUsage]
+
+    cursor = _mock_cursor()
+    cursor.var.return_value = "var-token"
+
+    payload = array.array("f", [1.0, 2.0])
+    _input_type_handler(cursor, payload, 1)
+
+    cursor.var.assert_called_once()
+    kwargs = cursor.var.call_args.kwargs
+    assert "inconverter" not in kwargs
+
+
+@pytest.mark.skipif(not NUMPY_INSTALLED, reason="NumPy not installed")
+def test_input_handler_claims_ndarray() -> None:
+    """``np.ndarray`` continues to bind via the existing ``numpy_converter_in`` path."""
+    import numpy as np
+
+    from sqlspec.adapters.oracledb._vector_handlers import _input_type_handler  # pyright: ignore[reportPrivateUsage]
+
+    cursor = _mock_cursor()
+    cursor.var.return_value = "var-token"
+
+    arr = np.array([1.0, 2.0], dtype=np.float32)
+    _input_type_handler(cursor, arr, 1)
+
+    cursor.var.assert_called_once()
+    assert callable(cursor.var.call_args.kwargs["inconverter"])
+
+
+def test_input_handler_rejects_empty_list() -> None:
+    """Empty list yields ``None`` so JSON / generic handlers can claim it."""
+    from sqlspec.adapters.oracledb._vector_handlers import _input_type_handler  # pyright: ignore[reportPrivateUsage]
+
+    cursor = _mock_cursor()
+
+    assert _input_type_handler(cursor, [], 1) is None
+    cursor.var.assert_not_called()
+
+
+def test_input_handler_rejects_list_of_str() -> None:
+    """A list of strings is not a numeric vector — falls through."""
+    from sqlspec.adapters.oracledb._vector_handlers import _input_type_handler  # pyright: ignore[reportPrivateUsage]
+
+    cursor = _mock_cursor()
+
+    assert _input_type_handler(cursor, ["a", "b"], 1) is None
+    cursor.var.assert_not_called()
+
+
+def test_input_handler_rejects_list_of_bool() -> None:
+    """``bool`` is a subclass of ``int``; the predicate must explicitly reject it."""
+    from sqlspec.adapters.oracledb._vector_handlers import _input_type_handler  # pyright: ignore[reportPrivateUsage]
+
+    cursor = _mock_cursor()
+
+    assert _input_type_handler(cursor, [True, False], 1) is None
+    cursor.var.assert_not_called()
+
+
+def test_input_handler_rejects_list_of_dict() -> None:
+    """``list[dict]`` belongs to the JSON handler, not vectors."""
+    from sqlspec.adapters.oracledb._vector_handlers import _input_type_handler  # pyright: ignore[reportPrivateUsage]
+
+    cursor = _mock_cursor()
+
+    assert _input_type_handler(cursor, [{"a": 1}, {"b": 2}], 1) is None
+    cursor.var.assert_not_called()
+
+
+def test_input_handler_rejects_dict() -> None:
+    """A bare dict is owned by the JSON handler."""
+    from sqlspec.adapters.oracledb._vector_handlers import _input_type_handler  # pyright: ignore[reportPrivateUsage]
+
+    cursor = _mock_cursor()
+
+    assert _input_type_handler(cursor, {"a": 1}, 1) is None
+    cursor.var.assert_not_called()
+
+
+def test_output_handler_returns_none_for_non_vector_column() -> None:
+    """Non-VECTOR columns are not claimed by the vector output handler."""
+    import oracledb
+
+    from sqlspec.adapters.oracledb._vector_handlers import _output_type_handler  # pyright: ignore[reportPrivateUsage]
+
+    cursor = _mock_cursor_with_format("numpy")
+    metadata = _mock_metadata(oracledb.DB_TYPE_VARCHAR)
+
+    assert _output_type_handler(cursor, metadata) is None
+
+
+@pytest.mark.skipif(not NUMPY_INSTALLED, reason="NumPy not installed")
+def test_output_handler_numpy_format_uses_numpy_outconverter() -> None:
+    """``vector_return_format="numpy"`` registers the numpy outconverter."""
+    import oracledb
+
+    from sqlspec.adapters.oracledb._vector_handlers import (
+        _output_type_handler,  # pyright: ignore[reportPrivateUsage]
+        numpy_converter_out,
+    )
+
+    cursor = _mock_cursor_with_format("numpy")
+    cursor.var.return_value = "var-token"
+    metadata = _mock_metadata(oracledb.DB_TYPE_VECTOR)
+
+    result = _output_type_handler(cursor, metadata)
+
+    assert result == "var-token"
+    kwargs = cursor.var.call_args.kwargs
+    assert kwargs["arraysize"] == cursor.arraysize
+    assert kwargs["outconverter"] is numpy_converter_out
+
+
+def test_output_handler_list_format_uses_list_outconverter() -> None:
+    """``vector_return_format="list"`` registers ``list`` as the outconverter."""
+    import oracledb
+
+    from sqlspec.adapters.oracledb._vector_handlers import _output_type_handler  # pyright: ignore[reportPrivateUsage]
+
+    cursor = _mock_cursor_with_format("list")
+    cursor.var.return_value = "var-token"
+    metadata = _mock_metadata(oracledb.DB_TYPE_VECTOR)
+
+    result = _output_type_handler(cursor, metadata)
+
+    assert result == "var-token"
+    kwargs = cursor.var.call_args.kwargs
+    assert kwargs["outconverter"] is list
+
+
+def test_output_handler_array_format_passes_through() -> None:
+    """``vector_return_format="array"`` returns ``None`` (oracledb default)."""
+    import oracledb
+
+    from sqlspec.adapters.oracledb._vector_handlers import _output_type_handler  # pyright: ignore[reportPrivateUsage]
+
+    cursor = _mock_cursor_with_format("array")
+    metadata = _mock_metadata(oracledb.DB_TYPE_VECTOR)
+
+    assert _output_type_handler(cursor, metadata) is None
+    cursor.var.assert_not_called()
+
+
+def test_output_handler_invalid_format_raises_value_error() -> None:
+    """An unknown ``vector_return_format`` raises a clear ``ValueError``."""
+    import oracledb
+
+    from sqlspec.adapters.oracledb._vector_handlers import _output_type_handler  # pyright: ignore[reportPrivateUsage]
+
+    cursor = _mock_cursor_with_format("yaml")
+    metadata = _mock_metadata(oracledb.DB_TYPE_VECTOR)
+
+    with pytest.raises(ValueError, match="Invalid vector_return_format"):
+        _output_type_handler(cursor, metadata)
+
+
+def test_output_handler_numpy_without_numpy_raises_runtime_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``"numpy"`` format with NumPy missing raises a friendly ``RuntimeError``."""
+    import oracledb
+
+    import sqlspec.adapters.oracledb._vector_handlers as vh
+
+    monkeypatch.setattr(vh, "NUMPY_INSTALLED", False)
+
+    cursor = _mock_cursor_with_format("numpy")
+    metadata = _mock_metadata(oracledb.DB_TYPE_VECTOR)
+
+    with pytest.raises(RuntimeError, match="vector_return_format='numpy' requires numpy"):
+        vh._output_type_handler(cursor, metadata)  # pyright: ignore[reportPrivateUsage]
+
+
+def test_output_handler_default_format_when_attr_missing() -> None:
+    """When the connection lacks ``_sqlspec_vector_return_format``, fall back to default."""
+    import oracledb
+
+    from sqlspec.adapters.oracledb._vector_handlers import _output_type_handler  # pyright: ignore[reportPrivateUsage]
+
+    cursor = MagicMock()
+    cursor.arraysize = 100
+    cursor.connection = Mock(spec=[])
+    cursor.var.return_value = "var-token"
+
+    metadata = _mock_metadata(oracledb.DB_TYPE_VECTOR)
+    result = _output_type_handler(cursor, metadata)
+
+    assert result == "var-token"
+    cursor.var.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[manifest]
+overrides = [{ name = "mysql-connector-python", marker = "python_full_version >= '3.12'", specifier = "<9.7.0" }]
+
 [[package]]
 name = "adbc-driver-bigquery"
 version = "1.11.0"
@@ -1454,7 +1457,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -3746,16 +3749,36 @@ wheels = [
 
 [[package]]
 name = "mysql-connector-python"
-version = "9.7.0"
+version = "9.6.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6e/c89babc7de3df01467d159854414659c885152579903a8220c8db02a3835/mysql_connector_python-9.6.0.tar.gz", hash = "sha256:c453bb55347174d87504b534246fb10c589daf5d057515bf615627198a3c7ef1", size = 12254999, upload-time = "2026-02-10T12:04:52.63Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/7b/bfbe1732bdc413fa29d4431e04f257bed32b0f3efe775ca2e70e9d347008/mysql_connector_python-9.7.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:ee90c5f44f706f012be17f03f6ad158ff96e7f2dcc077896fe4537d3d28b3cf4", size = 20265583, upload-time = "2026-04-23T07:15:43.703Z" },
-    { url = "https://files.pythonhosted.org/packages/43/40/cba971fdc54522742955f12d4b019e9f3325d9a5c734abf5f012fde7cfff/mysql_connector_python-9.7.0-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:a2f371ab69d65c61136c51ad7026017400166cef3c959cab7a9fb668c7acbfba", size = 19826949, upload-time = "2026-04-23T07:15:46.443Z" },
-    { url = "https://files.pythonhosted.org/packages/83/5c/724577da77cd33d056ad48d1e29149f6c123371d651c0d824f6bfd2af28f/mysql_connector_python-9.7.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:9bdfc2d4c4444cd1cc79cc6487c047b28fe2b26d0327b27eb9f5737bb553cb5c", size = 21917561, upload-time = "2026-04-23T07:15:49.077Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/40/f0184970f6483a4e5ffcb99028f8402f3789b885872a5779edd3fa53da44/mysql_connector_python-9.7.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6546e0b60c275409a5add9e3308c3897fcf478d1338cd845b1664c1a8946f72f", size = 21687512, upload-time = "2026-04-23T07:15:51.614Z" },
-    { url = "https://files.pythonhosted.org/packages/50/ee/0be8e060376e518897f4b3433e768ccd05bc8bb3d08c436cc2441b44ac0b/mysql_connector_python-9.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:c51be697bfdfdf63bb71c5ecc51f7c6faf4aaa3d14a0136fa16e97cc37df1185", size = 17678391, upload-time = "2026-04-23T07:15:54.626Z" },
-    { url = "https://files.pythonhosted.org/packages/70/fa/babe981ec8c24eece7f47dc52c5e3fe3f126bc99cc80d637b49ac2fe50a4/mysql_connector_python-9.7.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:b5cb8a3ba42b539f79cd13e4c8376d28506f3180f7079c9b04ea7bfd0424fb03", size = 20265659, upload-time = "2026-04-23T07:15:57.375Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/4b/c45b8b601b0270faf1d4384e4c7270af9abb8d95ea39425253217c3c236c/mysql_connector_python-9.7.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:5492d57a6a0e5127a928290737fbb91b66b46d31dac8de3e7604e550bf3b3a6e", size = 19826940, upload-time = "2026-04-23T07:16:00.156Z" },
+    { url = "https://files.pythonhosted.org/packages/16/27/106f5b7a69381c58cb0ba6bf44e6488969ce6cd9f69f62df340f379141ee/mysql_connector_python-9.6.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:478e035ebcf734b3a1497bfd3eb72ce3632da6384545b08cf6329471b3849b6e", size = 17582676, upload-time = "2026-01-21T09:04:35.755Z" },
+    { url = "https://files.pythonhosted.org/packages/17/97/d3cbab27663d7b5063d891c6bd322db6cf1cdb42d4e0d2d2ec9a1952c67f/mysql_connector_python-9.6.0-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:228000bb951810dad724821d04000174ffcc7fa94b4dcef884b17a3cdae07283", size = 18449353, upload-time = "2026-01-21T09:04:38.032Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/9e/0e14e30dddb8f9a5230c6dbce6f874fba2aeaab1ce971dce3912cf81773e/mysql_connector_python-9.6.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:477e86182aefbf693b71ff8bda7679ab4487af64c027759af831a70080aaaeac", size = 34161450, upload-time = "2026-01-21T09:04:40.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/80/1b0012fd86b5a7c0952878e33938ccd4b2862eb882e08a502b99348988d0/mysql_connector_python-9.6.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:4bf932724a2702d8b9cde4bf764b843a35e85c59479a870997d37a2a68a5632d", size = 34533941, upload-time = "2026-01-21T09:04:43.759Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ed/9ff5ff9ea8421ffdf248fa71b9328fd8b9a23e1e3a2a523db5f7d58240c6/mysql_connector_python-9.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:b507372c060eb39e2a10ebcb3eb1b12e1778b0120808062fc23e3856268cd2d9", size = 16515417, upload-time = "2026-01-21T09:04:46.47Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/08/0e9bce000736454c2b8bb4c40bded79328887483689487dad7df4cf59fb7/mysql_connector_python-9.6.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:011931f7392a1087e10d305b0303f2a20cc1af2c1c8a15cd5691609aa95dfcbd", size = 17582646, upload-time = "2026-01-21T09:04:48.327Z" },
+    { url = "https://files.pythonhosted.org/packages/93/aa/3dd4db039fc6a9bcbdbade83be9914ead6786c0be4918170dfaf89327b76/mysql_connector_python-9.6.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:b5212372aff6833473d2560ac87d3df9fb2498d0faacb7ebf231d947175fa36a", size = 18449358, upload-time = "2026-01-21T09:04:50.278Z" },
+    { url = "https://files.pythonhosted.org/packages/53/38/ecd6d35382b6265ff5f030464d53b45e51ff2c2523ab88771c277fd84c05/mysql_connector_python-9.6.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:61deca6e243fafbb3cf08ae27bd0c83d0f8188de8456e46aeba0d3db15bb7230", size = 34169309, upload-time = "2026-01-21T09:04:52.402Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1d/fe1133eb76089342854d8fbe88e28598f7e06bc684a763d21fc7b23f1d5e/mysql_connector_python-9.6.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:adabbc5e1475cdf5fb6f1902a25edc3bd1e0726fa45f01ab1b8f479ff43b3337", size = 34541101, upload-time = "2026-01-21T09:04:55.897Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/99/da0f55beb970ca049fd7d37a6391d686222af89a8b13e636d8e9bbd06536/mysql_connector_python-9.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:8732ca0b7417b45238bcbfc7e64d9c4d62c759672207c6284f0921c366efddc7", size = 16514767, upload-time = "2026-02-10T12:03:50.584Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d9/2a4b4d90b52f4241f0f71618cd4bd8779dd6d18db8058b0a4dd83ec0541c/mysql_connector_python-9.6.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9664e217c72dd6fb700f4c8512af90261f72d2f5d7c00c4e13e4c1e09bfa3d5e", size = 17585672, upload-time = "2026-02-10T12:03:52.955Z" },
+    { url = "https://files.pythonhosted.org/packages/33/91/2495835733a054e716a17dc28404748b33f2dc1da1ae4396fb45574adf40/mysql_connector_python-9.6.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:1ed4b5c4761e5333035293e746683890e4ef2e818e515d14023fd80293bc31fa", size = 18452624, upload-time = "2026-02-10T12:03:56.153Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/69/e83abbbbf7f8eed855b5a5ff7285bc0afb1199418ac036c7691edf41e154/mysql_connector_python-9.6.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5095758dcb89a6bce2379f349da336c268c407129002b595c5dba82ce387e2a5", size = 34169154, upload-time = "2026-02-10T12:03:58.831Z" },
+    { url = "https://files.pythonhosted.org/packages/82/44/67bb61c71f398fbc739d07e8dcadad94e2f655874cb32ae851454066bea0/mysql_connector_python-9.6.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4ae4e7780fad950a4f267dea5851048d160f5b71314a342cdbf30b154f1c74f7", size = 34542947, upload-time = "2026-02-10T12:04:02.408Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/39/994c4f7e9c59d3ca534a831d18442ac4c529865db20aeaa4fd94e2af5efd/mysql_connector_python-9.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:c180e0b4100d7402e03993bfac5c97d18e01d7ca9d198d742fffc245077f8ffe", size = 16515709, upload-time = "2026-02-10T12:04:04.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/58/9521aa678708ec6cebfd40524c14c3d151e4f29e3774e6086aa0a30d203b/mysql_connector_python-9.6.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e86e45a7b540ca09af8a18ecfa761e0cdeccfdb62818331614ec030ae44bfd26", size = 17585837, upload-time = "2026-02-10T12:04:07.004Z" },
+    { url = "https://files.pythonhosted.org/packages/39/8d/b108f9bcce9780f6a1f91decb2af54defdaf845e237ddc42f2b4578f1cd7/mysql_connector_python-9.6.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:8d3e9252384e1b7f95b07020664f2673d9c29c5e95eeda2e048b3331e190b9d4", size = 18452844, upload-time = "2026-02-10T12:04:09.418Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/28/735cd93d16e76dc2feb4abb3f1229a1d9475af34d80c26712fec6abe1d70/mysql_connector_python-9.6.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:0fa18ead33cb699ea92005695077cef09aa494eebf51164ee30c891c3eaea90c", size = 34169374, upload-time = "2026-02-10T12:04:12.13Z" },
+    { url = "https://files.pythonhosted.org/packages/42/07/069983799cf4050c68f61a494f94b06f095fee6026ab0dd863a14de30867/mysql_connector_python-9.6.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a26490cb029bf7b18a1d2093101105b3526a1036b51ad01553d30138f5beb8d2", size = 34543019, upload-time = "2026-02-10T12:04:15.065Z" },
+    { url = "https://files.pythonhosted.org/packages/32/00/fbeb7d666ab8153f719e620bac5abfbc74640e8ec511612493110a75fe66/mysql_connector_python-9.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:3460ed976e1b88b7284335d9397a3c519dff56d71580ca1f76ff1c0c7714c813", size = 16515701, upload-time = "2026-02-10T12:04:19.26Z" },
+    { url = "https://files.pythonhosted.org/packages/70/51/13cc90b2a703784cd9a0aa0a6fce07946cf6a2abe7c8fd0b585562e250fc/mysql_connector_python-9.6.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e2cc13cd3dcdb845d636e52c4e7a9509b63da09bec6ce1b3696be53a79847e2d", size = 17585800, upload-time = "2026-02-10T12:04:21.6Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/6b/ce7ab998fbdd17f35a1b54624365d039045cbb2d42bbc7b03f50d7597c7b/mysql_connector_python-9.6.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:a08c2149d4b52a010c4353f18c84716d18114a4ecd00b466ea34138de2c640f2", size = 18452823, upload-time = "2026-02-10T12:04:23.995Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/8157ed61d17878c33511dcb97c68ecaaaf6220bea5a2944ea4eba73cc63a/mysql_connector_python-9.6.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:b00228b985edd208b20f45c5e684c54e08e31e01bc1d8c3c18a36641c3be5bf7", size = 34171594, upload-time = "2026-02-10T12:04:27.401Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/06/5efdd28819afdb9f1487a62842fda4277febe128a3cd6e9090dbe0a6524e/mysql_connector_python-9.6.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4617ef5216da7ca32dd46afda61a1552807762434127413bba46fbe4379f59d4", size = 34542851, upload-time = "2026-02-10T12:04:31.021Z" },
+    { url = "https://files.pythonhosted.org/packages/40/6a/26e08a4a79f159cd8e5b64eb10bd056e7735b65d4464d98641f59eb9ca3a/mysql_connector_python-9.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:bc782f64ca00b6b933d4c6a35568f1349d115cc4434c849b5b9edc015bee3e62", size = 17002947, upload-time = "2026-02-10T12:04:34.386Z" },
+    { url = "https://files.pythonhosted.org/packages/15/dd/b3250826c29cee7816de4409a2fe5e469a68b9a89f6bfaa5eed74f05532c/mysql_connector_python-9.6.0-py2.py3-none-any.whl", hash = "sha256:44b0fb57207ebc6ae05b5b21b7968a9ed33b29187fe87b38951bad2a334d75d5", size = 480527, upload-time = "2026-02-10T12:04:36.176Z" },
 ]
 
 [[package]]
@@ -5678,7 +5701,7 @@ minio = [
     { name = "minio" },
 ]
 mysql = [
-    { name = "mysql-connector-python" },
+    { name = "mysql-connector-python", marker = "python_full_version >= '3.12'" },
 ]
 oracle = [
     { name = "oracledb" },
@@ -6970,7 +6993,7 @@ mypyc = [
     { name = "sqlglot", extra = ["c"] },
 ]
 mysql-connector = [
-    { name = "mysql-connector-python" },
+    { name = "mysql-connector-python", marker = "python_full_version >= '3.12'" },
 ]
 nanoid = [
     { name = "fastnanoid" },
@@ -7220,7 +7243,8 @@ requires-dist = [
     { name = "msgspec", marker = "extra == 'msgspec'" },
     { name = "msgspec", marker = "extra == 'performance'" },
     { name = "mypy-extensions" },
-    { name = "mysql-connector-python", marker = "extra == 'mysql-connector'" },
+    { name = "mysql-connector-python", marker = "python_full_version >= '3.12' and extra == 'mysql-connector'", specifier = "<9.7.0" },
+    { name = "mysql-connector-python", marker = "python_full_version < '3.12' and extra == 'mysql-connector'" },
     { name = "obstore", marker = "extra == 'obstore'" },
     { name = "opentelemetry-instrumentation", marker = "extra == 'opentelemetry'" },
     { name = "oracledb", marker = "extra == 'oracledb'" },

--- a/uv.lock
+++ b/uv.lock
@@ -962,7 +962,7 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "7.13.0"
+version = "7.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boltons" },
@@ -975,9 +975,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/3b/61fab1784a949eec5337cfd45ceb12f87d12757d0cffac850b50cafc269e/click_extra-7.13.0.tar.gz", hash = "sha256:52b27d746e8254c93320cc463750f376aea45aa61bd0de9a45412f471e54f63e", size = 138062, upload-time = "2026-04-16T16:09:40.328Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/44/e8200fc42682c544c4597f4674910fad1358af63c5b6d45bf89d20a18708/click_extra-7.14.0.tar.gz", hash = "sha256:7e2f83aa631219bcff414208e20bd23d3f1bf92802e2820b3c49a9a87fa5f771", size = 144761, upload-time = "2026-04-24T13:35:04.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/0b/af0f24dfd34ddb2f77c8164ba47b1a8f4a3e6a84ce8d41a414145ca7502d/click_extra-7.13.0-py3-none-any.whl", hash = "sha256:a7abe62dd3c045e4299692e2fe77a274244d46a2b327980b543e45b3dd540e9e", size = 151712, upload-time = "2026-04-16T16:09:38.712Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/50/f5159c0fe0a59b7ad8c1fb12e4133e2b073bc99778d19ab9b111378117d4/click_extra-7.14.0-py3-none-any.whl", hash = "sha256:3aaa50566d44db263db3aed02552c89950b1d09f01df300c041907bcf29882e6", size = 159274, upload-time = "2026-04-24T13:35:05.95Z" },
 ]
 
 [package.optional-dependencies]
@@ -1179,62 +1179,62 @@ toml = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.7"
+version = "47.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb", size = 830863, upload-time = "2026-04-24T19:54:57.056Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
-    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
-    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
-    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
-    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
-    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
-    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
-    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
-    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
-    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
-    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
-    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
-    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
-    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
-    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
-    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
-    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
-    { url = "https://files.pythonhosted.org/packages/63/0c/dca8abb64e7ca4f6b2978769f6fea5ad06686a190cec381f0a796fdcaaba/cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f", size = 3476879, upload-time = "2026-04-08T01:57:38.664Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/ea/075aac6a84b7c271578d81a2f9968acb6e273002408729f2ddff517fed4a/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15", size = 4219700, upload-time = "2026-04-08T01:57:40.625Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/7b/1c55db7242b5e5612b29fc7a630e91ee7a6e3c8e7bf5406d22e206875fbd/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455", size = 4385982, upload-time = "2026-04-08T01:57:42.725Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/da/9870eec4b69c63ef5925bf7d8342b7e13bc2ee3d47791461c4e49ca212f4/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65", size = 4219115, upload-time = "2026-04-08T01:57:44.939Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/72/05aa5832b82dd341969e9a734d1812a6aadb088d9eb6f0430fc337cc5a8f/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968", size = 4385479, upload-time = "2026-04-08T01:57:46.86Z" },
-    { url = "https://files.pythonhosted.org/packages/20/2a/1b016902351a523aa2bd446b50a5bc1175d7a7d1cf90fe2ef904f9b84ebc/cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4", size = 3412829, upload-time = "2026-04-08T01:57:48.874Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/98/40dfe932134bdcae4f6ab5927c87488754bf9eb79297d7e0070b78dd58e9/cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0", size = 7912214, upload-time = "2026-04-24T19:53:03.864Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c6/2733531243fba725f58611b918056b277692f1033373dcc8bd01af1c05d4/cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973", size = 4644617, upload-time = "2026-04-24T19:53:06.909Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/b27be1a670a9b87f855d211cf0e1174a5d721216b7616bd52d8581d912ed/cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8", size = 4668186, upload-time = "2026-04-24T19:53:09.053Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b9/8443cfe5d17d482d348cee7048acf502bb89a51b6382f06240fd290d4ca3/cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b", size = 4651244, upload-time = "2026-04-24T19:53:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5e/13ed0cdd0eb88ba159d6dd5ebfece8cb901dbcf1ae5ac4072e28b55d3153/cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92", size = 5252906, upload-time = "2026-04-24T19:53:13.532Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/ed058e1df0f33d440217cd120d41d5dda9dd215a80b8187f68483185af82/cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7", size = 4701842, upload-time = "2026-04-24T19:53:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3d30986b30fdbd9e969abbdf8ba00ed0618615144341faeb57f395a084fe/cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93", size = 4289313, upload-time = "2026-04-24T19:53:17.755Z" },
+    { url = "https://files.pythonhosted.org/packages/df/fd/32db38e3ad0cb331f0691cb4c7a8a6f176f679124dee746b3af6633db4d9/cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac", size = 4650964, upload-time = "2026-04-24T19:53:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/86/53/5395d944dfd48cb1f67917f533c609c34347185ef15eb4308024c876f274/cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f", size = 5207817, upload-time = "2026-04-24T19:53:22.498Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4f/e5711b28e1901f7d480a2b1b688b645aa4c77c73f10731ed17e7f7db3f0d/cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8", size = 4701544, upload-time = "2026-04-24T19:53:24.356Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/c8ddc25de3010fc8da447648f5a092c40e7a8fadf01dd6d255d9c0b9373d/cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318", size = 4783536, upload-time = "2026-04-24T19:53:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b6/d4a68f4ea999c6d89e8498579cba1c5fcba4276284de7773b17e4fa69293/cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001", size = 4926106, upload-time = "2026-04-24T19:53:28.686Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ed/5f524db1fade9c013aa618e1c99c6ed05e8ffc9ceee6cda22fed22dda3f4/cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203", size = 3258581, upload-time = "2026-04-24T19:53:31.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dc/1b901990b174786569029f67542b3edf72ac068b6c3c8683c17e6a2f5363/cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa", size = 3775309, upload-time = "2026-04-24T19:53:33.054Z" },
+    { url = "https://files.pythonhosted.org/packages/14/88/7aa18ad9c11bc87689affa5ce4368d884b517502d75739d475fc6f4a03c7/cryptography-47.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:be12cb6a204f77ed968bcefe68086eb061695b540a3dd05edac507a3111b25f0", size = 7904299, upload-time = "2026-04-24T19:53:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/07/55/c18f75724544872f234678fdedc871391722cb34a2aee19faa9f63100bb2/cryptography-47.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2ebd84adf0728c039a3be2700289378e1c164afc6748df1a5ed456767bef9ba7", size = 4631180, upload-time = "2026-04-24T19:53:37.517Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/65/31a5cc0eaca99cec5bafffe155d407115d96136bb161e8b49e0ef73f09a7/cryptography-47.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f68d6fbc7fbbcfb0939fea72c3b96a9f9a6edfc0e1b1d29778a2066030418b1", size = 4653529, upload-time = "2026-04-24T19:53:39.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/bc/641c0519a495f3bfd0421b48d7cd325c4336578523ccd76ea322b6c29c7a/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:6651d32eff255423503aa276739da98c30f26c40cbeffcc6048e0d54ef704c0c", size = 4638570, upload-time = "2026-04-24T19:53:42.129Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f2/300327b0a47f6dc94dd8b71b57052aefe178bb51745073d73d80604f11ab/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3fb8fa48075fad7193f2e5496135c6a76ac4b2aa5a38433df0a539296b377829", size = 5238019, upload-time = "2026-04-24T19:53:44.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/5b5cf994391d4bf9d9c7efd4c66aabe4d95227256627f8fea6cff7dfadbd/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11438c7518132d95f354fa01a4aa2f806d172a061a7bed18cf18cbdacdb204d7", size = 4686832, upload-time = "2026-04-24T19:53:47.015Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2c/ae950e28fd6475c852fc21a44db3e6b5bcc1261d1e370f2b6e42fa800fef/cryptography-47.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8c1a736bbb3288005796c3f7ccb9453360d7fed483b13b9f468aea5171432923", size = 4269301, upload-time = "2026-04-24T19:53:48.97Z" },
+    { url = "https://files.pythonhosted.org/packages/67/fb/6a39782e150ffe5cc1b0018cb6ddc48bf7ca62b498d7539ffc8a758e977d/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:f1557695e5c2b86e204f6ce9470497848634100787935ab7adc5397c54abd7ab", size = 4638110, upload-time = "2026-04-24T19:53:51.011Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d7/0b3c71090a76e5c203164a47688b697635ece006dcd2499ab3a4dbd3f0bd/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:f9a034b642b960767fb343766ae5ba6ad653f2e890ddd82955aef288ffea8736", size = 5194988, upload-time = "2026-04-24T19:53:52.962Z" },
+    { url = "https://files.pythonhosted.org/packages/63/33/63a961498a9df51721ab578c5a2622661411fc520e00bd83b0cc64eb20c4/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b1c76fca783aa7698eb21eb14f9c4aa09452248ee54a627d125025a43f83e7a7", size = 4686563, upload-time = "2026-04-24T19:53:55.274Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/5ee5b145248f92250de86145d1c1d6edebbd57a7fe7caa4dedb5d4cf06a1/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4f7722c97826770bab8ae92959a2e7b20a5e9e9bf4deae68fd86c3ca457bab52", size = 4770094, upload-time = "2026-04-24T19:53:57.753Z" },
+    { url = "https://files.pythonhosted.org/packages/92/43/21d220b2da5d517773894dacdcdb5c682c28d3fffce65548cb06e87d5501/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:09f6d7bf6724f8db8b32f11eccf23efc8e759924bc5603800335cf8859a3ddbd", size = 4913811, upload-time = "2026-04-24T19:54:00.236Z" },
+    { url = "https://files.pythonhosted.org/packages/31/98/dc4ad376ac5f1a1a7d4a83f7b0c6f2bcad36b5d2d8f30aeb482d3a7d9582/cryptography-47.0.0-cp314-cp314t-win32.whl", hash = "sha256:6eebcaf0df1d21ce1f90605c9b432dd2c4f4ab665ac29a40d5e3fc68f51b5e63", size = 3237158, upload-time = "2026-04-24T19:54:02.606Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/da/97f62d18306b5133468bc3f8cc73a3111e8cdc8cf8d3e69474d6e5fd2d1b/cryptography-47.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:51c9313e90bd1690ec5a75ed047c27c0b8e6c570029712943d6116ef9a90620b", size = 3758706, upload-time = "2026-04-24T19:54:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/34/a4fae8ae7c3bc227460c9ae43f56abf1b911da0ec29e0ebac53bb0a4b6b7/cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4", size = 7904072, upload-time = "2026-04-24T19:54:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/01/64/d7b1e54fdb69f22d24a64bb3e88dc718b31c7fb10ef0b9691a3cf7eeea6e/cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27", size = 4635767, upload-time = "2026-04-24T19:54:08.519Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/7b/cca826391fb2a94efdcdfe4631eb69306ee1cff0b22f664a412c90713877/cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10", size = 4654350, upload-time = "2026-04-24T19:54:10.795Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/4b57bcc823f42a991627c51c2f68c9fd6eb1393c1756aac876cba2accae2/cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b", size = 4643394, upload-time = "2026-04-24T19:54:13.275Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/2c5fbeea70adbbca2bbae865e1d605d6a4a7f8dbd9d33eaf69645087f06c/cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74", size = 5225777, upload-time = "2026-04-24T19:54:15.18Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/b8/ac57107ef32749d2b244e36069bb688792a363aaaa3acc9e3cf84c130315/cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515", size = 4688771, upload-time = "2026-04-24T19:54:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fc/9f1de22ff8be99d991f240a46863c52d475404c408886c5a38d2b5c3bb26/cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc", size = 4270753, upload-time = "2026-04-24T19:54:19.963Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/d70c852797aa68e8e48d12e5a87170c43f67bb4a59403627259dd57d15de/cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca", size = 4642911, upload-time = "2026-04-24T19:54:21.818Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/51/661cbee74f594c5d97ff82d34f10d5551c085ca4668645f4606ebd22bd5d/cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76", size = 5181411, upload-time = "2026-04-24T19:54:24.376Z" },
+    { url = "https://files.pythonhosted.org/packages/94/87/f2b6c374a82cf076cfa1416992ac8e8ec94d79facc37aec87c1a5cb72352/cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe", size = 4688262, upload-time = "2026-04-24T19:54:26.946Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/8b7462f4acf21ec509616f0245018bb197194ab0b65c2ea21a0bdd53c0eb/cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31", size = 4775506, upload-time = "2026-04-24T19:54:28.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/75/158e494e4c08dc05e039da5bb48553826bd26c23930cf8d3cd5f21fa8921/cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7", size = 4912060, upload-time = "2026-04-24T19:54:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bd/0a9d3edbf5eadbac926d7b9b3cd0c4be584eeeae4a003d24d9eda4affbbd/cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310", size = 3248487, upload-time = "2026-04-24T19:54:33.494Z" },
+    { url = "https://files.pythonhosted.org/packages/60/80/5681af756d0da3a599b7bdb586fac5a1540f1bcefd2717a20e611ddade45/cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769", size = 3755737, upload-time = "2026-04-24T19:54:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a0/928c9ce0d120a40a81aa99e3ba383e87337b9ac9ef9f6db02e4d7822424d/cryptography-47.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:7f1207974a904e005f762869996cf620e9bf79ecb4622f148550bb48e0eb35a7", size = 3909893, upload-time = "2026-04-24T19:54:38.334Z" },
+    { url = "https://files.pythonhosted.org/packages/81/75/d691e284750df5d9569f2b1ce4a00a71e1d79566da83b2b3e5549c84917f/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:1a405c08857258c11016777e11c02bacbe7ef596faf259305d282272a3a05cbe", size = 4587867, upload-time = "2026-04-24T19:54:40.619Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d6/1b90f1a4e453009730b4545286f0b39bb348d805c11181fc31544e4f9a65/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:20fdbe3e38fb67c385d233c89371fa27f9909f6ebca1cecc20c13518dae65475", size = 4627192, upload-time = "2026-04-24T19:54:42.849Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/53/cb358a80e9e359529f496870dd08c102aa8a4b5b9f9064f00f0d6ed5b527/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:f7db373287273d8af1414cf95dc4118b13ffdc62be521997b0f2b270771fef50", size = 4587486, upload-time = "2026-04-24T19:54:44.908Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/57/aaa3d53876467a226f9a7a82fd14dd48058ad2de1948493442dfa16e2ffd/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:9fe6b7c64926c765f9dff301f9c1b867febcda5768868ca084e18589113732ab", size = 4626327, upload-time = "2026-04-24T19:54:47.813Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/9c/51f28c3550276bcf35660703ba0ab829a90b88be8cd98a71ef23c2413913/cryptography-47.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cffbba3392df0fa8629bb7f43454ee2925059ee158e23c54620b9063912b86c8", size = 3698916, upload-time = "2026-04-24T19:54:49.782Z" },
 ]
 
 [[package]]
@@ -1295,14 +1295,14 @@ wheels = [
 
 [[package]]
 name = "dishka"
-version = "1.10.0"
+version = "1.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/82/f0b47d43ed57a071b86122c941769f9a822dfbd0ba01448a0b5da1a2f2a6/dishka-1.10.0.tar.gz", hash = "sha256:cb4f2603e05195f352a8d2f0eff1ea726a3b51a6310586d5d6d8fd55e9b02ef4", size = 281742, upload-time = "2026-04-18T21:27:04.829Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/da/b75b5fe665d16725e1d46e291c8dd4b0ed1731c7964f41087fda92f03d40/dishka-1.10.1.tar.gz", hash = "sha256:51fb624b9acc948b90f57128460061d1f3a1780121fe1c7d14c565e8bbff2083", size = 282008, upload-time = "2026-04-25T12:07:57.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/15/75f92305d907677d56b337589e11e1897259a1f9f61ff4b1eeebfff98492/dishka-1.10.0-py3-none-any.whl", hash = "sha256:a490fee102ee52123058f52c65b78d240fa1d95533ad7dbc271bf3eba394ebeb", size = 119836, upload-time = "2026-04-18T21:27:03.354Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/08/dd3259a319ba45c48d975caf237c830c7873a203288cb4ab186cc5bef585/dishka-1.10.1-py3-none-any.whl", hash = "sha256:84f40c1115eb391ce3fb558fd7946c5bcaf6361c35b77b7a185b7697a5720ec7", size = 120062, upload-time = "2026-04-25T12:07:59.153Z" },
 ]
 
 [[package]]
@@ -1454,7 +1454,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1481,11 +1481,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "11.1.0"
+version = "12.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/7b/0049f8a7817ac4eb6ad1af72c7938fff3e2677d55468c87de792208e068c/extra_platforms-11.1.0.tar.gz", hash = "sha256:3045d722cab2b422a8fcbcba7f52026c33523cb147616d99fc50947f8e952375", size = 69265, upload-time = "2026-04-21T08:28:21.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/56/068be906510dae5dec901a46efa0dcf2aee7f5640af0f0ea770f8c9710ca/extra_platforms-12.0.0.tar.gz", hash = "sha256:bfa32f5b17e810f6f97e35045db4245e6c9c45c87a9f27101f44d795e46042da", size = 72090, upload-time = "2026-04-24T12:49:18.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/75/5985d4b10248cc03f5d0ef03026f3cc69a427baa77b6b07fe26a674bba1a/extra_platforms-11.1.0-py3-none-any.whl", hash = "sha256:5d4476774e5d639813060c239b40481a714f785515db66bcbb19a7b3881debc1", size = 72560, upload-time = "2026-04-21T08:28:20.216Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/4f/8e3562108157fe9bc6160a73019532bb57090e4194a07d6f3ac6ef2d10ba/extra_platforms-12.0.0-py3-none-any.whl", hash = "sha256:5f6d0abad22cc3bea0f32bf8aa62a6a106e38203bb4c7c19989e56a61b542b52", size = 75347, upload-time = "2026-04-24T12:49:19.94Z" },
 ]
 
 [[package]]
@@ -1502,7 +1502,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.0"
+version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1511,9 +1511,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/d9/e66315807e41e69e7f6a1b42a162dada2f249c5f06ad3f1a95f84ab336ef/fastapi-0.136.0.tar.gz", hash = "sha256:cf08e067cc66e106e102d9ba659463abfac245200752f8a5b7b1e813de4ff73e", size = 396607, upload-time = "2026-04-16T11:47:13.623Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/a3/0bd5f0cdb0bbc92650e8dc457e9250358411ee5d1b65e42b6632387daf81/fastapi-0.136.0-py3-none-any.whl", hash = "sha256:8793d44ec7378e2be07f8a013cf7f7aa47d6327d0dfe9804862688ec4541a6b4", size = 117556, upload-time = "2026-04-16T11:47:11.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [[package]]
@@ -2755,8 +2755,7 @@ dependencies = [
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "ipython", version = "9.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jupyter-client" },
     { name = "jupyter-core" },
     { name = "matplotlib-inline" },
@@ -2799,34 +2798,7 @@ wheels = [
 
 [[package]]
 name = "ipython"
-version = "9.10.1"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version == '3.11.*'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version == '3.11.*'" },
-    { name = "jedi", marker = "python_full_version == '3.11.*'" },
-    { name = "matplotlib-inline", marker = "python_full_version == '3.11.*'" },
-    { name = "pexpect", marker = "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "stack-data", marker = "python_full_version == '3.11.*'" },
-    { name = "traitlets", marker = "python_full_version == '3.11.*'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/25/daae0e764047b0a2480c7bbb25d48f4f509b5818636562eeac145d06dfee/ipython-9.10.1.tar.gz", hash = "sha256:e170e9b2a44312484415bdb750492699bf329233b03f2557a9692cce6466ada4", size = 4426663, upload-time = "2026-03-27T09:53:26.244Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/09/ba70f8d662d5671687da55ad2cc0064cf795b15e1eea70907532202e7c97/ipython-9.10.1-py3-none-any.whl", hash = "sha256:82d18ae9fb9164ded080c71ef92a182ee35ee7db2395f67616034bebb020a232", size = 622827, upload-time = "2026-03-27T09:53:24.566Z" },
-]
-
-[[package]]
-name = "ipython"
-version = "9.12.0"
+version = "9.13.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -2837,26 +2809,31 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "psutil", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3a/73/7114f80a8f9cabdb13c27732dce24af945b2923dcab80723602f7c8bc2d8/ipython-9.12.0.tar.gz", hash = "sha256:01daa83f504b693ba523b5a407246cabde4eb4513285a3c6acaff11a66735ee4", size = 4428879, upload-time = "2026-03-27T09:42:45.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/22/906c8108974c673ebef6356c506cebb6870d48cedea3c41e949e2dd556bb/ipython-9.12.0-py3-none-any.whl", hash = "sha256:0f2701e8ee86e117e37f50563205d36feaa259d2e08d4a6bc6b6d74b18ce128d", size = 625661, upload-time = "2026-03-27T09:42:42.831Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/86/3060e8029b7cc505cce9a0137431dda81d0a3fde93a8f0f50ee0bf37a795/ipython-9.13.0-py3-none-any.whl", hash = "sha256:57f9d4639e20818d328d287c7b549af3d05f12486ea8f2e7f73e52a36ec4d201", size = 627274, upload-time = "2026-04-24T12:24:53.038Z" },
 ]
 
 [[package]]
@@ -2878,8 +2855,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "comm" },
     { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "ipython", version = "9.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jupyterlab-widgets" },
     { name = "traitlets" },
     { name = "widgetsnbextension" },
@@ -3006,8 +2982,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ipykernel" },
     { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "ipython", version = "9.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "ipython", version = "9.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "ipython", version = "9.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "ipywidgets" },
     { name = "nbconvert" },
     { name = "nbformat" },
@@ -3771,36 +3746,16 @@ wheels = [
 
 [[package]]
 name = "mysql-connector-python"
-version = "9.6.0"
+version = "9.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6e/c89babc7de3df01467d159854414659c885152579903a8220c8db02a3835/mysql_connector_python-9.6.0.tar.gz", hash = "sha256:c453bb55347174d87504b534246fb10c589daf5d057515bf615627198a3c7ef1", size = 12254999, upload-time = "2026-02-10T12:04:52.63Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/27/106f5b7a69381c58cb0ba6bf44e6488969ce6cd9f69f62df340f379141ee/mysql_connector_python-9.6.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:478e035ebcf734b3a1497bfd3eb72ce3632da6384545b08cf6329471b3849b6e", size = 17582676, upload-time = "2026-01-21T09:04:35.755Z" },
-    { url = "https://files.pythonhosted.org/packages/17/97/d3cbab27663d7b5063d891c6bd322db6cf1cdb42d4e0d2d2ec9a1952c67f/mysql_connector_python-9.6.0-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:228000bb951810dad724821d04000174ffcc7fa94b4dcef884b17a3cdae07283", size = 18449353, upload-time = "2026-01-21T09:04:38.032Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/9e/0e14e30dddb8f9a5230c6dbce6f874fba2aeaab1ce971dce3912cf81773e/mysql_connector_python-9.6.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:477e86182aefbf693b71ff8bda7679ab4487af64c027759af831a70080aaaeac", size = 34161450, upload-time = "2026-01-21T09:04:40.763Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/80/1b0012fd86b5a7c0952878e33938ccd4b2862eb882e08a502b99348988d0/mysql_connector_python-9.6.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:4bf932724a2702d8b9cde4bf764b843a35e85c59479a870997d37a2a68a5632d", size = 34533941, upload-time = "2026-01-21T09:04:43.759Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/ed/9ff5ff9ea8421ffdf248fa71b9328fd8b9a23e1e3a2a523db5f7d58240c6/mysql_connector_python-9.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:b507372c060eb39e2a10ebcb3eb1b12e1778b0120808062fc23e3856268cd2d9", size = 16515417, upload-time = "2026-01-21T09:04:46.47Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/08/0e9bce000736454c2b8bb4c40bded79328887483689487dad7df4cf59fb7/mysql_connector_python-9.6.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:011931f7392a1087e10d305b0303f2a20cc1af2c1c8a15cd5691609aa95dfcbd", size = 17582646, upload-time = "2026-01-21T09:04:48.327Z" },
-    { url = "https://files.pythonhosted.org/packages/93/aa/3dd4db039fc6a9bcbdbade83be9914ead6786c0be4918170dfaf89327b76/mysql_connector_python-9.6.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:b5212372aff6833473d2560ac87d3df9fb2498d0faacb7ebf231d947175fa36a", size = 18449358, upload-time = "2026-01-21T09:04:50.278Z" },
-    { url = "https://files.pythonhosted.org/packages/53/38/ecd6d35382b6265ff5f030464d53b45e51ff2c2523ab88771c277fd84c05/mysql_connector_python-9.6.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:61deca6e243fafbb3cf08ae27bd0c83d0f8188de8456e46aeba0d3db15bb7230", size = 34169309, upload-time = "2026-01-21T09:04:52.402Z" },
-    { url = "https://files.pythonhosted.org/packages/18/1d/fe1133eb76089342854d8fbe88e28598f7e06bc684a763d21fc7b23f1d5e/mysql_connector_python-9.6.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:adabbc5e1475cdf5fb6f1902a25edc3bd1e0726fa45f01ab1b8f479ff43b3337", size = 34541101, upload-time = "2026-01-21T09:04:55.897Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/99/da0f55beb970ca049fd7d37a6391d686222af89a8b13e636d8e9bbd06536/mysql_connector_python-9.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:8732ca0b7417b45238bcbfc7e64d9c4d62c759672207c6284f0921c366efddc7", size = 16514767, upload-time = "2026-02-10T12:03:50.584Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/d9/2a4b4d90b52f4241f0f71618cd4bd8779dd6d18db8058b0a4dd83ec0541c/mysql_connector_python-9.6.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9664e217c72dd6fb700f4c8512af90261f72d2f5d7c00c4e13e4c1e09bfa3d5e", size = 17585672, upload-time = "2026-02-10T12:03:52.955Z" },
-    { url = "https://files.pythonhosted.org/packages/33/91/2495835733a054e716a17dc28404748b33f2dc1da1ae4396fb45574adf40/mysql_connector_python-9.6.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:1ed4b5c4761e5333035293e746683890e4ef2e818e515d14023fd80293bc31fa", size = 18452624, upload-time = "2026-02-10T12:03:56.153Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/69/e83abbbbf7f8eed855b5a5ff7285bc0afb1199418ac036c7691edf41e154/mysql_connector_python-9.6.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5095758dcb89a6bce2379f349da336c268c407129002b595c5dba82ce387e2a5", size = 34169154, upload-time = "2026-02-10T12:03:58.831Z" },
-    { url = "https://files.pythonhosted.org/packages/82/44/67bb61c71f398fbc739d07e8dcadad94e2f655874cb32ae851454066bea0/mysql_connector_python-9.6.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4ae4e7780fad950a4f267dea5851048d160f5b71314a342cdbf30b154f1c74f7", size = 34542947, upload-time = "2026-02-10T12:04:02.408Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/39/994c4f7e9c59d3ca534a831d18442ac4c529865db20aeaa4fd94e2af5efd/mysql_connector_python-9.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:c180e0b4100d7402e03993bfac5c97d18e01d7ca9d198d742fffc245077f8ffe", size = 16515709, upload-time = "2026-02-10T12:04:04.924Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/58/9521aa678708ec6cebfd40524c14c3d151e4f29e3774e6086aa0a30d203b/mysql_connector_python-9.6.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e86e45a7b540ca09af8a18ecfa761e0cdeccfdb62818331614ec030ae44bfd26", size = 17585837, upload-time = "2026-02-10T12:04:07.004Z" },
-    { url = "https://files.pythonhosted.org/packages/39/8d/b108f9bcce9780f6a1f91decb2af54defdaf845e237ddc42f2b4578f1cd7/mysql_connector_python-9.6.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:8d3e9252384e1b7f95b07020664f2673d9c29c5e95eeda2e048b3331e190b9d4", size = 18452844, upload-time = "2026-02-10T12:04:09.418Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/28/735cd93d16e76dc2feb4abb3f1229a1d9475af34d80c26712fec6abe1d70/mysql_connector_python-9.6.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:0fa18ead33cb699ea92005695077cef09aa494eebf51164ee30c891c3eaea90c", size = 34169374, upload-time = "2026-02-10T12:04:12.13Z" },
-    { url = "https://files.pythonhosted.org/packages/42/07/069983799cf4050c68f61a494f94b06f095fee6026ab0dd863a14de30867/mysql_connector_python-9.6.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a26490cb029bf7b18a1d2093101105b3526a1036b51ad01553d30138f5beb8d2", size = 34543019, upload-time = "2026-02-10T12:04:15.065Z" },
-    { url = "https://files.pythonhosted.org/packages/32/00/fbeb7d666ab8153f719e620bac5abfbc74640e8ec511612493110a75fe66/mysql_connector_python-9.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:3460ed976e1b88b7284335d9397a3c519dff56d71580ca1f76ff1c0c7714c813", size = 16515701, upload-time = "2026-02-10T12:04:19.26Z" },
-    { url = "https://files.pythonhosted.org/packages/70/51/13cc90b2a703784cd9a0aa0a6fce07946cf6a2abe7c8fd0b585562e250fc/mysql_connector_python-9.6.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e2cc13cd3dcdb845d636e52c4e7a9509b63da09bec6ce1b3696be53a79847e2d", size = 17585800, upload-time = "2026-02-10T12:04:21.6Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/6b/ce7ab998fbdd17f35a1b54624365d039045cbb2d42bbc7b03f50d7597c7b/mysql_connector_python-9.6.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:a08c2149d4b52a010c4353f18c84716d18114a4ecd00b466ea34138de2c640f2", size = 18452823, upload-time = "2026-02-10T12:04:23.995Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/bf/8157ed61d17878c33511dcb97c68ecaaaf6220bea5a2944ea4eba73cc63a/mysql_connector_python-9.6.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:b00228b985edd208b20f45c5e684c54e08e31e01bc1d8c3c18a36641c3be5bf7", size = 34171594, upload-time = "2026-02-10T12:04:27.401Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/06/5efdd28819afdb9f1487a62842fda4277febe128a3cd6e9090dbe0a6524e/mysql_connector_python-9.6.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4617ef5216da7ca32dd46afda61a1552807762434127413bba46fbe4379f59d4", size = 34542851, upload-time = "2026-02-10T12:04:31.021Z" },
-    { url = "https://files.pythonhosted.org/packages/40/6a/26e08a4a79f159cd8e5b64eb10bd056e7735b65d4464d98641f59eb9ca3a/mysql_connector_python-9.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:bc782f64ca00b6b933d4c6a35568f1349d115cc4434c849b5b9edc015bee3e62", size = 17002947, upload-time = "2026-02-10T12:04:34.386Z" },
-    { url = "https://files.pythonhosted.org/packages/15/dd/b3250826c29cee7816de4409a2fe5e469a68b9a89f6bfaa5eed74f05532c/mysql_connector_python-9.6.0-py2.py3-none-any.whl", hash = "sha256:44b0fb57207ebc6ae05b5b21b7968a9ed33b29187fe87b38951bad2a334d75d5", size = 480527, upload-time = "2026-02-10T12:04:36.176Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/7b/bfbe1732bdc413fa29d4431e04f257bed32b0f3efe775ca2e70e9d347008/mysql_connector_python-9.7.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:ee90c5f44f706f012be17f03f6ad158ff96e7f2dcc077896fe4537d3d28b3cf4", size = 20265583, upload-time = "2026-04-23T07:15:43.703Z" },
+    { url = "https://files.pythonhosted.org/packages/43/40/cba971fdc54522742955f12d4b019e9f3325d9a5c734abf5f012fde7cfff/mysql_connector_python-9.7.0-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:a2f371ab69d65c61136c51ad7026017400166cef3c959cab7a9fb668c7acbfba", size = 19826949, upload-time = "2026-04-23T07:15:46.443Z" },
+    { url = "https://files.pythonhosted.org/packages/83/5c/724577da77cd33d056ad48d1e29149f6c123371d651c0d824f6bfd2af28f/mysql_connector_python-9.7.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:9bdfc2d4c4444cd1cc79cc6487c047b28fe2b26d0327b27eb9f5737bb553cb5c", size = 21917561, upload-time = "2026-04-23T07:15:49.077Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/40/f0184970f6483a4e5ffcb99028f8402f3789b885872a5779edd3fa53da44/mysql_connector_python-9.7.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6546e0b60c275409a5add9e3308c3897fcf478d1338cd845b1664c1a8946f72f", size = 21687512, upload-time = "2026-04-23T07:15:51.614Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ee/0be8e060376e518897f4b3433e768ccd05bc8bb3d08c436cc2441b44ac0b/mysql_connector_python-9.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:c51be697bfdfdf63bb71c5ecc51f7c6faf4aaa3d14a0136fa16e97cc37df1185", size = 17678391, upload-time = "2026-04-23T07:15:54.626Z" },
+    { url = "https://files.pythonhosted.org/packages/70/fa/babe981ec8c24eece7f47dc52c5e3fe3f126bc99cc80d637b49ac2fe50a4/mysql_connector_python-9.7.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:b5cb8a3ba42b539f79cd13e4c8376d28506f3180f7079c9b04ea7bfd0424fb03", size = 20265659, upload-time = "2026-04-23T07:15:57.375Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4b/c45b8b601b0270faf1d4384e4c7270af9abb8d95ea39425253217c3c236c/mysql_connector_python-9.7.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:5492d57a6a0e5127a928290737fbb91b66b46d31dac8de3e7604e550bf3b3a6e", size = 19826940, upload-time = "2026-04-23T07:16:00.156Z" },
 ]
 
 [[package]]
@@ -4129,77 +4084,77 @@ wheels = [
 
 [[package]]
 name = "obstore"
-version = "0.9.3"
+version = "0.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/96/b4e0d466715daec9e221cccb8ac57dc91ba08830a68d7ed5a2729ab21a32/obstore-0.9.3.tar.gz", hash = "sha256:0f56e7efd53c22e7eaf14ccce931c678b01a016ceb2226cd4bb01c741a58f5a2", size = 124143, upload-time = "2026-04-15T18:16:56.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/7a/3a37b0bf0da898478029fcc511a0d2a7252689b1f29e46db7ae74a219c74/obstore-0.9.4.tar.gz", hash = "sha256:e2b93f1372c59da2c7e74122fc6dc4b713d84fd4528b5b500ef7f548425496b5", size = 124167, upload-time = "2026-04-22T19:51:05.261Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/b0/a5a1bfda794d4b00dc945ec00864cf5ba5d1ad17e610e200a4954e4d9900/obstore-0.9.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:e88c4a872b25a04812faa689fb15e8ac078e9c4a9cee058f1000f87285282a0a", size = 4103765, upload-time = "2026-04-15T18:14:41.093Z" },
-    { url = "https://files.pythonhosted.org/packages/15/ce/04c4b8b8b478131732cfe68c3718c6faa14e630ffb9323fb436604eb1bf1/obstore-0.9.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e39a47a5d35976809d98dd980a401b9b7b92307b84722cc7caf747fb37df493b", size = 3880808, upload-time = "2026-04-15T18:14:43.272Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/f5/beabe78b635eefba3d6fa66ae31750154bb61d45312a6689232a997c7221/obstore-0.9.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c19c8e7271d594ce35ad3d73fc47d6de572d0e5ff32bc05cd6ddef2dbb67b83f", size = 4040670, upload-time = "2026-04-15T18:14:45.116Z" },
-    { url = "https://files.pythonhosted.org/packages/64/b5/0b19187984f1ef79455b96b0a68bc107eaf6a664cd4227f71ae294b7669e/obstore-0.9.3-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:755af07fa18ea9316797585f9dc5979bedb9a5c06cea74d31a19e8cb58999784", size = 4142501, upload-time = "2026-04-15T18:14:47.15Z" },
-    { url = "https://files.pythonhosted.org/packages/13/81/9ade05770bd502c6c245124be861ff1a0a7e4a874763aa937ef2c7ae2e24/obstore-0.9.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:45273020f93bbcebbfb10a159cf34b45ba2b9ab849976f0e74e6c791d24b316e", size = 4424903, upload-time = "2026-04-15T18:14:49.099Z" },
-    { url = "https://files.pythonhosted.org/packages/13/41/286cbd677faaeb2dcb21100a79f5e8645ab6ea53920a017261bb0b9b048f/obstore-0.9.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:784e79dd356acb9fcf83d7d7ab6d3c5a85ab53bf8cfda0c107aad1eb14096b6b", size = 4347882, upload-time = "2026-04-15T18:14:51.064Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/04/18befcf5a4f24a86673fc0ad3c0ffb862fd5f97d76d383f3fc3b31f3d052/obstore-0.9.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fbf78744b2ef5baa78a360aea9e1deea05e8bf8f1c9b9bcf45a8d8f8352cb7e2", size = 4226757, upload-time = "2026-04-15T18:14:53.32Z" },
-    { url = "https://files.pythonhosted.org/packages/67/f2/5d1de99248b1531da548c526cb0622f59637e9c90a3fdce97b453b7724f1/obstore-0.9.3-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:72d23f7b84fe76eb37e1c62c01cd7aca177c8935a0c16bf38a41665a8df99c53", size = 4108158, upload-time = "2026-04-15T18:14:55.663Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/93/fd24ccfde3926e3603119849455de87c16f70680258e384302ecbc448943/obstore-0.9.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d14c8c0fc93169ec87136618d52b0b832ca76c84670b062d6d09b1737a195d68", size = 4297040, upload-time = "2026-04-15T18:14:58.1Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/1e/862867e213ffffaa865527dc47568cc4ef868cd54b4e97d9d4c575860e50/obstore-0.9.3-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:833af3b05773fd6c700221f75e71ec45d7a97aeb84d2f18224becdf4de428a23", size = 4276309, upload-time = "2026-04-15T18:15:00.505Z" },
-    { url = "https://files.pythonhosted.org/packages/89/90/71eae92544a15d20587f10e7d804656770e8591a8c73bead10d09a90ee5a/obstore-0.9.3-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:4590a53db7e1681f849a6bd2c452df7db7880796cb69fd34ee85bd3ee64949d0", size = 4262030, upload-time = "2026-04-15T18:15:02.474Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/23/8df98f302053d6790871cc287c7437dd6c53b7983e010e75174341e848f9/obstore-0.9.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4d0b45f46192c9f6b47295bc633082bff7b929595a3c93557ea2e9f91de8e828", size = 4446607, upload-time = "2026-04-15T18:15:05.158Z" },
-    { url = "https://files.pythonhosted.org/packages/61/86/e9f8eab09b51f60b1ea27bfff98243b0def6f0c9ba858d9744a830eff327/obstore-0.9.3-cp310-cp310-win_amd64.whl", hash = "sha256:4ae0cd72e50481f8ebccc9daff87538f15667b60df7bde1181d532c77a2eefbb", size = 4184771, upload-time = "2026-04-15T18:15:07.634Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/c0/202a30127786169e74516ae700de8f153c430d349985bf6d09b33ab7f481/obstore-0.9.3-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e56bd948c87e0b16211ea0363913529c1cda67d9ada809c28e70a9b22c385433", size = 4112171, upload-time = "2026-04-15T18:15:09.478Z" },
-    { url = "https://files.pythonhosted.org/packages/df/8e/fc4995a82b53cdd8e61f5ebfe5007deeeda4f0746b0e46e1dbbd293d9d3d/obstore-0.9.3-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b65c3d17ff6fa7a239b99df05e6f2badb1852a1cc56ebcd24f9347d88b5cc629", size = 3880522, upload-time = "2026-04-15T18:15:11.744Z" },
-    { url = "https://files.pythonhosted.org/packages/86/82/5f6c3ff5b25e6bd0b97c6d5459b91edcbc4ab71e66a2df1b9a6884a8a4bc/obstore-0.9.3-cp311-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7178850a492a3bd534bf6d178d20aee4a171e6b4a4fead46f9879a630db06353", size = 4042745, upload-time = "2026-04-15T18:15:13.712Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/b1/5df6a6b2f1a8039b3dc06e9a0d990fe26471f153529a8e92dad4167f505a/obstore-0.9.3-cp311-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5fdc75d11d4f17dd79fe47bb7576dd404675d52f99e0d998319f4bf032541171", size = 4145646, upload-time = "2026-04-15T18:15:15.829Z" },
-    { url = "https://files.pythonhosted.org/packages/54/3a/a238ad9e1c4f3aba8a7acff04eba7d7e143aa07f7a26435acf5655372953/obstore-0.9.3-cp311-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1943511b022ce49010059b4b274f1608daf041827e9a8e0ae2311c70fcea921b", size = 4427486, upload-time = "2026-04-15T18:15:17.635Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/be/adffdbec3edb4cf2bea2f856ebf14efc0e398843a477823040c95a39c754/obstore-0.9.3-cp311-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:35c4ed947b1cb5da6d8a8af8d2378b038dab34deb86e679c940a8a09f2ad72a4", size = 4340837, upload-time = "2026-04-15T18:15:19.711Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/cf/92593c3981e38e9f682d858aff251f6731517d682a9b389cb1e2c94ed6a4/obstore-0.9.3-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab427bec57b8b5084eccd78d7592cf28860a1cf631bd0e0b8c0e0b793efdc033", size = 4231679, upload-time = "2026-04-15T18:15:21.473Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/8b/920f726117180e57c51bf6bc503f286782a3bbb6fb8f70ed9bff4f674796/obstore-0.9.3-cp311-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:48f58c44c9a5c7b82346fe5e3469bae3109c8b168c1c096c41b80a9f0bc8d5a6", size = 4105350, upload-time = "2026-04-15T18:15:23.566Z" },
-    { url = "https://files.pythonhosted.org/packages/48/5c/6abd29ae02f64f677a67cab6ee5492d14f004b483bafbf397c3ddef4f4bf/obstore-0.9.3-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:591db6375f90a7528f902d3cff8738d93219d6162d517e4d464bd333133daa1d", size = 4296104, upload-time = "2026-04-15T18:15:25.388Z" },
-    { url = "https://files.pythonhosted.org/packages/21/92/a1eacdf5bf0ca2d2d7fc6d6430e1f305782abaa0409fe120fcfc3083dea4/obstore-0.9.3-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:e42c3caf9f77a2a5aaddfd6a2356c3ad317884f188cfec5b000c48c21362af79", size = 4278210, upload-time = "2026-04-15T18:15:27.43Z" },
-    { url = "https://files.pythonhosted.org/packages/48/c6/8e62cab73552f5491f01bffbb279b7d25ec148fb89ca4ad4192ac00c6d95/obstore-0.9.3-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:bb509ea1fec9dcee996151f2c5d6664b1516da12675d2c27583ef9fff81c43ec", size = 4266039, upload-time = "2026-04-15T18:15:29.179Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/3f/36b1823574277d3a494b7280883a0d78ed46e71d3e8e4de2b8135b15792a/obstore-0.9.3-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6eec5a7a917ec6a5148d4dd6a0e53ce87949c520de96b1822bbbc4aa79b65610", size = 4451602, upload-time = "2026-04-15T18:15:31.468Z" },
-    { url = "https://files.pythonhosted.org/packages/20/4c/8f4650d2e29472998bbcbfb1f0a67e865fea419108faa43f5d180bdb166a/obstore-0.9.3-cp311-abi3-win_amd64.whl", hash = "sha256:87a1d5db9804df06f0ed5cd25b209c527fc2ec54a91c56ae6ff62d27db680b92", size = 4190181, upload-time = "2026-04-15T18:15:33.235Z" },
-    { url = "https://files.pythonhosted.org/packages/22/9f/8df3b10646a3b90c318f85f8e89feca337c6cf56cb50f003e03124186dd2/obstore-0.9.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:d738d976a15cca90fb6a900c4f546544644b38a559bb99f6372030bb80e058d5", size = 4084824, upload-time = "2026-04-15T18:15:35.038Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/ce/e5729f8504e48ab88586138a0311ae7800a2f61a3fc989444ee29a1dbdb6/obstore-0.9.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:663ed5b534d3896e703725d2b4f11959fbbb3e499b39e7f2fb9044aad658c568", size = 3867311, upload-time = "2026-04-15T18:15:36.805Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/30/c96619b6faf1337edd0ba82bf06cbf6d20124152d9848a20bbe4ec8da046/obstore-0.9.3-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5c3d84f21424dbb9d7acd0111d3f281e61ca0f8a21f7b7f2e5599d515fff5b02", size = 4036006, upload-time = "2026-04-15T18:15:39.071Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/ab/48e5caf2bac13deba9d4e87dda28850f68b39b69a0431e5254200bfed786/obstore-0.9.3-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d535037d5c4240a849716b69e98aa7e7e5cea1b116558ede08a9962f501c23b3", size = 4135380, upload-time = "2026-04-15T18:15:41.783Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/d4/11f6a74df6d0b891be9538129c61cee50518835face031d0138a2505e371/obstore-0.9.3-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:71cdbebbcb78f63ffe4042e86e1ad41e723245bad42cf79b4c750592cb01aa57", size = 4414425, upload-time = "2026-04-15T18:15:43.586Z" },
-    { url = "https://files.pythonhosted.org/packages/14/c3/d299c174875490bbe9110d68887acbf4e197dd13becda75f1b8e13033f46/obstore-0.9.3-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d196a009870151d8c1bf8a550e3ce0c15c6a48af9bb36bb8954e70e52136863d", size = 4338358, upload-time = "2026-04-15T18:15:45.898Z" },
-    { url = "https://files.pythonhosted.org/packages/01/ab/29b55e1536ea0891062d0f2109f5c81804cb36976590418700bf8ec287b9/obstore-0.9.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da32f949a21dfa15739ce6286572a67ce167b827e0a28cbcbb956c25d29162fa", size = 4220536, upload-time = "2026-04-15T18:15:47.822Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/08/3ee0302ccb106c82600e9e0c1985c426f9906116ef68ecb0a0547ad0e728/obstore-0.9.3-cp313-cp313t-manylinux_2_24_aarch64.whl", hash = "sha256:a97b7ba1211c39ec58821c52a8719fde710e17ee17c40067e360f45c1e444a0b", size = 4102754, upload-time = "2026-04-15T18:15:49.855Z" },
-    { url = "https://files.pythonhosted.org/packages/17/04/fa33f40d8f96ecce24bcd1c92989a95885c78509e587748960b0299df696/obstore-0.9.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f5051b250080f739b53ff0c09a16b369206aa0aa904449cd8eadae8f51b03d0f", size = 4290696, upload-time = "2026-04-15T18:15:52.003Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/43/30e1d06f1c037a2e032d016ba381950ba8589432f012b88c3866af00f6ea/obstore-0.9.3-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:9a7251b2ffbb945cf19daf05c074850a79661ee667ba1e95cb53891cb706b9aa", size = 4272490, upload-time = "2026-04-15T18:15:53.969Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/d6/2b4fe6979a4f2b0c53b0caea2fa7ceaf1494a0662cd8fa1d127fdc3d659d/obstore-0.9.3-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:b8db25033f71e17e996ca05043118e64cf2067190081912dee85cb4c0ab192e5", size = 4254455, upload-time = "2026-04-15T18:15:56.313Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/a2/6974c786022f5339243d44a10f53708a8a17c8b7f7b5ad7cf7d9236c9e36/obstore-0.9.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e5f07ca479133dd1768b763cddcd1f3990a22ca4f2f071f5fd77d2bdf7d2baec", size = 4440612, upload-time = "2026-04-15T18:15:58.219Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/72/9efbd4331a7c58b520a15bf11086ef483c2f86859fa08788741442bb0b76/obstore-0.9.3-cp313-cp313t-win_amd64.whl", hash = "sha256:48e4debe9e0f2efc89208b95cc72dbc666debafd453fe6e9e71e6a24260fb4f6", size = 4177664, upload-time = "2026-04-15T18:16:00.642Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/cb/5128b750bf529a56f9723561add27035bcbdd7b5fd74e157d08f7bf4527b/obstore-0.9.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:4100e2e811a692a67fccbce5bab357c3a430e0243e1c894a49543b2d8dcfa203", size = 4085201, upload-time = "2026-04-15T18:16:03.2Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/93/deefdc898239f777066ba98fe1a58f706aed5e1e5c7c14b6503880383f14/obstore-0.9.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:95eedc2b47640ce892e39244775bbf59a73a75fae8d2d2ed4446ba24ffba1e50", size = 3868333, upload-time = "2026-04-15T18:16:04.981Z" },
-    { url = "https://files.pythonhosted.org/packages/19/eb/68059d436055fc3378bf66bcfcb7df19a0f3a544fed4d327d325d0b1db51/obstore-0.9.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:17a0eb8a812d3f229e989547bb28e50dbc8bb5ff7f98b0cd58353e1b5ef9ca22", size = 4036100, upload-time = "2026-04-15T18:16:07.098Z" },
-    { url = "https://files.pythonhosted.org/packages/37/b1/772a84fa919530a25c1b55b5f493ef3be965b9e8fbef2c8d158dee2105dd/obstore-0.9.3-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7245fbd83633c4c6c75e3f359ef249b679dd8f7d0aa7cf825fc09c70bd1b14fc", size = 4135329, upload-time = "2026-04-15T18:16:09.14Z" },
-    { url = "https://files.pythonhosted.org/packages/61/78/247c3fcf50674a477ebdcdc265aa93dc06bf197b700f0dd99967f1239ccb/obstore-0.9.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e003515ba8605d31ce7110f7238b0f5963784e02b936c932f35d7723bfcd7bc4", size = 4414818, upload-time = "2026-04-15T18:16:11.552Z" },
-    { url = "https://files.pythonhosted.org/packages/46/ca/becd3c0534e1d2433c33ac1a7342d2984282c41619eda3fa32d9a1190a57/obstore-0.9.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:13f74d0c81104f7fecab017a2df23a1f7ed049088d7d5aff179edaac88d99a81", size = 4337670, upload-time = "2026-04-15T18:16:13.458Z" },
-    { url = "https://files.pythonhosted.org/packages/36/90/57e4d351f89ac779783a4d80f22f7aa6a332d0196a0db4412ae23d0743ca/obstore-0.9.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df9a86804d4135ff81e7bd7a2622e098c8b11b7bdf5df66164906069df2cd4cf", size = 4220838, upload-time = "2026-04-15T18:16:15.679Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/dc/9d05879a5f0e4d2ef13738a4a0db5f83ec36e8f13a85df613148a40fd5d1/obstore-0.9.3-cp314-cp314t-manylinux_2_24_aarch64.whl", hash = "sha256:976d167998ac05aff47ced10c5e1603b05dad509f06a74368609fef956f5c129", size = 4103173, upload-time = "2026-04-15T18:16:17.997Z" },
-    { url = "https://files.pythonhosted.org/packages/35/92/21a0406c5aef9681b8290c80478bf777c3d63413e5c8928490fd760d5fdc/obstore-0.9.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:543f4a13f8cdf8d70a4b2283c58f6bb8e77f1b083567ca147187876b66870065", size = 4291176, upload-time = "2026-04-15T18:16:19.961Z" },
-    { url = "https://files.pythonhosted.org/packages/81/56/0ca8ad32a68c1e496ae9e6958638f38789c8549128bc0bed4980ca24db9e/obstore-0.9.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:32c1db99f6c0c6d12e8c53bc6961a6564925492dc035d069e53c6045f291ad0f", size = 4273148, upload-time = "2026-04-15T18:16:22.274Z" },
-    { url = "https://files.pythonhosted.org/packages/11/75/d7c424569fbfad9edcb009b7fac19b1433d971a3fd7a882e7b7a7db84d1d/obstore-0.9.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:cc8af837d139bc92d32cdd8eb78119ae936689bc25fe67ac5d19f8d0c2666370", size = 4254697, upload-time = "2026-04-15T18:16:24.102Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/7d/615aaf24ea0f0de38fb8ccbc9923637f1e7564946539fc19709aaea43907/obstore-0.9.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ac2d51451500e2cdbec196470ddd5e3f6eea686f3fbd3702c9270254e8f41d39", size = 4441326, upload-time = "2026-04-15T18:16:25.931Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/e2/7fafcd7c09d6a6eb689c1293f8a61e9c6965f5c8753c4f1fb779216c221d/obstore-0.9.3-cp314-cp314t-win_amd64.whl", hash = "sha256:ddcfc72d68d26782ce6f4ef382125beb0609e29047240e19be4407fc3be1871e", size = 4178356, upload-time = "2026-04-15T18:16:27.91Z" },
-    { url = "https://files.pythonhosted.org/packages/41/82/61db9df729f68792d78ba6560170aa7b39d451c54440d8dc723b67c7b4b6/obstore-0.9.3-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:f3ea671fa7b9b4a747f6d1cc9cbb295a35c41171332109d36b5e5c1f50fdb694", size = 4103422, upload-time = "2026-04-15T18:16:30.035Z" },
-    { url = "https://files.pythonhosted.org/packages/16/53/fe91fdc82618ad8340dc9563657cf45067f71ce49dbb2ebe7f365f57d591/obstore-0.9.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:539b53904d19a799bc529e26167fbea1a52b38b9416dc07ff44b5974503e33f7", size = 3879166, upload-time = "2026-04-15T18:16:32.451Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/a5/a244936878db8fd779d631f1f30dbdcd2915e6244f60e5e135987a0a8a63/obstore-0.9.3-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:52023f4db28db172333cda3b9bb24b3c41ee48c4ff97a9876a5cc3ed34f28bdf", size = 4037836, upload-time = "2026-04-15T18:16:34.815Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/10/34d9d7002a5761d6bddbee9bf73db1f40292e80686e994e225f6e05d584b/obstore-0.9.3-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:44569738ecef405d08da4ed0e60e8963f140cb1e1618ee08a479eb5595eb240f", size = 4140661, upload-time = "2026-04-15T18:16:36.884Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/2f/08e295450cd68ebb9b69b7989122fe84f8600c2b2cfd16d72d193a232b74/obstore-0.9.3-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dcfcb58949f7fad3c75bd45b8df7a0250d6d76d8f3ce47d7054f78f78a6b3ec6", size = 4425305, upload-time = "2026-04-15T18:16:39.341Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/29/2ee6bd2a0a93e488c7f7bab51ab2df7f7debf1dd5d5e722c19665b776dc2/obstore-0.9.3-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cec1d9f151fe901e1574ed94672b18b789f0f1b2576969e96e3ccd5de393994d", size = 4346828, upload-time = "2026-04-15T18:16:41.498Z" },
-    { url = "https://files.pythonhosted.org/packages/13/f0/4122b7b5ec3c2fad5898bb4adfaad9454ba8abf9e91a475b3da4d768948d/obstore-0.9.3-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f81c21558cad2b666275e455f5a40c163885cdce8235e23e20647300e40cf074", size = 4225582, upload-time = "2026-04-15T18:16:43.823Z" },
-    { url = "https://files.pythonhosted.org/packages/31/bb/7eafc5df31ead23e57a0f5fc2eb88bac4f7aadfda5ad6ea4b99835080a2d/obstore-0.9.3-pp311-pypy311_pp73-manylinux_2_24_aarch64.whl", hash = "sha256:8a76a5074ef019d4eedaf747606e3d0b94bfb0f6725ef1c23b1da632aceaedc1", size = 4106284, upload-time = "2026-04-15T18:16:45.807Z" },
-    { url = "https://files.pythonhosted.org/packages/50/44/03caac89cdd9abbae09aff86a7b0dca1ed134624a09b4646647602fb930d/obstore-0.9.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:742b9ad609686afccf3408d8994ccd85b90011f6d4a6a6f98814a98b9c4b7d36", size = 4296260, upload-time = "2026-04-15T18:16:48.107Z" },
-    { url = "https://files.pythonhosted.org/packages/62/24/9efafe732452bd2399264034942ee2dfef6116586c68dc29d3f970819c9c/obstore-0.9.3-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:e1a00ad01062d1c5909e0693a47dbfd6d8aa5c4f3638ee4e6c88ba2576be23cf", size = 4273800, upload-time = "2026-04-15T18:16:50.355Z" },
-    { url = "https://files.pythonhosted.org/packages/91/62/8534c1e5f9ba09d55e6c6b0feda4f2cb05a21a4f0f99151b05a3e4302a98/obstore-0.9.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:8a9191174747f298c1f18c49f3f4644c50b4bef876c95d4773b3d66814261cfc", size = 4260738, upload-time = "2026-04-15T18:16:53.298Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/32/f56676fbe5da65eac1ae633d9c52a1dc5ea3e6a5a1a2296e056dd3803988/obstore-0.9.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:a9d2acec03c2e8eb9b83c16dc065a4cbaf327050e51757435ac914bfbb861aff", size = 4446126, upload-time = "2026-04-15T18:16:55.11Z" },
+    { url = "https://files.pythonhosted.org/packages/df/4d/8ef516eee1b5b99ee439cf0f6202267b3d6ee7df6f2680ab9bd61ba0bfb3/obstore-0.9.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:caad50ef758d4342a2a772661fbcae2b4c6c3d242096910aa8d4614a40dee38c", size = 4087299, upload-time = "2026-04-22T19:49:03.339Z" },
+    { url = "https://files.pythonhosted.org/packages/21/34/965181eee58ed11b0af56677f8101cdd028d9853e4d89b71e4609f4089fa/obstore-0.9.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:36eb8e95efa63e0d01fbb6c56a7102d96ba0469278f4c6cc230f54871e1b3605", size = 3880204, upload-time = "2026-04-22T19:49:05.284Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/4821c7b8534e89b074162162537e9ba4684846e406e8f4b5aed4c6865245/obstore-0.9.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:06881c82d0175d80bdd0a795ae2e4ed6b6c67437d8ddcdb670d3f5a6dee685cb", size = 4028659, upload-time = "2026-04-22T19:49:07.091Z" },
+    { url = "https://files.pythonhosted.org/packages/45/e0/349af04fd98ddbd1c838f5e18fb54f21189b26305a37afee1232b04f2bd2/obstore-0.9.4-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:006573a9b69d91dbb73b491508b68dd5b8b5e4096d0ec825c8b8ee0b5b1364cc", size = 4125547, upload-time = "2026-04-22T19:49:08.74Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b2/a86c5c207d6b30dbf54cf63fead506a5c4a137c53cd013f832654d4099b6/obstore-0.9.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f4c4ede2313c865bac5f57198dbad8daa8779d7f4e63f92067f5f398d6341df4", size = 4412045, upload-time = "2026-04-22T19:49:10.359Z" },
+    { url = "https://files.pythonhosted.org/packages/20/b8/ed60b0acff6344fe5f69d0b309f0788708cac5326cb44d6f9aefff289d92/obstore-0.9.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:35563432aa42be69c5e5aa47520aae6af398f8c33b599efeb96640e97a2b612c", size = 4313478, upload-time = "2026-04-22T19:49:12.317Z" },
+    { url = "https://files.pythonhosted.org/packages/28/cb/b46810d28cc12352ea800388d717309d9739fcdd54de7f19d49e0dcbdaec/obstore-0.9.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1723313902127d5df021203b0e90218636cbbf8954dbe845656bb0a6bc2d907e", size = 4217553, upload-time = "2026-04-22T19:49:13.975Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ef/b4553d61263bc140ec9eeb22c3c61168b172bd35038c82463a1a1e6a7c91/obstore-0.9.4-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:780a5aec49ca6c081af029250e4c20686e6236ccea42a489fccb689065391438", size = 4106903, upload-time = "2026-04-22T19:49:15.578Z" },
+    { url = "https://files.pythonhosted.org/packages/24/10/ef29b56f9cbb6be832de83e1d5a5a3066eca4abcbe62e6146af67e075c90/obstore-0.9.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:755781392c3e4bef90844c10749d2898ca10e10aab15c1c1cd6deef0e5145697", size = 4293964, upload-time = "2026-04-22T19:49:17.582Z" },
+    { url = "https://files.pythonhosted.org/packages/05/07/403808dd57571a28aaf1c26d80c0a0a426e971fda959791810f3bc2f426f/obstore-0.9.4-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:5063221a224110c4cebc2a982d4049324f7c205b5b4334ed2d15cc63c541b790", size = 4265781, upload-time = "2026-04-22T19:49:19.749Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d6/0173e8b5abba7f734cf01da9036b11c7ef0885afbb1b30768f3a1c8949ac/obstore-0.9.4-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:dbd0dde6436f0bfa97a219cd892f9681f2d20dfdf396a8239a318c75e565f342", size = 4253246, upload-time = "2026-04-22T19:49:21.537Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/20/4ae3ed97020b337748e4f77d4d7c81c539a2779f0f1f04bd7d59f62cc673/obstore-0.9.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9206ebfd5fc594e038f2cbe2f7631a8b442a89f37ed5d14fd0bd31a10ff19281", size = 4438367, upload-time = "2026-04-22T19:49:23.249Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/0cc6eb54411ced59a4ff51073bae62656987bf5d9f9599747ea455e71a85/obstore-0.9.4-cp310-cp310-win_amd64.whl", hash = "sha256:b23579c6901749e3507cb01c9fd4412eaf29e15a6c85441f124a223c183f0136", size = 4185826, upload-time = "2026-04-22T19:49:24.791Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/25/4449a0066796b91e282d7604a66387bba399b14752598c748ea9557c4c32/obstore-0.9.4-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0d17cd04e7f22960050a85f8daa6e274d693e8fb3b97b81eeaa293c6f9e62eb4", size = 4090743, upload-time = "2026-04-22T19:49:26.461Z" },
+    { url = "https://files.pythonhosted.org/packages/93/91/639fe5f5644593b9f4bea66f8f29c7bfd4de3b3381fb74b4f7df678f505f/obstore-0.9.4-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:d4beec92710fb8826fb357baf28fb79a91ee07dcdfe73777207aa762164aaa35", size = 3876313, upload-time = "2026-04-22T19:49:28.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/71/d6675f845ebe1e3927f2dce6a2a4d5a393359274762ee00c5e6855d5f468/obstore-0.9.4-cp311-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d523c8c365ab60afb8d232614a00a92bea439a9f5c55b92486c23a47af038a1e", size = 4029950, upload-time = "2026-04-22T19:49:30.279Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/3a/5915a173f5c6a95f9ec186a7e29b0ce6a23bd9b04c2b0b29a351dbe2baf6/obstore-0.9.4-cp311-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee0483619088337ee365cb344fceee337e2670ec4de2a1da92ac7f6b2220f18e", size = 4129455, upload-time = "2026-04-22T19:49:31.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a9/63c31d2d436c06c4d39ed5cb154fe54202b303854532ec09537c4ce0755b/obstore-0.9.4-cp311-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:83da348bf0a7dd84e5839c0cd54d79dcd08e0729c394e566f73a605b93b9e998", size = 4416727, upload-time = "2026-04-22T19:49:34.016Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/fa/23c5c6db02be0e13abcbe01c1ca94c5f7876e8c58e74cb9ac2b57b068866/obstore-0.9.4-cp311-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f282a17200bcc37b8d7a1d02a146ed41812eb6e76fd0a4c9a154f02da1b8031f", size = 4311520, upload-time = "2026-04-22T19:49:35.905Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f0/49f6b02dab9c05e3fd79d6129e4d9e7e9874d6e5e05369ca3b3b80a48aaa/obstore-0.9.4-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d29dcfceaa0a205ded2263d29a2a3aa206819d549e0325c1f2106f79e2658584", size = 4220536, upload-time = "2026-04-22T19:49:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ab/d0bfd6d68422e7d8f2204d91736c7e62767e0576ad749da442a71e7773b2/obstore-0.9.4-cp311-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:caecb912723ab8e9da8da26def249d66da4318959df2bafc0a55af64f3255902", size = 4105099, upload-time = "2026-04-22T19:49:40.384Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3b/f595d0ee354f9daa69438991f8818602f34bc59498c8468456a02d45fb27/obstore-0.9.4-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c1c06fec8837595a2829b5f7536d0d01e940ce10b07ad2a8594fec1cfd0b7d5", size = 4294206, upload-time = "2026-04-22T19:49:42.016Z" },
+    { url = "https://files.pythonhosted.org/packages/60/54/3c5af2d59258aaa9e5bef05320658ea6e9b1f3897a3a977bf7f54a0b6ec1/obstore-0.9.4-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c132795a789ec5ade31bf4d5b55ed321fb41d9749e9145520bf19063e1da5f7b", size = 4265047, upload-time = "2026-04-22T19:49:43.983Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/af/a8ba1feb81b9833b253147839da40405ec6bfa51feb3abfe909c800208a5/obstore-0.9.4-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:c6e342360a5d0ae71486bc5f8311778aa144ec1a905c23593f8ef57b5bceae24", size = 4255361, upload-time = "2026-04-22T19:49:45.864Z" },
+    { url = "https://files.pythonhosted.org/packages/15/f7/3ccc0288111e057f8ba3d99bee14f95d9e9bb00acaf6e9700e0eb4cd82c3/obstore-0.9.4-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:aeb6f7e7e862550f5020a10692ef6f02d5ba4912dba08942eb59bb7d73f93fe0", size = 4439378, upload-time = "2026-04-22T19:49:47.581Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b1/3ac8b5772743c60064f3c7e02d27f346dbb58feaa99a49ee09798d1cfb00/obstore-0.9.4-cp311-abi3-win_amd64.whl", hash = "sha256:a58ef942292841f99d69ac11d19d05544c835447c8c09dacbfb7409c6374c4a1", size = 4191594, upload-time = "2026-04-22T19:49:49.308Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/81/8f6b6509f8df603261cdb5ddb521c49891457775669c6ad857812bf4a7c1/obstore-0.9.4-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:fff17f59390ed307afcd1fb18c56076c1f911dd9f5c2636b7d7133c4d07f8c3f", size = 4071300, upload-time = "2026-04-22T19:49:51.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/fe/0c74ddf3ab9b24ef356925bfb613bc7846f869220361a784b63f754d8563/obstore-0.9.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4527c4c7889f1bd1f1952017d74774870e14e199d6b50b9e72f291f9498d898c", size = 3870593, upload-time = "2026-04-22T19:49:53.481Z" },
+    { url = "https://files.pythonhosted.org/packages/73/fa/260ec94f9a7b4f4c8afbdd016710bed0736615488d3ac0c5620f9179bfcd/obstore-0.9.4-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a57c2016e3e569de35050f95c679ffe61813c4e3cb6d6028c4c3f57231021eb4", size = 4023990, upload-time = "2026-04-22T19:49:55.644Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/84/5b8e2b9607fb93c96a39a4cfa6d37bd3049ebf7265d0e9f8afa938bf32fe/obstore-0.9.4-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bd5327cee4fb3578b51beb1c92915cc3a05ffe794be40f50bd68d27e97d78c5c", size = 4119971, upload-time = "2026-04-22T19:49:57.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2b/e6c093acb7e62009d5b1678d82839903287c29d4a6e1dfbea8fbf41313d5/obstore-0.9.4-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12b1e6105eafe02d8973dbeb2d274eeac2271c67f1126ffa16f18ddea8dd5443", size = 4407147, upload-time = "2026-04-22T19:49:59.928Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3d/5c93a9adee8f045b89d5f21b337f53667499db770bda129f805723ab14e4/obstore-0.9.4-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0b0d378248fda4e36652808d73eaaeb7e67154427e6c724248c9b0b9b03e70a6", size = 4312215, upload-time = "2026-04-22T19:50:01.534Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/de/507f60b4e6a8c0cad9f93a51a7b28132c9db49e20aadbcd542fa2abc57c4/obstore-0.9.4-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a78fb77c346abd2bcdfa071d7166be2bdc38c28573ae5a230746df6158a5593e", size = 4216936, upload-time = "2026-04-22T19:50:03.244Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ff/612bd5f8258349bfe9e8c349d184b5ea3333038d4cce0d003eefafb2160c/obstore-0.9.4-cp313-cp313t-manylinux_2_24_aarch64.whl", hash = "sha256:f4e5a6dfe6877fb599868d560d6fcf4d7416cadbdf3bd947254b53830c2f11c0", size = 4105091, upload-time = "2026-04-22T19:50:05.038Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/73/b083b99e7bc0b529bee7b4437cafd7cc7d9f59c10995a48b6c26447fdf7f/obstore-0.9.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8114a2b84268c991232d89b105d9239299b6afb56e4941a61c09f3a89033022", size = 4292570, upload-time = "2026-04-22T19:50:06.823Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cd/3c4555f98db9a49432bc0afa68bfc33dd47bdfa3699c915b4b0e887577e3/obstore-0.9.4-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:9d7b959f5f74532a142fb449c0bef5814dfe3fa5c43c31ac4284a15221a75aaf", size = 4261946, upload-time = "2026-04-22T19:50:08.789Z" },
+    { url = "https://files.pythonhosted.org/packages/96/f8/bdc66df3d0dfdcfb3931a585a7fb3b74336619baf6d3540b1425b424232b/obstore-0.9.4-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:a8e9101fc2659dd938e7ae06512075bc0a8f02ab28d2ee438d6fca8b4f3bdfba", size = 4245595, upload-time = "2026-04-22T19:50:10.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/22/1aa58ea676293e5b888391c8433ff6ab8f66622aae30427287f9daac6d46/obstore-0.9.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:538384255545b5c575497fcab26389c8f01707402b6ddcdd73b769b66311635d", size = 4436599, upload-time = "2026-04-22T19:50:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/9e/b52f2c97be27952d488cf1980af0c635f9947003e5744e3e1dc6252f0040/obstore-0.9.4-cp313-cp313t-win_amd64.whl", hash = "sha256:eef1c772657bb1293adad0d671ca1ff1e1dcae84ec4dfbf1a34e47c2a1f134ac", size = 4180463, upload-time = "2026-04-22T19:50:14.288Z" },
+    { url = "https://files.pythonhosted.org/packages/19/76/c53583f95c6811057abd3116756dca46785318d564a0e99c207cbb2d8938/obstore-0.9.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:e009e7437770c85beae4c32cb79f662f0a9922676ef127e943d107a5c082d38d", size = 4071302, upload-time = "2026-04-22T19:50:15.967Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/23/ac3b9c05a09b3d5f178ed6f288c5d6913df8f7386059590194e0fee65d15/obstore-0.9.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ac5f3ad314bd4592fe484b79c229518be7bb5f6218bed33c20742026d5caf860", size = 3870813, upload-time = "2026-04-22T19:50:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ec/c3458e0f24d2d1a4f185f541905b07e51c91b3fec589b1600c77d511e585/obstore-0.9.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:db79d5ebc4177360565ffcec4abd49930cf052cdbeb94e3a3ece2e2d08f087d0", size = 4024237, upload-time = "2026-04-22T19:50:19.81Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/eb/6cf468a200e491fdc6c04075e2fbbac1707bbecd243f0f56ae1e75d052ed/obstore-0.9.4-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:05b565d89c3115fb74385852dd628e12f6645a1bba97523dceae016b538a3f33", size = 4119635, upload-time = "2026-04-22T19:50:21.605Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fb/b44d002767fa5af95ab4ca8e16c3a9057fc11f13de03f498b99adf0c4e50/obstore-0.9.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7dfc4fc98403d8fbb316eb04257c8122b6f1dda37e80869491fdacf60a815e4c", size = 4406906, upload-time = "2026-04-22T19:50:23.654Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/18/9a75ad5082cd581c4a55f0e62bedf4b030a8b53824976fc1f030eff225b3/obstore-0.9.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c69af620fd3d06a8cfb62d25faf1adb6ccc97cc572f47ee04dddcde5a5e5444e", size = 4311826, upload-time = "2026-04-22T19:50:25.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/03/b0f945b31f40364a7ed4dbc5677abc66331fcf478732f4d643e17e56bb13/obstore-0.9.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa78c0230e0b9d49b25ed18980e1751331ddfe05782d6ce97579a9ccda8229ea", size = 4217086, upload-time = "2026-04-22T19:50:27.266Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/26/bdd85264c806802086f21d73cc7c95a5baca5feeeac4bce8acb97142163f/obstore-0.9.4-cp314-cp314t-manylinux_2_24_aarch64.whl", hash = "sha256:c828719f0bb310a9cf0e0f08cb62a0b8cc550138617cb03ac897900aec9d3d47", size = 4105560, upload-time = "2026-04-22T19:50:29.324Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/36/4a4a6a398e5f145edd1886388ebe5e6f6bbaf74950a5dea1a6ceae63e6b5/obstore-0.9.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:49a0455519f284b6bc2e0694298114926aff1d1f3d5d344e9163e03b446826cc", size = 4292582, upload-time = "2026-04-22T19:50:31.028Z" },
+    { url = "https://files.pythonhosted.org/packages/39/4c/9caa197cd2eba726e9a5285db34027049b9527a23e1a7e08479678ad6a4a/obstore-0.9.4-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf437309fc0fe852591ae50405300490229f876ea06574651fd753ca3fd23f25", size = 4261613, upload-time = "2026-04-22T19:50:32.868Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/94/a3fbe6fb3ee1c57fd4943ddbb21848eea3925b77e0789614c857d86b795e/obstore-0.9.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d83dbd20b6a5d42e35794ef64046de39040854829ec4f1eb2f6dfb54df48cc3d", size = 4245638, upload-time = "2026-04-22T19:50:35.009Z" },
+    { url = "https://files.pythonhosted.org/packages/56/a7/d18e168f318327d63512dfa7cf3b5e89ed9bfba6d6a8917ad7d4700b8657/obstore-0.9.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5a0c337f37f30a2d66555d69bf3abd840457a279c57ede93bd02e014721ed364", size = 4437226, upload-time = "2026-04-22T19:50:36.635Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ce/66aadd155db1e273c6ec2236c0fb904666d10c2e3b791b40624c272e586c/obstore-0.9.4-cp314-cp314t-win_amd64.whl", hash = "sha256:24e37a1c713c95a964e119f8ef879415a495432162e74e80ed29d645aeeca114", size = 4180746, upload-time = "2026-04-22T19:50:38.396Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/01/cc2446a87e051ce567817a4b61ca3a9c62297a4c5a0fba4ec6659123fe24/obstore-0.9.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c7bb85a892d5f1ac5a24170fc26068eec5e4cc46b11689af5058c033e494c1af", size = 4086409, upload-time = "2026-04-22T19:50:40.204Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f6/41cd2a14d90ae81e26b511c04dfedb0fec17dff5bc64e174acf1c3335208/obstore-0.9.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:704d83e5d94e3c9b8c84d33a9d302e9c5110cdbeba3ff27c859e864b03e44fc1", size = 3878348, upload-time = "2026-04-22T19:50:42.382Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7b/88a30f98c96d138836024057be18aedc8bb669ee1bf69d9809a49ad2a806/obstore-0.9.4-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f1b3626429fc223ed4b7355c444587d0c328a0126d81812f4f54984526fbf66", size = 4028849, upload-time = "2026-04-22T19:50:44.418Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c6/d0d3c08eac256f380dfdf12e07ec870b8f58ea85f6accea03c65e78ee7f7/obstore-0.9.4-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:78000bda795dccc6f48b2e743be3a92ed1e2933b974439f3dbb3549f9038668b", size = 4124212, upload-time = "2026-04-22T19:50:46.424Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3d/89838eb1d7ae54edeeac41d1aa962361e24988505836c5e2753ce7fe750e/obstore-0.9.4-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:31590b64afe19d13f1b668b35900519810881636cea05366f3790b96d5881a6a", size = 4411073, upload-time = "2026-04-22T19:50:48.502Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/70db25327b13b412ee4f33731942d2828789260ace057c173d8692be3a00/obstore-0.9.4-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4f42cde6f3424ef02e9bfe50ca21d1b0ae6c313b12515a45d5c2bb3e6de9bd20", size = 4312441, upload-time = "2026-04-22T19:50:50.423Z" },
+    { url = "https://files.pythonhosted.org/packages/55/84/76decc415ce07ca61b63b6ece3848fcc83785193c7fb984c4e45287fa781/obstore-0.9.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c228b545925510bef514ff2f954231a985ab1ef21c02e7c7ac448b3cc55c6377", size = 4214735, upload-time = "2026-04-22T19:50:52.12Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/52/0d8ca76cfc483a2ec74dde4c67ef609024b1b6f72e89cdb9ce8c4e4ec2f0/obstore-0.9.4-pp311-pypy311_pp73-manylinux_2_24_aarch64.whl", hash = "sha256:b99f5a681ad4dafe7ce21fbfff225a96522ce5a79c0f9042b57db31a530ab216", size = 4106235, upload-time = "2026-04-22T19:50:54.567Z" },
+    { url = "https://files.pythonhosted.org/packages/18/58/dbe535e31b3fd7e3e227408a43a35233b2a48a38311b29619113262fd87e/obstore-0.9.4-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:8e63a7bdf69efdb49b2081daf11144e226eafa20606d3993e97ea0729c5c5cb7", size = 4293068, upload-time = "2026-04-22T19:50:56.51Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d3/5f3f57f44f29a89c01a7f5c1ae7a657c960ad1fd86221bae04a27e5e3af2/obstore-0.9.4-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:2acaa282058d2f1bcffe1ec4ba7cd74746fc498fa400d5887579fdb155d16f39", size = 4265141, upload-time = "2026-04-22T19:50:58.583Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5e/45572a456b99d83335fee623b92c79bfa89a8bf22284f065895ab0847dd3/obstore-0.9.4-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1fc897945bd6d0eb0de1044c71bec8c961fa4f176453d28421c80a11e37f00ae", size = 4252425, upload-time = "2026-04-22T19:51:00.842Z" },
+    { url = "https://files.pythonhosted.org/packages/54/e5/447801d3c962ba386875928ccaee83044829821c6437fc0eb526bfb5fb2d/obstore-0.9.4-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:7c39e3575796a712cbf437197404975d7d5e3f046f9bd6580a76be7f46b2ade6", size = 4435460, upload-time = "2026-04-22T19:51:02.718Z" },
 ]
 
 [[package]]
@@ -4479,11 +4434,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.1"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
@@ -4692,11 +4647,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "1.0.4"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/17/9c3094b822982b9f1ea666d8580ce59000f61f87c1663556fb72031ad9ec/pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080", size = 133918, upload-time = "2026-04-23T01:46:22.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c9/8eed0486f074e9f1ca7f8ce5ad663e65f12fdab344028d658fa1b03d35e0/pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42", size = 56264, upload-time = "2026-04-23T01:46:20.606Z" },
 ]
 
 [[package]]
@@ -4744,30 +4699,30 @@ wheels = [
 
 [[package]]
 name = "polars"
-version = "1.40.0"
+version = "1.40.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "polars-runtime-32" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/1b/eea7d6fe6daafc1d784cc0f76c729b28051837ccb2d51ae64a0a3f798142/polars-1.40.0.tar.gz", hash = "sha256:711dd50dcbc35ba42a2625fcadc2a1349e2e9abf48e35631bdabafb90d89874b", size = 732943, upload-time = "2026-04-18T05:25:26.077Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8c/bc9bc948058348ed43117cecc3007cd608f395915dae8a00974579a5dab1/polars-1.40.1.tar.gz", hash = "sha256:ab2694134b137596b5a59bfd7b4c54ebbc9b59f9403127f18e32d363777552e8", size = 733574, upload-time = "2026-04-22T19:15:55.507Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/ad/d5ed79269b7fe59a3dbbfbdbecbe1e59a0b56e38d36491e57d2bfb5846c1/polars-1.40.0-py3-none-any.whl", hash = "sha256:60b1d677ca363e2fc6fdea8c3d16c0653fd52cc37f0249e0f29d9536d5aa45ef", size = 828012, upload-time = "2026-04-18T05:23:39.055Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/91/74fc60d94488685a92ac9d49d7ec55f3e91fe9b77942a6235a5fa7f249c3/polars-1.40.1-py3-none-any.whl", hash = "sha256:c0f861219d1319cdea45c4ce4d30355a47176b8f98dcedf95ea8269f131b8abd", size = 828723, upload-time = "2026-04-22T19:14:25.452Z" },
 ]
 
 [[package]]
 name = "polars-runtime-32"
-version = "1.40.0"
+version = "1.40.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fb/b2/eae6c1b3d16c7a64ff382f557985ff939cce13455e8c9d056ab8e1e0fc87/polars_runtime_32-1.40.0.tar.gz", hash = "sha256:e31bff8bd37492c714e155e2e1429ac2d9ddf2dd6ec6474cc1cc70ac0b2bd6af", size = 2935285, upload-time = "2026-04-18T05:25:28.038Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ba/26d40f039be9f552b5fd7365a621bdfc0f8e912ef77094ae4693491b0bae/polars_runtime_32-1.40.1.tar.gz", hash = "sha256:37f3065615d1bf90d03b5326222df4c5c1f8a5d33e50470aa588e3465e6eb814", size = 2935843, upload-time = "2026-04-22T19:15:57.26Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/e4/2325689d2af4f9e70699ff98e8a2543707bebc34af78a5fe0e654107d9ed/polars_runtime_32-1.40.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:cab3ac7ff5bc9e0f4b3b146015569e9417cf0eaff8d3fb71004d73d67b6f09c7", size = 52092528, upload-time = "2026-04-18T05:23:42.341Z" },
-    { url = "https://files.pythonhosted.org/packages/19/a6/82157b19c5c40b2c1ed0493b87b9eaf9b4863cdedca5575ee083488b45ba/polars_runtime_32-1.40.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d29624c75c4049253300786d00882fce620b3677ce495ebc4199292de8c2ba02", size = 46365073, upload-time = "2026-04-18T05:23:46.7Z" },
-    { url = "https://files.pythonhosted.org/packages/85/b5/5c4f1f2545f56c664cc57bbdd1aa66fcfcb129aa137ed72cc81d58eb480f/polars_runtime_32-1.40.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a034dc0d8481fc1ca0456ab33e98e53a4c6d6cc6a2edb36246cc81c936b925dc", size = 50250561, upload-time = "2026-04-18T05:23:51.316Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/51/cb5eb75394f39c0ec14fddcc9b11adb707e1f28224a552ecbfa72d39b61b/polars_runtime_32-1.40.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70e78c2f13a54a9d92ae30d2625bda759173cc4867ad6a39f85f140058d899c6", size = 56243695, upload-time = "2026-04-18T05:23:55.932Z" },
-    { url = "https://files.pythonhosted.org/packages/16/3a/be1437c0fbecbb07d81b151456089c3cf054eea5a791f849ed39b67611ca/polars_runtime_32-1.40.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1843272c0ef49f4a07435888f0059eca08ec16ab9880219c457195a081df0281", size = 50427843, upload-time = "2026-04-18T05:24:00.159Z" },
-    { url = "https://files.pythonhosted.org/packages/be/c7/ea6449a2161816a13ed1d8aa02177d5a0594e011f0df5ddd2fad8e5bf20e/polars_runtime_32-1.40.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:081237dba07f15d61fc151825f203165480e9503ebe72a474a8c99aa78021962", size = 54153077, upload-time = "2026-04-18T05:24:05.066Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/1a/0b239138afe8b80a1a0b4c95db3884e6afbbe82ec3318918ab03bc57f231/polars_runtime_32-1.40.0-cp310-abi3-win_amd64.whl", hash = "sha256:a916040e0b7f461ce987e4551fed9eea5914b4fbb5af907b1d9e80db71fadeb5", size = 51822748, upload-time = "2026-04-18T05:24:09.384Z" },
-    { url = "https://files.pythonhosted.org/packages/06/ce/c16ef8fd3030b7342032b040fab21a42f6fee57e47ee7f41e2f1a1e36f01/polars_runtime_32-1.40.0-cp310-abi3-win_arm64.whl", hash = "sha256:719c64eecde24a95aa3599eb9c8efc98c1499bab7ef9c01cbbe8939cd583e654", size = 45819617, upload-time = "2026-04-18T05:24:13.214Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/46/22c8af5eed68ac2eeb556e0fa3ca8a7b798e984ceff4450888f3b5ac61fd/polars_runtime_32-1.40.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b748ef652270cc49e9e69f99a035e0eb4d5f856d42bcd6ac4d9d80a40142aa1e", size = 52098755, upload-time = "2026-04-22T19:14:28.555Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/48599a38009ca60ff82a6f38c8a621ce3c0286aa7397c7d79e741bd9060e/polars_runtime_32-1.40.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d249b3743e05986060cec0a7aaa542d020df6c6b876e556023a310efd581f9be", size = 46367542, upload-time = "2026-04-22T19:14:32.433Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e9/384bc069367a1a36ee31c13782c178dbd039b2b873b772d4a0fc23a2373d/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5987b30e7aa1059d069498496e8dda35afd592b0ac3d46ed87e3ff8df1ad652c", size = 50252104, upload-time = "2026-04-22T19:14:35.945Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ef/7d57ceb0651af74194e97ed6583e148d352f03d696090221b8059cdfc90b/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d7f42a8b3f16fc66002cc0f6516f7dd7653396886ae0ed362ab95c0b3408b59", size = 56250788, upload-time = "2026-04-22T19:14:39.743Z" },
+    { url = "https://files.pythonhosted.org/packages/10/0f/e4b3ffc748827a14a474ec9c42e45c066050e440fec57e914091d9adda75/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e5f7becc237a7ec9d9a10878dc8e54b73bbf4e2d94a2991c37d7a0b38590d8f9", size = 50432590, upload-time = "2026-04-22T19:14:43.388Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/0b/b8d95fbed869fa4caabe9c400e4210374913b376e925e96fdcfa9be6416b/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:992d14cf191dde043d36fbdbc98a65e43fbc7e9a5024cecd45f838ac4988c1ee", size = 54155564, upload-time = "2026-04-22T19:14:47.239Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d9/d091d8fb5cbed5e9536adfed955c4c89987a4cc3b8e73ae4532402b91c74/polars_runtime_32-1.40.1-cp310-abi3-win_amd64.whl", hash = "sha256:f78bb2abd00101cbb23cc0cb068f7e36e081057a15d2ec2dde3dda280709f030", size = 51829755, upload-time = "2026-04-22T19:14:50.85Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ad/b33c3022a394f3eb55c3310597cec615412a8a33880055eee191d154a628/polars_runtime_32-1.40.1-cp310-abi3-win_arm64.whl", hash = "sha256:b5cbfaf6b085b420b4bfcbe24e8f665076d1cccfdb80c0484c02a023ce205537", size = 45822104, upload-time = "2026-04-22T19:14:54.192Z" },
 ]
 
 [[package]]
@@ -5636,15 +5591,15 @@ wheels = [
 
 [[package]]
 name = "pyopenssl"
-version = "26.0.0"
+version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/11/a62e1d33b373da2b2c2cd9eb508147871c80f12b1cacde3c5d314922afdd/pyopenssl-26.0.0.tar.gz", hash = "sha256:f293934e52936f2e3413b89c6ce36df66a0b34ae1ea3a053b8c5020ff2f513fc", size = 185534, upload-time = "2026-03-15T14:28:26.353Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/a8/26d36401e3ab8eed9030ad33f381da7856fcfad5691780fccd1b019718fc/pyopenssl-26.1.0.tar.gz", hash = "sha256:737f0a2275c5bc54f3b02137687e1a765931fb3949b9a92a825e4d33b9eec08b", size = 186181, upload-time = "2026-04-24T20:23:48.115Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/7d/d4f7d908fa8415571771b30669251d57c3cf313b36a856e6d7548ae01619/pyopenssl-26.0.0-py3-none-any.whl", hash = "sha256:df94d28498848b98cc1c0ffb8ef1e71e40210d3b0a8064c9d29571ed2904bf81", size = 57969, upload-time = "2026-03-15T14:28:24.864Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/41/52f3a3e812b816a91e89aa504199d8bf989a1f873192b10762be66cf2009/pyopenssl-26.1.0-py3-none-any.whl", hash = "sha256:115563879b2c8ccb207975705d3e491434d8c9d7c79667c902ecbf5f3bbd2ece", size = 58109, upload-time = "2026-04-24T20:23:46.273Z" },
 ]
 
 [[package]]
@@ -5658,15 +5613,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.408"
+version = "1.1.409"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
 ]
 
 [[package]]
@@ -6199,27 +6154,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.11"
+version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
-    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
-    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
-    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
-    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
-    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
-    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
-    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
-    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]
@@ -7444,15 +7399,15 @@ test = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.3.4"
+version = "3.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/9a/f35932a8c0eb6b2287b66fa65a0321df8c84e4e355a659c1841a37c39fdb/sse_starlette-3.4.1.tar.gz", hash = "sha256:f780bebcf6c8997fe514e3bd8e8c648d8284976b391c8bed0bcb1f611632b555", size = 35127, upload-time = "2026-04-26T13:32:32.292Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/07/45c21ed03d708c477367305726b89919b020a3a2a01f72aaf5ad941caf35/sse_starlette-3.4.1-py3-none-any.whl", hash = "sha256:6b43cf21f1d574d582a6e1b0cfbde1c94dc86a32a701a7168c99c4475c6bd1d0", size = 16487, upload-time = "2026-04-26T13:32:30.819Z" },
 ]
 
 [[package]]
@@ -7746,11 +7701,11 @@ wheels = [
 
 [[package]]
 name = "tzdata"
-version = "2026.1"
+version = "2026.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]
@@ -7879,16 +7834,16 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.45.0"
+version = "0.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/62b0d9a2cfc8b4de6771322dae30f2db76c66dae9ec32e94e176a44ad563/uvicorn-0.45.0.tar.gz", hash = "sha256:3fe650df136c5bd2b9b06efc5980636344a2fbb840e9ddd86437d53144fa335d", size = 87818, upload-time = "2026-04-21T10:43:46.815Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/88/d0f7512465b166a4e931ccf7e77792be60fb88466a43964c7566cbaff752/uvicorn-0.45.0-py3-none-any.whl", hash = "sha256:2db26f588131aeec7439de00f2dd52d5f210710c1f01e407a52c90b880d1fd4f", size = 69838, upload-time = "2026-04-21T10:43:45.029Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -21,7 +21,10 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "mysql-connector-python", marker = "python_full_version >= '3.12'", specifier = "<9.7.0" }]
+overrides = [
+    { name = "mysql-connector-python", marker = "python_full_version < '3.12'" },
+    { name = "mysql-connector-python", marker = "python_full_version >= '3.12'", specifier = "<9.7.0" },
+]
 
 [[package]]
 name = "adbc-driver-bigquery"
@@ -5701,7 +5704,7 @@ minio = [
     { name = "minio" },
 ]
 mysql = [
-    { name = "mysql-connector-python", marker = "python_full_version >= '3.12'" },
+    { name = "mysql-connector-python" },
 ]
 oracle = [
     { name = "oracledb" },
@@ -6993,7 +6996,7 @@ mypyc = [
     { name = "sqlglot", extra = ["c"] },
 ]
 mysql-connector = [
-    { name = "mysql-connector-python", marker = "python_full_version >= '3.12'" },
+    { name = "mysql-connector-python" },
 ]
 nanoid = [
     { name = "fastnanoid" },


### PR DESCRIPTION
## Summary

Overhauls Oracle's type coercion path so the common cases just work and the
uncommon cases have an explicit escape hatch.

### Native JSON

- 21c+ binds Python `dict` / `list` directly via `DB_TYPE_JSON` (binary OSON);
  19c-20c falls back to `BLOB CHECK (... IS JSON)`; pre-19c uses
  `CLOB CHECK (... IS JSON)`. The right path is picked from the server's
  major version, cached on the connection.
- The default JSON serializer strategy is now `"driver"` so the binary path
  isn't skipped by an upstream string serialization.
- Output side: `DB_TYPE_JSON` columns return Python objects as-is, and BLOB /
  CLOB columns whose `type_name` includes `JSON` are auto-parsed.

### VECTOR ergonomics (Oracle 23ai)

- `list[float]`, `list[int]`, `tuple[...]`, `array.array`, and `np.ndarray`
  all bind to `DB_TYPE_VECTOR` with no flag toggle. Integer sequences in the
  int8 range pack as int8; everything else falls back to float32.
- New `vector_return_format` driver feature (`"numpy"` / `"list"` / `"array"`)
  controls how VECTOR reads materialize. Defaults to `"numpy"` when NumPy is
  installed, `"list"` otherwise. Errors loudly if `"numpy"` is requested
  without NumPy.
- Module renamed from `_numpy_handlers` to `_vector_handlers` to reflect
  the broader payload coverage. Public API (`numpy_converter_in`, etc.)
  is unchanged.

### Smart LOB coercion

- New typed wrappers — `OracleClob`, `OracleBlob`, `OracleJson` — let users
  bypass the size heuristics when they want explicit control. `OracleClob(bytes)`
  decodes utf-8 before binding; `OracleBlob(str)` encodes utf-8;
  `OracleJson(...)` defers to the JSON handler chain so the value never gets
  coerced into a CLOB intermediary.
- Wrappers work for both named (`{"col": OracleClob(...)}`) and positional
  (`(1, OracleClob(...))`) bind shapes.
- The 4000 / 2000 byte thresholds are now `driver_features` settings —
  `oracle_varchar2_byte_limit` and `oracle_raw_byte_limit` — so users on
  databases with `MAX_STRING_SIZE=EXTENDED` can opt into 32767-byte VARCHAR2
  without auto-coercion to CLOB.