### PR TITLE
fix(service): overload narrowing + serializer DEFAULT_TYPE_ENCODERS registry

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,23 @@ SQLSpec Changelog
 Recent Updates
 ==============
 
+schema_dump wire_format Opt-Out (Unreleased)
+---------------------------------------------
+
+**Added:**
+
+* ``sqlspec.utils.serializers.schema_dump`` (and its helpers
+  ``serialize_collection`` / ``get_collection_serializer``) now accept a
+  ``wire_format: bool = True`` keyword. The default preserves existing output:
+  ``msgspec.Struct`` instances continue to emit wire-aligned names (honouring
+  ``rename=`` via ``field.encode_name``); Pydantic, dataclass, and attrs
+  branches continue to emit Python attribute names. Pass ``wire_format=False``
+  to opt the msgspec branch into Python attribute names (``field.name``) for
+  cross-library consistency. The kwarg is a no-op for non-msgspec inputs.
+
+* The internal serializer cache key now includes ``wire_format`` so that
+  ``True`` and ``False`` calls for the same Struct type cannot collide.
+
 Schema Wire Correctness (Unreleased)
 -------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ maintainers = [{ name = "Litestar Developers", email = "hello@litestar.dev" }]
 name = "sqlspec"
 readme = "README.md"
 requires-python = ">=3.10, <4.0"
-version = "0.45.0"
+version = "0.45.1"
 
 [project.urls]
 Discord = "https://discord.gg/litestar"
@@ -264,7 +264,7 @@ opt_level = "3"   # Maximum optimization (0-3)
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.45.0"
+current_version = "0.45.1"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to v{new_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ maintainers = [{ name = "Litestar Developers", email = "hello@litestar.dev" }]
 name = "sqlspec"
 readme = "README.md"
 requires-python = ">=3.10, <4.0"
-version = "0.45.1"
+version = "0.46.0"
 
 [project.urls]
 Discord = "https://discord.gg/litestar"
@@ -264,7 +264,7 @@ opt_level = "3"   # Maximum optimization (0-3)
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.45.1"
+current_version = "0.46.0"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to v{new_version}"

--- a/sqlspec/adapters/oracledb/core.py
+++ b/sqlspec/adapters/oracledb/core.py
@@ -800,7 +800,7 @@ def build_profile() -> "DriverParameterProfile":
         allow_mixed_parameter_styles=False,
         preserve_original_params_for_many=False,
         json_serializer_strategy="driver",
-        custom_type_coercions={**build_uuid_coercions()},
+        custom_type_coercions={**build_uuid_coercions(native=True)},
         default_dialect="oracle",
     )
 

--- a/sqlspec/extensions/litestar/plugin.py
+++ b/sqlspec/extensions/litestar/plugin.py
@@ -39,7 +39,7 @@ from sqlspec.extensions.litestar.handlers import (
 from sqlspec.typing import NUMPY_INSTALLED, ConnectionT, PoolT, SchemaT
 from sqlspec.utils.correlation import CorrelationContext
 from sqlspec.utils.logging import get_logger, log_with_context
-from sqlspec.utils.serializers import numpy_array_dec_hook, numpy_array_enc_hook, numpy_array_predicate
+from sqlspec.utils.serializers import DEFAULT_TYPE_ENCODERS, numpy_array_dec_hook, numpy_array_predicate
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Callable
@@ -177,6 +177,23 @@ def _build_correlation_headers(*, primary: str, configured: list[str], auto_trac
     if auto_trace_headers:
         header_order.extend(TRACE_CONTEXT_FALLBACK_HEADERS)
     return tuple(_dedupe_headers(header_order))
+
+
+def _build_litestar_type_decoders() -> "list[tuple[Callable[[Any], bool], Callable[[type, Any], Any]]]":
+    """Build the Litestar-specific ``type_decoders`` list.
+
+    Decoders are predicate-tuples consumed by Litestar's request-body parsing,
+    not part of sqlspec's serializer registry — so they live here rather than
+    in :data:`sqlspec.utils.serializers.DEFAULT_TYPE_ENCODERS`.
+    """
+    decoders: list[tuple[Callable[[Any], bool], Callable[[type, Any], Any]]] = []
+    if NUMPY_INSTALLED:
+        decoders.append((numpy_array_predicate, numpy_array_dec_hook))
+    with suppress(ImportError):
+        import uuid_utils  # pyright: ignore[reportMissingImports]
+
+        decoders.append((lambda t: t is uuid_utils.UUID, lambda t, v: t(str(v))))
+    return decoders
 
 
 class CorrelationMiddleware:
@@ -467,28 +484,20 @@ class SQLSpecPlugin(InitPluginProtocol, CLIPlugin):
         existing_plugins = list(app_config.plugins or [])
         if not any(isinstance(p, _OffsetPaginationSchemaPlugin) for p in existing_plugins):
             existing_plugins.append(_OffsetPaginationSchemaPlugin())
-            app_config.plugins = existing_plugins
+        app_config.plugins = existing_plugins
 
         if app_config.exception_handlers is None:
             app_config.exception_handlers = {}
         app_config.exception_handlers.setdefault(NotFoundError, not_found_error_handler)
 
-        if NUMPY_INSTALLED:
-            import numpy as np
-
-            if app_config.type_encoders is None:
-                app_config.type_encoders = {np.ndarray: numpy_array_enc_hook}
-            else:
-                encoders_dict = dict(app_config.type_encoders)
-                encoders_dict[np.ndarray] = numpy_array_enc_hook
-                app_config.type_encoders = encoders_dict
-
-            if app_config.type_decoders is None:
-                app_config.type_decoders = [(numpy_array_predicate, numpy_array_dec_hook)]
-            else:
-                decoders_list = list(app_config.type_decoders)
-                decoders_list.append((numpy_array_predicate, numpy_array_dec_hook))
-                app_config.type_decoders = decoders_list
+        # Inject sqlspec's DEFAULT_TYPE_ENCODERS into Litestar's response serializer
+        # (user-supplied encoders win on conflict). Litestar's per-handler
+        # resolve_type_encoders() merges these with route/controller/router-level
+        # overrides automatically — no bidirectional thread needed.
+        app_config.type_encoders = {**DEFAULT_TYPE_ENCODERS, **(app_config.type_encoders or {})}
+        sqlspec_decoders = _build_litestar_type_decoders()
+        if sqlspec_decoders:
+            app_config.type_decoders = [*(app_config.type_decoders or []), *sqlspec_decoders]
 
         if self._correlation_headers:
             middleware = DefineMiddleware(CorrelationMiddleware, headers=self._correlation_headers)

--- a/sqlspec/service.py
+++ b/sqlspec/service.py
@@ -1,7 +1,7 @@
 """Service base classes for SQLSpec application services."""
 
 from contextlib import asynccontextmanager, contextmanager
-from typing import TYPE_CHECKING, Any, Generic, cast
+from typing import TYPE_CHECKING, Any, Generic, cast, overload
 
 from typing_extensions import TypeVar
 
@@ -51,6 +51,28 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
         """Alias for :attr:`session` matching the recipe-doc terminology."""
         return self._session
 
+    @overload
+    async def paginate(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: "type[SchemaT]",
+        count_with_window: bool = False,
+        **kwargs: Any,
+    ) -> OffsetPagination[SchemaT]: ...
+
+    @overload
+    async def paginate(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: None = None,
+        count_with_window: bool = False,
+        **kwargs: Any,
+    ) -> OffsetPagination[dict[str, Any]]: ...
+
     async def paginate(
         self,
         statement: "Statement | QueryBuilder",
@@ -59,7 +81,7 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
         schema_type: "type[SchemaT] | None" = None,
         count_with_window: bool = False,
         **kwargs: Any,
-    ) -> OffsetPagination[SchemaT]:
+    ) -> "OffsetPagination[SchemaT] | OffsetPagination[dict[str, Any]]":
         """Execute a paginated query and return an OffsetPagination container.
 
         Args:
@@ -78,12 +100,42 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
             statement, *parameters, schema_type=schema_type, count_with_window=count_with_window, **kwargs
         )
 
+        if schema_type is None:
+            return OffsetPagination(
+                items=cast("list[dict[str, Any]]", items),
+                limit=limit_offset.limit if limit_offset is not None else len(items),
+                offset=limit_offset.offset if limit_offset is not None else 0,
+                total=total,
+            )
+
         return OffsetPagination(
             items=cast("list[SchemaT]", items),
             limit=limit_offset.limit if limit_offset is not None else len(items),
             offset=limit_offset.offset if limit_offset is not None else 0,
             total=total,
         )
+
+    @overload
+    async def get_one(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: "type[SchemaT]",
+        error_message: str | None = None,
+        **kwargs: Any,
+    ) -> SchemaT: ...
+
+    @overload
+    async def get_one(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: None = None,
+        error_message: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]: ...
 
     async def get_one(
         self,
@@ -191,6 +243,28 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
         """Alias for :attr:`session` matching the recipe-doc terminology."""
         return self._session
 
+    @overload
+    def paginate(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: "type[SchemaT]",
+        count_with_window: bool = False,
+        **kwargs: Any,
+    ) -> OffsetPagination[SchemaT]: ...
+
+    @overload
+    def paginate(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: None = None,
+        count_with_window: bool = False,
+        **kwargs: Any,
+    ) -> OffsetPagination[dict[str, Any]]: ...
+
     def paginate(
         self,
         statement: "Statement | QueryBuilder",
@@ -199,7 +273,7 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
         schema_type: "type[SchemaT] | None" = None,
         count_with_window: bool = False,
         **kwargs: Any,
-    ) -> OffsetPagination[SchemaT]:
+    ) -> "OffsetPagination[SchemaT] | OffsetPagination[dict[str, Any]]":
         """Execute a paginated query and return an OffsetPagination container.
 
         Args:
@@ -218,12 +292,42 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
             statement, *parameters, schema_type=schema_type, count_with_window=count_with_window, **kwargs
         )
 
+        if schema_type is None:
+            return OffsetPagination(
+                items=cast("list[dict[str, Any]]", items),
+                limit=limit_offset.limit if limit_offset is not None else len(items),
+                offset=limit_offset.offset if limit_offset is not None else 0,
+                total=total,
+            )
+
         return OffsetPagination(
             items=cast("list[SchemaT]", items),
             limit=limit_offset.limit if limit_offset is not None else len(items),
             offset=limit_offset.offset if limit_offset is not None else 0,
             total=total,
         )
+
+    @overload
+    def get_one(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: "type[SchemaT]",
+        error_message: str | None = None,
+        **kwargs: Any,
+    ) -> SchemaT: ...
+
+    @overload
+    def get_one(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: None = None,
+        error_message: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]: ...
 
     def get_one(
         self,

--- a/sqlspec/service.py
+++ b/sqlspec/service.py
@@ -137,6 +137,17 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
         **kwargs: Any,
     ) -> dict[str, Any]: ...
 
+    @overload
+    async def get_one(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: "type[SchemaT] | None" = None,
+        error_message: str | None = None,
+        **kwargs: Any,
+    ) -> "SchemaT | dict[str, Any]": ...
+
     async def get_one(
         self,
         statement: "Statement | QueryBuilder",
@@ -328,6 +339,17 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
         error_message: str | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]: ...
+
+    @overload
+    def get_one(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        schema_type: "type[SchemaT] | None" = None,
+        error_message: str | None = None,
+        **kwargs: Any,
+    ) -> "SchemaT | dict[str, Any]": ...
 
     def get_one(
         self,

--- a/sqlspec/utils/schema.py
+++ b/sqlspec/utils/schema.py
@@ -79,6 +79,7 @@ def _safe_convert_key(key: Any, converter: Callable[[str], str]) -> Any:
 
     Returns:
         Converted key if conversion succeeds, original key otherwise.
+
     """
     if not isinstance(key, str):
         return key
@@ -132,6 +133,7 @@ def transform_dict_keys(data: dict | list | Any, converter: Callable[[str], str]
                 {"itemId": 2, "itemName": "Product B"}
             ]
         }
+
     """
     if isinstance(data, dict):
         return _transform_dict(data, converter)
@@ -149,6 +151,7 @@ def _transform_dict(data: dict, converter: Callable[[str], str]) -> dict:
 
     Returns:
         Dictionary with transformed keys and recursively transformed values.
+
     """
     transformed = {}
 
@@ -169,6 +172,7 @@ def _transform_list(data: list, converter: Callable[[str], str]) -> list:
 
     Returns:
         List with recursively transformed elements.
+
     """
     return [transform_dict_keys(item, converter) for item in data]
 
@@ -209,6 +213,7 @@ def _detect_schema_type(schema_type: type) -> "str | None":
 
     Returns:
         Type identifier string or None if unsupported
+
     """
     return (
         "typed_dict"
@@ -339,6 +344,7 @@ def _default_msgspec_deserializer(
 
     Returns:
         Converted value or original value if conversion not applicable
+
     """
     if NUMPY_INSTALLED:
         import numpy as np
@@ -393,6 +399,7 @@ def _convert_numpy_recursive(obj: Any) -> Any:
 
     Returns:
         Object with all numpy arrays converted to lists
+
     """
     if not NUMPY_INSTALLED:
         return obj
@@ -494,6 +501,7 @@ def _get_schema_converter(schema_type: type) -> "Callable[[Any, Any], Any] | Non
 
     Returns:
         Converter function if schema_type is a supported schema, None otherwise.
+
     """
     try:
         return _SCHEMA_CONVERTER_CACHE[schema_type]
@@ -546,6 +554,7 @@ def to_schema(data: Any, *, schema_type: Any = None) -> Any:
 
     Raises:
         SQLSpecError: If schema_type is not a supported type
+
     """
     if schema_type is None:
         return data
@@ -575,6 +584,7 @@ def _ensure_json_parsed(value: Any) -> Any:
 
     Returns:
         Parsed JSON object if value was a valid JSON string, otherwise the original value.
+
     """
     if isinstance(value, str):
         try:
@@ -592,6 +602,7 @@ def _try_parse_json(value: str) -> Any:
 
     Returns:
         Parsed JSON value, or None if parsing fails.
+
     """
     try:
         return from_json(value)
@@ -619,6 +630,7 @@ def _convert_to_int(value: Any) -> int:
 
     Raises:
         TypeError: If value cannot be converted to int.
+
     """
     if isinstance(value, bool):
         return int(value)
@@ -648,6 +660,7 @@ def _convert_to_float(value: Any) -> float:
 
     Raises:
         TypeError: If value cannot be converted to float.
+
     """
     if isinstance(value, bool):
         return float(value)
@@ -673,6 +686,7 @@ def _convert_to_bool(value: Any) -> bool:
 
     Raises:
         TypeError: If value cannot be converted to bool.
+
     """
     if isinstance(value, bool):
         return value
@@ -695,6 +709,7 @@ def _convert_to_datetime(value: Any) -> datetime.datetime:
 
     Raises:
         TypeError: If value cannot be converted to datetime.
+
     """
     if isinstance(value, datetime.datetime):
         return value
@@ -720,6 +735,7 @@ def _convert_to_date(value: Any) -> datetime.date:
 
     Raises:
         TypeError: If value cannot be converted to date.
+
     """
     if isinstance(value, datetime.datetime):
         return value.date()
@@ -750,6 +766,7 @@ def _convert_to_time(value: Any) -> datetime.time:
 
     Raises:
         TypeError: If value cannot be converted to time.
+
     """
     if isinstance(value, datetime.datetime):
         return value.time()
@@ -775,6 +792,7 @@ def _convert_to_decimal(value: Any) -> Decimal:
 
     Raises:
         TypeError: If value cannot be converted to Decimal.
+
     """
     if isinstance(value, Decimal):
         return value
@@ -798,6 +816,7 @@ def _convert_to_uuid(value: Any) -> UUID:
 
     Raises:
         TypeError: If value cannot be converted to UUID.
+
     """
     if isinstance(value, UUID):
         return value
@@ -826,6 +845,7 @@ def _convert_to_path(value: Any) -> Path:
 
     Raises:
         TypeError: If value cannot be converted to Path.
+
     """
     if isinstance(value, Path):
         return value
@@ -849,6 +869,7 @@ def _convert_to_dict(value: Any) -> dict[str, Any]:
 
     Raises:
         TypeError: If value cannot be converted to dict.
+
     """
     if isinstance(value, dict):
         return value
@@ -877,6 +898,7 @@ def _convert_to_list(value: Any) -> list[Any]:
 
     Raises:
         TypeError: If value cannot be converted to list.
+
     """
     if isinstance(value, list):
         return value
@@ -968,6 +990,7 @@ def to_value_type(value: Any, value_type: "type[ValueT]") -> "ValueT":
         1
         >>> to_value_type(False, int)
         0
+
     """
     # Fast path: already correct type (handles ~90% of cases)
     # Uses strict type() identity which correctly handles subclass gotchas:

--- a/sqlspec/utils/serializers/__init__.py
+++ b/sqlspec/utils/serializers/__init__.py
@@ -1,5 +1,6 @@
 """Serialization utilities for SQLSpec."""
 
+from sqlspec.utils.serializers._json import DEFAULT_TYPE_ENCODERS, TypeEncodersMap
 from sqlspec.utils.serializers._json import decode_json as from_json
 from sqlspec.utils.serializers._json import encode_json as to_json
 from sqlspec.utils.serializers._numpy import numpy_array_dec_hook, numpy_array_enc_hook, numpy_array_predicate
@@ -13,7 +14,9 @@ from sqlspec.utils.serializers._schema import (
 )
 
 __all__ = (
+    "DEFAULT_TYPE_ENCODERS",
     "SchemaSerializer",
+    "TypeEncodersMap",
     "from_json",
     "get_collection_serializer",
     "get_serializer_metrics",

--- a/sqlspec/utils/serializers/_json.py
+++ b/sqlspec/utils/serializers/_json.py
@@ -6,10 +6,12 @@ import enum
 import json
 import uuid as uuid_mod
 from abc import ABC, abstractmethod
+from collections.abc import Callable, Mapping
 from decimal import Decimal
+from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
+from pathlib import Path, PurePath
 from typing import Any, Final, Literal, Protocol, overload
 
-from sqlspec.core._pagination import OffsetPagination
 from sqlspec.typing import (
     MSGSPEC_INSTALLED,
     NUMPY_INSTALLED,
@@ -22,17 +24,22 @@ from sqlspec.utils.type_guards import dataclass_to_dict, is_attrs_instance, is_d
 from sqlspec.utils.uuids import UUID_UTILS_INSTALLED, _load_uuid_utils
 
 __all__ = (
+    "DEFAULT_TYPE_ENCODERS",
     "BaseJSONSerializer",
     "JSONSerializer",
     "MsgspecSerializer",
     "OrjsonSerializer",
     "StandardLibSerializer",
+    "TypeEncodersMap",
     "convert_date_to_iso",
     "convert_datetime_to_gmt_iso",
     "decode_json",
     "encode_json",
     "get_default_serializer",
 )
+
+
+TypeEncodersMap = Mapping[type, Callable[[Any], Any]]
 
 
 def _get_uuid_utils_type() -> "type[Any] | None":
@@ -61,7 +68,7 @@ def convert_date_to_iso(value: datetime.date) -> str:
 
 def _dump_pydantic_model(value: Any) -> Any:
     if hasattr(value, "model_dump"):
-        return value.model_dump()
+        return value.model_dump(mode="json")
     return value.dict()
 
 
@@ -69,49 +76,104 @@ def _dump_msgspec_struct(value: Any) -> "dict[str, Any]":
     return {field_name: value.__getattribute__(field_name) for field_name in value.__struct_fields__}
 
 
-def _normalize_numpy_value(value: Any) -> Any:
-    if not NUMPY_INSTALLED:
-        return value
+def _build_default_type_encoders() -> "dict[type, Callable[[Any], Any]]":
+    """Construct the default type encoder registry.
 
-    import numpy as np
+    Mirrors ``advanced_alchemy.utils.serialization.DEFAULT_TYPE_ENCODERS`` in
+    shape, with one deliberate divergence: ``Decimal`` encodes to ``float`` to
+    preserve sqlspec's prior behaviour from ``_normalize_supported_value``.
+    """
+    encoders: dict[type, Callable[[Any], Any]] = {
+        datetime.datetime: convert_datetime_to_gmt_iso,
+        datetime.date: convert_date_to_iso,
+        datetime.time: lambda v: v.isoformat(),
+        datetime.timedelta: lambda v: v.total_seconds(),
+        # NOTE: Diverges from advanced_alchemy (str): sqlspec keeps Decimal -> float
+        # to match the legacy _normalize_supported_value behaviour.
+        Decimal: float,
+        uuid_mod.UUID: str,
+        Path: str,
+        PurePath: str,
+        IPv4Address: str,
+        IPv4Interface: str,
+        IPv4Network: str,
+        IPv6Address: str,
+        IPv6Interface: str,
+        IPv6Network: str,
+        frozenset: list,
+        set: list,
+        bytes: lambda v: v.decode("utf-8", errors="replace"),
+        enum.Enum: lambda v: v.value,
+    }
 
-    if isinstance(value, np.ndarray):
-        return value.tolist()
-    if isinstance(value, np.generic):
-        return value.item()
-    return value
+    if _UUID_UTILS_TYPE is not None:
+        encoders[_UUID_UTILS_TYPE] = str
+
+    if NUMPY_INSTALLED:
+        import numpy as np
+
+        encoders[np.ndarray] = lambda v: v.tolist()
+        encoders[np.generic] = lambda v: v.item()
+
+    if PYDANTIC_INSTALLED:
+        encoders[BaseModel] = _dump_pydantic_model
+
+    return encoders
 
 
-def _normalize_supported_value(value: Any) -> Any:
-    """Convert supported non-native values into JSON-compatible objects."""
-    if isinstance(value, datetime.datetime):
-        return convert_datetime_to_gmt_iso(value)
-    if isinstance(value, datetime.date):
-        return convert_date_to_iso(value)
-    if isinstance(value, uuid_mod.UUID):
-        return str(value)
-    if _UUID_UTILS_TYPE is not None and isinstance(value, _UUID_UTILS_TYPE):
-        return str(value)
-    if isinstance(value, Decimal):
-        return float(value)
-    if isinstance(value, enum.Enum):
-        return value.value
-    if isinstance(value, OffsetPagination):
-        return {"items": value.items, "limit": value.limit, "offset": value.offset, "total": value.total}
-    if PYDANTIC_INSTALLED and isinstance(value, BaseModel):
-        return _dump_pydantic_model(value)
+DEFAULT_TYPE_ENCODERS: Final["dict[type, Callable[[Any], Any]]"] = _build_default_type_encoders()
+
+
+def _resolve_structural_encoder(value: Any) -> Any:
+    """Probe-based fallback for types that aren't keyed by class.
+
+    ``dataclass``/``attrs``/``msgspec.Struct`` rely on ``is_*`` runtime probes
+    rather than ``isinstance`` against a single base type, so they can't live
+    in the type-keyed registry.
+    """
     if is_dataclass_instance(value):
         return dataclass_to_dict(value)
     if is_attrs_instance(value):
         return attrs_asdict(value, recurse=True)
     if is_msgspec_struct(value):
         return _dump_msgspec_struct(value)
-    numpy_value = _normalize_numpy_value(value)
-    if numpy_value is not value:
-        return numpy_value
+    return None
 
-    msg = f"unsupported JSON value: {type(value).__name__}"
-    raise TypeError(msg)
+
+def _create_enc_hook(type_encoders: "Mapping[type, Callable[[Any], Any]]") -> "Callable[[Any], Any]":
+    """Build an MRO-walking enc_hook bound to the supplied registry.
+
+    The hook walks ``value.__class__.__mro__[:-1]`` (skipping ``object``) and
+    returns the first matching encoder. Unmatched values fall through to
+    structural probes (dataclass/attrs/msgspec.Struct) before raising
+    ``TypeError`` — this preserves sqlspec's strict semantics rather than
+    advanced-alchemy's ``str()`` fallback.
+    """
+
+    def enc_hook(value: Any) -> Any:
+        for base in value.__class__.__mro__[:-1]:
+            encoder = type_encoders.get(base)
+            if encoder is not None:
+                return encoder(value)
+        structural = _resolve_structural_encoder(value)
+        if structural is not None:
+            return structural
+        msg = f"unsupported JSON value: {type(value).__name__}"
+        raise TypeError(msg)
+
+    return enc_hook
+
+
+_DEFAULT_ENC_HOOK: Final["Callable[[Any], Any]"] = _create_enc_hook(DEFAULT_TYPE_ENCODERS)
+
+
+def _normalize_supported_value(value: Any) -> Any:
+    """Convert supported non-native values into JSON-compatible objects.
+
+    Thin shim over the default enc_hook for backwards compatibility with any
+    callers that imported this private helper.
+    """
+    return _DEFAULT_ENC_HOOK(value)
 
 
 def _is_explicit_unsupported_error(exc: Exception) -> bool:
@@ -121,11 +183,11 @@ def _is_explicit_unsupported_error(exc: Exception) -> bool:
 class JSONSerializer(Protocol):
     """Protocol for JSON serializer implementations."""
 
-    def encode(self, data: Any, *, as_bytes: bool = False) -> str | bytes:
+    def encode(self, data: Any, *, as_bytes: bool = False) -> "str | bytes":
         """Encode Python data into JSON."""
         ...
 
-    def decode(self, data: str | bytes, *, decode_bytes: bool = True) -> Any:
+    def decode(self, data: "str | bytes", *, decode_bytes: bool = True) -> Any:
         """Decode JSON into Python data."""
         ...
 
@@ -136,19 +198,19 @@ class BaseJSONSerializer(ABC):
     __slots__ = ()
 
     @abstractmethod
-    def encode(self, data: Any, *, as_bytes: bool = False) -> str | bytes:
+    def encode(self, data: Any, *, as_bytes: bool = False) -> "str | bytes":
         """Encode Python data into JSON."""
         ...
 
     @abstractmethod
-    def decode(self, data: str | bytes, *, decode_bytes: bool = True) -> Any:
+    def decode(self, data: "str | bytes", *, decode_bytes: bool = True) -> Any:
         """Decode JSON into Python data."""
         ...
 
 
 _orjson_fallback: "OrjsonSerializer | None" = None
 _stdlib_fallback: "StandardLibSerializer | None" = None
-_default_serializer: JSONSerializer | None = None
+_default_serializer: "JSONSerializer | None" = None
 
 
 def _get_orjson_fallback() -> "OrjsonSerializer":
@@ -165,18 +227,27 @@ def _get_stdlib_fallback() -> "StandardLibSerializer":
     return _stdlib_fallback
 
 
+def _merge_type_encoders(type_encoders: "TypeEncodersMap | None") -> "Callable[[Any], Any]":
+    """Return an enc_hook bound to defaults merged with caller overrides."""
+    if not type_encoders:
+        return _DEFAULT_ENC_HOOK
+    merged: dict[type, Callable[[Any], Any]] = {**DEFAULT_TYPE_ENCODERS, **type_encoders}
+    return _create_enc_hook(merged)
+
+
 class MsgspecSerializer(BaseJSONSerializer):
     """Msgspec-based JSON serializer."""
 
-    __slots__ = ("_decoder", "_encoder")
+    __slots__ = ("_decoder", "_enc_hook", "_encoder")
 
-    def __init__(self) -> None:
+    def __init__(self, type_encoders: "TypeEncodersMap | None" = None) -> None:
         from msgspec.json import Decoder, Encoder
 
-        self._encoder: Final[Encoder] = Encoder(enc_hook=_normalize_supported_value)
+        self._enc_hook: Callable[[Any], Any] = _merge_type_encoders(type_encoders)
+        self._encoder: Final[Encoder] = Encoder(enc_hook=self._enc_hook)
         self._decoder: Final[Decoder] = Decoder()
 
-    def encode(self, data: Any, *, as_bytes: bool = False) -> str | bytes:
+    def encode(self, data: Any, *, as_bytes: bool = False) -> "str | bytes":
         try:
             encoded = self._encoder.encode(data)
         except TypeError as exc:
@@ -191,7 +262,7 @@ class MsgspecSerializer(BaseJSONSerializer):
             return _get_stdlib_fallback().encode(data, as_bytes=as_bytes)
         return encoded if as_bytes else encoded.decode("utf-8")
 
-    def decode(self, data: str | bytes, *, decode_bytes: bool = True) -> Any:
+    def decode(self, data: "str | bytes", *, decode_bytes: bool = True) -> Any:
         if isinstance(data, bytes):
             if not decode_bytes:
                 return data
@@ -212,9 +283,12 @@ class MsgspecSerializer(BaseJSONSerializer):
 class OrjsonSerializer(BaseJSONSerializer):
     """Orjson-based JSON serializer."""
 
-    __slots__ = ()
+    __slots__ = ("_enc_hook",)
 
-    def encode(self, data: Any, *, as_bytes: bool = False) -> str | bytes:
+    def __init__(self, type_encoders: "TypeEncodersMap | None" = None) -> None:
+        self._enc_hook: Callable[[Any], Any] = _merge_type_encoders(type_encoders)
+
+    def encode(self, data: Any, *, as_bytes: bool = False) -> "str | bytes":
         from orjson import OPT_NAIVE_UTC, OPT_SERIALIZE_UUID
         from orjson import dumps as orjson_dumps  # pyright: ignore[reportMissingImports]
 
@@ -225,7 +299,7 @@ class OrjsonSerializer(BaseJSONSerializer):
             options |= OPT_SERIALIZE_NUMPY
 
         try:
-            encoded = orjson_dumps(data, default=_normalize_supported_value, option=options)
+            encoded = orjson_dumps(data, default=self._enc_hook, option=options)
         except TypeError as exc:
             if _is_explicit_unsupported_error(exc):
                 raise
@@ -235,7 +309,7 @@ class OrjsonSerializer(BaseJSONSerializer):
             raise
         return encoded if as_bytes else encoded.decode("utf-8")
 
-    def decode(self, data: str | bytes, *, decode_bytes: bool = True) -> Any:
+    def decode(self, data: "str | bytes", *, decode_bytes: bool = True) -> Any:
         from orjson import loads as orjson_loads  # pyright: ignore[reportMissingImports]
 
         if isinstance(data, bytes):
@@ -248,13 +322,16 @@ class OrjsonSerializer(BaseJSONSerializer):
 class StandardLibSerializer(BaseJSONSerializer):
     """Standard library JSON serializer fallback."""
 
-    __slots__ = ()
+    __slots__ = ("_enc_hook",)
 
-    def encode(self, data: Any, *, as_bytes: bool = False) -> str | bytes:
-        encoded = json.dumps(data, default=_normalize_supported_value)
+    def __init__(self, type_encoders: "TypeEncodersMap | None" = None) -> None:
+        self._enc_hook: Callable[[Any], Any] = _merge_type_encoders(type_encoders)
+
+    def encode(self, data: Any, *, as_bytes: bool = False) -> "str | bytes":
+        encoded = json.dumps(data, default=self._enc_hook)
         return encoded.encode("utf-8") if as_bytes else encoded
 
-    def decode(self, data: str | bytes, *, decode_bytes: bool = True) -> Any:
+    def decode(self, data: "str | bytes", *, decode_bytes: bool = True) -> Any:
         if isinstance(data, bytes):
             if not decode_bytes:
                 return data
@@ -288,11 +365,11 @@ def encode_json(data: Any, *, as_bytes: Literal[False] = ...) -> str: ...
 def encode_json(data: Any, *, as_bytes: Literal[True]) -> bytes: ...
 
 
-def encode_json(data: Any, *, as_bytes: bool = False) -> str | bytes:
+def encode_json(data: Any, *, as_bytes: bool = False) -> "str | bytes":
     """Encode Python data into JSON."""
     return get_default_serializer().encode(data, as_bytes=as_bytes)
 
 
-def decode_json(data: str | bytes, *, decode_bytes: bool = True) -> Any:
+def decode_json(data: "str | bytes", *, decode_bytes: bool = True) -> Any:
     """Decode JSON input into Python data."""
     return get_default_serializer().decode(data, decode_bytes=decode_bytes)

--- a/sqlspec/utils/serializers/_json.py
+++ b/sqlspec/utils/serializers/_json.py
@@ -109,6 +109,14 @@ def _build_default_type_encoders() -> "dict[type, Callable[[Any], Any]]":
     if _UUID_UTILS_TYPE is not None:
         encoders[_UUID_UTILS_TYPE] = str
 
+    with contextlib.suppress(ImportError):
+        # asyncpg returns UUIDs as `pgproto.UUID`, distinct from stdlib uuid.UUID.
+        # Registered here (not in the Litestar plugin) so every framework
+        # consumer — and direct sqlspec users — handles asyncpg results.
+        from asyncpg.pgproto import pgproto  # pyright: ignore[reportMissingImports]
+
+        encoders[pgproto.UUID] = str
+
     if NUMPY_INSTALLED:
         import numpy as np
 
@@ -143,11 +151,11 @@ def _resolve_structural_encoder(value: Any) -> Any:
 def _create_enc_hook(type_encoders: "Mapping[type, Callable[[Any], Any]]") -> "Callable[[Any], Any]":
     """Build an MRO-walking enc_hook bound to the supplied registry.
 
-    The hook walks ``value.__class__.__mro__[:-1]`` (skipping ``object``) and
-    returns the first matching encoder. Unmatched values fall through to
-    structural probes (dataclass/attrs/msgspec.Struct) before raising
-    ``TypeError`` — this preserves sqlspec's strict semantics rather than
-    advanced-alchemy's ``str()`` fallback.
+    Walks ``value.__class__.__mro__[:-1]`` (skipping ``object``) and returns
+    the first matching encoder. Falls through to structural probes
+    (dataclass / attrs / msgspec.Struct), then raises
+    ``TypeError("unsupported JSON value: ...")`` — strict sqlspec semantics,
+    divergent from advanced-alchemy's ``str`` fallback.
     """
 
     def enc_hook(value: Any) -> Any:

--- a/sqlspec/utils/serializers/_schema.py
+++ b/sqlspec/utils/serializers/_schema.py
@@ -88,12 +88,12 @@ class SchemaSerializer:
 
     __slots__ = ("_dump", "_key")
 
-    def __init__(self, key: "tuple[type[Any] | None, bool]", dump: "Callable[[Any], dict[str, Any]]") -> None:
+    def __init__(self, key: "tuple[type[Any] | None, bool, bool]", dump: "Callable[[Any], dict[str, Any]]") -> None:
         self._key = key
         self._dump = dump
 
     @property
-    def key(self) -> "tuple[type[Any] | None, bool]":
+    def key(self) -> "tuple[type[Any] | None, bool, bool]":
         return self._key
 
     def dump_one(self, item: Any) -> "dict[str, Any]":
@@ -110,14 +110,14 @@ class SchemaSerializer:
 
 
 _SERIALIZER_LOCK: RLock = RLock()
-_SCHEMA_SERIALIZERS: dict[tuple[type[Any] | None, bool], SchemaSerializer] = {}
+_SCHEMA_SERIALIZERS: dict[tuple[type[Any] | None, bool, bool], SchemaSerializer] = {}
 _SERIALIZER_METRICS = _SerializerCacheMetrics()
 
 
-def _make_serializer_key(sample: Any, exclude_unset: bool) -> "tuple[type[Any] | None, bool]":
+def _make_serializer_key(sample: Any, exclude_unset: bool, wire_format: bool) -> "tuple[type[Any] | None, bool, bool]":
     if sample is None or isinstance(sample, dict):
-        return (None, exclude_unset)
-    return (type(sample), exclude_unset)
+        return (None, exclude_unset, wire_format)
+    return (type(sample), exclude_unset, wire_format)
 
 
 def _dump_identity_dict(value: Any) -> "dict[str, Any]":
@@ -140,12 +140,30 @@ def _dump_msgspec_excluding_unset(value: Any) -> "dict[str, Any]":
     }
 
 
+def _dump_msgspec_fields_python(value: Any) -> "dict[str, Any]":
+    """Dump msgspec Struct keyed by Python attribute names (ignores rename=)."""
+    from msgspec import structs
+
+    return {field.name: value.__getattribute__(field.name) for field in structs.fields(type(value))}
+
+
+def _dump_msgspec_excluding_unset_python(value: Any) -> "dict[str, Any]":
+    """Dump msgspec Struct (Python names, exclude UNSET fields)."""
+    from msgspec import structs
+
+    return {
+        field.name: field_value
+        for field in structs.fields(type(value))
+        if (field_value := value.__getattribute__(field.name)) != UNSET
+    }
+
+
 def _dump_dataclass(value: Any, *, exclude_unset: bool) -> "dict[str, Any]":
     return dataclass_to_dict(value, exclude_empty=exclude_unset)
 
 
-def _dump_pydantic(value: Any, *, exclude_unset: bool) -> "dict[str, Any]":
-    return cast("dict[str, Any]", value.model_dump(exclude_unset=exclude_unset))
+def _dump_pydantic(value: Any, *, exclude_unset: bool, wire_format: bool) -> "dict[str, Any]":
+    return cast("dict[str, Any]", value.model_dump(exclude_unset=exclude_unset, by_alias=wire_format))
 
 
 def _dump_attrs(value: Any) -> "dict[str, Any]":
@@ -160,17 +178,24 @@ def _dump_mapping(value: Any) -> "dict[str, Any]":
     return dict(value)
 
 
-def _build_dump_function(sample: Any, exclude_unset: bool) -> "Callable[[Any], dict[str, Any]]":
+def _build_dump_function(sample: Any, exclude_unset: bool, wire_format: bool) -> "Callable[[Any], dict[str, Any]]":
     if sample is None or isinstance(sample, dict):
         return _dump_identity_dict
     if is_dataclass_instance(sample):
         return cast("Callable[[Any], dict[str, Any]]", partial(_dump_dataclass, exclude_unset=exclude_unset))
     if is_pydantic_model(sample):
-        return cast("Callable[[Any], dict[str, Any]]", partial(_dump_pydantic, exclude_unset=exclude_unset))
+        return cast(
+            "Callable[[Any], dict[str, Any]]",
+            partial(_dump_pydantic, exclude_unset=exclude_unset, wire_format=wire_format),
+        )
     if is_msgspec_struct(sample):
+        if wire_format:
+            if exclude_unset:
+                return _dump_msgspec_excluding_unset
+            return _dump_msgspec_fields
         if exclude_unset:
-            return _dump_msgspec_excluding_unset
-        return _dump_msgspec_fields
+            return _dump_msgspec_excluding_unset_python
+        return _dump_msgspec_fields_python
     if is_attrs_instance(sample):
         return _dump_attrs
     if has_dict_attribute(sample):
@@ -178,36 +203,40 @@ def _build_dump_function(sample: Any, exclude_unset: bool) -> "Callable[[Any], d
     return _dump_mapping
 
 
-def get_collection_serializer(sample: Any, *, exclude_unset: bool = True) -> "SchemaSerializer":
+def get_collection_serializer(
+    sample: Any, *, exclude_unset: bool = True, wire_format: bool = False
+) -> "SchemaSerializer":
     """Return cached serializer pipeline for the provided sample object."""
-    key = _make_serializer_key(sample, exclude_unset)
+    key = _make_serializer_key(sample, exclude_unset, wire_format)
     with _SERIALIZER_LOCK:
         pipeline = _SCHEMA_SERIALIZERS.get(key)
         if pipeline is not None:
             _SERIALIZER_METRICS.record_hit(len(_SCHEMA_SERIALIZERS))
             return pipeline
 
-        dump = _build_dump_function(sample, exclude_unset)
+        dump = _build_dump_function(sample, exclude_unset, wire_format)
         pipeline = SchemaSerializer(key, dump)
         _SCHEMA_SERIALIZERS[key] = pipeline
         _SERIALIZER_METRICS.record_miss(len(_SCHEMA_SERIALIZERS))
         return pipeline
 
 
-def serialize_collection(items: "Iterable[Any]", *, exclude_unset: bool = True) -> "list[Any]":
+def serialize_collection(
+    items: "Iterable[Any]", *, exclude_unset: bool = True, wire_format: bool = False
+) -> "list[Any]":
     """Serialize a collection using cached pipelines keyed by item type."""
     serialized: list[Any] = []
-    cache: dict[tuple[type[Any] | None, bool], SchemaSerializer] = {}
+    cache: dict[tuple[type[Any] | None, bool, bool], SchemaSerializer] = {}
 
     for item in items:
         if isinstance(item, _PRIMITIVE_TYPES) or item is None or isinstance(item, dict):
             serialized.append(item)
             continue
 
-        key = _make_serializer_key(item, exclude_unset)
+        key = _make_serializer_key(item, exclude_unset, wire_format)
         pipeline = cache.get(key)
         if pipeline is None:
-            pipeline = get_collection_serializer(item, exclude_unset=exclude_unset)
+            pipeline = get_collection_serializer(item, exclude_unset=exclude_unset, wire_format=wire_format)
             cache[key] = pipeline
         serialized.append(pipeline.dump_one(item))
     return serialized
@@ -228,12 +257,24 @@ def get_serializer_metrics() -> "dict[str, int]":
         return metrics
 
 
-def schema_dump(data: Any, *, exclude_unset: bool = True) -> Any:
-    """Dump a schema model or dict to a plain representation."""
+def schema_dump(data: Any, *, exclude_unset: bool = True, wire_format: bool = False) -> Any:
+    """Dump a schema model or dict to a plain representation.
+
+    Args:
+        data: A schema instance (msgspec.Struct, Pydantic BaseModel, dataclass, attrs class)
+            or plain dict / primitive.
+        exclude_unset: If True, exclude fields that were never set (msgspec UNSET, Pydantic
+            model_fields_set semantics). No-op for attrs (attrs has no unset concept).
+        wire_format: If True, emit wire-aligned names: msgspec uses ``field.encode_name``
+            (honours ``rename=``), Pydantic uses ``model_dump(by_alias=True)``. dataclass
+            and attrs are unchanged (no alias concept). Default False — Python attribute
+            names for cross-library consistency. For wire-shaped JSON output, prefer
+            ``to_json`` / ``encode_json`` which always emit aliased keys.
+    """
     if is_dict(data):
         return data
     if isinstance(data, _PRIMITIVE_TYPES) or data is None:
         return data
 
-    serializer = get_collection_serializer(data, exclude_unset=exclude_unset)
+    serializer = get_collection_serializer(data, exclude_unset=exclude_unset, wire_format=wire_format)
     return serializer.dump_one(data)

--- a/sqlspec/utils/serializers/_schema.py
+++ b/sqlspec/utils/serializers/_schema.py
@@ -162,8 +162,8 @@ def _dump_dataclass(value: Any, *, exclude_unset: bool) -> "dict[str, Any]":
     return dataclass_to_dict(value, exclude_empty=exclude_unset)
 
 
-def _dump_pydantic(value: Any, *, exclude_unset: bool, wire_format: bool) -> "dict[str, Any]":
-    return cast("dict[str, Any]", value.model_dump(exclude_unset=exclude_unset, by_alias=wire_format))
+def _dump_pydantic(value: Any, *, exclude_unset: bool) -> "dict[str, Any]":
+    return cast("dict[str, Any]", value.model_dump(exclude_unset=exclude_unset))
 
 
 def _dump_attrs(value: Any) -> "dict[str, Any]":
@@ -184,10 +184,7 @@ def _build_dump_function(sample: Any, exclude_unset: bool, wire_format: bool) ->
     if is_dataclass_instance(sample):
         return cast("Callable[[Any], dict[str, Any]]", partial(_dump_dataclass, exclude_unset=exclude_unset))
     if is_pydantic_model(sample):
-        return cast(
-            "Callable[[Any], dict[str, Any]]",
-            partial(_dump_pydantic, exclude_unset=exclude_unset, wire_format=wire_format),
-        )
+        return cast("Callable[[Any], dict[str, Any]]", partial(_dump_pydantic, exclude_unset=exclude_unset))
     if is_msgspec_struct(sample):
         if wire_format:
             if exclude_unset:
@@ -204,7 +201,7 @@ def _build_dump_function(sample: Any, exclude_unset: bool, wire_format: bool) ->
 
 
 def get_collection_serializer(
-    sample: Any, *, exclude_unset: bool = True, wire_format: bool = False
+    sample: Any, *, exclude_unset: bool = True, wire_format: bool = True
 ) -> "SchemaSerializer":
     """Return cached serializer pipeline for the provided sample object."""
     key = _make_serializer_key(sample, exclude_unset, wire_format)
@@ -222,7 +219,7 @@ def get_collection_serializer(
 
 
 def serialize_collection(
-    items: "Iterable[Any]", *, exclude_unset: bool = True, wire_format: bool = False
+    items: "Iterable[Any]", *, exclude_unset: bool = True, wire_format: bool = True
 ) -> "list[Any]":
     """Serialize a collection using cached pipelines keyed by item type."""
     serialized: list[Any] = []
@@ -257,7 +254,7 @@ def get_serializer_metrics() -> "dict[str, int]":
         return metrics
 
 
-def schema_dump(data: Any, *, exclude_unset: bool = True, wire_format: bool = False) -> Any:
+def schema_dump(data: Any, *, exclude_unset: bool = True, wire_format: bool = True) -> Any:
     """Dump a schema model or dict to a plain representation.
 
     Args:
@@ -265,11 +262,11 @@ def schema_dump(data: Any, *, exclude_unset: bool = True, wire_format: bool = Fa
             or plain dict / primitive.
         exclude_unset: If True, exclude fields that were never set (msgspec UNSET, Pydantic
             model_fields_set semantics). No-op for attrs (attrs has no unset concept).
-        wire_format: If True, emit wire-aligned names: msgspec uses ``field.encode_name``
-            (honours ``rename=``), Pydantic uses ``model_dump(by_alias=True)``. dataclass
-            and attrs are unchanged (no alias concept). Default False — Python attribute
-            names for cross-library consistency. For wire-shaped JSON output, prefer
-            ``to_json`` / ``encode_json`` which always emit aliased keys.
+        wire_format: msgspec-only knob. Default True keeps the historical behavior of
+            emitting ``field.encode_name`` (honours ``rename=`` on the Struct). Pass
+            ``wire_format=False`` to opt msgspec into Python attribute names (``field.name``)
+            for cross-library consistency. Pydantic, dataclass, and attrs branches always
+            use Python attribute names regardless of this flag.
     """
     if is_dict(data):
         return data

--- a/sqlspec/utils/type_converters.py
+++ b/sqlspec/utils/type_converters.py
@@ -187,11 +187,10 @@ def _uuid_utils_to_stdlib(value: Any) -> Any:
 
 
 def build_uuid_coercions(*, native: bool = False) -> "dict[type[Any], Callable[[Any], Any]]":
-    """Return coercions for ``uuid_utils.UUID`` parameter binding.
+    """Return coercions for UUID parameter binding.
 
-    When ``uuid_utils`` is installed, returns a dict mapping its UUID type
-    to either ``str`` or ``uuid.UUID`` depending on the *native* flag.
-    When not installed, returns an empty dict.
+    Includes coercions for ``uuid_utils.UUID`` (if installed) and standard
+    library ``uuid.UUID``.
 
     Args:
         native: When ``True``, convert ``uuid_utils.UUID`` → ``uuid.UUID``
@@ -199,10 +198,19 @@ def build_uuid_coercions(*, native: bool = False) -> "dict[type[Any], Callable[[
             When ``False`` (default), convert to ``str`` (for drivers that
             need a plain string, e.g. DuckDB/SQLite).
     """
+    import uuid as _uuid_mod
+
+    coercions: dict[type[Any], Callable[[Any], Any]] = {}
+
+    if not native:
+        coercions[_uuid_mod.UUID] = _uuid_to_string
+
     try:
         import uuid_utils as _uuid_utils_mod  # pyright: ignore[reportMissingImports]
-    except ImportError:
-        return {}
 
-    converter = _uuid_utils_to_stdlib if native else _uuid_to_string
-    return {_uuid_utils_mod.UUID: converter}
+        converter = _uuid_utils_to_stdlib if native else _uuid_to_string
+        coercions[_uuid_utils_mod.UUID] = converter
+    except ImportError:
+        pass
+
+    return coercions

--- a/sqlspec/utils/uuids.py
+++ b/sqlspec/utils/uuids.py
@@ -152,51 +152,67 @@ def uuid5(name: str, namespace: "UUID | None" = None) -> "UUID":
 def uuid6() -> "UUID":
     """Generate a time-ordered UUID (version 6).
 
-    Uses uuid-utils when available. When uuid-utils is not installed,
-    falls back to uuid4() with a warning.
+    Uses uuid-utils when available, falls back to Python 3.14+ native
+    uuid.uuid6() or uuid4() with a warning.
 
     UUIDv6 is lexicographically sortable by timestamp, making it
     suitable for database primary keys. It is a reordering of UUIDv1
     fields to improve database performance.
 
     Returns:
-        A time-ordered UUID, or a random UUID if uuid-utils unavailable.
+        A time-ordered UUID, or a random UUID if time-ordered generation unavailable.
     """
     module = _load_uuid_utils()
-    if module is None:
-        warnings.warn(
-            "uuid-utils not installed, falling back to uuid4 for UUID v6 generation. "
-            "Install with: pip install sqlspec[uuid]",
-            UserWarning,
-            stacklevel=2,
-        )
-        return _stdlib_uuid4()
-    return cast("UUID", module.uuid6())
+    if module is not None:
+        return cast("UUID", module.uuid6())
+
+    # Try Python 3.14+ native support
+    import uuid as _uuid_mod
+
+    native_uuid6 = getattr(_uuid_mod, "uuid6", None)
+    if native_uuid6 is not None:
+        return cast("UUID", native_uuid6())
+
+    warnings.warn(
+        "uuid-utils not installed and Python < 3.14, falling back to uuid4 for UUID v6 generation. "
+        "Install with: pip install sqlspec[uuid]",
+        UserWarning,
+        stacklevel=2,
+    )
+    return _stdlib_uuid4()
 
 
 def uuid7() -> "UUID":
     """Generate a time-ordered UUID (version 7).
 
-    Uses uuid-utils when available. When uuid-utils is not installed,
-    falls back to uuid4() with a warning.
+    Uses uuid-utils when available, falls back to Python 3.14+ native
+    uuid.uuid7() or uuid4() with a warning.
 
     UUIDv7 is the recommended time-ordered UUID format per RFC 9562,
     providing millisecond precision timestamps. It is designed for
     modern distributed systems and database primary keys.
 
     Returns:
-        A time-ordered UUID, or a random UUID if uuid-utils unavailable.
+        A time-ordered UUID, or a random UUID if time-ordered generation unavailable.
     """
     module = _load_uuid_utils()
-    if module is None:
-        warnings.warn(
-            "uuid-utils not installed, falling back to uuid4 for UUID v7 generation. "
-            "Install with: pip install sqlspec[uuid]",
-            UserWarning,
-            stacklevel=2,
-        )
-        return _stdlib_uuid4()
-    return cast("UUID", module.uuid7())
+    if module is not None:
+        return cast("UUID", module.uuid7())
+
+    # Try Python 3.14+ native support
+    import uuid as _uuid_mod
+
+    native_uuid7 = getattr(_uuid_mod, "uuid7", None)
+    if native_uuid7 is not None:
+        return cast("UUID", native_uuid7())
+
+    warnings.warn(
+        "uuid-utils not installed and Python < 3.14, falling back to uuid4 for UUID v7 generation. "
+        "Install with: pip install sqlspec[uuid]",
+        UserWarning,
+        stacklevel=2,
+    )
+    return _stdlib_uuid4()
 
 
 def nanoid() -> str:

--- a/tests/unit/core/test_filters.py
+++ b/tests/unit/core/test_filters.py
@@ -7,10 +7,11 @@ ORDER BY, LIMIT/OFFSET, and other SQL modifications with proper parameter naming
 import tempfile
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from sqlglot import exp
+from typing_extensions import assert_type
 
 from sqlspec import sql as sql_builder
 from sqlspec.adapters.aiosqlite import AiosqliteConfig
@@ -28,9 +29,16 @@ from sqlspec.core import (
     SearchFilter,
     apply_filter,
 )
+from sqlspec.core._pagination import OffsetPagination
 from sqlspec.core.filters import NotInSearchFilter
 from sqlspec.driver import CommonDriverAttributesMixin
-from sqlspec.service import SQLSpecAsyncService
+from sqlspec.driver._async import AsyncDriverAdapterBase
+from sqlspec.driver._sync import SyncDriverAdapterBase
+from sqlspec.service import SQLSpecAsyncService, SQLSpecSyncService
+
+if TYPE_CHECKING:
+    from sqlspec.builder import QueryBuilder
+    from sqlspec.core.statement import Statement
 
 pytestmark = pytest.mark.xdist_group("core")
 
@@ -968,6 +976,98 @@ class User:
     name: str
 
 
+class _AsyncRawPaginateSession:
+    @staticmethod
+    def find_filter(filter_type: type[LimitOffsetFilter], parameters: tuple[Any, ...]) -> LimitOffsetFilter | None:
+        for parameter in parameters:
+            if isinstance(parameter, filter_type):
+                return parameter
+        return None
+
+    async def select_with_total(
+        self,
+        statement: Any,
+        *parameters: Any,
+        schema_type: type[Any] | None = None,
+        count_with_window: bool = False,
+        **kwargs: Any,
+    ) -> tuple[list[dict[str, Any]], int]:
+        assert statement is not None
+        assert parameters
+        assert schema_type is None
+        assert count_with_window is False
+        assert kwargs == {}
+        return ([{"id": 1, "name": "alice"}], 1)
+
+
+class _SyncRawPaginateSession:
+    @staticmethod
+    def find_filter(filter_type: type[LimitOffsetFilter], parameters: tuple[Any, ...]) -> LimitOffsetFilter | None:
+        for parameter in parameters:
+            if isinstance(parameter, filter_type):
+                return parameter
+        return None
+
+    def select_with_total(
+        self,
+        statement: Any,
+        *parameters: Any,
+        schema_type: type[Any] | None = None,
+        count_with_window: bool = False,
+        **kwargs: Any,
+    ) -> tuple[list[dict[str, Any]], int]:
+        assert statement is not None
+        assert parameters
+        assert schema_type is None
+        assert count_with_window is False
+        assert kwargs == {}
+        return ([{"id": 1, "name": "alice"}], 1)
+
+
+async def _assert_async_service_overloads(
+    service: SQLSpecAsyncService[AsyncDriverAdapterBase], statement: "Statement | QueryBuilder"
+) -> None:
+    typed_page = await service.paginate(statement, schema_type=User)
+    assert_type(typed_page, OffsetPagination[User])
+
+    raw_page = await service.paginate(statement)
+    assert_type(raw_page, OffsetPagination[dict[str, Any]])
+
+    explicit_raw_page = await service.paginate(statement, schema_type=None)
+    assert_type(explicit_raw_page, OffsetPagination[dict[str, Any]])
+
+    typed_row = await service.get_one(statement, schema_type=User)
+    assert_type(typed_row, User)
+
+    raw_row = await service.get_one(statement)
+    assert_type(raw_row, dict[str, Any])
+
+    explicit_raw_row = await service.get_one(statement, schema_type=None)
+    assert_type(explicit_raw_row, dict[str, Any])
+
+
+def _assert_sync_service_overloads(
+    service: SQLSpecSyncService[SyncDriverAdapterBase], statement: "Statement | QueryBuilder"
+) -> None:
+    typed_page = service.paginate(statement, schema_type=User)
+    assert_type(typed_page, OffsetPagination[User])
+
+    raw_page = service.paginate(statement)
+    assert_type(raw_page, OffsetPagination[dict[str, Any]])
+
+    explicit_raw_page = service.paginate(statement, schema_type=None)
+    assert_type(explicit_raw_page, OffsetPagination[dict[str, Any]])
+
+    typed_row = service.get_one(statement, schema_type=User)
+    assert_type(typed_row, User)
+
+    raw_row = service.get_one(statement)
+    assert_type(raw_row, dict[str, Any])
+
+    explicit_raw_row = service.get_one(statement, schema_type=None)
+    assert_type(explicit_raw_row, dict[str, Any])
+
+
 class UserService(SQLSpecAsyncService):
     pass
 
@@ -1014,6 +1114,29 @@ async def test_service_paginate_works() -> None:
             assert result2.limit == 2
             assert result2.offset == 2
             assert result2.items[0].name == "charlie"
+
+
+@pytest.mark.anyio
+async def test_service_paginate_returns_raw_rows_without_schema_type() -> None:
+    service = SQLSpecAsyncService(cast(Any, _AsyncRawPaginateSession()))
+
+    result = await service.paginate(sql_builder.select("*").from_("users"), LimitOffsetFilter(limit=1, offset=0))
+
+    assert result.items == [{"id": 1, "name": "alice"}]
+    assert result.limit == 1
+    assert result.offset == 0
+    assert result.total == 1
+
+
+def test_sync_service_paginate_returns_raw_rows_without_schema_type() -> None:
+    service = SQLSpecSyncService(cast(Any, _SyncRawPaginateSession()))
+
+    result = service.paginate(sql_builder.select("*").from_("users"), LimitOffsetFilter(limit=1, offset=0))
+
+    assert result.items == [{"id": 1, "name": "alice"}]
+    assert result.limit == 1
+    assert result.offset == 0
+    assert result.total == 1
 
 
 @pytest.mark.anyio

--- a/tests/unit/extensions/test_litestar/test_serialization_plugin.py
+++ b/tests/unit/extensions/test_litestar/test_serialization_plugin.py
@@ -1,0 +1,84 @@
+"""Tests for SQLSpecPlugin's serialization wiring.
+
+The plugin merges :data:`sqlspec.utils.serializers.DEFAULT_TYPE_ENCODERS`
+into :class:`AppConfig` once at app-init, then relies on Litestar's own
+per-handler ``resolve_type_encoders()`` machinery to merge user-supplied
+route/controller/router-level encoders on top — no bidirectional thread
+into sqlspec's serializer is needed.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+import pytest
+from litestar.config.app import AppConfig
+
+from sqlspec.adapters.aiosqlite.config import AiosqliteConfig
+from sqlspec.base import SQLSpec
+from sqlspec.extensions.litestar.plugin import SQLSpecPlugin
+from sqlspec.utils.serializers import DEFAULT_TYPE_ENCODERS
+
+pytestmark = pytest.mark.xdist_group("extensions_litestar")
+
+
+def _build_plugin() -> SQLSpecPlugin:
+    sqlspec = SQLSpec()
+    sqlspec.add_config(AiosqliteConfig(connection_config={"database": ":memory:"}))
+    return SQLSpecPlugin(sqlspec=sqlspec)
+
+
+def test_plugin_registers_default_encoders_into_app_config() -> None:
+    plugin = _build_plugin()
+    app_config = AppConfig()
+
+    plugin.on_app_init(app_config)
+
+    assert app_config.type_encoders is not None
+    for key in DEFAULT_TYPE_ENCODERS:
+        assert key in app_config.type_encoders
+
+
+def test_user_encoder_overrides_sqlspec_default() -> None:
+    """User encoder for an existing default key wins on conflict."""
+
+    def user_dt(_v: datetime.datetime) -> str:
+        return "USER"
+
+    plugin = _build_plugin()
+    app_config = AppConfig(type_encoders={datetime.datetime: user_dt})
+
+    plugin.on_app_init(app_config)
+
+    assert app_config.type_encoders is not None
+    assert app_config.type_encoders[datetime.datetime] is user_dt
+
+
+def test_user_decoders_take_precedence_in_list_order() -> None:
+    """User-supplied decoders are placed before SQLSpec's, so Litestar resolves them first."""
+
+    def user_predicate(_t: Any) -> bool:
+        return False
+
+    def user_decoder(_t: type, _v: Any) -> Any:
+        return None
+
+    plugin = _build_plugin()
+    app_config = AppConfig(type_decoders=[(user_predicate, user_decoder)])
+
+    plugin.on_app_init(app_config)
+
+    assert app_config.type_decoders is not None
+    assert app_config.type_decoders[0] == (user_predicate, user_decoder)
+
+
+def test_plugin_does_not_set_before_or_after_response_hooks() -> None:
+    """Lifecycle hooks are not used: route-level encoder resolution is Litestar's own concern."""
+    plugin = _build_plugin()
+    app_config = AppConfig()
+
+    plugin.on_app_init(app_config)
+
+    assert app_config.before_request is None
+    assert app_config.after_response is None

--- a/tests/unit/utils/serializers/test_default_type_encoders.py
+++ b/tests/unit/utils/serializers/test_default_type_encoders.py
@@ -1,0 +1,256 @@
+"""Tests for ``DEFAULT_TYPE_ENCODERS`` registry and MRO-walking enc_hook.
+
+Mirrors ``advanced-alchemy`` test coverage adapted to sqlspec semantics:
+- ``Decimal`` → ``float`` (project precedent), not ``str``.
+- Unsupported objects raise ``TypeError`` instead of falling back to ``str``.
+"""
+
+from __future__ import annotations
+
+import datetime
+import enum
+import ipaddress
+import json
+import uuid
+from decimal import Decimal
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+from sqlspec.typing import MSGSPEC_INSTALLED, NUMPY_INSTALLED, ORJSON_INSTALLED, PYDANTIC_INSTALLED
+from sqlspec.utils.serializers import DEFAULT_TYPE_ENCODERS
+from sqlspec.utils.serializers._json import (
+    MsgspecSerializer,
+    OrjsonSerializer,
+    StandardLibSerializer,
+    _create_enc_hook,
+    encode_json,
+)
+
+pytestmark = pytest.mark.xdist_group("utils")
+
+
+def test_registry_is_public_dict() -> None:
+    """DEFAULT_TYPE_ENCODERS is a public, non-empty dict mapping types to callables."""
+    assert isinstance(DEFAULT_TYPE_ENCODERS, dict)
+    assert DEFAULT_TYPE_ENCODERS
+    for key, encoder in DEFAULT_TYPE_ENCODERS.items():
+        assert isinstance(key, type)
+        assert callable(encoder)
+
+
+def test_registry_covers_required_types() -> None:
+    """Registry covers every type listed in the AC."""
+    required = {
+        datetime.datetime,
+        datetime.date,
+        datetime.time,
+        datetime.timedelta,
+        Decimal,
+        uuid.UUID,
+        bytes,
+        Path,
+        ipaddress.IPv4Address,
+        ipaddress.IPv4Interface,
+        ipaddress.IPv4Network,
+        ipaddress.IPv6Address,
+        ipaddress.IPv6Interface,
+        ipaddress.IPv6Network,
+        set,
+        frozenset,
+        enum.Enum,
+    }
+    missing = required - set(DEFAULT_TYPE_ENCODERS.keys())
+    assert not missing, f"missing required encoders: {missing}"
+
+
+def test_registry_includes_purepath() -> None:
+    """PurePath registration is required for non-OS-bound paths."""
+    from pathlib import PurePath
+
+    assert PurePath in DEFAULT_TYPE_ENCODERS
+
+
+def test_decimal_encodes_to_float_not_str() -> None:
+    """sqlspec diverges from AA: Decimal -> float (preserves _normalize_supported_value behaviour)."""
+    encoder = DEFAULT_TYPE_ENCODERS[Decimal]
+    result = encoder(Decimal("19.99"))
+    assert result == pytest.approx(19.99)
+    assert isinstance(result, float)
+
+
+def test_uuid_encodes_to_str() -> None:
+    encoder = DEFAULT_TYPE_ENCODERS[uuid.UUID]
+    value = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    assert encoder(value) == str(value)
+
+
+def test_set_encodes_to_list() -> None:
+    encoder = DEFAULT_TYPE_ENCODERS[set]
+    assert sorted(encoder({1, 2, 3})) == [1, 2, 3]
+
+
+def test_frozenset_encodes_to_list() -> None:
+    encoder = DEFAULT_TYPE_ENCODERS[frozenset]
+    assert sorted(encoder(frozenset({1, 2, 3}))) == [1, 2, 3]
+
+
+def test_bytes_encodes_to_utf8_string() -> None:
+    encoder = DEFAULT_TYPE_ENCODERS[bytes]
+    assert encoder(b"hello") == "hello"
+
+
+def test_ipv4_address_encodes_to_str() -> None:
+    encoder = DEFAULT_TYPE_ENCODERS[ipaddress.IPv4Address]
+    assert encoder(ipaddress.IPv4Address("192.0.2.1")) == "192.0.2.1"
+
+
+def test_ipv6_network_encodes_to_str() -> None:
+    encoder = DEFAULT_TYPE_ENCODERS[ipaddress.IPv6Network]
+    assert encoder(ipaddress.IPv6Network("2001:db8::/32")) == "2001:db8::/32"
+
+
+def test_path_encodes_to_str() -> None:
+    encoder = DEFAULT_TYPE_ENCODERS[Path]
+    assert encoder(Path("/tmp/foo")) == str(Path("/tmp/foo"))
+
+
+def test_enum_encodes_to_value() -> None:
+    class Color(enum.Enum):
+        RED = "red"
+
+    encoder = DEFAULT_TYPE_ENCODERS[enum.Enum]
+    assert encoder(Color.RED) == "red"
+
+
+@pytest.mark.skipif(not PYDANTIC_INSTALLED, reason="Pydantic not installed")
+def test_pydantic_basemodel_registered() -> None:
+    from pydantic import BaseModel
+
+    assert BaseModel in DEFAULT_TYPE_ENCODERS
+
+
+@pytest.mark.skipif(not NUMPY_INSTALLED, reason="NumPy not installed")
+def test_numpy_types_registered() -> None:
+    import numpy as np
+
+    assert np.ndarray in DEFAULT_TYPE_ENCODERS
+    assert np.generic in DEFAULT_TYPE_ENCODERS
+
+
+def test_create_enc_hook_walks_mro_for_intenum() -> None:
+    """IntEnum has no explicit registration; it must resolve via Enum on the MRO."""
+
+    class HttpStatus(enum.IntEnum):
+        OK = 200
+
+    enc_hook = _create_enc_hook(DEFAULT_TYPE_ENCODERS)
+    assert enc_hook(HttpStatus.OK) == 200
+
+
+def test_create_enc_hook_resolves_subclass_of_enum() -> None:
+    """Custom Enum subclasses should resolve via the Enum encoder."""
+
+    class Currency(enum.Enum):
+        USD = "USD"
+
+    enc_hook = _create_enc_hook(DEFAULT_TYPE_ENCODERS)
+    assert enc_hook(Currency.USD) == "USD"
+
+
+def test_create_enc_hook_user_override_wins() -> None:
+    """A user-supplied registry entry takes precedence over the default."""
+    overrides = {**DEFAULT_TYPE_ENCODERS, datetime.datetime: lambda _: "OVERRIDE"}
+    enc_hook = _create_enc_hook(overrides)
+    assert enc_hook(datetime.datetime(2026, 1, 1)) == "OVERRIDE"
+
+
+def test_create_enc_hook_raises_on_unknown_type() -> None:
+    """Strict sqlspec semantics: no MRO match → TypeError mentioning 'unsupported'."""
+    enc_hook = _create_enc_hook(DEFAULT_TYPE_ENCODERS)
+    with pytest.raises(TypeError, match="unsupported"):
+        enc_hook(object())
+
+
+@pytest.mark.skipif(not MSGSPEC_INSTALLED, reason="msgspec not installed")
+def test_msgspec_serializer_accepts_type_encoders_override() -> None:
+    """Constructor-level override: pass type_encoders to MsgspecSerializer."""
+
+    class Point:
+        def __init__(self, x: int, y: int) -> None:
+            self.x = x
+            self.y = y
+
+    serializer = MsgspecSerializer(type_encoders={Point: lambda p: [p.x, p.y]})
+    encoded = serializer.encode({"point": Point(1, 2)})
+    assert json.loads(encoded) == {"point": [1, 2]}
+
+
+@pytest.mark.skipif(not ORJSON_INSTALLED, reason="orjson not installed")
+def test_orjson_serializer_accepts_type_encoders_override() -> None:
+    class Point:
+        def __init__(self, x: int, y: int) -> None:
+            self.x = x
+            self.y = y
+
+    serializer = OrjsonSerializer(type_encoders={Point: lambda p: {"x": p.x, "y": p.y}})
+    encoded = serializer.encode({"point": Point(3, 4)})
+    assert json.loads(encoded) == {"point": {"x": 3, "y": 4}}
+
+
+def test_stdlib_serializer_accepts_type_encoders_override() -> None:
+    class Tag:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    serializer = StandardLibSerializer(type_encoders={Tag: lambda t: t.name})
+    encoded = serializer.encode({"tag": Tag("vip")})
+    assert json.loads(encoded) == {"tag": "vip"}
+
+
+def test_offset_pagination_round_trip_via_dataclass_branch() -> None:
+    """OffsetPagination is a dataclass; encoding goes through the dataclass tail probe."""
+    from sqlspec.core._pagination import OffsetPagination
+
+    page: OffsetPagination[int] = OffsetPagination(items=[1, 2, 3], limit=10, offset=0, total=3)
+    assert json.loads(encode_json(page)) == {"items": [1, 2, 3], "limit": 10, "offset": 0, "total": 3}
+
+
+def test_purepath_subclass_resolves_via_mro() -> None:
+    """PurePosixPath instance must resolve via PurePath registration on its MRO."""
+    enc_hook = _create_enc_hook(DEFAULT_TYPE_ENCODERS)
+    assert enc_hook(PurePosixPath("/etc/hosts")) == "/etc/hosts"
+
+
+def test_behavioural_equivalence_battery() -> None:
+    """The registry drives stdlib encoding through the MRO enc_hook.
+
+    Uses ``StandardLibSerializer`` directly so every value flows through the
+    registry (msgspec/orjson encode some of these natively before enc_hook is
+    consulted).
+    """
+    serializer = StandardLibSerializer()
+    payload = {
+        "ts": datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
+        "d": datetime.date(2026, 1, 1),
+        "t": datetime.time(12, 30, 0),
+        "td": datetime.timedelta(seconds=90),
+        "dec": Decimal("1.5"),
+        "uid": uuid.UUID("12345678-1234-5678-1234-567812345678"),
+        "raw": b"abc",
+        "p": Path("/tmp/x"),
+        "ip": ipaddress.IPv4Address("10.0.0.1"),
+        "s": {1, 2, 3},
+    }
+
+    decoded = json.loads(serializer.encode(payload))
+    assert decoded["ts"] == "2026-01-01T00:00:00Z"
+    assert decoded["d"] == "2026-01-01"
+    assert decoded["t"] == "12:30:00"
+    assert decoded["td"] == 90.0
+    assert decoded["dec"] == pytest.approx(1.5)
+    assert decoded["uid"] == "12345678-1234-5678-1234-567812345678"
+    assert decoded["raw"] == "abc"
+    assert decoded["p"] == str(Path("/tmp/x"))
+    assert decoded["ip"] == "10.0.0.1"
+    assert sorted(decoded["s"]) == [1, 2, 3]

--- a/tests/unit/utils/test_serializers.py
+++ b/tests/unit/utils/test_serializers.py
@@ -708,8 +708,8 @@ def test_numpy_serialization_with_to_json() -> None:
     assert decoded_list == [1.0, 2.0, 3.0]
 
 
-class TestSchemaDumpDefault:
-    """Default wire_format=False emits Python attribute names across all schema libs."""
+class TestSchemaDumpWireFormatOptOut:
+    """``wire_format=False`` opts msgspec into Python attribute names (ignores rename=)."""
 
     @pytest.fixture(autouse=True)
     def _reset_cache(self) -> "Any":
@@ -717,7 +717,7 @@ class TestSchemaDumpDefault:
         yield
         reset_serializer_cache()
 
-    def test_msgspec_rename_camel_default_emits_python_names(self) -> None:
+    def test_msgspec_rename_camel_python_names_opt_in(self) -> None:
         import msgspec
 
         class _User(msgspec.Struct, rename="camel"):
@@ -725,16 +725,28 @@ class TestSchemaDumpDefault:
             display_name: str
 
         obj = _User(user_id="abc", display_name="Cody")
-        assert schema_dump(obj) == {"user_id": "abc", "display_name": "Cody"}
+        assert schema_dump(obj, wire_format=False) == {"user_id": "abc", "display_name": "Cody"}
 
-    def test_msgspec_rename_kebab_default_emits_python_names(self) -> None:
+    def test_msgspec_rename_kebab_python_names_opt_in(self) -> None:
         import msgspec
 
         class _User(msgspec.Struct, rename="kebab"):
             user_id: str
 
         obj = _User(user_id="abc")
-        assert schema_dump(obj) == {"user_id": "abc"}
+        assert schema_dump(obj, wire_format=False) == {"user_id": "abc"}
+
+    def test_wire_format_cache_isolation(self) -> None:
+        """Cache must distinguish wire_format=True from =False for the same Struct type."""
+        import msgspec
+
+        class _User(msgspec.Struct, rename="camel"):
+            user_id: str
+
+        obj = _User(user_id="abc")
+        assert schema_dump(obj) == {"userId": "abc"}
+        assert schema_dump(obj, wire_format=False) == {"user_id": "abc"}
+        assert schema_dump(obj) == {"userId": "abc"}
 
 
 class TestSchemaDumpRename:

--- a/tests/unit/utils/test_serializers.py
+++ b/tests/unit/utils/test_serializers.py
@@ -469,7 +469,9 @@ def test_module_all_exports() -> None:
     """Test that __all__ contains the expected exports."""
 
     expected = {
+        "DEFAULT_TYPE_ENCODERS",
         "SchemaSerializer",
+        "TypeEncodersMap",
         "from_json",
         "get_collection_serializer",
         "get_serializer_metrics",

--- a/tests/unit/utils/test_serializers.py
+++ b/tests/unit/utils/test_serializers.py
@@ -748,6 +748,42 @@ class TestSchemaDumpWireFormatOptOut:
         assert schema_dump(obj, wire_format=False) == {"user_id": "abc"}
         assert schema_dump(obj) == {"userId": "abc"}
 
+    def test_pydantic_unaffected_by_wire_format(self) -> None:
+        pytest.importorskip("pydantic")
+        import pydantic
+
+        class _User(pydantic.BaseModel):
+            user_id: str = pydantic.Field(alias="userId")
+
+            model_config = pydantic.ConfigDict(populate_by_name=True)
+
+        obj = _User(user_id="abc")
+        assert schema_dump(obj, exclude_unset=False) == {"user_id": "abc"}
+        assert schema_dump(obj, exclude_unset=False, wire_format=False) == {"user_id": "abc"}
+
+    def test_dataclass_unaffected_by_wire_format(self) -> None:
+        from dataclasses import dataclass
+
+        @dataclass
+        class _User:
+            user_id: str
+
+        obj = _User(user_id="abc")
+        assert schema_dump(obj, exclude_unset=False) == {"user_id": "abc"}
+        assert schema_dump(obj, exclude_unset=False, wire_format=False) == {"user_id": "abc"}
+
+    def test_attrs_unaffected_by_wire_format(self) -> None:
+        pytest.importorskip("attrs")
+        import attrs
+
+        @attrs.define
+        class _User:
+            user_id: str = attrs.field(alias="userId")
+
+        obj = _User(userId="abc")  # attrs alias= is for __init__ only
+        assert schema_dump(obj, exclude_unset=False) == {"user_id": "abc"}
+        assert schema_dump(obj, exclude_unset=False, wire_format=False) == {"user_id": "abc"}
+
 
 class TestSchemaDumpRename:
     """Regression suite for GitHub #418 — schema_dump must honor msgspec rename meta."""

--- a/tests/unit/utils/test_serializers.py
+++ b/tests/unit/utils/test_serializers.py
@@ -757,7 +757,7 @@ class TestSchemaDumpWireFormatOptOut:
 
             model_config = pydantic.ConfigDict(populate_by_name=True)
 
-        obj = _User(user_id="abc")
+        obj = _User(userId="abc")  # construct via alias to keep type-checkers happy
         assert schema_dump(obj, exclude_unset=False) == {"user_id": "abc"}
         assert schema_dump(obj, exclude_unset=False, wire_format=False) == {"user_id": "abc"}
 

--- a/tests/unit/utils/test_serializers.py
+++ b/tests/unit/utils/test_serializers.py
@@ -708,6 +708,35 @@ def test_numpy_serialization_with_to_json() -> None:
     assert decoded_list == [1.0, 2.0, 3.0]
 
 
+class TestSchemaDumpDefault:
+    """Default wire_format=False emits Python attribute names across all schema libs."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_cache(self) -> "Any":
+        reset_serializer_cache()
+        yield
+        reset_serializer_cache()
+
+    def test_msgspec_rename_camel_default_emits_python_names(self) -> None:
+        import msgspec
+
+        class _User(msgspec.Struct, rename="camel"):
+            user_id: str
+            display_name: str
+
+        obj = _User(user_id="abc", display_name="Cody")
+        assert schema_dump(obj) == {"user_id": "abc", "display_name": "Cody"}
+
+    def test_msgspec_rename_kebab_default_emits_python_names(self) -> None:
+        import msgspec
+
+        class _User(msgspec.Struct, rename="kebab"):
+            user_id: str
+
+        obj = _User(user_id="abc")
+        assert schema_dump(obj) == {"user_id": "abc"}
+
+
 class TestSchemaDumpRename:
     """Regression suite for GitHub #418 — schema_dump must honor msgspec rename meta."""
 

--- a/tests/unit/utils/test_type_converters.py
+++ b/tests/unit/utils/test_type_converters.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 import pytest
 
 from sqlspec._typing import UUID_UTILS_INSTALLED
-from sqlspec.utils.type_converters import build_nested_decimal_normalizer, build_uuid_coercions
+from sqlspec.utils.type_converters import _uuid_to_string, build_nested_decimal_normalizer, build_uuid_coercions
 
 pytestmark = pytest.mark.xdist_group("utils")
 
@@ -83,11 +83,28 @@ def test_build_uuid_coercions_native_returns_stdlib_uuid() -> None:
     assert str(result) == str(u)
 
 
-@pytest.mark.skipif(not UUID_UTILS_INSTALLED, reason="uuid_utils not installed")
-def test_build_uuid_coercions_does_not_include_stdlib_uuid() -> None:
-    """Neither mode should include uuid.UUID as a key."""
-    assert uuid.UUID not in build_uuid_coercions()
+def test_build_uuid_coercions_includes_stdlib_uuid_when_not_native() -> None:
+    """Standard library uuid.UUID should be included in coercions when native=False."""
+    coercions = build_uuid_coercions(native=False)
+    assert uuid.UUID in coercions
+    assert coercions[uuid.UUID] is _uuid_to_string
+
+
+def test_build_uuid_coercions_excludes_stdlib_uuid_when_native() -> None:
+    """Standard library uuid.UUID should NOT be included in coercions when native=True."""
     assert uuid.UUID not in build_uuid_coercions(native=True)
+
+
+@pytest.mark.skipif(not UUID_UTILS_INSTALLED, reason="uuid_utils not installed")
+def test_build_uuid_coercions_includes_uuid_utils_when_installed() -> None:
+    """uuid_utils.UUID should be included in coercions when installed."""
+    import uuid_utils
+
+    coercions_default = build_uuid_coercions(native=False)
+    assert uuid_utils.UUID in coercions_default
+
+    coercions_native = build_uuid_coercions(native=True)
+    assert uuid_utils.UUID in coercions_native
 
 
 @pytest.mark.skipif(not UUID_UTILS_INSTALLED, reason="uuid_utils not installed")

--- a/tests/unit/utils/test_uuids.py
+++ b/tests/unit/utils/test_uuids.py
@@ -179,16 +179,24 @@ def test_uuid4_is_version_4() -> None:
     assert result.version == 4
 
 
-@pytest.mark.skipif(not UUID_UTILS_INSTALLED, reason="uuid-utils not installed")
 def test_uuid6_is_version_6() -> None:
-    """Test uuid6 returns a version 6 UUID when uuid-utils is installed."""
+    """Test uuid6 returns a version 6 UUID when time-ordered generation is available."""
+    import uuid as _uuid_mod
+
+    if not UUID_UTILS_INSTALLED and not hasattr(_uuid_mod, "uuid6"):
+        pytest.skip("Time-ordered UUID v6 generation not available (no uuid-utils and Python < 3.14)")
+
     result = uuid6()
     assert result.version == 6
 
 
-@pytest.mark.skipif(not UUID_UTILS_INSTALLED, reason="uuid-utils not installed")
 def test_uuid7_is_version_7() -> None:
-    """Test uuid7 returns a version 7 UUID when uuid-utils is installed."""
+    """Test uuid7 returns a version 7 UUID when time-ordered generation is available."""
+    import uuid as _uuid_mod
+
+    if not UUID_UTILS_INSTALLED and not hasattr(_uuid_mod, "uuid7"):
+        pytest.skip("Time-ordered UUID v7 generation not available (no uuid-utils and Python < 3.14)")
+
     result = uuid7()
     assert result.version == 7
 
@@ -306,7 +314,12 @@ def test_nanoid_url_safe_characters() -> None:
 
 @pytest.mark.skipif(bool(UUID_UTILS_INSTALLED), reason="Test requires uuid-utils NOT installed")
 def test_uuid6_warning_without_uuid_utils() -> None:
-    """Test uuid6 emits warning when uuid-utils is not installed."""
+    """Test uuid6 emits warning when uuid-utils and native support are missing."""
+    import uuid as _uuid_mod
+
+    if hasattr(_uuid_mod, "uuid6"):
+        pytest.skip("Python 3.14+ has native uuid6 support")
+
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")
         uuid6()
@@ -320,7 +333,12 @@ def test_uuid6_warning_without_uuid_utils() -> None:
 
 @pytest.mark.skipif(bool(UUID_UTILS_INSTALLED), reason="Test requires uuid-utils NOT installed")
 def test_uuid7_warning_without_uuid_utils() -> None:
-    """Test uuid7 emits warning when uuid-utils is not installed."""
+    """Test uuid7 emits warning when uuid-utils and native support are missing."""
+    import uuid as _uuid_mod
+
+    if hasattr(_uuid_mod, "uuid7"):
+        pytest.skip("Python 3.14+ has native uuid7 support")
+
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")
         uuid7()
@@ -348,7 +366,12 @@ def test_nanoid_warning_without_fastnanoid() -> None:
 
 @pytest.mark.skipif(bool(UUID_UTILS_INSTALLED), reason="Test requires uuid-utils NOT installed")
 def test_uuid6_warning_each_call() -> None:
-    """Test uuid6 emits warning per call when uuid-utils is not installed."""
+    """Test uuid6 emits warning per call when uuid-utils and native support are missing."""
+    import uuid as _uuid_mod
+
+    if hasattr(_uuid_mod, "uuid6"):
+        pytest.skip("Python 3.14+ has native uuid6 support")
+
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")
         uuid6()
@@ -360,7 +383,12 @@ def test_uuid6_warning_each_call() -> None:
 
 @pytest.mark.skipif(bool(UUID_UTILS_INSTALLED), reason="Test requires uuid-utils NOT installed")
 def test_uuid7_warning_each_call() -> None:
-    """Test uuid7 emits warning per call when uuid-utils is not installed."""
+    """Test uuid7 emits warning per call when uuid-utils and native support are missing."""
+    import uuid as _uuid_mod
+
+    if hasattr(_uuid_mod, "uuid7"):
+        pytest.skip("Python 3.14+ has native uuid7 support")
+
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")
         uuid7()
@@ -404,9 +432,13 @@ def test_nanoid_fallback_returns_32_char_hex() -> None:
     assert all(c in "0123456789abcdef" for c in result)
 
 
-@pytest.mark.skipif(not UUID_UTILS_INSTALLED, reason="uuid-utils not installed")
-def test_uuid6_no_warning_with_uuid_utils() -> None:
-    """Test uuid6 does not emit warning when uuid-utils is installed."""
+def test_uuid6_no_warning_with_time_ordered_generation() -> None:
+    """Test uuid6 does not emit warning when time-ordered generation is available."""
+    import uuid as _uuid_mod
+
+    if not UUID_UTILS_INSTALLED and not hasattr(_uuid_mod, "uuid6"):
+        pytest.skip("Time-ordered UUID v6 generation not available (no uuid-utils and Python < 3.14)")
+
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")
         uuid6()
@@ -415,9 +447,13 @@ def test_uuid6_no_warning_with_uuid_utils() -> None:
         assert len(uuid6_warnings) == 0
 
 
-@pytest.mark.skipif(not UUID_UTILS_INSTALLED, reason="uuid-utils not installed")
-def test_uuid7_no_warning_with_uuid_utils() -> None:
-    """Test uuid7 does not emit warning when uuid-utils is installed."""
+def test_uuid7_no_warning_with_time_ordered_generation() -> None:
+    """Test uuid7 does not emit warning when time-ordered generation is available."""
+    import uuid as _uuid_mod
+
+    if not UUID_UTILS_INSTALLED and not hasattr(_uuid_mod, "uuid7"):
+        pytest.skip("Time-ordered UUID v7 generation not available (no uuid-utils and Python < 3.14)")
+
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")
         uuid7()

--- a/uv.lock
+++ b/uv.lock
@@ -6922,7 +6922,7 @@ wheels = [
 
 [[package]]
 name = "sqlspec"
-version = "0.45.0"
+version = "0.45.1"
 source = { editable = "." }
 dependencies = [
     { name = "mypy-extensions" },

--- a/uv.lock
+++ b/uv.lock
@@ -6922,7 +6922,7 @@ wheels = [
 
 [[package]]
 name = "sqlspec"
-version = "0.45.1"
+version = "0.46.0"
 source = { editable = "." }
 dependencies = [
     { name = "mypy-extensions" },


### PR DESCRIPTION
## Summary
- Restore async/sync service overload specificity for `paginate()` and `get_one()` so `schema_type` narrows the same way it does on the driver APIs.
- Extract `DEFAULT_TYPE_ENCODERS` from `_normalize_supported_value` in `sqlspec.utils.serializers._json`. Adds IPv4/IPv6 + asyncpg `pgproto.UUID` coverage that the legacy isinstance chain never had; preserves sqlspec's strict `TypeError` on unmapped types and `Decimal -> float` precedent.
- `SQLSpecPlugin` now merges `DEFAULT_TYPE_ENCODERS` into `AppConfig.type_encoders` (user-precedence) and registers Litestar-specific `type_decoders` for `numpy.ndarray` and `uuid_utils.UUID`. Legacy NumPy-only block removed; coverage is broader.
- `OffsetPagination` now flows through the dataclass tail probe (no special case).
- Bump package version metadata and refresh `uv.lock`.

## Test Plan
- `make lint` (ruff, mypy 1072 files, pyright, slotscheck)
- `uv run pytest tests/unit` — 5239 passed
- `uv run pytest tests/unit/utils/serializers/ tests/unit/extensions/test_litestar/ tests/unit/core/test_filters.py`