### PR TITLE
feat: filter & service corrections

### DIFF
--- a/docs/recipes/service_layer.rst
+++ b/docs/recipes/service_layer.rst
@@ -39,7 +39,7 @@ Base Service
 
 
          class SQLSpecAsyncService(Generic[AsyncDriverT]):
-             """Base async service with pagination, get-or-404, and transactions."""
+             """Base async service with pagination, get-one, and transactions."""
 
              def __init__(self, driver: AsyncDriverT) -> None:
                  self.driver = driver
@@ -88,7 +88,7 @@ Base Service
                      total=total,
                  )
 
-             async def get_or_404(
+             async def get_one(
                  self,
                  statement: Statement | QueryBuilder,
                  /,
@@ -160,7 +160,7 @@ Base Service
 
 
          class SQLSpecSyncService(Generic[SyncDriverT]):
-             """Base sync service with pagination, get-or-404, and transactions."""
+             """Base sync service with pagination, get-one, and transactions."""
 
              def __init__(self, driver: SyncDriverT) -> None:
                  self.driver = driver
@@ -209,7 +209,7 @@ Base Service
                      total=total,
                  )
 
-             def get_or_404(
+             def get_one(
                  self,
                  statement: Statement | QueryBuilder,
                  /,
@@ -294,7 +294,7 @@ Filters from Litestar dependencies flow straight through ``*filters`` to the dri
                  )
 
              async def get_user(self, user_id: UUID) -> User:
-                 return await self.get_or_404(
+                 return await self.get_one(
                      sql.select("id", "email", "name").from_("users").where_eq("id", user_id),
                      schema_type=User,
                      error_message=f"User {user_id} not found",
@@ -338,7 +338,7 @@ Filters from Litestar dependencies flow straight through ``*filters`` to the dri
                  )
 
              def get_user(self, user_id: UUID) -> User:
-                 return self.get_or_404(
+                 return self.get_one(
                      sql.select("id", "email", "name").from_("users").where_eq("id", user_id),
                      schema_type=User,
                      error_message=f"User {user_id} not found",

--- a/docs/usage/filtering.rst
+++ b/docs/usage/filtering.rst
@@ -17,7 +17,6 @@ to get both the page data and the total matching count.
    :end-before: # end-example
    :dedent: 4
    :no-upgrade:
-
 Core Filter Types
 -----------------
 
@@ -25,7 +24,7 @@ SQLSpec defines filter types in ``sqlspec.core`` that can be used independently
 or with framework integrations:
 
 - ``LimitOffsetFilter(limit, offset)`` -- pagination
-- ``OrderByFilter(field_name, sort_order)`` -- sorting
+- ``OrderByFilter(field_name, sort_order)`` -- sorting (supports expression mode)
 - ``SearchFilter(field_name, value, ignore_case)`` -- text search
 - ``BeforeAfterFilter(field_name, before, after)`` -- date range
 - ``InCollectionFilter(field_name, values)`` -- set membership
@@ -33,7 +32,44 @@ or with framework integrations:
 - ``NullFilter(field_name)`` -- IS NULL check
 - ``NotNullFilter(field_name)`` -- IS NOT NULL check
 
+Qualified Field Names
+~~~~~~~~~~~~~~~~~~~~~
+
+Every field-name-bearing filter supports table-qualified field names (e.g. ``p.name``).
+SQLSpec correctly parses these into qualified SQLGlot column references and sanitizes
+generated parameter names (e.g. ``p_name_search``), making filters safe to use in
+joined queries.
+
+.. code-block:: python
+
+    # Disambiguate columns in a JOIN
+    query = sql.select("p.name", "c.name").from_("parent p").join("child c", "p.id = c.parent_id")
+    filter_obj = SearchFilter(field_name="p.name", value="alice")
+    # Results in: WHERE p.name LIKE :p_name_search
+
+Expression Mode
+~~~~~~~~~~~~~~~
+
+Filters like ``OrderByFilter`` support passing a SQLGlot expression instead of a
+string field name. This allows complex sorting and filtering logic:
+
+.. code-block:: python
+
+    from sqlglot import exp
+
+    # Sort by COALESCE(lines, 0)
+    expr = exp.func("COALESCE", exp.column("lines"), exp.Literal.number(0))
+    filter_obj = OrderByFilter(field_name=expr, sort_order="desc")
+
+Search Patterns
+~~~~~~~~~~~~~~~
+
+``SearchFilter`` and ``NotInSearchFilter`` expose a ``like_pattern`` property
+that returns the percent-wrapped search value (e.g. ``%alice%``). This is useful
+when you need to use the pattern construction logic outside of the filter system.
+
 Litestar Filter Dependencies
+
 -----------------------------
 
 When using the Litestar extension, ``create_filter_dependencies()`` auto-generates
@@ -75,6 +111,27 @@ Using filters in a Litestar handler:
 
 The generated dependencies automatically handle query parameters for configured fields like
 ``?currentPage=2&pageSize=10&searchString=alice&orderBy=name&sortOrder=asc``.
+
+Service Layer
+-------------
+
+For common database operations and pagination in application services, SQLSpec provides
+base classes ``SQLSpecAsyncService`` and ``SQLSpecSyncService`` in ``sqlspec.service``.
+
+.. code-block:: python
+
+    from sqlspec.service import SQLSpecAsyncService
+    from sqlspec.core.filters import LimitOffsetFilter
+
+    class UserService(SQLSpecAsyncService):
+        async def list_users(self, filters: list[StatementFilter]) -> OffsetPagination[User]:
+            query = sql.select("*").from_("users")
+            return await self.paginate(query, *filters, schema_type=User)
+
+    async def some_handler(db_session: AsyncDriver, filters: list[StatementFilter]):
+        service = UserService(db_session)
+        page = await service.list_users(filters)
+        return page  # Returns OffsetPagination container
 
 Related Guides
 --------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ maintainers = [{ name = "Litestar Developers", email = "hello@litestar.dev" }]
 name = "sqlspec"
 readme = "README.md"
 requires-python = ">=3.10, <4.0"
-version = "0.44.1"
+version = "0.45.0"
 
 [project.urls]
 Discord = "https://discord.gg/litestar"
@@ -264,7 +264,7 @@ opt_level = "3"   # Maximum optimization (0-3)
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.44.1"
+current_version = "0.45.0"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to v{new_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ maintainers = [{ name = "Litestar Developers", email = "hello@litestar.dev" }]
 name = "sqlspec"
 readme = "README.md"
 requires-python = ">=3.10, <4.0"
-version = "0.44.0"
+version = "0.44.1"
 
 [project.urls]
 Discord = "https://discord.gg/litestar"
@@ -264,7 +264,7 @@ opt_level = "3"   # Maximum optimization (0-3)
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.44.0"
+current_version = "0.44.1"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to v{new_version}"

--- a/sqlspec/builder/_select.py
+++ b/sqlspec/builder/_select.py
@@ -425,7 +425,13 @@ class OrderByClauseMixin:
                     order_item = order_item.desc()
             else:
                 extracted_item = extract_expression(item)
-                order_item = extracted_item.desc() if desc and not isinstance(item, exp.Ordered) else extracted_item
+                if isinstance(extracted_item, exp.Alias):
+                    alias_name = (extracted_item.alias or "").lower()
+                    if alias_name in {"asc", "desc"}:
+                        extracted_item = exp.Ordered(this=extracted_item.this, desc=alias_name == "desc")
+                order_item = (
+                    extracted_item.desc() if desc and not isinstance(extracted_item, exp.Ordered) else extracted_item
+                )
             current_expr = current_expr.order_by(order_item, copy=False)
         builder.set_expression(current_expr)
         return cast("Self", builder)

--- a/sqlspec/core/filters.py
+++ b/sqlspec/core/filters.py
@@ -135,7 +135,7 @@ class StatementFilter(ABC):
 
         if "." in field_name:
             # Use maybe_parse for dotted names to get qualified columns
-            parsed = exp.maybe_parse(field_name)
+            parsed: exp.Expression | None = exp.maybe_parse(field_name)
             if isinstance(parsed, exp.Column):
                 return parsed
         return exp.column(field_name)

--- a/sqlspec/core/filters.py
+++ b/sqlspec/core/filters.py
@@ -59,6 +59,7 @@ __all__ = (
     "apply_filter",
     "canonicalize_filters",
     "create_filters",
+    "find_filter",
 )
 
 T = TypeVar("T")
@@ -742,6 +743,15 @@ class SearchFilter(StatementFilter):
     def ignore_case(self) -> bool | None:
         return self._ignore_case
 
+    @property
+    def like_pattern(self) -> str | None:
+        """Return the search value wrapped in LIKE wildcards.
+
+        Returns:
+            The pattern for a LIKE operation, or None if no value.
+        """
+        return f"%{self.value}%" if self.value else None
+
     def get_param_name(self) -> str | None:
         """Get parameter name without storing it."""
         if not self.value:
@@ -756,8 +766,7 @@ class SearchFilter(StatementFilter):
         named_parameters = {}
         param_name = self.get_param_name()
         if self.value and param_name:
-            search_value_with_wildcards = f"%{self.value}%"
-            named_parameters[param_name] = search_value_with_wildcards
+            named_parameters[param_name] = self.like_pattern
         return [], named_parameters
 
     def append_to_statement(self, statement: "SQL") -> "SQL":
@@ -788,8 +797,7 @@ class SearchFilter(StatementFilter):
         else:
             result = statement
 
-        search_value_with_wildcards = f"%{self.value}%"
-        return result.add_named_parameter(param_name, search_value_with_wildcards)
+        return result.add_named_parameter(param_name, self.like_pattern)
 
     def get_cache_key(self) -> "tuple[Any, ...]":
         """Return cache key for this filter configuration."""
@@ -884,8 +892,7 @@ class NotInSearchFilter(SearchFilter):
         named_parameters = {}
         param_name = self.get_param_name()
         if self.value and param_name:
-            search_value_with_wildcards = f"%{self.value}%"
-            named_parameters[param_name] = search_value_with_wildcards
+            named_parameters[param_name] = self.like_pattern
         return [], named_parameters
 
     def append_to_statement(self, statement: "SQL") -> "SQL":
@@ -920,8 +927,7 @@ class NotInSearchFilter(SearchFilter):
         else:
             result = statement
 
-        search_value_with_wildcards = f"%{self.value}%"
-        return result.add_named_parameter(param_name, search_value_with_wildcards)
+        return result.add_named_parameter(param_name, self.like_pattern)
 
     def get_cache_key(self) -> "tuple[Any, ...]":
         """Return cache key for this filter configuration."""
@@ -940,6 +946,22 @@ def apply_filter(statement: "SQL", filter_obj: StatementFilter) -> "SQL":
         The modified query object.
     """
     return filter_obj.append_to_statement(statement)
+
+
+def find_filter(filter_type: type[FilterTypeT], filters: abc.Sequence[StatementFilter | Any]) -> FilterTypeT | None:
+    """Get the filter specified by filter type from the filters.
+
+    Args:
+        filter_type: The type of filter to find.
+        filters: Filters to search through.
+
+    Returns:
+        The match filter instance or None.
+    """
+    for filter_ in filters:
+        if isinstance(filter_, filter_type):
+            return filter_
+    return None
 
 
 FilterTypes: TypeAlias = (

--- a/sqlspec/core/filters.py
+++ b/sqlspec/core/filters.py
@@ -120,6 +120,33 @@ class StatementFilter(ABC):
 
         return resolved_names
 
+    def _get_column_expression(self, field_name: str) -> exp.Column:
+        """Parse field name into a qualified column if dotted, else bare column.
+
+        Args:
+            field_name: Field name string (e.g. "name" or "users.name")
+
+        Returns:
+            exp.Column: SQLGlot column expression
+        """
+        if "." in field_name:
+            # Use maybe_parse for dotted names to get qualified columns
+            parsed = exp.maybe_parse(field_name)
+            if isinstance(parsed, exp.Column):
+                return parsed
+        return exp.column(field_name)
+
+    def _sanitize_param_name(self, name: str) -> str:
+        """Sanitize field name for use as a parameter name by replacing dots with underscores.
+
+        Args:
+            name: Original parameter name string
+
+        Returns:
+            str: Sanitized parameter name
+        """
+        return name.replace(".", "_")
+
     @abstractmethod
     def get_cache_key(self) -> "tuple[Any, ...]":
         """Return a cache key for this filter's configuration.
@@ -157,10 +184,11 @@ class BeforeAfterFilter(StatementFilter):
     def get_param_names(self) -> "list[str]":
         """Get parameter names without storing them."""
         names = []
+        sanitized_field = self._sanitize_param_name(self.field_name)
         if self.before:
-            names.append(f"{self.field_name}_before")
+            names.append(f"{sanitized_field}_before")
         if self.after:
-            names.append(f"{self.field_name}_after")
+            names.append(f"{sanitized_field}_after")
         return names
 
     def extract_parameters(self) -> "tuple[list[Any], dict[str, Any]]":
@@ -178,7 +206,7 @@ class BeforeAfterFilter(StatementFilter):
     def append_to_statement(self, statement: "SQL") -> "SQL":
         """Apply filter to SQL expression only."""
         conditions: list[Condition] = []
-        col_expr = exp.column(self.field_name)
+        col_expr = self._get_column_expression(self.field_name)
 
         proposed_names = self.get_param_names()
         if not proposed_names:
@@ -239,10 +267,11 @@ class OnBeforeAfterFilter(StatementFilter):
     def get_param_names(self) -> "list[str]":
         """Get parameter names without storing them."""
         names = []
+        sanitized_field = self._sanitize_param_name(self.field_name)
         if self.on_or_before:
-            names.append(f"{self.field_name}_on_or_before")
+            names.append(f"{sanitized_field}_on_or_before")
         if self.on_or_after:
-            names.append(f"{self.field_name}_on_or_after")
+            names.append(f"{sanitized_field}_on_or_after")
         return names
 
     def extract_parameters(self) -> "tuple[list[Any], dict[str, Any]]":
@@ -259,6 +288,7 @@ class OnBeforeAfterFilter(StatementFilter):
 
     def append_to_statement(self, statement: "SQL") -> "SQL":
         conditions: list[Condition] = []
+        col_expr = self._get_column_expression(self.field_name)
 
         proposed_names = self.get_param_names()
         if not proposed_names:
@@ -271,16 +301,12 @@ class OnBeforeAfterFilter(StatementFilter):
         if self.on_or_before:
             before_param_name = resolved_names[param_idx]
             param_idx += 1
-            conditions.append(
-                exp.LTE(this=exp.column(self.field_name), expression=exp.Placeholder(this=before_param_name))
-            )
+            conditions.append(exp.LTE(this=col_expr, expression=exp.Placeholder(this=before_param_name)))
             result = result.add_named_parameter(before_param_name, self.on_or_before)
 
         if self.on_or_after:
             after_param_name = resolved_names[param_idx]
-            conditions.append(
-                exp.GTE(this=exp.column(self.field_name), expression=exp.Placeholder(this=after_param_name))
-            )
+            conditions.append(exp.GTE(this=col_expr, expression=exp.Placeholder(this=after_param_name)))
             result = result.add_named_parameter(after_param_name, self.on_or_after)
 
         final_condition = conditions[0]
@@ -326,7 +352,8 @@ class InCollectionFilter(InAnyFilter[T]):
         """Get parameter names without storing them."""
         if not self.values:
             return []
-        return [f"{self.field_name}_in_{i}" for i, _ in enumerate(self.values)]
+        sanitized_field = self._sanitize_param_name(self.field_name)
+        return [f"{sanitized_field}_in_{i}" for i, _ in enumerate(self.values)]
 
     def extract_parameters(self) -> "tuple[list[Any], dict[str, Any]]":
         """Extract filter parameters."""
@@ -344,13 +371,14 @@ class InCollectionFilter(InAnyFilter[T]):
         if not self.values:
             return statement.where(exp.false())
 
+        col_expr = self._get_column_expression(self.field_name)
         resolved_names = self._resolve_parameter_conflicts(statement, self.get_param_names())
 
         placeholder_expressions: list[exp.Placeholder] = [
             exp.Placeholder(this=param_name) for param_name in resolved_names
         ]
 
-        result = statement.where(exp.In(this=exp.column(self.field_name), expressions=placeholder_expressions))
+        result = statement.where(exp.In(this=col_expr, expressions=placeholder_expressions))
 
         for resolved_name, value in zip(resolved_names, self.values, strict=False):
             result = result.add_named_parameter(resolved_name, value)
@@ -386,7 +414,8 @@ class NotInCollectionFilter(InAnyFilter[T]):
         """Get parameter names without storing them."""
         if not self.values:
             return []
-        return [f"{self.field_name}_notin_{i}" for i, _ in enumerate(self.values)]
+        sanitized_field = self._sanitize_param_name(self.field_name)
+        return [f"{sanitized_field}_notin_{i}" for i, _ in enumerate(self.values)]
 
     def extract_parameters(self) -> "tuple[list[Any], dict[str, Any]]":
         """Extract filter parameters."""
@@ -401,15 +430,14 @@ class NotInCollectionFilter(InAnyFilter[T]):
         if self.values is None or not self.values:
             return statement
 
+        col_expr = self._get_column_expression(self.field_name)
         resolved_names = self._resolve_parameter_conflicts(statement, self.get_param_names())
 
         placeholder_expressions: list[exp.Placeholder] = [
             exp.Placeholder(this=param_name) for param_name in resolved_names
         ]
 
-        result = statement.where(
-            exp.Not(this=exp.In(this=exp.column(self.field_name), expressions=placeholder_expressions))
-        )
+        result = statement.where(exp.Not(this=exp.In(this=col_expr, expressions=placeholder_expressions)))
 
         for resolved_name, value in zip(resolved_names, self.values, strict=False):
             result = result.add_named_parameter(resolved_name, value)
@@ -445,7 +473,8 @@ class AnyCollectionFilter(InAnyFilter[T]):
         """Get parameter names without storing them."""
         if not self.values:
             return []
-        return [f"{self.field_name}_any_{i}" for i, _ in enumerate(self.values)]
+        sanitized_field = self._sanitize_param_name(self.field_name)
+        return [f"{sanitized_field}_any_{i}" for i, _ in enumerate(self.values)]
 
     def extract_parameters(self) -> "tuple[list[Any], dict[str, Any]]":
         """Extract filter parameters."""
@@ -463,12 +492,13 @@ class AnyCollectionFilter(InAnyFilter[T]):
         if not self.values:
             return statement.where(exp.false())
 
+        col_expr = self._get_column_expression(self.field_name)
         resolved_names = self._resolve_parameter_conflicts(statement, self.get_param_names())
 
         placeholder_expressions: list[exp.Expr] = [exp.Placeholder(this=param_name) for param_name in resolved_names]
 
         array_expr = exp.Array(expressions=placeholder_expressions)
-        result = statement.where(exp.EQ(this=exp.column(self.field_name), expression=exp.Any(this=array_expr)))
+        result = statement.where(exp.EQ(this=col_expr, expression=exp.Any(this=array_expr)))
 
         for resolved_name, value in zip(resolved_names, self.values, strict=False):
             result = result.add_named_parameter(resolved_name, value)
@@ -504,7 +534,8 @@ class NotAnyCollectionFilter(InAnyFilter[T]):
         """Get parameter names without storing them."""
         if not self.values:
             return []
-        return [f"{self.field_name}_not_any_{i}" for i, _ in enumerate(self.values)]
+        sanitized_field = self._sanitize_param_name(self.field_name)
+        return [f"{sanitized_field}_not_any_{i}" for i, _ in enumerate(self.values)]
 
     def extract_parameters(self) -> "tuple[list[Any], dict[str, Any]]":
         """Extract filter parameters."""
@@ -519,12 +550,13 @@ class NotAnyCollectionFilter(InAnyFilter[T]):
         if self.values is None or not self.values:
             return statement
 
+        col_expr = self._get_column_expression(self.field_name)
         resolved_names = self._resolve_parameter_conflicts(statement, self.get_param_names())
 
         placeholder_expressions: list[exp.Expr] = [exp.Placeholder(this=param_name) for param_name in resolved_names]
 
         array_expr = exp.Array(expressions=placeholder_expressions)
-        condition = exp.EQ(this=exp.column(self.field_name), expression=exp.Any(this=array_expr))
+        condition = exp.EQ(this=col_expr, expression=exp.Any(this=array_expr))
         result = statement.where(exp.Not(this=condition))
 
         for resolved_name, value in zip(resolved_names, self.values, strict=False):
@@ -640,7 +672,7 @@ class OrderByFilter(StatementFilter):
         if converted_sort_order not in {"asc", "desc"}:
             converted_sort_order = "asc"
 
-        col_expr = exp.column(self.field_name)
+        col_expr = self._get_column_expression(self.field_name)
         order_expr = col_expr.desc() if converted_sort_order == "desc" else col_expr.asc()
 
         # Prefer cached expression to avoid re-parsing
@@ -699,7 +731,8 @@ class SearchFilter(StatementFilter):
         if not self.value:
             return None
         if isinstance(self.field_name, str):
-            return f"{self.field_name}_search"
+            sanitized_field = self._sanitize_param_name(self.field_name)
+            return f"{sanitized_field}_search"
         return "search_value"
 
     def extract_parameters(self) -> "tuple[list[Any], dict[str, Any]]":
@@ -722,12 +755,11 @@ class SearchFilter(StatementFilter):
         like_op = exp.ILike if self.ignore_case else exp.Like
 
         if isinstance(self.field_name, str):
-            result = statement.where(
-                like_op(this=exp.column(self.field_name), expression=exp.Placeholder(this=param_name))
-            )
+            col_expr = self._get_column_expression(self.field_name)
+            result = statement.where(like_op(this=col_expr, expression=exp.Placeholder(this=param_name)))
         elif isinstance(self.field_name, set) and self.field_name:
             field_conditions: list[Condition] = [
-                like_op(this=exp.column(field), expression=exp.Placeholder(this=param_name))
+                like_op(this=self._get_column_expression(field), expression=exp.Placeholder(this=param_name))
                 for field in self.field_name
             ]
             if not field_conditions:
@@ -773,7 +805,7 @@ class NullFilter(StatementFilter):
 
     def append_to_statement(self, statement: "SQL") -> "SQL":
         """Apply IS NULL filter to SQL expression."""
-        col_expr = exp.column(self.field_name)
+        col_expr = self._get_column_expression(self.field_name)
         is_null_condition = exp.Is(this=col_expr, expression=exp.Null())
         return statement.where(is_null_condition)
 
@@ -806,7 +838,7 @@ class NotNullFilter(StatementFilter):
 
     def append_to_statement(self, statement: "SQL") -> "SQL":
         """Apply IS NOT NULL filter to SQL expression."""
-        col_expr = exp.column(self.field_name)
+        col_expr = self._get_column_expression(self.field_name)
         is_null_condition = exp.Is(this=col_expr, expression=exp.Null())
         is_not_null_condition = exp.Not(this=is_null_condition)
         return statement.where(is_not_null_condition)
@@ -827,7 +859,8 @@ class NotInSearchFilter(SearchFilter):
         if not self.value:
             return None
         if isinstance(self.field_name, str):
-            return f"{self.field_name}_not_search"
+            sanitized_field = self._sanitize_param_name(self.field_name)
+            return f"{sanitized_field}_not_search"
         return "not_search_value"
 
     def extract_parameters(self) -> "tuple[list[Any], dict[str, Any]]":
@@ -851,12 +884,13 @@ class NotInSearchFilter(SearchFilter):
 
         result = statement
         if isinstance(self.field_name, str):
-            result = statement.where(
-                exp.Not(this=like_op(this=exp.column(self.field_name), expression=exp.Placeholder(this=param_name)))
-            )
+            col_expr = self._get_column_expression(self.field_name)
+            result = statement.where(exp.Not(this=like_op(this=col_expr, expression=exp.Placeholder(this=param_name))))
         elif isinstance(self.field_name, set) and self.field_name:
             field_conditions: list[Condition] = [
-                exp.Not(this=like_op(this=exp.column(field), expression=exp.Placeholder(this=param_name)))
+                exp.Not(
+                    this=like_op(this=self._get_column_expression(field), expression=exp.Placeholder(this=param_name))
+                )
                 for field in self.field_name
             ]
             if not field_conditions:
@@ -867,6 +901,8 @@ class NotInSearchFilter(SearchFilter):
                 for cond in field_conditions[1:]:
                     final_condition = exp.And(this=final_condition, expression=cond)
             result = statement.where(final_condition)
+        else:
+            result = statement
 
         search_value_with_wildcards = f"%{self.value}%"
         return result.add_named_parameter(param_name, search_value_with_wildcards)

--- a/sqlspec/core/filters.py
+++ b/sqlspec/core/filters.py
@@ -120,15 +120,18 @@ class StatementFilter(ABC):
 
         return resolved_names
 
-    def _get_column_expression(self, field_name: str) -> exp.Column:
+    def _get_column_expression(self, field_name: "str | exp.Expression") -> exp.Column | exp.Expression:
         """Parse field name into a qualified column if dotted, else bare column.
 
         Args:
-            field_name: Field name string (e.g. "name" or "users.name")
+            field_name: Field name string (e.g. "name" or "users.name") or SQLGlot expression
 
         Returns:
-            exp.Column: SQLGlot column expression
+            exp.Column | exp.Expression: SQLGlot column expression or provided expression
         """
+        if isinstance(field_name, exp.Expression):
+            return field_name
+
         if "." in field_name:
             # Use maybe_parse for dotted names to get qualified columns
             parsed = exp.maybe_parse(field_name)
@@ -136,15 +139,18 @@ class StatementFilter(ABC):
                 return parsed
         return exp.column(field_name)
 
-    def _sanitize_param_name(self, name: str) -> str:
+    def _sanitize_param_name(self, name: "str | exp.Expression") -> str:
         """Sanitize field name for use as a parameter name by replacing dots with underscores.
 
         Args:
-            name: Original parameter name string
+            name: Original parameter name string or expression
 
         Returns:
             str: Sanitized parameter name
         """
+        if isinstance(name, exp.Expression):
+            # For expressions, we use a hash or a generic name since we can't easily sanitize
+            return f"expr_{str(hash(name)).replace('-', '')[:8]}"
         return name.replace(".", "_")
 
     @abstractmethod
@@ -164,13 +170,15 @@ class BeforeAfterFilter(StatementFilter):
 
     __slots__ = ("_after", "_before", "_field_name")
 
-    def __init__(self, field_name: str, before: datetime | None = None, after: datetime | None = None) -> None:
+    def __init__(
+        self, field_name: "str | exp.Expression", before: datetime | None = None, after: datetime | None = None
+    ) -> None:
         self._field_name = field_name
         self._before = before
         self._after = after
 
     @property
-    def field_name(self) -> str:
+    def field_name(self) -> "str | exp.Expression":
         return self._field_name
 
     @property
@@ -246,14 +254,17 @@ class OnBeforeAfterFilter(StatementFilter):
     __slots__ = ("_field_name", "_on_or_after", "_on_or_before")
 
     def __init__(
-        self, field_name: str, on_or_before: datetime | None = None, on_or_after: datetime | None = None
+        self,
+        field_name: "str | exp.Expression",
+        on_or_before: datetime | None = None,
+        on_or_after: datetime | None = None,
     ) -> None:
         self._field_name = field_name
         self._on_or_before = on_or_before
         self._on_or_after = on_or_after
 
     @property
-    def field_name(self) -> str:
+    def field_name(self) -> "str | exp.Expression":
         return self._field_name
 
     @property
@@ -336,12 +347,12 @@ class InCollectionFilter(InAnyFilter[T]):
 
     __slots__ = ("_field_name", "_values")
 
-    def __init__(self, field_name: str, values: abc.Collection[T] | None = None) -> None:
+    def __init__(self, field_name: "str | exp.Expression", values: abc.Collection[T] | None = None) -> None:
         self._field_name = field_name
         self._values = values
 
     @property
-    def field_name(self) -> str:
+    def field_name(self) -> "str | exp.Expression":
         return self._field_name
 
     @property
@@ -398,12 +409,12 @@ class NotInCollectionFilter(InAnyFilter[T]):
 
     __slots__ = ("_field_name", "_values")
 
-    def __init__(self, field_name: str, values: abc.Collection[T] | None = None) -> None:
+    def __init__(self, field_name: "str | exp.Expression", values: abc.Collection[T] | None = None) -> None:
         self._field_name = field_name
         self._values = values
 
     @property
-    def field_name(self) -> str:
+    def field_name(self) -> "str | exp.Expression":
         return self._field_name
 
     @property
@@ -457,12 +468,12 @@ class AnyCollectionFilter(InAnyFilter[T]):
 
     __slots__ = ("_field_name", "_values")
 
-    def __init__(self, field_name: str, values: abc.Collection[T] | None = None) -> None:
+    def __init__(self, field_name: "str | exp.Expression", values: abc.Collection[T] | None = None) -> None:
         self._field_name = field_name
         self._values = values
 
     @property
-    def field_name(self) -> str:
+    def field_name(self) -> "str | exp.Expression":
         return self._field_name
 
     @property
@@ -518,12 +529,12 @@ class NotAnyCollectionFilter(InAnyFilter[T]):
 
     __slots__ = ("_field_name", "_values")
 
-    def __init__(self, field_name: str, values: abc.Collection[T] | None = None) -> None:
+    def __init__(self, field_name: "str | exp.Expression", values: abc.Collection[T] | None = None) -> None:
         self._field_name = field_name
         self._values = values
 
     @property
-    def field_name(self) -> str:
+    def field_name(self) -> "str | exp.Expression":
         return self._field_name
 
     @property
@@ -651,12 +662,12 @@ class OrderByFilter(StatementFilter):
 
     __slots__ = ("_field_name", "_sort_order")
 
-    def __init__(self, field_name: str, sort_order: Literal["asc", "desc"] = "asc") -> None:
+    def __init__(self, field_name: "str | exp.Expression", sort_order: Literal["asc", "desc"] = "asc") -> None:
         self._field_name = field_name
         self._sort_order = sort_order
 
     @property
-    def field_name(self) -> str:
+    def field_name(self) -> "str | exp.Expression":
         return self._field_name
 
     @property
@@ -709,13 +720,18 @@ class SearchFilter(StatementFilter):
 
     __slots__ = ("_field_name", "_ignore_case", "_value")
 
-    def __init__(self, field_name: str | set[str], value: str | None, ignore_case: bool | None = False) -> None:
+    def __init__(
+        self,
+        field_name: "str | exp.Expression | set[str | exp.Expression]",
+        value: str | None,
+        ignore_case: bool | None = False,
+    ) -> None:
         self._field_name = field_name
         self._value = value
         self._ignore_case = ignore_case if ignore_case is not None else False
 
     @property
-    def field_name(self) -> "str | set[str]":
+    def field_name(self) -> "str | exp.Expression | set[str | exp.Expression]":
         return self._field_name
 
     @property
@@ -789,11 +805,11 @@ class NullFilter(StatementFilter):
 
     __slots__ = ("_field_name",)
 
-    def __init__(self, field_name: str) -> None:
+    def __init__(self, field_name: "str | exp.Expression") -> None:
         self._field_name = field_name
 
     @property
-    def field_name(self) -> str:
+    def field_name(self) -> "str | exp.Expression":
         return self._field_name
 
     def extract_parameters(self) -> "tuple[list[Any], dict[str, Any]]":
@@ -822,11 +838,11 @@ class NotNullFilter(StatementFilter):
 
     __slots__ = ("_field_name",)
 
-    def __init__(self, field_name: str) -> None:
+    def __init__(self, field_name: "str | exp.Expression") -> None:
         self._field_name = field_name
 
     @property
-    def field_name(self) -> str:
+    def field_name(self) -> "str | exp.Expression":
         return self._field_name
 
     def extract_parameters(self) -> "tuple[list[Any], dict[str, Any]]":

--- a/sqlspec/core/filters.py
+++ b/sqlspec/core/filters.py
@@ -752,6 +752,22 @@ class SearchFilter(StatementFilter):
         """
         return f"%{self.value}%" if self.value else None
 
+    @staticmethod
+    def escape_like_value(value: str) -> str:
+        r"""Escape ``%`` and ``_`` metacharacters for safe LIKE/ILIKE pattern matching.
+
+        Backslash is the default LIKE escape character in PostgreSQL (with
+        ``standard_conforming_strings`` on), SQLite, and MySQL, so the produced
+        pattern is safe without an explicit ``ESCAPE`` clause on those engines.
+
+        Args:
+            value: Raw user input to escape before wrapping in wildcards.
+
+        Returns:
+            The input with ``\``, ``%``, and ``_`` escaped using ``\``.
+        """
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
     def get_param_name(self) -> str | None:
         """Get parameter name without storing it."""
         if not self.value:
@@ -759,6 +775,8 @@ class SearchFilter(StatementFilter):
         if isinstance(self.field_name, str):
             sanitized_field = self._sanitize_param_name(self.field_name)
             return f"{sanitized_field}_search"
+        if isinstance(self.field_name, exp.Expression):
+            return f"{self._sanitize_param_name(self.field_name)}_search"
         return "search_value"
 
     def extract_parameters(self) -> "tuple[list[Any], dict[str, Any]]":
@@ -782,6 +800,8 @@ class SearchFilter(StatementFilter):
         if isinstance(self.field_name, str):
             col_expr = self._get_column_expression(self.field_name)
             result = statement.where(like_op(this=col_expr, expression=exp.Placeholder(this=param_name)))
+        elif isinstance(self.field_name, exp.Expression):
+            result = statement.where(like_op(this=self.field_name, expression=exp.Placeholder(this=param_name)))
         elif isinstance(self.field_name, set) and self.field_name:
             field_conditions: list[Condition] = [
                 like_op(this=self._get_column_expression(field), expression=exp.Placeholder(this=param_name))
@@ -794,14 +814,27 @@ class SearchFilter(StatementFilter):
             for cond in field_conditions[1:]:
                 final_condition = exp.Or(this=final_condition, expression=cond)
             result = statement.where(final_condition)
+        elif isinstance(self.field_name, set):
+            return statement
         else:
-            result = statement
+            msg = (
+                f"SearchFilter.field_name must be str, exp.Expression, or set thereof; "
+                f"got {type(self.field_name).__name__}"
+            )
+            raise TypeError(msg)
 
         return result.add_named_parameter(param_name, self.like_pattern)
 
     def get_cache_key(self) -> "tuple[Any, ...]":
         """Return cache key for this filter configuration."""
-        field_names = tuple(sorted(self.field_name)) if isinstance(self.field_name, set) else self.field_name
+        if isinstance(self.field_name, set):
+            field_names: Any = tuple(
+                sorted(item.sql() if isinstance(item, exp.Expression) else item for item in self.field_name)
+            )
+        elif isinstance(self.field_name, exp.Expression):
+            field_names = self.field_name.sql()
+        else:
+            field_names = self.field_name
         return ("SearchFilter", field_names, self.value, self.ignore_case)
 
 
@@ -885,6 +918,8 @@ class NotInSearchFilter(SearchFilter):
         if isinstance(self.field_name, str):
             sanitized_field = self._sanitize_param_name(self.field_name)
             return f"{sanitized_field}_not_search"
+        if isinstance(self.field_name, exp.Expression):
+            return f"{self._sanitize_param_name(self.field_name)}_not_search"
         return "not_search_value"
 
     def extract_parameters(self) -> "tuple[list[Any], dict[str, Any]]":
@@ -905,10 +940,13 @@ class NotInSearchFilter(SearchFilter):
 
         like_op = exp.ILike if self.ignore_case else exp.Like
 
-        result = statement
         if isinstance(self.field_name, str):
             col_expr = self._get_column_expression(self.field_name)
             result = statement.where(exp.Not(this=like_op(this=col_expr, expression=exp.Placeholder(this=param_name))))
+        elif isinstance(self.field_name, exp.Expression):
+            result = statement.where(
+                exp.Not(this=like_op(this=self.field_name, expression=exp.Placeholder(this=param_name)))
+            )
         elif isinstance(self.field_name, set) and self.field_name:
             field_conditions: list[Condition] = [
                 exp.Not(
@@ -924,14 +962,27 @@ class NotInSearchFilter(SearchFilter):
                 for cond in field_conditions[1:]:
                     final_condition = exp.And(this=final_condition, expression=cond)
             result = statement.where(final_condition)
+        elif isinstance(self.field_name, set):
+            return statement
         else:
-            result = statement
+            msg = (
+                f"NotInSearchFilter.field_name must be str, exp.Expression, or set thereof; "
+                f"got {type(self.field_name).__name__}"
+            )
+            raise TypeError(msg)
 
         return result.add_named_parameter(param_name, self.like_pattern)
 
     def get_cache_key(self) -> "tuple[Any, ...]":
         """Return cache key for this filter configuration."""
-        field_names = tuple(sorted(self.field_name)) if isinstance(self.field_name, set) else self.field_name
+        if isinstance(self.field_name, set):
+            field_names: Any = tuple(
+                sorted(item.sql() if isinstance(item, exp.Expression) else item for item in self.field_name)
+            )
+        elif isinstance(self.field_name, exp.Expression):
+            field_names = self.field_name.sql()
+        else:
+            field_names = self.field_name
         return ("NotInSearchFilter", field_names, self.value, self.ignore_case)
 
 

--- a/sqlspec/driver/_common.py
+++ b/sqlspec/driver/_common.py
@@ -26,6 +26,7 @@ from sqlspec.core import (
     split_sql_script,
 )
 from sqlspec.core._pool import get_processed_state_pool, get_sql_pool
+from sqlspec.core.filters import find_filter as _find_filter_impl
 from sqlspec.core.metrics import StackExecutionMetrics
 from sqlspec.core.parameters import ParameterProcessor, structural_fingerprint, value_fingerprint
 from sqlspec.core.statement import ProcessedState
@@ -51,7 +52,8 @@ from sqlspec.utils.type_guards import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Sequence
+    import abc
+    from collections.abc import Awaitable, Callable
     from types import TracebackType
 
     from sqlspec.core import FilterTypeT, StatementFilter
@@ -2005,7 +2007,7 @@ class CommonDriverAttributesMixin:
     @staticmethod
     def find_filter(
         filter_type: "type[FilterTypeT]",
-        filters: "Sequence[StatementFilter | StatementParameters] | Sequence[StatementFilter]",
+        filters: "abc.Sequence[StatementFilter | StatementParameters] | abc.Sequence[StatementFilter]",
     ) -> "FilterTypeT | None":
         """Get the filter specified by filter type from the filters.
 
@@ -2017,10 +2019,7 @@ class CommonDriverAttributesMixin:
             The match filter instance or None
 
         """
-        for filter_ in filters:
-            if isinstance(filter_, filter_type):
-                return filter_
-        return None
+        return _find_filter_impl(filter_type, filters)
 
     def _create_count_query(self, original_sql: "SQL") -> "SQL":
         """Create a COUNT query from the original SQL statement.

--- a/sqlspec/driver/_common.py
+++ b/sqlspec/driver/_common.py
@@ -52,7 +52,7 @@ from sqlspec.utils.type_guards import (
 )
 
 if TYPE_CHECKING:
-    import abc
+    from collections import abc
     from collections.abc import Awaitable, Callable
     from types import TracebackType
 

--- a/sqlspec/extensions/fastapi/__init__.py
+++ b/sqlspec/extensions/fastapi/__init__.py
@@ -7,13 +7,16 @@ Depends() system, including filter dependency builders.
 from sqlspec.extensions.fastapi.extension import SQLSpecPlugin
 from sqlspec.extensions.fastapi.providers import DependencyDefaults, FieldNameType, FilterConfig, provide_filters
 from sqlspec.extensions.starlette.middleware import SQLSpecAutocommitMiddleware, SQLSpecManualMiddleware
+from sqlspec.service import SQLSpecAsyncService, SQLSpecSyncService
 
 __all__ = (
     "DependencyDefaults",
     "FieldNameType",
     "FilterConfig",
+    "SQLSpecAsyncService",
     "SQLSpecAutocommitMiddleware",
     "SQLSpecManualMiddleware",
     "SQLSpecPlugin",
+    "SQLSpecSyncService",
     "provide_filters",
 )

--- a/sqlspec/extensions/fastapi/providers.py
+++ b/sqlspec/extensions/fastapi/providers.py
@@ -30,6 +30,8 @@ from sqlspec.utils.text import camelize
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from sqlglot import exp
+
 __all__ = (
     "DEPENDENCY_DEFAULTS",
     "BooleanOrNone",
@@ -432,7 +434,9 @@ def _create_filter_aggregate_function_fastapi(  # noqa: C901
                 bool | None, Query(alias="searchIgnoreCase", description="Whether search should be case-insensitive.")
             ] = config.get("search_ignore_case", False),
         ) -> "SearchFilter | None":
-            field_names = set(search_fields.split(",")) if isinstance(search_fields, str) else search_fields
+            field_names: set[str | exp.Expression] = (
+                set(search_fields.split(",")) if isinstance(search_fields, str) else set(search_fields)
+            )
 
             return (
                 SearchFilter(field_name=field_names, value=search_string, ignore_case=ignore_case or False)

--- a/sqlspec/extensions/flask/__init__.py
+++ b/sqlspec/extensions/flask/__init__.py
@@ -33,5 +33,6 @@ Example:
 
 from sqlspec.extensions.flask._state import FlaskConfigState
 from sqlspec.extensions.flask.extension import SQLSpecPlugin
+from sqlspec.service import SQLSpecSyncService
 
-__all__ = ("FlaskConfigState", "SQLSpecPlugin")
+__all__ = ("FlaskConfigState", "SQLSpecPlugin", "SQLSpecSyncService")

--- a/sqlspec/extensions/flask/__init__.py
+++ b/sqlspec/extensions/flask/__init__.py
@@ -33,6 +33,6 @@ Example:
 
 from sqlspec.extensions.flask._state import FlaskConfigState
 from sqlspec.extensions.flask.extension import SQLSpecPlugin
-from sqlspec.service import SQLSpecSyncService
+from sqlspec.service import SQLSpecAsyncService, SQLSpecSyncService
 
-__all__ = ("FlaskConfigState", "SQLSpecPlugin", "SQLSpecSyncService")
+__all__ = ("FlaskConfigState", "SQLSpecAsyncService", "SQLSpecPlugin", "SQLSpecSyncService")

--- a/sqlspec/extensions/litestar/__init__.py
+++ b/sqlspec/extensions/litestar/__init__.py
@@ -11,6 +11,7 @@ from sqlspec.extensions.litestar.plugin import (
     SQLSpecPlugin,
 )
 from sqlspec.extensions.litestar.store import BaseSQLSpecStore
+from sqlspec.service import SQLSpecAsyncService, SQLSpecSyncService
 
 __all__ = (
     "DEFAULT_COMMIT_MODE",
@@ -20,8 +21,10 @@ __all__ = (
     "BaseSQLSpecStore",
     "CommitMode",
     "LitestarConfig",
+    "SQLSpecAsyncService",
     "SQLSpecChannelsBackend",
     "SQLSpecPlugin",
+    "SQLSpecSyncService",
     "database_group",
     "get_sqlspec_scope_state",
     "set_sqlspec_scope_state",

--- a/sqlspec/extensions/litestar/plugin.py
+++ b/sqlspec/extensions/litestar/plugin.py
@@ -19,7 +19,7 @@ from sqlspec.config import (
     SyncConfigT,
     SyncDatabaseConfig,
 )
-from sqlspec.core.filters import OffsetPagination
+from sqlspec.core._pagination import OffsetPagination
 from sqlspec.core.sqlcommenter import SQLCommenterContext
 from sqlspec.exceptions import ImproperConfigurationError
 from sqlspec.extensions.litestar._utils import (

--- a/sqlspec/extensions/litestar/plugin.py
+++ b/sqlspec/extensions/litestar/plugin.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, NoReturn, cast, overload
 
 from litestar.di import Provide
+from litestar.exceptions import NotFoundException
 from litestar.middleware import DefineMiddleware
 from litestar.plugins import CLIPlugin, InitPluginProtocol, OpenAPISchemaPlugin
 
@@ -21,7 +22,7 @@ from sqlspec.config import (
 )
 from sqlspec.core._pagination import OffsetPagination
 from sqlspec.core.sqlcommenter import SQLCommenterContext
-from sqlspec.exceptions import ImproperConfigurationError
+from sqlspec.exceptions import ImproperConfigurationError, NotFoundError
 from sqlspec.extensions.litestar._utils import (
     delete_sqlspec_scope_state,
     get_sqlspec_scope_state,
@@ -44,7 +45,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Callable
     from contextlib import AbstractAsyncContextManager
 
-    from litestar import Litestar
+    from litestar import Litestar, Request
     from litestar._openapi.schema_generation.schema import SchemaCreator
     from litestar.config.app import AppConfig
     from litestar.datastructures.state import State
@@ -89,7 +90,19 @@ __all__ = (
     "PluginConfigState",
     "SQLSpecPlugin",
     "_OffsetPaginationSchemaPlugin",
+    "not_found_error_handler",
 )
+
+
+def not_found_error_handler(_request: "Request[Any, Any, Any]", exc: NotFoundError) -> NoReturn:
+    """Translate :class:`sqlspec.exceptions.NotFoundError` into Litestar's HTTP 404.
+
+    Re-raised as :class:`litestar.exceptions.NotFoundException` so the standard
+    Litestar exception-handler chain renders it (including any RFC 7807 handler
+    the user has registered) and the OpenAPI 404 schema stays consistent.
+    """
+    detail = str(exc) or "Not Found"
+    raise NotFoundException(detail=detail) from exc
 
 
 class _OffsetPaginationSchemaPlugin(OpenAPISchemaPlugin):
@@ -455,6 +468,10 @@ class SQLSpecPlugin(InitPluginProtocol, CLIPlugin):
         if not any(isinstance(p, _OffsetPaginationSchemaPlugin) for p in existing_plugins):
             existing_plugins.append(_OffsetPaginationSchemaPlugin())
             app_config.plugins = existing_plugins
+
+        if app_config.exception_handlers is None:
+            app_config.exception_handlers = {}
+        app_config.exception_handlers.setdefault(NotFoundError, not_found_error_handler)
 
         if NUMPY_INSTALLED:
             import numpy as np

--- a/sqlspec/extensions/litestar/providers.py
+++ b/sqlspec/extensions/litestar/providers.py
@@ -7,7 +7,7 @@ This module contains functions to create dependency providers for services and f
 import datetime
 import inspect
 from collections.abc import Callable
-from typing import Any, Literal, NamedTuple, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict, cast
 from uuid import UUID
 
 from litestar.di import Provide
@@ -28,6 +28,9 @@ from sqlspec.core import (
 )
 from sqlspec.utils.singleton import SingletonMeta
 from sqlspec.utils.text import camelize
+
+if TYPE_CHECKING:
+    from sqlglot import exp
 
 __all__ = (
     "DEPENDENCY_DEFAULTS",
@@ -241,7 +244,9 @@ def _create_statement_filters(  # noqa: C901
                 required=False,
             ),
         ) -> SearchFilter:
-            field_names = set(search_fields.split(",")) if isinstance(search_fields, str) else set(search_fields)
+            field_names: set[str | exp.Expression] = (
+                set(search_fields.split(",")) if isinstance(search_fields, str) else set(search_fields)
+            )
             return SearchFilter(field_name=field_names, value=search_string, ignore_case=ignore_case or False)
 
         filters[dep_defaults.SEARCH_FILTER_DEPENDENCY_KEY] = Provide(provide_search_filter, sync_to_thread=False)

--- a/sqlspec/extensions/sanic/__init__.py
+++ b/sqlspec/extensions/sanic/__init__.py
@@ -7,5 +7,13 @@ connection lifecycle and request-scoped sessions.
 from sqlspec.extensions.sanic._state import SanicConfigState
 from sqlspec.extensions.sanic._utils import get_connection_from_request, get_or_create_session
 from sqlspec.extensions.sanic.extension import SQLSpecPlugin
+from sqlspec.service import SQLSpecAsyncService, SQLSpecSyncService
 
-__all__ = ("SQLSpecPlugin", "SanicConfigState", "get_connection_from_request", "get_or_create_session")
+__all__ = (
+    "SQLSpecAsyncService",
+    "SQLSpecPlugin",
+    "SQLSpecSyncService",
+    "SanicConfigState",
+    "get_connection_from_request",
+    "get_or_create_session",
+)

--- a/sqlspec/extensions/starlette/__init__.py
+++ b/sqlspec/extensions/starlette/__init__.py
@@ -8,12 +8,15 @@ from sqlspec.extensions.starlette._state import SQLSpecConfigState
 from sqlspec.extensions.starlette._utils import get_connection_from_request, get_or_create_session
 from sqlspec.extensions.starlette.extension import SQLSpecPlugin
 from sqlspec.extensions.starlette.middleware import SQLSpecAutocommitMiddleware, SQLSpecManualMiddleware
+from sqlspec.service import SQLSpecAsyncService, SQLSpecSyncService
 
 __all__ = (
+    "SQLSpecAsyncService",
     "SQLSpecAutocommitMiddleware",
     "SQLSpecConfigState",
     "SQLSpecManualMiddleware",
     "SQLSpecPlugin",
+    "SQLSpecSyncService",
     "get_connection_from_request",
     "get_or_create_session",
 )

--- a/sqlspec/service.py
+++ b/sqlspec/service.py
@@ -1,12 +1,14 @@
 """Service base classes for SQLSpec application services."""
 
 from contextlib import asynccontextmanager, contextmanager
-from typing import TYPE_CHECKING, Any, Generic
+from typing import TYPE_CHECKING, Any, Generic, cast
 
 from typing_extensions import TypeVar
 
 from sqlspec.core._pagination import OffsetPagination
 from sqlspec.core.filters import LimitOffsetFilter
+from sqlspec.driver._async import AsyncDriverAdapterBase
+from sqlspec.driver._sync import SyncDriverAdapterBase
 from sqlspec.exceptions import NotFoundError
 from sqlspec.typing import SchemaT
 
@@ -21,10 +23,11 @@ if TYPE_CHECKING:
 
 __all__ = ("SQLSpecAsyncService", "SQLSpecSyncService")
 
-DriverT = TypeVar("DriverT")
+AsyncDriverT = TypeVar("AsyncDriverT", bound=AsyncDriverAdapterBase, default=AsyncDriverAdapterBase)
+SyncDriverT = TypeVar("SyncDriverT", bound=SyncDriverAdapterBase, default=SyncDriverAdapterBase)
 
 
-class SQLSpecAsyncService(Generic[DriverT]):
+class SQLSpecAsyncService(Generic[AsyncDriverT]):
     """Base class for asynchronous SQLSpec services.
 
     Provides common database operations and pagination support using a driver session.
@@ -35,16 +38,16 @@ class SQLSpecAsyncService(Generic[DriverT]):
 
     __slots__ = ("_session",)
 
-    def __init__(self, session: DriverT) -> None:
+    def __init__(self, session: AsyncDriverT) -> None:
         self._session = session
 
     @property
-    def session(self) -> DriverT:
+    def session(self) -> AsyncDriverT:
         """Return the driver session."""
         return self._session
 
     @property
-    def driver(self) -> DriverT:
+    def driver(self) -> AsyncDriverT:
         """Alias for :attr:`session` matching the recipe-doc terminology."""
         return self._session
 
@@ -69,21 +72,20 @@ class SQLSpecAsyncService(Generic[DriverT]):
         Returns:
             An OffsetPagination instance containing items and total count.
         """
-        session: Any = self.session
-        limit_offset: LimitOffsetFilter | None = session.find_filter(LimitOffsetFilter, parameters)
+        limit_offset: LimitOffsetFilter | None = self._session.find_filter(LimitOffsetFilter, parameters)
 
-        items, total = await session.select_with_total(
+        items, total = await self._session.select_with_total(
             statement, *parameters, schema_type=schema_type, count_with_window=count_with_window, **kwargs
         )
 
         return OffsetPagination(
-            items=items,
+            items=cast("list[SchemaT]", items),
             limit=limit_offset.limit if limit_offset is not None else len(items),
             offset=limit_offset.offset if limit_offset is not None else 0,
             total=total,
         )
 
-    async def get_or_404(
+    async def get_one(
         self,
         statement: "Statement | QueryBuilder",
         /,
@@ -93,6 +95,11 @@ class SQLSpecAsyncService(Generic[DriverT]):
         **kwargs: Any,
     ) -> "SchemaT | dict[str, Any]":
         """Fetch one row or raise :class:`~sqlspec.exceptions.NotFoundError`.
+
+        HTTP status mapping (e.g. translating ``NotFoundError`` to a 404 response)
+        is the responsibility of the calling framework integration. The Litestar
+        extension registers a default mapping; other framework integrations do
+        not.
 
         Args:
             statement: The SQL statement or QueryBuilder instance.
@@ -107,11 +114,10 @@ class SQLSpecAsyncService(Generic[DriverT]):
         Raises:
             NotFoundError: If the query returns zero rows.
         """
-        session: Any = self.session
-        result = await session.select_one_or_none(statement, *parameters, schema_type=schema_type, **kwargs)
+        result = await self._session.select_one_or_none(statement, *parameters, schema_type=schema_type, **kwargs)
         if result is None:
             raise NotFoundError(error_message or "Record not found")
-        return result  # type: ignore[no-any-return]
+        return result
 
     async def exists(
         self,
@@ -130,26 +136,22 @@ class SQLSpecAsyncService(Generic[DriverT]):
         Returns:
             True if at least one row exists, False otherwise.
         """
-        session: Any = self.session
-        return await session.select_one_or_none(statement, *parameters, **kwargs) is not None
+        return await self._session.select_one_or_none(statement, *parameters, **kwargs) is not None
 
     async def begin(self) -> None:
         """Begin a database transaction on the underlying session."""
-        session: Any = self.session
-        await session.begin()
+        await self._session.begin()
 
     async def commit(self) -> None:
         """Commit the current database transaction."""
-        session: Any = self.session
-        await session.commit()
+        await self._session.commit()
 
     async def rollback(self) -> None:
         """Roll back the current database transaction."""
-        session: Any = self.session
-        await session.rollback()
+        await self._session.rollback()
 
     @asynccontextmanager
-    async def begin_transaction(self) -> "AsyncIterator[DriverT]":
+    async def begin_transaction(self) -> "AsyncIterator[AsyncDriverT]":
         """Context manager that commits on success and rolls back on error.
 
         Yields:
@@ -165,7 +167,7 @@ class SQLSpecAsyncService(Generic[DriverT]):
             await self.commit()
 
 
-class SQLSpecSyncService(Generic[DriverT]):
+class SQLSpecSyncService(Generic[SyncDriverT]):
     """Base class for synchronous SQLSpec services.
 
     Provides common database operations and pagination support using a driver session.
@@ -176,16 +178,16 @@ class SQLSpecSyncService(Generic[DriverT]):
 
     __slots__ = ("_session",)
 
-    def __init__(self, session: DriverT) -> None:
+    def __init__(self, session: SyncDriverT) -> None:
         self._session = session
 
     @property
-    def session(self) -> DriverT:
+    def session(self) -> SyncDriverT:
         """Return the driver session."""
         return self._session
 
     @property
-    def driver(self) -> DriverT:
+    def driver(self) -> SyncDriverT:
         """Alias for :attr:`session` matching the recipe-doc terminology."""
         return self._session
 
@@ -210,21 +212,20 @@ class SQLSpecSyncService(Generic[DriverT]):
         Returns:
             An OffsetPagination instance containing items and total count.
         """
-        session: Any = self.session
-        limit_offset: LimitOffsetFilter | None = session.find_filter(LimitOffsetFilter, parameters)
+        limit_offset: LimitOffsetFilter | None = self._session.find_filter(LimitOffsetFilter, parameters)
 
-        items, total = session.select_with_total(
+        items, total = self._session.select_with_total(
             statement, *parameters, schema_type=schema_type, count_with_window=count_with_window, **kwargs
         )
 
         return OffsetPagination(
-            items=items,
+            items=cast("list[SchemaT]", items),
             limit=limit_offset.limit if limit_offset is not None else len(items),
             offset=limit_offset.offset if limit_offset is not None else 0,
             total=total,
         )
 
-    def get_or_404(
+    def get_one(
         self,
         statement: "Statement | QueryBuilder",
         /,
@@ -234,6 +235,11 @@ class SQLSpecSyncService(Generic[DriverT]):
         **kwargs: Any,
     ) -> "SchemaT | dict[str, Any]":
         """Fetch one row or raise :class:`~sqlspec.exceptions.NotFoundError`.
+
+        HTTP status mapping (e.g. translating ``NotFoundError`` to a 404 response)
+        is the responsibility of the calling framework integration. The Litestar
+        extension registers a default mapping; other framework integrations do
+        not.
 
         Args:
             statement: The SQL statement or QueryBuilder instance.
@@ -248,11 +254,10 @@ class SQLSpecSyncService(Generic[DriverT]):
         Raises:
             NotFoundError: If the query returns zero rows.
         """
-        session: Any = self.session
-        result = session.select_one_or_none(statement, *parameters, schema_type=schema_type, **kwargs)
+        result = self._session.select_one_or_none(statement, *parameters, schema_type=schema_type, **kwargs)
         if result is None:
             raise NotFoundError(error_message or "Record not found")
-        return result  # type: ignore[no-any-return]
+        return result
 
     def exists(
         self,
@@ -271,26 +276,22 @@ class SQLSpecSyncService(Generic[DriverT]):
         Returns:
             True if at least one row exists, False otherwise.
         """
-        session: Any = self.session
-        return session.select_one_or_none(statement, *parameters, **kwargs) is not None
+        return self._session.select_one_or_none(statement, *parameters, **kwargs) is not None
 
     def begin(self) -> None:
         """Begin a database transaction on the underlying session."""
-        session: Any = self.session
-        session.begin()
+        self._session.begin()
 
     def commit(self) -> None:
         """Commit the current database transaction."""
-        session: Any = self.session
-        session.commit()
+        self._session.commit()
 
     def rollback(self) -> None:
         """Roll back the current database transaction."""
-        session: Any = self.session
-        session.rollback()
+        self._session.rollback()
 
     @contextmanager
-    def begin_transaction(self) -> "Iterator[DriverT]":
+    def begin_transaction(self) -> "Iterator[SyncDriverT]":
         """Context manager that commits on success and rolls back on error.
 
         Yields:

--- a/sqlspec/service.py
+++ b/sqlspec/service.py
@@ -1,0 +1,191 @@
+"""Service base classes for SQLSpec application services."""
+
+from typing import TYPE_CHECKING, Any, Generic
+
+from typing_extensions import TypeVar
+
+from sqlspec.core._pagination import OffsetPagination
+from sqlspec.typing import SchemaT
+
+if TYPE_CHECKING:
+    from sqlspec.builder import QueryBuilder
+    from sqlspec.core.filters import StatementFilter
+    from sqlspec.core.parameters import StatementParameters
+    from sqlspec.core.statement import Statement
+
+
+__all__ = ("SQLSpecAsyncService", "SQLSpecSyncService")
+
+DriverT = TypeVar("DriverT")
+
+
+class SQLSpecAsyncService(Generic[DriverT]):
+    """Base class for asynchronous SQLSpec services.
+
+    Provides common database operations and pagination support using a driver session.
+
+    Args:
+        session: The driver session instance.
+    """
+
+    __slots__ = ("_session",)
+
+    def __init__(self, session: DriverT) -> None:
+        self._session = session
+
+    @property
+    def session(self) -> DriverT:
+        """Return the driver session."""
+        return self._session
+
+    async def paginate(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: "type[SchemaT]",
+        count_with_window: bool = False,
+        **kwargs: Any,
+    ) -> OffsetPagination[SchemaT]:
+        """Execute a paginated query and return an OffsetPagination container.
+
+        Args:
+            statement: The SQL statement or QueryBuilder instance.
+            *parameters: Statement parameters or filters.
+            schema_type: The schema type to map results to.
+            count_with_window: Whether to use COUNT(*) OVER() for total count.
+            **kwargs: Additional keyword arguments for the driver.
+
+        Returns:
+            An OffsetPagination instance containing items and total count.
+        """
+        # Determine limit and offset from filters if present
+        limit: int | None = None
+        offset: int | None = None
+
+        from sqlspec.core.filters import LimitOffsetFilter
+
+        for param in parameters:
+            if isinstance(param, LimitOffsetFilter):
+                limit = param.limit
+                offset = param.offset
+                break
+
+        # select_with_total returns (list[SchemaT], int)
+        session: Any = self.session
+        items, total = await session.select_with_total(
+            statement, *parameters, schema_type=schema_type, count_with_window=count_with_window, **kwargs
+        )
+
+        return OffsetPagination(
+            items=items,
+            limit=limit if limit is not None else len(items),
+            offset=offset if offset is not None else 0,
+            total=total,
+        )
+
+    async def exists(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        **kwargs: Any,
+    ) -> bool:
+        """Check if any rows exist for the given query.
+
+        Args:
+            statement: The SQL statement or QueryBuilder instance.
+            *parameters: Statement parameters or filters.
+            **kwargs: Additional keyword arguments for the driver.
+
+        Returns:
+            True if at least one row exists, False otherwise.
+        """
+        session: Any = self.session
+        result = await session.execute(statement, *parameters, **kwargs)
+        return result.one_or_none() is not None
+
+
+class SQLSpecSyncService(Generic[DriverT]):
+    """Base class for synchronous SQLSpec services.
+
+    Provides common database operations and pagination support using a driver session.
+
+    Args:
+        session: The driver session instance.
+    """
+
+    __slots__ = ("_session",)
+
+    def __init__(self, session: DriverT) -> None:
+        self._session = session
+
+    @property
+    def session(self) -> DriverT:
+        """Return the driver session."""
+        return self._session
+
+    def paginate(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: "type[SchemaT]",
+        count_with_window: bool = False,
+        **kwargs: Any,
+    ) -> OffsetPagination[SchemaT]:
+        """Execute a paginated query and return an OffsetPagination container.
+
+        Args:
+            statement: The SQL statement or QueryBuilder instance.
+            *parameters: Statement parameters or filters.
+            schema_type: The schema type to map results to.
+            count_with_window: Whether to use COUNT(*) OVER() for total count.
+            **kwargs: Additional keyword arguments for the driver.
+
+        Returns:
+            An OffsetPagination instance containing items and total count.
+        """
+        limit: int | None = None
+        offset: int | None = None
+
+        from sqlspec.core.filters import LimitOffsetFilter
+
+        for param in parameters:
+            if isinstance(param, LimitOffsetFilter):
+                limit = param.limit
+                offset = param.offset
+                break
+
+        session: Any = self.session
+        items, total = session.select_with_total(
+            statement, *parameters, schema_type=schema_type, count_with_window=count_with_window, **kwargs
+        )
+
+        return OffsetPagination(
+            items=items,
+            limit=limit if limit is not None else len(items),
+            offset=offset if offset is not None else 0,
+            total=total,
+        )
+
+    def exists(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        **kwargs: Any,
+    ) -> bool:
+        """Check if any rows exist for the given query.
+
+        Args:
+            statement: The SQL statement or QueryBuilder instance.
+            *parameters: Statement parameters or filters.
+            **kwargs: Additional keyword arguments for the driver.
+
+        Returns:
+            True if at least one row exists, False otherwise.
+        """
+        session: Any = self.session
+        result = session.execute(statement, *parameters, **kwargs)
+        return result.one_or_none() is not None

--- a/sqlspec/service.py
+++ b/sqlspec/service.py
@@ -1,13 +1,18 @@
 """Service base classes for SQLSpec application services."""
 
+from contextlib import asynccontextmanager, contextmanager
 from typing import TYPE_CHECKING, Any, Generic
 
 from typing_extensions import TypeVar
 
 from sqlspec.core._pagination import OffsetPagination
+from sqlspec.core.filters import LimitOffsetFilter
+from sqlspec.exceptions import NotFoundError
 from sqlspec.typing import SchemaT
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
     from sqlspec.builder import QueryBuilder
     from sqlspec.core.filters import StatementFilter
     from sqlspec.core.parameters import StatementParameters
@@ -38,12 +43,17 @@ class SQLSpecAsyncService(Generic[DriverT]):
         """Return the driver session."""
         return self._session
 
+    @property
+    def driver(self) -> DriverT:
+        """Alias for :attr:`session` matching the recipe-doc terminology."""
+        return self._session
+
     async def paginate(
         self,
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[SchemaT]",
+        schema_type: "type[SchemaT] | None" = None,
         count_with_window: bool = False,
         **kwargs: Any,
     ) -> OffsetPagination[SchemaT]:
@@ -59,30 +69,49 @@ class SQLSpecAsyncService(Generic[DriverT]):
         Returns:
             An OffsetPagination instance containing items and total count.
         """
-        # Determine limit and offset from filters if present
-        limit: int | None = None
-        offset: int | None = None
-
-        from sqlspec.core.filters import LimitOffsetFilter
-
-        for param in parameters:
-            if isinstance(param, LimitOffsetFilter):
-                limit = param.limit
-                offset = param.offset
-                break
-
-        # select_with_total returns (list[SchemaT], int)
         session: Any = self.session
+        limit_offset: LimitOffsetFilter | None = session.find_filter(LimitOffsetFilter, parameters)
+
         items, total = await session.select_with_total(
             statement, *parameters, schema_type=schema_type, count_with_window=count_with_window, **kwargs
         )
 
         return OffsetPagination(
             items=items,
-            limit=limit if limit is not None else len(items),
-            offset=offset if offset is not None else 0,
+            limit=limit_offset.limit if limit_offset is not None else len(items),
+            offset=limit_offset.offset if limit_offset is not None else 0,
             total=total,
         )
+
+    async def get_or_404(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: "type[SchemaT] | None" = None,
+        error_message: str | None = None,
+        **kwargs: Any,
+    ) -> "SchemaT | dict[str, Any]":
+        """Fetch one row or raise :class:`~sqlspec.exceptions.NotFoundError`.
+
+        Args:
+            statement: The SQL statement or QueryBuilder instance.
+            *parameters: Statement parameters or filters.
+            schema_type: The schema type to map the row to.
+            error_message: Optional message for the raised :class:`NotFoundError`.
+            **kwargs: Additional keyword arguments for the driver.
+
+        Returns:
+            The single matched row, mapped to ``schema_type`` when provided.
+
+        Raises:
+            NotFoundError: If the query returns zero rows.
+        """
+        session: Any = self.session
+        result = await session.select_one_or_none(statement, *parameters, schema_type=schema_type, **kwargs)
+        if result is None:
+            raise NotFoundError(error_message or "Record not found")
+        return result  # type: ignore[no-any-return]
 
     async def exists(
         self,
@@ -102,8 +131,34 @@ class SQLSpecAsyncService(Generic[DriverT]):
             True if at least one row exists, False otherwise.
         """
         session: Any = self.session
-        result = await session.execute(statement, *parameters, **kwargs)
-        return result.one_or_none() is not None
+        return await session.select_one_or_none(statement, *parameters, **kwargs) is not None
+
+    async def begin(self) -> None:
+        """Begin a database transaction on the underlying session."""
+        session: Any = self.session
+        await session.begin()
+
+    async def commit(self) -> None:
+        """Commit the current database transaction."""
+        session: Any = self.session
+        await session.commit()
+
+    async def rollback(self) -> None:
+        """Roll back the current database transaction."""
+        session: Any = self.session
+        await session.rollback()
+
+    @asynccontextmanager
+    async def begin_transaction(self) -> "AsyncIterator[DriverT]":
+        """Context manager that commits on success and rolls back on error."""
+        await self.begin()
+        try:
+            yield self._session
+        except Exception:
+            await self.rollback()
+            raise
+        else:
+            await self.commit()
 
 
 class SQLSpecSyncService(Generic[DriverT]):
@@ -125,12 +180,17 @@ class SQLSpecSyncService(Generic[DriverT]):
         """Return the driver session."""
         return self._session
 
+    @property
+    def driver(self) -> DriverT:
+        """Alias for :attr:`session` matching the recipe-doc terminology."""
+        return self._session
+
     def paginate(
         self,
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
-        schema_type: "type[SchemaT]",
+        schema_type: "type[SchemaT] | None" = None,
         count_with_window: bool = False,
         **kwargs: Any,
     ) -> OffsetPagination[SchemaT]:
@@ -146,28 +206,49 @@ class SQLSpecSyncService(Generic[DriverT]):
         Returns:
             An OffsetPagination instance containing items and total count.
         """
-        limit: int | None = None
-        offset: int | None = None
-
-        from sqlspec.core.filters import LimitOffsetFilter
-
-        for param in parameters:
-            if isinstance(param, LimitOffsetFilter):
-                limit = param.limit
-                offset = param.offset
-                break
-
         session: Any = self.session
+        limit_offset: LimitOffsetFilter | None = session.find_filter(LimitOffsetFilter, parameters)
+
         items, total = session.select_with_total(
             statement, *parameters, schema_type=schema_type, count_with_window=count_with_window, **kwargs
         )
 
         return OffsetPagination(
             items=items,
-            limit=limit if limit is not None else len(items),
-            offset=offset if offset is not None else 0,
+            limit=limit_offset.limit if limit_offset is not None else len(items),
+            offset=limit_offset.offset if limit_offset is not None else 0,
             total=total,
         )
+
+    def get_or_404(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: "type[SchemaT] | None" = None,
+        error_message: str | None = None,
+        **kwargs: Any,
+    ) -> "SchemaT | dict[str, Any]":
+        """Fetch one row or raise :class:`~sqlspec.exceptions.NotFoundError`.
+
+        Args:
+            statement: The SQL statement or QueryBuilder instance.
+            *parameters: Statement parameters or filters.
+            schema_type: The schema type to map the row to.
+            error_message: Optional message for the raised :class:`NotFoundError`.
+            **kwargs: Additional keyword arguments for the driver.
+
+        Returns:
+            The single matched row, mapped to ``schema_type`` when provided.
+
+        Raises:
+            NotFoundError: If the query returns zero rows.
+        """
+        session: Any = self.session
+        result = session.select_one_or_none(statement, *parameters, schema_type=schema_type, **kwargs)
+        if result is None:
+            raise NotFoundError(error_message or "Record not found")
+        return result  # type: ignore[no-any-return]
 
     def exists(
         self,
@@ -187,5 +268,31 @@ class SQLSpecSyncService(Generic[DriverT]):
             True if at least one row exists, False otherwise.
         """
         session: Any = self.session
-        result = session.execute(statement, *parameters, **kwargs)
-        return result.one_or_none() is not None
+        return session.select_one_or_none(statement, *parameters, **kwargs) is not None
+
+    def begin(self) -> None:
+        """Begin a database transaction on the underlying session."""
+        session: Any = self.session
+        session.begin()
+
+    def commit(self) -> None:
+        """Commit the current database transaction."""
+        session: Any = self.session
+        session.commit()
+
+    def rollback(self) -> None:
+        """Roll back the current database transaction."""
+        session: Any = self.session
+        session.rollback()
+
+    @contextmanager
+    def begin_transaction(self) -> "Iterator[DriverT]":
+        """Context manager that commits on success and rolls back on error."""
+        self.begin()
+        try:
+            yield self._session
+        except Exception:
+            self.rollback()
+            raise
+        else:
+            self.commit()

--- a/sqlspec/service.py
+++ b/sqlspec/service.py
@@ -15,8 +15,8 @@ if TYPE_CHECKING:
 
     from sqlspec.builder import QueryBuilder
     from sqlspec.core.filters import StatementFilter
-    from sqlspec.core.parameters import StatementParameters
     from sqlspec.core.statement import Statement
+    from sqlspec.typing import StatementParameters
 
 
 __all__ = ("SQLSpecAsyncService", "SQLSpecSyncService")
@@ -150,7 +150,11 @@ class SQLSpecAsyncService(Generic[DriverT]):
 
     @asynccontextmanager
     async def begin_transaction(self) -> "AsyncIterator[DriverT]":
-        """Context manager that commits on success and rolls back on error."""
+        """Context manager that commits on success and rolls back on error.
+
+        Yields:
+            The underlying driver session bound to the active transaction.
+        """
         await self.begin()
         try:
             yield self._session
@@ -287,7 +291,11 @@ class SQLSpecSyncService(Generic[DriverT]):
 
     @contextmanager
     def begin_transaction(self) -> "Iterator[DriverT]":
-        """Context manager that commits on success and rolls back on error."""
+        """Context manager that commits on success and rolls back on error.
+
+        Yields:
+            The underlying driver session bound to the active transaction.
+        """
         self.begin()
         try:
             yield self._session

--- a/sqlspec/utils/serializers/_json.py
+++ b/sqlspec/utils/serializers/_json.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from decimal import Decimal
 from typing import Any, Final, Literal, Protocol, overload
 
-from sqlspec.core.filters import OffsetPagination
+from sqlspec.core._pagination import OffsetPagination
 from sqlspec.typing import (
     MSGSPEC_INSTALLED,
     NUMPY_INSTALLED,

--- a/tests/integration/extensions/litestar/test_in_fields_filters.py
+++ b/tests/integration/extensions/litestar/test_in_fields_filters.py
@@ -6,8 +6,9 @@ from typing import Any
 import pytest
 from litestar import Litestar, get
 from litestar.params import Dependency
-from litestar.testing import TestClient
+from litestar.testing import AsyncTestClient, TestClient
 
+from sqlspec import sql as sql_builder
 from sqlspec.adapters.aiosqlite import AiosqliteConfig
 from sqlspec.base import SQLSpec
 from sqlspec.core import FilterTypes, InCollectionFilter, NotInCollectionFilter
@@ -165,3 +166,92 @@ def test_litestar_in_fields_single_value() -> None:
             assert data["filter_count"] == 1
             assert data["field_name"] == "status"
             assert data["values"] == ["active"]
+
+
+@pytest.mark.anyio
+async def test_litestar_qualified_column_search_filter() -> None:
+    """Verify that filtering on a qualified column name in a JOIN works correctly with SearchFilter."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=True) as tmp:
+        sql = SQLSpec()
+        config = AiosqliteConfig(connection_config={"database": tmp.name})
+        sql.add_config(config)
+
+        # Setup tables with overlapping column names
+        async with sql.provide_session(config) as session:
+            await session.execute_script("""
+                CREATE TABLE parent (id INTEGER PRIMARY KEY, name TEXT);
+                CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT);
+                INSERT INTO parent (id, name) VALUES (1, 'parent1');
+                INSERT INTO child (id, parent_id, name) VALUES (1, 1, 'child1');
+            """)
+            await session.commit()
+
+        # We want to search on 'p.name'. This should now work!
+        filter_deps = create_filter_dependencies({"search": "p.name"})
+
+        @get("/joined", dependencies=filter_deps)
+        async def joined_route(filters: list[Any] = Dependency(skip_validation=True)) -> dict[str, Any]:
+            async with sql.provide_session(config) as session:
+                query = (
+                    sql_builder
+                    .select("p.name as parent_name", "c.name as child_name")
+                    .from_("parent p")
+                    .join("child c", "p.id = c.parent_id")
+                )
+                results = await session.select(query, *filters)
+                return {"items": results}
+
+        app = Litestar(route_handlers=[joined_route], plugins=[SQLSpecPlugin(sqlspec=sql)])
+
+        async with AsyncTestClient(app=app) as client:
+            response = await client.get("/joined", params={"searchString": "parent"})
+
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data["items"]) == 1
+            assert data["items"][0]["parent_name"] == "parent1"
+
+
+@pytest.mark.anyio
+async def test_litestar_qualified_column_order_by_filter() -> None:
+    """Verify that filtering on a qualified column name in a JOIN works correctly with OrderByFilter."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=True) as tmp:
+        sql = SQLSpec()
+        config = AiosqliteConfig(connection_config={"database": tmp.name})
+        sql.add_config(config)
+
+        # Setup tables
+        async with sql.provide_session(config) as session:
+            await session.execute_script("""
+                CREATE TABLE parent (id INTEGER PRIMARY KEY, name TEXT);
+                INSERT INTO parent (id, name) VALUES (1, 'b');
+                INSERT INTO parent (id, name) VALUES (2, 'a');
+            """)
+            await session.commit()
+
+        # We want to order by 'p.name'
+        filter_deps = create_filter_dependencies({"sort_field": "p.name"})
+
+        @get("/ordered", dependencies=filter_deps)
+        async def ordered_route(filters: list[Any] = Dependency(skip_validation=True)) -> dict[str, Any]:
+            async with sql.provide_session(config) as session:
+                query = sql_builder.select("p.name").from_("parent p")
+                results = await session.select(query, *filters)
+                return {"items": results}
+
+        app = Litestar(route_handlers=[ordered_route], plugins=[SQLSpecPlugin(sqlspec=sql)])
+
+        async with AsyncTestClient(app=app) as client:
+            # Ascending
+            response = await client.get("/ordered", params={"orderBy": "p.name", "sortOrder": "asc"})
+            assert response.status_code == 200
+            items = response.json()["items"]
+            assert items[0]["name"] == "a"
+            assert items[1]["name"] == "b"
+
+            # Descending
+            response = await client.get("/ordered", params={"orderBy": "p.name", "sortOrder": "desc"})
+            assert response.status_code == 200
+            items = response.json()["items"]
+            assert items[0]["name"] == "b"
+            assert items[1]["name"] == "a"

--- a/tests/integration/extensions/litestar/test_in_fields_filters.py
+++ b/tests/integration/extensions/litestar/test_in_fields_filters.py
@@ -277,12 +277,15 @@ def test_litestar_order_by_openapi_schema() -> None:
     paths = schema.paths
     assert paths is not None
 
-    # Check parameters for /ordered
-    params = paths["/ordered"].get.parameters
+    operation = paths["/ordered"].get
+    assert operation is not None
+    params = operation.parameters
     assert params is not None
 
-    # orderBy and sortOrder should be there
-    order_by_param = next((p for p in params if p.name == "orderBy"), None)
+    def _named_param(name: str) -> Any:
+        return next((p for p in params if getattr(p, "name", None) == name), None)
+
+    order_by_param = _named_param("orderBy")
     assert order_by_param is not None
 
     # In newer Litestar, types can be a list or a single value, and might be in one_of
@@ -300,6 +303,6 @@ def test_litestar_order_by_openapi_schema() -> None:
 
     assert is_string_type(order_by_param.schema)
 
-    sort_order_param = next((p for p in params if p.name == "sortOrder"), None)
+    sort_order_param = _named_param("sortOrder")
     assert sort_order_param is not None
     assert is_string_type(sort_order_param.schema)

--- a/tests/integration/extensions/litestar/test_in_fields_filters.py
+++ b/tests/integration/extensions/litestar/test_in_fields_filters.py
@@ -255,3 +255,51 @@ async def test_litestar_qualified_column_order_by_filter() -> None:
             items = response.json()["items"]
             assert items[0]["name"] == "b"
             assert items[1]["name"] == "a"
+
+
+def test_litestar_order_by_openapi_schema() -> None:
+    """OrderByFilter must appear as a string in OpenAPI even with expression support."""
+    from typing import Any
+
+    sql = SQLSpec()
+    config = AiosqliteConfig(connection_config={"database": ":memory:"})
+    sql.add_config(config)
+
+    filter_deps = create_filter_dependencies({"sort_field": "p.name"})
+
+    @get("/ordered", dependencies=filter_deps)
+    async def ordered_route(filters: list[Any] = Dependency(skip_validation=True)) -> dict[str, Any]:
+        return {"items": []}
+
+    app = Litestar(route_handlers=[ordered_route], plugins=[SQLSpecPlugin(sqlspec=sql)])
+
+    schema = app.openapi_schema
+    paths = schema.paths
+    assert paths is not None
+
+    # Check parameters for /ordered
+    params = paths["/ordered"].get.parameters
+    assert params is not None
+
+    # orderBy and sortOrder should be there
+    order_by_param = next((p for p in params if p.name == "orderBy"), None)
+    assert order_by_param is not None
+
+    # In newer Litestar, types can be a list or a single value, and might be in one_of
+    def is_string_type(schema: Any) -> bool:
+        if not schema:
+            return False
+        stype = schema.type
+        if isinstance(stype, list):
+            return any("string" in str(t).lower() for t in stype)
+        if stype:
+            return "string" in str(stype).lower()
+        if schema.one_of:
+            return any(is_string_type(s) for s in schema.one_of)
+        return False
+
+    assert is_string_type(order_by_param.schema)
+
+    sort_order_param = next((p for p in params if p.name == "sortOrder"), None)
+    assert sort_order_param is not None
+    assert is_string_type(sort_order_param.schema)

--- a/tests/unit/builder/test_select_builder.py
+++ b/tests/unit/builder/test_select_builder.py
@@ -60,3 +60,38 @@ def test_select_only_not_available_on_update() -> None:
     # The method shouldn't exist on Update builder, so AttributeError is expected
     with pytest.raises(AttributeError):
         query.select_only("id")  # type: ignore
+
+
+def test_order_by_raw_trailing_desc_emits_descending_sort() -> None:
+    """sql.raw with trailing DESC must produce ORDER BY ... DESC, not an alias."""
+    from sqlglot import exp
+
+    builder = sql.select("a", "b").from_("things").order_by(sql.raw("COALESCE(a, b, 0) DESC"))
+    expr = builder._expression
+    order = expr.args.get("order")
+    assert order is not None
+    assert any(isinstance(o, exp.Ordered) and o.args.get("desc") for o in order.expressions)
+
+    sql_text = builder.to_sql()
+    assert "DESC" in sql_text
+    assert 'AS "desc"' not in sql_text.lower()
+
+
+def test_order_by_raw_trailing_asc_emits_ascending_sort() -> None:
+    """sql.raw with trailing ASC must produce an ascending Ordered expression."""
+    from sqlglot import exp
+
+    builder = sql.select("a").from_("things").order_by(sql.raw("LOWER(a) ASC"))
+    expr = builder._expression
+    order = expr.args.get("order")
+    assert order is not None
+    assert all(isinstance(o, exp.Ordered) and o.args.get("desc") is False for o in order.expressions)
+
+
+def test_order_by_raw_function_without_direction_unchanged() -> None:
+    """sql.raw without trailing direction must continue to work as a sort key."""
+
+    builder = sql.select("a").from_("things").order_by(sql.raw("COALESCE(a, b, 0)"))
+    sql_text = builder.to_sql()
+    assert "COALESCE" in sql_text.upper()
+    assert "ORDER BY" in sql_text.upper()

--- a/tests/unit/builder/test_select_builder.py
+++ b/tests/unit/builder/test_select_builder.py
@@ -1,5 +1,7 @@
 """Unit tests for SELECT builder methods."""
 
+from typing import cast
+
 import pytest
 
 from sqlspec import sql
@@ -66,8 +68,10 @@ def test_order_by_raw_trailing_desc_emits_descending_sort() -> None:
     """sql.raw with trailing DESC must produce ORDER BY ... DESC, not an alias."""
     from sqlglot import exp
 
-    builder = sql.select("a", "b").from_("things").order_by(sql.raw("COALESCE(a, b, 0) DESC"))
+    raw_desc = cast("exp.Ordered", sql.raw("COALESCE(a, b, 0) DESC"))
+    builder = sql.select("a", "b").from_("things").order_by(raw_desc)
     expr = builder._expression
+    assert expr is not None
     order = expr.args.get("order")
     assert order is not None
     assert any(isinstance(o, exp.Ordered) and o.args.get("desc") for o in order.expressions)
@@ -81,8 +85,10 @@ def test_order_by_raw_trailing_asc_emits_ascending_sort() -> None:
     """sql.raw with trailing ASC must produce an ascending Ordered expression."""
     from sqlglot import exp
 
-    builder = sql.select("a").from_("things").order_by(sql.raw("LOWER(a) ASC"))
+    raw_asc = cast("exp.Ordered", sql.raw("LOWER(a) ASC"))
+    builder = sql.select("a").from_("things").order_by(raw_asc)
     expr = builder._expression
+    assert expr is not None
     order = expr.args.get("order")
     assert order is not None
     assert all(isinstance(o, exp.Ordered) and o.args.get("desc") is False for o in order.expressions)
@@ -90,8 +96,10 @@ def test_order_by_raw_trailing_asc_emits_ascending_sort() -> None:
 
 def test_order_by_raw_function_without_direction_unchanged() -> None:
     """sql.raw without trailing direction must continue to work as a sort key."""
+    from sqlglot import exp
 
-    builder = sql.select("a").from_("things").order_by(sql.raw("COALESCE(a, b, 0)"))
+    raw_expr = cast("exp.Ordered", sql.raw("COALESCE(a, b, 0)"))
+    builder = sql.select("a").from_("things").order_by(raw_expr)
     sql_text = builder.to_sql()
     assert "COALESCE" in sql_text.upper()
     assert "ORDER BY" in sql_text.upper()

--- a/tests/unit/core/test_filters.py
+++ b/tests/unit/core/test_filters.py
@@ -4,10 +4,15 @@ This module tests the filter system that provides dynamic WHERE clauses,
 ORDER BY, LIMIT/OFFSET, and other SQL modifications with proper parameter naming.
 """
 
+import tempfile
+from dataclasses import dataclass
 from datetime import datetime
 
 import pytest
 
+from sqlspec import sql as sql_builder
+from sqlspec.adapters.aiosqlite import AiosqliteConfig
+from sqlspec.base import SQLSpec
 from sqlspec.core import (
     SQL,
     AnyCollectionFilter,
@@ -23,6 +28,7 @@ from sqlspec.core import (
 )
 from sqlspec.core.filters import NotInSearchFilter
 from sqlspec.driver import CommonDriverAttributesMixin
+from sqlspec.service import SQLSpecAsyncService
 
 pytestmark = pytest.mark.xdist_group("core")
 
@@ -921,6 +927,15 @@ def test_search_filter_with_expression_in_set_appends_to_statement_correctly() -
     assert "OR" in sql_upper
 
 
+def test_search_filter_like_pattern() -> None:
+    """Test that SearchFilter.like_pattern returns the correct pattern."""
+    filter_obj = SearchFilter("name", "john")
+    assert filter_obj.like_pattern == "%john%"
+
+    filter_no_value = SearchFilter("name", None)
+    assert filter_no_value.like_pattern is None
+
+
 def test_query_builder_apply_filters_produces_valid_sql_for_execution() -> None:
     """QueryBuilder.apply_filters produces SQL that can be used with prepare_statement (issue #405).
 
@@ -946,3 +961,83 @@ def test_query_builder_apply_filters_produces_valid_sql_for_execution() -> None:
     assert result.parameters["status_in_1"] == "pending"
     assert result.parameters["limit"] == 10
     assert result.parameters["offset"] == 0
+
+
+@dataclass
+class User:
+    id: int
+    name: str
+
+
+class UserService(SQLSpecAsyncService):
+    pass
+
+
+@pytest.mark.anyio
+async def test_service_paginate_works() -> None:
+    """Test that the base service paginate helper works correctly."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=True) as tmp:
+        sqlspec = SQLSpec()
+        config = AiosqliteConfig(connection_config={"database": tmp.name})
+        sqlspec.add_config(config)
+
+        async with sqlspec.provide_session(config) as session:
+            await session.execute_script("""
+                CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);
+                INSERT INTO users (id, name) VALUES (1, 'alice');
+                INSERT INTO users (id, name) VALUES (2, 'bob');
+                INSERT INTO users (id, name) VALUES (3, 'charlie');
+            """)
+            await session.commit()
+
+            service = UserService(session)
+
+            # Query all
+            query = sql_builder.select("*").from_("users")
+
+            # Paginate first 2
+            pagination_filter = LimitOffsetFilter(limit=2, offset=0)
+            result = await service.paginate(query, pagination_filter, schema_type=User)
+
+            assert len(result.items) == 2
+            assert result.total == 3
+            assert result.limit == 2
+            assert result.offset == 0
+            assert result.items[0].name == "alice"
+            assert result.items[1].name == "bob"
+
+            # Paginate next
+            pagination_filter2 = LimitOffsetFilter(limit=2, offset=2)
+            result2 = await service.paginate(query, pagination_filter2, schema_type=User)
+
+            assert len(result2.items) == 1
+            assert result2.total == 3
+            assert result2.limit == 2
+            assert result2.offset == 2
+            assert result2.items[0].name == "charlie"
+
+
+@pytest.mark.anyio
+async def test_service_exists_works() -> None:
+    """Test that the base service exists helper works correctly."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=True) as tmp:
+        sqlspec = SQLSpec()
+        config = AiosqliteConfig(connection_config={"database": tmp.name})
+        sqlspec.add_config(config)
+
+        async with sqlspec.provide_session(config) as session:
+            await session.execute_script("""
+                CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);
+                INSERT INTO users (id, name) VALUES (1, 'alice');
+            """)
+            await session.commit()
+
+            service = UserService(session)
+
+            # Exists
+            query = sql_builder.select("*").from_("users").where_eq("name", "alice")
+            assert await service.exists(query) is True
+
+            # Does not exist
+            query2 = sql_builder.select("*").from_("users").where_eq("name", "bob")
+            assert await service.exists(query2) is False

--- a/tests/unit/core/test_filters.py
+++ b/tests/unit/core/test_filters.py
@@ -834,6 +834,57 @@ def test_query_builder_apply_filters_empty() -> None:
     assert "WHERE" not in result.sql.upper()
 
 
+def test_search_filter_with_qualified_name_uses_sanitized_parameters() -> None:
+    """Test that SearchFilter with a dotted name uses sanitized parameter names."""
+    filter_obj = SearchFilter("users.name", "john")
+
+    positional, named = filter_obj.extract_parameters()
+
+    assert positional == []
+    assert "users_name_search" in named
+    assert named["users_name_search"] == "%john%"
+
+
+def test_search_filter_with_qualified_name_appends_to_statement_correctly() -> None:
+    """Test that SearchFilter with a dotted name appends to statement with qualified column."""
+    from sqlspec.core import SQL
+
+    statement = SQL("SELECT * FROM users u JOIN profiles p ON u.id = p.user_id")
+    filter_obj = SearchFilter("u.name", "john")
+
+    result = apply_filter(statement, filter_obj)
+
+    sql_upper = result.sql.upper()
+    assert "U.NAME LIKE" in sql_upper or '"U"."NAME" LIKE' in sql_upper or 'U."NAME" LIKE' in sql_upper
+    assert "u_name_search" in result.named_parameters
+    assert result.named_parameters["u_name_search"] == "%john%"
+
+
+def test_in_collection_filter_with_qualified_name_uses_sanitized_parameters() -> None:
+    """Test that InCollectionFilter with a dotted name uses sanitized parameter names."""
+    values = ["active", "pending"]
+    filter_obj = InCollectionFilter("u.status", values)
+
+    positional, named = filter_obj.extract_parameters()
+
+    assert positional == []
+    assert "u_status_in_0" in named
+    assert "u_status_in_1" in named
+
+
+def test_order_by_filter_with_qualified_name_appends_to_statement_correctly() -> None:
+    """Test that OrderByFilter with a dotted name appends to statement correctly."""
+    from sqlspec.core import SQL
+
+    statement = SQL("SELECT * FROM users u JOIN profiles p ON u.id = p.user_id")
+    filter_obj = OrderByFilter("u.created_at", "desc")
+
+    result = apply_filter(statement, filter_obj)
+
+    sql_upper = result.sql.upper()
+    assert "ORDER BY U.CREATED_AT DESC" in sql_upper or 'ORDER BY "U"."CREATED_AT" DESC' in sql_upper
+
+
 def test_query_builder_apply_filters_produces_valid_sql_for_execution() -> None:
     """QueryBuilder.apply_filters produces SQL that can be used with prepare_statement (issue #405).
 

--- a/tests/unit/core/test_filters.py
+++ b/tests/unit/core/test_filters.py
@@ -1043,8 +1043,8 @@ async def test_service_exists_works() -> None:
 
 
 @pytest.mark.anyio
-async def test_service_get_or_404_returns_row_or_raises() -> None:
-    """get_or_404 returns the row when present and raises NotFoundError otherwise."""
+async def test_service_get_one_returns_row_or_raises() -> None:
+    """get_one returns the row when present and raises NotFoundError otherwise."""
     from sqlspec.exceptions import NotFoundError
 
     with tempfile.NamedTemporaryFile(suffix=".db", delete=True) as tmp:
@@ -1063,14 +1063,14 @@ async def test_service_get_or_404_returns_row_or_raises() -> None:
 
             service = UserService(session)
 
-            row = await service.get_or_404(
+            row = await service.get_one(
                 sql_builder.select("id", "name").from_("users").where_eq("name", "alice"), schema_type=User
             )
             assert isinstance(row, User)
             assert row.name == "alice"
 
             with pytest.raises(NotFoundError, match="missing user"):
-                await service.get_or_404(
+                await service.get_one(
                     sql_builder.select("id", "name").from_("users").where_eq("name", "ghost"),
                     schema_type=User,
                     error_message="missing user",

--- a/tests/unit/core/test_filters.py
+++ b/tests/unit/core/test_filters.py
@@ -1041,3 +1041,125 @@ async def test_service_exists_works() -> None:
             # Does not exist
             query2 = sql_builder.select("*").from_("users").where_eq("name", "bob")
             assert await service.exists(query2) is False
+
+
+@pytest.mark.anyio
+async def test_service_get_or_404_returns_row_or_raises() -> None:
+    """get_or_404 returns the row when present and raises NotFoundError otherwise."""
+    from sqlspec.exceptions import NotFoundError
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=True) as tmp:
+        sqlspec = SQLSpec()
+        config = AiosqliteConfig(connection_config={"database": tmp.name})
+        sqlspec.add_config(config)
+
+        async with sqlspec.provide_session(config) as session:
+            await session.execute_script(
+                """
+                CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);
+                INSERT INTO users (id, name) VALUES (1, 'alice');
+                """
+            )
+            await session.commit()
+
+            service = UserService(session)
+
+            row = await service.get_or_404(
+                sql_builder.select("id", "name").from_("users").where_eq("name", "alice"), schema_type=User
+            )
+            assert isinstance(row, User)
+            assert row.name == "alice"
+
+            with pytest.raises(NotFoundError, match="missing user"):
+                await service.get_or_404(
+                    sql_builder.select("id", "name").from_("users").where_eq("name", "ghost"),
+                    schema_type=User,
+                    error_message="missing user",
+                )
+
+
+@pytest.mark.anyio
+async def test_service_begin_transaction_commits_and_rolls_back() -> None:
+    """begin_transaction commits on success and rolls back on exception."""
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=True) as tmp:
+        sqlspec = SQLSpec()
+        config = AiosqliteConfig(connection_config={"database": tmp.name})
+        sqlspec.add_config(config)
+
+        async with sqlspec.provide_session(config) as session:
+            await session.execute_script("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+            await session.commit()
+
+            service = UserService(session)
+
+            async with service.begin_transaction():
+                await session.execute(sql_builder.insert("users").columns("id", "name").values(1, "alice"))
+
+            count_after_commit = await session.execute(sql_builder.select("COUNT(*) AS n").from_("users"))
+            assert count_after_commit.one()["n"] == 1
+
+            with pytest.raises(RuntimeError, match="boom"):
+                async with service.begin_transaction():
+                    await session.execute(sql_builder.insert("users").columns("id", "name").values(2, "bob"))
+                    raise RuntimeError("boom")
+
+            count_after_rollback = await session.execute(sql_builder.select("COUNT(*) AS n").from_("users"))
+            assert count_after_rollback.one()["n"] == 1
+
+
+def test_search_filter_raises_typeerror_on_invalid_field_name() -> None:
+    """SearchFilter raises TypeError instead of silently dropping the WHERE."""
+    from sqlspec.core.filters import SearchFilter as _SF
+
+    sql_stmt = SQL("SELECT * FROM things")
+    bad: object = 123
+    f = _SF(field_name=bad, value="x")
+    with pytest.raises(TypeError, match="field_name must be"):
+        f.append_to_statement(sql_stmt)
+
+
+def test_not_in_search_filter_raises_typeerror_on_invalid_field_name() -> None:
+    """NotInSearchFilter raises TypeError instead of silently dropping the WHERE."""
+
+    sql_stmt = SQL("SELECT * FROM things")
+    bad: object = 123
+    f = NotInSearchFilter(field_name=bad, value="x")
+    with pytest.raises(TypeError, match="field_name must be"):
+        f.append_to_statement(sql_stmt)
+
+
+def test_search_filter_accepts_expression_field_name() -> None:
+    """SearchFilter applies a WHERE clause when given a SQLGlot expression."""
+    from sqlglot import exp
+
+    sql_stmt = SQL("SELECT id, name FROM things")
+    f = SearchFilter(field_name=exp.func("LOWER", exp.column("name")), value="foo")
+    result = f.append_to_statement(sql_stmt)
+    assert "WHERE" in result.sql.upper()
+    assert "LOWER" in result.sql.upper()
+    assert any(v == "%foo%" for v in result.parameters.values())
+
+
+def test_not_in_search_filter_accepts_expression_field_name() -> None:
+    """NotInSearchFilter applies WHERE NOT LIKE when given a SQLGlot expression."""
+    from sqlglot import exp
+
+    sql_stmt = SQL("SELECT id, name FROM things")
+    f = NotInSearchFilter(field_name=exp.func("LOWER", exp.column("name")), value="foo")
+    result = f.append_to_statement(sql_stmt)
+    sql_upper = result.sql.upper()
+    assert "WHERE" in sql_upper
+    assert "NOT" in sql_upper and "LIKE" in sql_upper
+
+
+def test_search_filter_escape_like_value() -> None:
+    """escape_like_value escapes backslash, percent, and underscore."""
+
+    assert SearchFilter.escape_like_value("plain") == "plain"
+    assert SearchFilter.escape_like_value("50% off") == "50\\% off"
+    assert SearchFilter.escape_like_value("a_b") == "a\\_b"
+    assert SearchFilter.escape_like_value("a\\b") == "a\\\\b"
+    # Backslash escapes apply first, so "%" inside an already-backslashed string
+    # is escaped exactly once.
+    assert SearchFilter.escape_like_value("\\%_") == "\\\\\\%\\_"

--- a/tests/unit/core/test_filters.py
+++ b/tests/unit/core/test_filters.py
@@ -885,6 +885,42 @@ def test_order_by_filter_with_qualified_name_appends_to_statement_correctly() ->
     assert "ORDER BY U.CREATED_AT DESC" in sql_upper or 'ORDER BY "U"."CREATED_AT" DESC' in sql_upper
 
 
+def test_order_by_filter_with_expression_appends_to_statement_correctly() -> None:
+    """Test that OrderByFilter with a SQLGlot expression appends to statement correctly."""
+    from sqlglot import exp
+
+    from sqlspec.core import SQL
+
+    statement = SQL("SELECT id, lines, occurrences FROM stats")
+    # COALESCE(lines, occurrences, 0)
+    coalesce_expr = exp.func("COALESCE", exp.column("lines"), exp.column("occurrences"), exp.Literal.number(0))
+    filter_obj = OrderByFilter(field_name=coalesce_expr, sort_order="desc")
+
+    result = apply_filter(statement, filter_obj)
+
+    sql_upper = result.sql.upper()
+    assert "ORDER BY COALESCE(LINES, OCCURRENCES, 0) DESC" in sql_upper
+
+
+def test_search_filter_with_expression_in_set_appends_to_statement_correctly() -> None:
+    """Test that SearchFilter with a SQLGlot expression in a set appends to statement correctly."""
+    from sqlglot import exp
+
+    from sqlspec.core import SQL
+
+    statement = SQL("SELECT name, email FROM users")
+    # UPPER(name)
+    upper_name = exp.func("UPPER", exp.column("name"))
+    filter_obj = SearchFilter(field_name={upper_name, "email"}, value="john")
+
+    result = apply_filter(statement, filter_obj)
+
+    sql_upper = result.sql.upper()
+    assert "UPPER(NAME) LIKE" in sql_upper
+    assert "EMAIL LIKE" in sql_upper
+    assert "OR" in sql_upper
+
+
 def test_query_builder_apply_filters_produces_valid_sql_for_execution() -> None:
     """QueryBuilder.apply_filters produces SQL that can be used with prepare_statement (issue #405).
 

--- a/tests/unit/core/test_filters.py
+++ b/tests/unit/core/test_filters.py
@@ -7,8 +7,10 @@ ORDER BY, LIMIT/OFFSET, and other SQL modifications with proper parameter naming
 import tempfile
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any
 
 import pytest
+from sqlglot import exp
 
 from sqlspec import sql as sql_builder
 from sqlspec.adapters.aiosqlite import AiosqliteConfig
@@ -204,7 +206,7 @@ def test_filter_with_empty_values() -> None:
 
 def test_search_filter_multiple_fields() -> None:
     """Test SearchFilter with multiple field names."""
-    fields = {"first_name", "last_name", "email"}
+    fields: set[str | exp.Expression] = {"first_name", "last_name", "email"}
     filter_obj = SearchFilter(fields, "john")
 
     positional, named = filter_obj.extract_parameters()
@@ -893,13 +895,12 @@ def test_order_by_filter_with_qualified_name_appends_to_statement_correctly() ->
 
 def test_order_by_filter_with_expression_appends_to_statement_correctly() -> None:
     """Test that OrderByFilter with a SQLGlot expression appends to statement correctly."""
-    from sqlglot import exp
-
     from sqlspec.core import SQL
 
     statement = SQL("SELECT id, lines, occurrences FROM stats")
-    # COALESCE(lines, occurrences, 0)
-    coalesce_expr = exp.func("COALESCE", exp.column("lines"), exp.column("occurrences"), exp.Literal.number(0))
+    coalesce_expr = exp.Coalesce(
+        this=exp.column("lines"), expressions=[exp.column("occurrences"), exp.Literal.number(0)]
+    )
     filter_obj = OrderByFilter(field_name=coalesce_expr, sort_order="desc")
 
     result = apply_filter(statement, filter_obj)
@@ -910,14 +911,12 @@ def test_order_by_filter_with_expression_appends_to_statement_correctly() -> Non
 
 def test_search_filter_with_expression_in_set_appends_to_statement_correctly() -> None:
     """Test that SearchFilter with a SQLGlot expression in a set appends to statement correctly."""
-    from sqlglot import exp
-
     from sqlspec.core import SQL
 
     statement = SQL("SELECT name, email FROM users")
-    # UPPER(name)
-    upper_name = exp.func("UPPER", exp.column("name"))
-    filter_obj = SearchFilter(field_name={upper_name, "email"}, value="john")
+    upper_name = exp.Upper(this=exp.column("name"))
+    fields: set[str | exp.Expression] = {upper_name, "email"}
+    filter_obj = SearchFilter(field_name=fields, value="john")
 
     result = apply_filter(statement, filter_obj)
 
@@ -1110,20 +1109,17 @@ async def test_service_begin_transaction_commits_and_rolls_back() -> None:
 
 def test_search_filter_raises_typeerror_on_invalid_field_name() -> None:
     """SearchFilter raises TypeError instead of silently dropping the WHERE."""
-    from sqlspec.core.filters import SearchFilter as _SF
-
     sql_stmt = SQL("SELECT * FROM things")
-    bad: object = 123
-    f = _SF(field_name=bad, value="x")
+    bad: Any = 123
+    f = SearchFilter(field_name=bad, value="x")
     with pytest.raises(TypeError, match="field_name must be"):
         f.append_to_statement(sql_stmt)
 
 
 def test_not_in_search_filter_raises_typeerror_on_invalid_field_name() -> None:
     """NotInSearchFilter raises TypeError instead of silently dropping the WHERE."""
-
     sql_stmt = SQL("SELECT * FROM things")
-    bad: object = 123
+    bad: Any = 123
     f = NotInSearchFilter(field_name=bad, value="x")
     with pytest.raises(TypeError, match="field_name must be"):
         f.append_to_statement(sql_stmt)
@@ -1131,10 +1127,8 @@ def test_not_in_search_filter_raises_typeerror_on_invalid_field_name() -> None:
 
 def test_search_filter_accepts_expression_field_name() -> None:
     """SearchFilter applies a WHERE clause when given a SQLGlot expression."""
-    from sqlglot import exp
-
     sql_stmt = SQL("SELECT id, name FROM things")
-    f = SearchFilter(field_name=exp.func("LOWER", exp.column("name")), value="foo")
+    f = SearchFilter(field_name=exp.Lower(this=exp.column("name")), value="foo")
     result = f.append_to_statement(sql_stmt)
     assert "WHERE" in result.sql.upper()
     assert "LOWER" in result.sql.upper()
@@ -1143,10 +1137,8 @@ def test_search_filter_accepts_expression_field_name() -> None:
 
 def test_not_in_search_filter_accepts_expression_field_name() -> None:
     """NotInSearchFilter applies WHERE NOT LIKE when given a SQLGlot expression."""
-    from sqlglot import exp
-
     sql_stmt = SQL("SELECT id, name FROM things")
-    f = NotInSearchFilter(field_name=exp.func("LOWER", exp.column("name")), value="foo")
+    f = NotInSearchFilter(field_name=exp.Lower(this=exp.column("name")), value="foo")
     result = f.append_to_statement(sql_stmt)
     sql_upper = result.sql.upper()
     assert "WHERE" in sql_upper

--- a/tests/unit/extensions/test_litestar/test_not_found_handler.py
+++ b/tests/unit/extensions/test_litestar/test_not_found_handler.py
@@ -1,0 +1,60 @@
+"""Tests for the NotFoundError -> HTTP 404 default handler in the Litestar plugin."""
+
+from typing import Any
+
+from litestar import get
+from litestar.config.app import AppConfig
+from litestar.exceptions import NotFoundException
+from litestar.testing import create_test_client
+
+from sqlspec.adapters.aiosqlite.config import AiosqliteConfig
+from sqlspec.base import SQLSpec
+from sqlspec.exceptions import NotFoundError
+from sqlspec.extensions.litestar.plugin import SQLSpecPlugin, not_found_error_handler
+
+
+def _build_plugin() -> SQLSpecPlugin:
+    sqlspec = SQLSpec()
+    sqlspec.add_config(AiosqliteConfig(connection_config={"database": ":memory:"}))
+    return SQLSpecPlugin(sqlspec=sqlspec)
+
+
+def test_default_handler_registered_for_not_found_error() -> None:
+    """Plugin should register NotFoundError -> not_found_error_handler by default."""
+    plugin = _build_plugin()
+    app_config = AppConfig()
+
+    plugin.on_app_init(app_config)
+
+    handlers = app_config.exception_handlers or {}
+    assert handlers.get(NotFoundError) is not_found_error_handler
+
+
+def test_user_handler_takes_precedence() -> None:
+    """A user-supplied NotFoundError handler must not be overwritten."""
+
+    def user_handler(_request: Any, exc: NotFoundError) -> Any:
+        raise NotFoundException(detail=f"custom: {exc}") from exc
+
+    plugin = _build_plugin()
+    app_config = AppConfig(exception_handlers={NotFoundError: user_handler})
+
+    plugin.on_app_init(app_config)
+
+    handlers = app_config.exception_handlers or {}
+    assert handlers[NotFoundError] is user_handler
+
+
+def test_handler_translates_to_404_in_real_app() -> None:
+    """End-to-end: a handler raising NotFoundError yields a 404 response."""
+
+    @get("/missing")
+    async def raise_missing() -> None:
+        raise NotFoundError("nothing here")
+
+    plugin = _build_plugin()
+
+    with create_test_client(route_handlers=[raise_missing], plugins=[plugin]) as client:
+        response = client.get("/missing")
+        assert response.status_code == 404
+        assert "nothing here" in response.text

--- a/tests/unit/extensions/test_service_reexports.py
+++ b/tests/unit/extensions/test_service_reexports.py
@@ -1,0 +1,39 @@
+"""Verify that framework extension packages re-export the SQLSpec service base classes.
+
+The base classes live in :mod:`sqlspec.service`. Each first-party framework integration
+re-exports them so consumers can pull the canonical service base from the framework
+namespace they are already importing from.
+"""
+
+import importlib
+
+import pytest
+
+from sqlspec.service import SQLSpecAsyncService, SQLSpecSyncService
+
+pytestmark = pytest.mark.xdist_group("extensions")
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "sqlspec.extensions.litestar",
+        "sqlspec.extensions.fastapi",
+        "sqlspec.extensions.starlette",
+        "sqlspec.extensions.sanic",
+    ],
+)
+def test_async_and_sync_service_reexports(module_name: str) -> None:
+    """Async + sync framework packages re-export both service base classes."""
+    module = importlib.import_module(module_name)
+    assert module.SQLSpecAsyncService is SQLSpecAsyncService
+    assert module.SQLSpecSyncService is SQLSpecSyncService
+    assert "SQLSpecAsyncService" in module.__all__
+    assert "SQLSpecSyncService" in module.__all__
+
+
+def test_flask_reexports_sync_only() -> None:
+    """Flask is sync-only, so it re-exports the sync service base."""
+    module = importlib.import_module("sqlspec.extensions.flask")
+    assert module.SQLSpecSyncService is SQLSpecSyncService
+    assert "SQLSpecSyncService" in module.__all__

--- a/tests/unit/extensions/test_service_reexports.py
+++ b/tests/unit/extensions/test_service_reexports.py
@@ -21,19 +21,17 @@ pytestmark = pytest.mark.xdist_group("extensions")
         "sqlspec.extensions.fastapi",
         "sqlspec.extensions.starlette",
         "sqlspec.extensions.sanic",
+        "sqlspec.extensions.flask",
     ],
 )
 def test_async_and_sync_service_reexports(module_name: str) -> None:
-    """Async + sync framework packages re-export both service base classes."""
+    """Every framework package re-exports both service base classes.
+
+    Flask is included because its plugin can portal an async driver, so
+    consumers need access to the async service even from a sync framework.
+    """
     module = importlib.import_module(module_name)
     assert module.SQLSpecAsyncService is SQLSpecAsyncService
     assert module.SQLSpecSyncService is SQLSpecSyncService
     assert "SQLSpecAsyncService" in module.__all__
-    assert "SQLSpecSyncService" in module.__all__
-
-
-def test_flask_reexports_sync_only() -> None:
-    """Flask is sync-only, so it re-exports the sync service base."""
-    module = importlib.import_module("sqlspec.extensions.flask")
-    assert module.SQLSpecSyncService is SQLSpecSyncService
     assert "SQLSpecSyncService" in module.__all__

--- a/uv.lock
+++ b/uv.lock
@@ -10,12 +10,12 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version < '3.11'",
 ]
@@ -1386,12 +1386,12 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
@@ -1460,7 +1460,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2815,12 +2815,12 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
@@ -3178,12 +3178,12 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
@@ -3754,20 +3754,6 @@ wheels = [
 name = "mysql-connector-python"
 version = "9.6.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6e/c89babc7de3df01467d159854414659c885152579903a8220c8db02a3835/mysql_connector_python-9.6.0.tar.gz", hash = "sha256:c453bb55347174d87504b534246fb10c589daf5d057515bf615627198a3c7ef1", size = 12254999, upload-time = "2026-02-10T12:04:52.63Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/27/106f5b7a69381c58cb0ba6bf44e6488969ce6cd9f69f62df340f379141ee/mysql_connector_python-9.6.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:478e035ebcf734b3a1497bfd3eb72ce3632da6384545b08cf6329471b3849b6e", size = 17582676, upload-time = "2026-01-21T09:04:35.755Z" },
@@ -3796,26 +3782,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/06/5efdd28819afdb9f1487a62842fda4277febe128a3cd6e9090dbe0a6524e/mysql_connector_python-9.6.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4617ef5216da7ca32dd46afda61a1552807762434127413bba46fbe4379f59d4", size = 34542851, upload-time = "2026-02-10T12:04:31.021Z" },
     { url = "https://files.pythonhosted.org/packages/40/6a/26e08a4a79f159cd8e5b64eb10bd056e7735b65d4464d98641f59eb9ca3a/mysql_connector_python-9.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:bc782f64ca00b6b933d4c6a35568f1349d115cc4434c849b5b9edc015bee3e62", size = 17002947, upload-time = "2026-02-10T12:04:34.386Z" },
     { url = "https://files.pythonhosted.org/packages/15/dd/b3250826c29cee7816de4409a2fe5e469a68b9a89f6bfaa5eed74f05532c/mysql_connector_python-9.6.0-py2.py3-none-any.whl", hash = "sha256:44b0fb57207ebc6ae05b5b21b7968a9ed33b29187fe87b38951bad2a334d75d5", size = 480527, upload-time = "2026-02-10T12:04:36.176Z" },
-]
-
-[[package]]
-name = "mysql-connector-python"
-version = "9.7.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.11'",
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/7b/bfbe1732bdc413fa29d4431e04f257bed32b0f3efe775ca2e70e9d347008/mysql_connector_python-9.7.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:ee90c5f44f706f012be17f03f6ad158ff96e7f2dcc077896fe4537d3d28b3cf4", size = 20265583, upload-time = "2026-04-23T07:15:43.703Z" },
-    { url = "https://files.pythonhosted.org/packages/43/40/cba971fdc54522742955f12d4b019e9f3325d9a5c734abf5f012fde7cfff/mysql_connector_python-9.7.0-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:a2f371ab69d65c61136c51ad7026017400166cef3c959cab7a9fb668c7acbfba", size = 19826949, upload-time = "2026-04-23T07:15:46.443Z" },
-    { url = "https://files.pythonhosted.org/packages/83/5c/724577da77cd33d056ad48d1e29149f6c123371d651c0d824f6bfd2af28f/mysql_connector_python-9.7.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:9bdfc2d4c4444cd1cc79cc6487c047b28fe2b26d0327b27eb9f5737bb553cb5c", size = 21917561, upload-time = "2026-04-23T07:15:49.077Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/40/f0184970f6483a4e5ffcb99028f8402f3789b885872a5779edd3fa53da44/mysql_connector_python-9.7.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6546e0b60c275409a5add9e3308c3897fcf478d1338cd845b1664c1a8946f72f", size = 21687512, upload-time = "2026-04-23T07:15:51.614Z" },
-    { url = "https://files.pythonhosted.org/packages/50/ee/0be8e060376e518897f4b3433e768ccd05bc8bb3d08c436cc2441b44ac0b/mysql_connector_python-9.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:c51be697bfdfdf63bb71c5ecc51f7c6faf4aaa3d14a0136fa16e97cc37df1185", size = 17678391, upload-time = "2026-04-23T07:15:54.626Z" },
-    { url = "https://files.pythonhosted.org/packages/70/fa/babe981ec8c24eece7f47dc52c5e3fe3f126bc99cc80d637b49ac2fe50a4/mysql_connector_python-9.7.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:b5cb8a3ba42b539f79cd13e4c8376d28506f3180f7079c9b04ea7bfd0424fb03", size = 20265659, upload-time = "2026-04-23T07:15:57.375Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/4b/c45b8b601b0270faf1d4384e4c7270af9abb8d95ea39425253217c3c236c/mysql_connector_python-9.7.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:5492d57a6a0e5127a928290737fbb91b66b46d31dac8de3e7604e550bf3b3a6e", size = 19826940, upload-time = "2026-04-23T07:16:00.156Z" },
 ]
 
 [[package]]
@@ -3851,12 +3817,12 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
@@ -4044,12 +4010,12 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
@@ -4578,12 +4544,12 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
@@ -4671,12 +4637,12 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
@@ -5738,8 +5704,7 @@ minio = [
     { name = "minio" },
 ]
 mysql = [
-    { name = "mysql-connector-python", version = "9.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "mysql-connector-python", version = "9.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "mysql-connector-python" },
 ]
 oracle = [
     { name = "oracledb" },
@@ -6507,12 +6472,12 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
@@ -6662,12 +6627,12 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
@@ -6957,7 +6922,7 @@ wheels = [
 
 [[package]]
 name = "sqlspec"
-version = "0.44.0"
+version = "0.44.1"
 source = { editable = "." }
 dependencies = [
     { name = "mypy-extensions" },
@@ -7031,8 +6996,7 @@ mypyc = [
     { name = "sqlglot", extra = ["c"] },
 ]
 mysql-connector = [
-    { name = "mysql-connector-python", version = "9.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "mysql-connector-python", version = "9.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "mysql-connector-python" },
 ]
 nanoid = [
     { name = "fastnanoid" },

--- a/uv.lock
+++ b/uv.lock
@@ -1460,7 +1460,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -6922,7 +6922,7 @@ wheels = [
 
 [[package]]
 name = "sqlspec"
-version = "0.44.1"
+version = "0.45.0"
 source = { editable = "." }
 dependencies = [
     { name = "mypy-extensions" },

--- a/uv.lock
+++ b/uv.lock
@@ -968,7 +968,7 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "7.14.0"
+version = "7.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boltons" },
@@ -981,9 +981,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/44/e8200fc42682c544c4597f4674910fad1358af63c5b6d45bf89d20a18708/click_extra-7.14.0.tar.gz", hash = "sha256:7e2f83aa631219bcff414208e20bd23d3f1bf92802e2820b3c49a9a87fa5f771", size = 144761, upload-time = "2026-04-24T13:35:04.859Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/c9/f02eef46dd487565fac61a0cf7b77bd2c1ce255129bbf04507a6bd3a2cf5/click_extra-7.14.1.tar.gz", hash = "sha256:acfa952375f5051e509643623ef9e66e2691435b9f4ceb50f5fb078e87761028", size = 145060, upload-time = "2026-04-26T20:34:58.762Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/50/f5159c0fe0a59b7ad8c1fb12e4133e2b073bc99778d19ab9b111378117d4/click_extra-7.14.0-py3-none-any.whl", hash = "sha256:3aaa50566d44db263db3aed02552c89950b1d09f01df300c041907bcf29882e6", size = 159274, upload-time = "2026-04-24T13:35:05.95Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a4/61d5e395a62cd8e8a8cca9eb4a055666a56841fef11eaa6fbea3d13ac779/click_extra-7.14.1-py3-none-any.whl", hash = "sha256:1dc23b5f0caeade5d643e3f162f3b8b5acef16ee56e39944bbec6744dd2f2e23", size = 159513, upload-time = "2026-04-26T20:34:56.885Z" },
 ]
 
 [package.optional-dependencies]
@@ -1487,11 +1487,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "12.0.0"
+version = "12.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/56/068be906510dae5dec901a46efa0dcf2aee7f5640af0f0ea770f8c9710ca/extra_platforms-12.0.0.tar.gz", hash = "sha256:bfa32f5b17e810f6f97e35045db4245e6c9c45c87a9f27101f44d795e46042da", size = 72090, upload-time = "2026-04-24T12:49:18.843Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/3e/b7dfcbd8ccfb8127f2b907e3c7eabf0ff34bebdc7ae126266fbb7eba7208/extra_platforms-12.0.1.tar.gz", hash = "sha256:55146246c1e4babe385d2438c4da54e3f0078cedc70914288bedbe6502849218", size = 72199, upload-time = "2026-04-26T21:06:51.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/4f/8e3562108157fe9bc6160a73019532bb57090e4194a07d6f3ac6ef2d10ba/extra_platforms-12.0.0-py3-none-any.whl", hash = "sha256:5f6d0abad22cc3bea0f32bf8aa62a6a106e38203bb4c7c19989e56a61b542b52", size = 75347, upload-time = "2026-04-24T12:49:19.94Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/dc/b61a087ba06eb0a53ebf8d3d51b901e84993a6e0138537d3239f15a82f3c/extra_platforms-12.0.1-py3-none-any.whl", hash = "sha256:e5df76a229c518fe5d12a049d6e54457b2f64bd1c440b185c60256f816b4d747", size = 75447, upload-time = "2026-04-26T21:06:49.757Z" },
 ]
 
 [[package]]
@@ -2389,68 +2389,68 @@ wheels = [
 
 [[package]]
 name = "greenlet"
-version = "3.4.0"
+version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/94/a5935717b307d7c71fe877b52b884c6af707d2d2090db118a03fbd799369/greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff", size = 195913, upload-time = "2026-04-08T17:08:00.863Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/bc/e30e1e3d5e8860b0e0ce4d2b16b2681b77fd13542fc0d72f7e3c22d16eff/greenlet-3.4.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:d18eae9a7fb0f499efcd146b8c9750a2e1f6e0e93b5a382b3481875354a430e6", size = 284315, upload-time = "2026-04-08T17:02:52.322Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/cc/e023ae1967d2a26737387cac083e99e47f65f58868bd155c4c80c01ec4e0/greenlet-3.4.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:636d2f95c309e35f650e421c23297d5011716be15d966e6328b367c9fc513a82", size = 601916, upload-time = "2026-04-08T16:24:35.533Z" },
-    { url = "https://files.pythonhosted.org/packages/67/32/5be1677954b6d8810b33abe94e3eb88726311c58fa777dc97e390f7caf5a/greenlet-3.4.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:234582c20af9742583c3b2ddfbdbb58a756cfff803763ffaae1ac7990a9fac31", size = 616399, upload-time = "2026-04-08T16:30:54.536Z" },
-    { url = "https://files.pythonhosted.org/packages/82/0a/3a4af092b09ea02bcda30f33fd7db397619132fe52c6ece24b9363130d34/greenlet-3.4.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ac6a5f618be581e1e0713aecec8e54093c235e5fa17d6d8eb7ffc487e2300508", size = 621077, upload-time = "2026-04-08T16:40:34.946Z" },
-    { url = "https://files.pythonhosted.org/packages/74/bf/2d58d5ea515704f83e34699128c9072a34bea27d2b6a556e102105fe62a5/greenlet-3.4.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:523677e69cd4711b5a014e37bc1fb3a29947c3e3a5bb6a527e1cc50312e5a398", size = 611978, upload-time = "2026-04-08T15:56:31.335Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/39/3786520a7d5e33ee87b3da2531f589a3882abf686a42a3773183a41ef010/greenlet-3.4.0-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:d336d46878e486de7d9458653c722875547ac8d36a1cff9ffaf4a74a3c1f62eb", size = 416893, upload-time = "2026-04-08T16:43:02.392Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/69/6525049b6c179d8a923256304d8387b8bdd4acab1acf0407852463c6d514/greenlet-3.4.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b45e45fe47a19051a396abb22e19e7836a59ee6c5a90f3be427343c37908d65b", size = 1571957, upload-time = "2026-04-08T16:26:17.041Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/6c/bbfb798b05fec736a0d24dc23e81b45bcee87f45a83cfb39db031853bddc/greenlet-3.4.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5434271357be07f3ad0936c312645853b7e689e679e29310e2de09a9ea6c3adf", size = 1637223, upload-time = "2026-04-08T15:57:27.556Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/7d/981fe0e7c07bd9d5e7eb18decb8590a11e3955878291f7a7de2e9c668eb7/greenlet-3.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:a19093fbad824ed7c0f355b5ff4214bffda5f1a7f35f29b31fcaa240cc0135ab", size = 237902, upload-time = "2026-04-08T17:03:14.16Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/c6/dba32cab7e3a625b011aa5647486e2d28423a48845a2998c126dd69c85e1/greenlet-3.4.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:805bebb4945094acbab757d34d6e1098be6de8966009ab9ca54f06ff492def58", size = 285504, upload-time = "2026-04-08T15:52:14.071Z" },
-    { url = "https://files.pythonhosted.org/packages/54/f4/7cb5c2b1feb9a1f50e038be79980dfa969aa91979e5e3a18fdbcfad2c517/greenlet-3.4.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:439fc2f12b9b512d9dfa681c5afe5f6b3232c708d13e6f02c845e0d9f4c2d8c6", size = 605476, upload-time = "2026-04-08T16:24:37.064Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/af/b66ab0b2f9a4c5a867c136bf66d9599f34f21a1bcca26a2884a29c450bd9/greenlet-3.4.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a70ed1cb0295bee1df57b63bf7f46b4e56a5c93709eea769c1fec1bb23a95875", size = 618336, upload-time = "2026-04-08T16:30:56.59Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/31/56c43d2b5de476f77d36ceeec436328533bff960a4cba9a07616e93063ab/greenlet-3.4.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c5696c42e6bb5cfb7c6ff4453789081c66b9b91f061e5e9367fa15792644e76", size = 625045, upload-time = "2026-04-08T16:40:37.111Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/5c/8c5633ece6ba611d64bf2770219a98dd439921d6424e4e8cf16b0ac74ea5/greenlet-3.4.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c660bce1940a1acae5f51f0a064f1bc785d07ea16efcb4bc708090afc4d69e83", size = 613515, upload-time = "2026-04-08T15:56:32.478Z" },
-    { url = "https://files.pythonhosted.org/packages/80/ca/704d4e2c90acb8bdf7ae593f5cbc95f58e82de95cc540fb75631c1054533/greenlet-3.4.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:89995ce5ddcd2896d89615116dd39b9703bfa0c07b583b85b89bf1b5d6eddf81", size = 419745, upload-time = "2026-04-08T16:43:04.022Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/df/950d15bca0d90a0e7395eb777903060504cdb509b7b705631e8fb69ff415/greenlet-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ee407d4d1ca9dc632265aee1c8732c4a2d60adff848057cdebfe5fe94eb2c8a2", size = 1574623, upload-time = "2026-04-08T16:26:18.596Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/e7/0839afab829fcb7333c9ff6d80c040949510055d2d4d63251f0d1c7c804e/greenlet-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:956215d5e355fffa7c021d168728321fd4d31fd730ac609b1653b450f6a4bc71", size = 1639579, upload-time = "2026-04-08T15:57:29.231Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/2b/b4482401e9bcaf9f5c97f67ead38db89c19520ff6d0d6699979c6efcc200/greenlet-3.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:5cb614ace7c27571270354e9c9f696554d073f8aa9319079dcba466bbdead711", size = 238233, upload-time = "2026-04-08T17:02:54.286Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/4d/d8123a4e0bcd583d5cfc8ddae0bbe29c67aab96711be331a7cc935a35966/greenlet-3.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:04403ac74fe295a361f650818de93be11b5038a78f49ccfb64d3b1be8fbf1267", size = 235045, upload-time = "2026-04-08T17:04:05.072Z" },
-    { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
-    { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
-    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
-    { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
-    { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
-    { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/47/6c41314bac56e71436ce551c7fbe3cc830ed857e6aa9708dbb9c65142eb6/greenlet-3.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:f38b81880ba28f232f1f675893a39cf7b6db25b31cc0a09bb50787ecf957e85e", size = 235599, upload-time = "2026-04-08T15:52:54.3Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
-    { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
-    { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/96/795619651d39c7fbd809a522f881aa6f0ead504cc8201c3a5b789dfaef99/greenlet-3.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:9390ad88b652b1903814eaabd629ca184db15e0eeb6fe8a390bbf8b9106ae15a", size = 235498, upload-time = "2026-04-08T17:05:00.584Z" },
-    { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
-    { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
-    { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
-    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
-    { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
-    { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
-    { url = "https://files.pythonhosted.org/packages/71/c4/6f621023364d7e85a4769c014c8982f98053246d142420e0328980933ceb/greenlet-3.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:f8296d4e2b92af34ebde81085a01690f26a51eb9ac09a0fcadb331eb36dbc802", size = 236932, upload-time = "2026-04-08T17:04:33.551Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
-    { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
-    { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
-    { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
-    { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/03/84359833f7e1d49a883e92777637c592306030e30cee5e2b1e6476f95c88/greenlet-3.5.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:29ea813b2e1f45fa9649a17853b2b5465c4072fbcb072e5af6cd3a288216574a", size = 283502, upload-time = "2026-04-27T12:20:55.213Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ce/6f9f008266273aa14a2e011945797ac5802b97b8b40efe7afe1ee6c1afc9/greenlet-3.5.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:804a70b328e706b785c6ef16187051c394a63dd1a906d89be24b6ad77759f13f", size = 600508, upload-time = "2026-04-27T12:52:37.876Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/6d/b0f3272c2368ea2c1aa19a5ad70db0be8f8dff6e6d3d1eb82efa00cbcf19/greenlet-3.5.0-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:884f649de075b84739713d41dd4dfd41e2b910bfb769c4a3ea02ec1da52cd9bb", size = 613283, upload-time = "2026-04-27T12:59:37.957Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ae/1db979ff6ae7958d80b288f63d5f6c30df96682700ea9fc340ce994d94a1/greenlet-3.5.0-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4d0eadc7e4d9ffb2af4247b606cae307be8e448911e5a0d0b16d72fc3d224cfd", size = 619894, upload-time = "2026-04-27T13:02:35.13Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ac/0b509b6fb93551ce5a01612ee1acda7f7dda4bbb66c99aeb2ab403d205dc/greenlet-3.5.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b28037cb07768933c54d81bfe47a85f9f402f57d7d69743b991a713b63954eb", size = 613418, upload-time = "2026-04-27T12:25:23.852Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/94/b0590e3d1978f02419f30502341c40d72f77eb0a2198119fe27df47714ee/greenlet-3.5.0-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:f8c30c2225f40dd76c50790f0eb3b5c7c18431efb299e2782083e1981feed243", size = 415681, upload-time = "2026-04-27T13:05:11.494Z" },
+    { url = "https://files.pythonhosted.org/packages/03/03/2b2b680ec87aaa97998fb5b8d76658d4d3560386864f17efab33ba7c2e24/greenlet-3.5.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cda05425526240807408156b6960a17a79a0c760b813573b67027823be760977", size = 1572229, upload-time = "2026-04-27T12:53:23.509Z" },
+    { url = "https://files.pythonhosted.org/packages/61/e4/42b259e7a19aff1a270a4bd82caf6353109ed6860c9454e18f37162b83ae/greenlet-3.5.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9c615f869163e14bb1ced20322d8038fb680b08236521ac3f30cd4c1288785a0", size = 1639886, upload-time = "2026-04-27T12:25:22.325Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/b4/733ca47b883b67c57f90d3ecb21055c9ec753597d10754ac201644061f9d/greenlet-3.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:ba8f0bdc2fae6ce915dfd0c16d2d00bca7e4247c1eae4416e06430e522137858", size = 237795, upload-time = "2026-04-27T12:21:40.118Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0f/a91f143f356523ff682309732b175765a9bc2836fd7c081c2c67fedc1ad4/greenlet-3.5.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:8f1cc966c126639cd152fdaa52624d2655f492faa79e013fea161de3e6dda082", size = 284726, upload-time = "2026-04-27T12:20:51.402Z" },
+    { url = "https://files.pythonhosted.org/packages/95/82/800646c7ffc5dbabd75ddd2f6b519bb898c0c9c969e5d0473bfe5d20bcce/greenlet-3.5.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:362624e6a8e5bca3b8233e45eef33903a100e9539a2b995c364d595dbc4018b3", size = 604264, upload-time = "2026-04-27T12:52:39.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/354867c0bba812fc33b15bc55aedafedd0aee3c7dd91dfca22444157dc0c/greenlet-3.5.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5ecd83806b0f4c2f53b1018e0005cd82269ea01d42befc0368730028d850ed1c", size = 616099, upload-time = "2026-04-27T12:59:39.623Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ab/192090c4a5b30df148c22bf4b8895457d739a7c7c5a7b9c41e5dd7f537f2/greenlet-3.5.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa94cb2288681e3a11645958f1871d48ee9211bd2f66628fdace505927d6e564", size = 623976, upload-time = "2026-04-27T13:02:37.363Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/815bece7399e01cadb69014219eebd0042339875c59a59b0820a46ece356/greenlet-3.5.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ff251e9a0279522e62f6176412869395a64ddf2b5c5f782ff609a8216a4e662", size = 615198, upload-time = "2026-04-27T12:25:25.928Z" },
+    { url = "https://files.pythonhosted.org/packages/24/11/05eb2b9b188c6df7d68a89c99134d644a7af616a40b9808e8e6ced315d5d/greenlet-3.5.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:64d6ac45f7271f48e45f67c95b54ef73534c52ec041fcda8edf520c6d811f4bc", size = 418379, upload-time = "2026-04-27T13:05:12.755Z" },
+    { url = "https://files.pythonhosted.org/packages/10/80/3b2c0a895d6698f6ddb31b07942ebfa982f3e30888bc5546a5b5990de8b2/greenlet-3.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d874e79afd41a96e11ff4c5d0bc90a80973e476fda1c2c64985667397df432b", size = 1574927, upload-time = "2026-04-27T12:53:25.81Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0e/f354af514a4c61454dbc68e44d47544a5a4d6317e30b77ddfa3a09f4c5f3/greenlet-3.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0ed006e4b86c59de7467eb2601cd1b77b5a7d657d1ee55e30fe30d76451edba4", size = 1642683, upload-time = "2026-04-27T12:25:23.9Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/6a/87f38255201e993a1915265ebb80cd7c2c78b04a45744995abbf6b259fd8/greenlet-3.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:703cb211b820dbffbbc55a16bfc6e4583a6e6e990f33a119d2cc8b83211119c8", size = 238115, upload-time = "2026-04-27T12:21:48.845Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f8/450fe3c5938fa737ea4d22699772e6e34e8e24431a47bf4e8a1ceed4a98e/greenlet-3.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:6c18dfb59c70f5a94acd271c72e90128c3c776e41e5f07767908c8c1b74ad339", size = 235017, upload-time = "2026-04-27T12:22:26.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cb/baa584cb00532126ffe12d9787db0a60c5a4f55c27bfe2666df5d4c30a32/greenlet-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:83ed9f27f1680b50e89f40f6df348a290ea234b249a4003d366663a12eab94f2", size = 235615, upload-time = "2026-04-27T12:21:38.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
+    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
 ]
 
 [[package]]
@@ -3754,6 +3754,20 @@ wheels = [
 name = "mysql-connector-python"
 version = "9.6.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6e/c89babc7de3df01467d159854414659c885152579903a8220c8db02a3835/mysql_connector_python-9.6.0.tar.gz", hash = "sha256:c453bb55347174d87504b534246fb10c589daf5d057515bf615627198a3c7ef1", size = 12254999, upload-time = "2026-02-10T12:04:52.63Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/27/106f5b7a69381c58cb0ba6bf44e6488969ce6cd9f69f62df340f379141ee/mysql_connector_python-9.6.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:478e035ebcf734b3a1497bfd3eb72ce3632da6384545b08cf6329471b3849b6e", size = 17582676, upload-time = "2026-01-21T09:04:35.755Z" },
@@ -3782,6 +3796,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/06/5efdd28819afdb9f1487a62842fda4277febe128a3cd6e9090dbe0a6524e/mysql_connector_python-9.6.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4617ef5216da7ca32dd46afda61a1552807762434127413bba46fbe4379f59d4", size = 34542851, upload-time = "2026-02-10T12:04:31.021Z" },
     { url = "https://files.pythonhosted.org/packages/40/6a/26e08a4a79f159cd8e5b64eb10bd056e7735b65d4464d98641f59eb9ca3a/mysql_connector_python-9.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:bc782f64ca00b6b933d4c6a35568f1349d115cc4434c849b5b9edc015bee3e62", size = 17002947, upload-time = "2026-02-10T12:04:34.386Z" },
     { url = "https://files.pythonhosted.org/packages/15/dd/b3250826c29cee7816de4409a2fe5e469a68b9a89f6bfaa5eed74f05532c/mysql_connector_python-9.6.0-py2.py3-none-any.whl", hash = "sha256:44b0fb57207ebc6ae05b5b21b7968a9ed33b29187fe87b38951bad2a334d75d5", size = 480527, upload-time = "2026-02-10T12:04:36.176Z" },
+]
+
+[[package]]
+name = "mysql-connector-python"
+version = "9.7.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.11'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/7b/bfbe1732bdc413fa29d4431e04f257bed32b0f3efe775ca2e70e9d347008/mysql_connector_python-9.7.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:ee90c5f44f706f012be17f03f6ad158ff96e7f2dcc077896fe4537d3d28b3cf4", size = 20265583, upload-time = "2026-04-23T07:15:43.703Z" },
+    { url = "https://files.pythonhosted.org/packages/43/40/cba971fdc54522742955f12d4b019e9f3325d9a5c734abf5f012fde7cfff/mysql_connector_python-9.7.0-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:a2f371ab69d65c61136c51ad7026017400166cef3c959cab7a9fb668c7acbfba", size = 19826949, upload-time = "2026-04-23T07:15:46.443Z" },
+    { url = "https://files.pythonhosted.org/packages/83/5c/724577da77cd33d056ad48d1e29149f6c123371d651c0d824f6bfd2af28f/mysql_connector_python-9.7.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:9bdfc2d4c4444cd1cc79cc6487c047b28fe2b26d0327b27eb9f5737bb553cb5c", size = 21917561, upload-time = "2026-04-23T07:15:49.077Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/40/f0184970f6483a4e5ffcb99028f8402f3789b885872a5779edd3fa53da44/mysql_connector_python-9.7.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6546e0b60c275409a5add9e3308c3897fcf478d1338cd845b1664c1a8946f72f", size = 21687512, upload-time = "2026-04-23T07:15:51.614Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ee/0be8e060376e518897f4b3433e768ccd05bc8bb3d08c436cc2441b44ac0b/mysql_connector_python-9.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:c51be697bfdfdf63bb71c5ecc51f7c6faf4aaa3d14a0136fa16e97cc37df1185", size = 17678391, upload-time = "2026-04-23T07:15:54.626Z" },
+    { url = "https://files.pythonhosted.org/packages/70/fa/babe981ec8c24eece7f47dc52c5e3fe3f126bc99cc80d637b49ac2fe50a4/mysql_connector_python-9.7.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:b5cb8a3ba42b539f79cd13e4c8376d28506f3180f7079c9b04ea7bfd0424fb03", size = 20265659, upload-time = "2026-04-23T07:15:57.375Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4b/c45b8b601b0270faf1d4384e4c7270af9abb8d95ea39425253217c3c236c/mysql_connector_python-9.7.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:5492d57a6a0e5127a928290737fbb91b66b46d31dac8de3e7604e550bf3b3a6e", size = 19826940, upload-time = "2026-04-23T07:16:00.156Z" },
 ]
 
 [[package]]
@@ -4673,11 +4707,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "1.1.0"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/17/9c3094b822982b9f1ea666d8580ce59000f61f87c1663556fb72031ad9ec/pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080", size = 133918, upload-time = "2026-04-23T01:46:22.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/c9/8eed0486f074e9f1ca7f8ce5ad663e65f12fdab344028d658fa1b03d35e0/pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42", size = 56264, upload-time = "2026-04-23T01:46:20.606Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -5704,7 +5738,8 @@ minio = [
     { name = "minio" },
 ]
 mysql = [
-    { name = "mysql-connector-python" },
+    { name = "mysql-connector-python", version = "9.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "mysql-connector-python", version = "9.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
 ]
 oracle = [
     { name = "oracledb" },
@@ -5802,11 +5837,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]
@@ -6996,7 +7031,8 @@ mypyc = [
     { name = "sqlglot", extra = ["c"] },
 ]
 mysql-connector = [
-    { name = "mysql-connector-python" },
+    { name = "mysql-connector-python", version = "9.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "mysql-connector-python", version = "9.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
 ]
 nanoid = [
     { name = "fastnanoid" },


### PR DESCRIPTION
## Summary

Closes a cluster of filter-correctness issues filed 2026-04-26 and adds the
first-party service base classes that downstream consumers have been
re-implementing.

- Closes #424 — `StatementFilter`s now emit qualified columns; dotted
  `field_name="users.name"` works without `AmbiguousColumnError` on joined
  SELECTs and the count-query path.
- Closes #425 — `SearchFilter` / `NotInSearchFilter` now raise `TypeError`
  for unsupported `field_name` types instead of silently dropping the WHERE
  clause, and accept `exp.Expression` (e.g. `LOWER(name)`) as a sort/search
  key — finishing the type widening started for #427.
- Closes #426 — `QueryBuilder.order_by(sql.raw("COL DESC"))` correctly
  emits `ORDER BY ... DESC` instead of treating `DESC` as a column alias.
- Closes #427 — `OrderByFilter.field_name` (and `SearchFilter.field_name`)
  accept `exp.Expression` for computed-column ordering/search; the wire
  surface (`?orderBy=`) stays `str`-only.
- Closes #428 — exposes `SearchFilter.like_pattern` and adds
  `SearchFilter.escape_like_value()` so consumers bypassing the standard
  filter pipeline can opt into safe `%`/`_` escaping.
- Closes #429 — adds first-party `SQLSpecAsyncService` /
  `SQLSpecSyncService` in `sqlspec/service.py`
  (`paginate`, `get_or_404`, `exists`, `begin`/`commit`/`rollback`,
  `begin_transaction`) and re-exports them from every framework
  extension package. Flask re-exports the sync class only.