### PR TITLE
fix(litestar): unique provider signatures stop filter cross-binding (#435)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ maintainers = [{ name = "Litestar Developers", email = "hello@litestar.dev" }]
 name = "sqlspec"
 readme = "README.md"
 requires-python = ">=3.10, <4.0"
-version = "0.46.0"
+version = "0.46.1"
 
 [project.urls]
 Discord = "https://discord.gg/litestar"
@@ -264,7 +264,7 @@ opt_level = "3"   # Maximum optimization (0-3)
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.46.0"
+current_version = "0.46.1"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to v{new_version}"

--- a/sqlspec/extensions/litestar/providers.py
+++ b/sqlspec/extensions/litestar/providers.py
@@ -183,7 +183,7 @@ def _build_in_collection_provider(field: FieldNameType, *, negated: bool) -> Cal
     field_name = field.name
     param_name = f"{field_name}_values"
     alias = camelize(f"{field_name}_{'not_in' if negated else 'in'}")
-    filter_cls: type[Any] = NotInCollectionFilter if negated else InCollectionFilter
+    filter_cls: Any = NotInCollectionFilter if negated else InCollectionFilter
     annotation = list[type_hint] | None  # type: ignore[valid-type]
     return_annotation = filter_cls[type_hint] | None
 

--- a/sqlspec/extensions/litestar/providers.py
+++ b/sqlspec/extensions/litestar/providers.py
@@ -171,7 +171,103 @@ def _resolve_sort_fields(sort_field: SortField) -> tuple[str, set[str]]:
     return fields[0], set(fields)
 
 
-def _create_statement_filters(  # noqa: C901
+def _build_in_collection_provider(field: FieldNameType, *, negated: bool) -> Callable[..., Any]:
+    """Build a per-field `IN` / `NOT IN` filter provider with a unique parameter name.
+
+    Litestar's dependency resolver collapses parameters across distinct ``Provide()``
+    instances by Python parameter name, ignoring per-instance ``Parameter(query=...)``
+    aliases. Giving each provider a unique parameter name (via ``__signature__``)
+    prevents siblings in the same family from cross-binding (issue #435).
+    """
+    type_hint = field.type_hint
+    field_name = field.name
+    param_name = f"{field_name}_values"
+    alias = camelize(f"{field_name}_{'not_in' if negated else 'in'}")
+    filter_cls: type[Any] = NotInCollectionFilter if negated else InCollectionFilter
+    annotation = list[type_hint] | None  # type: ignore[valid-type]
+    return_annotation = filter_cls[type_hint] | None
+
+    def provide(**kwargs: Any) -> Any:
+        values = kwargs.get(param_name)
+        return filter_cls[type_hint](field_name=field_name, values=values) if values else None
+
+    provide.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
+        parameters=[
+            inspect.Parameter(
+                param_name,
+                kind=inspect.Parameter.KEYWORD_ONLY,
+                default=Parameter(query=alias, default=None, required=False),
+                annotation=annotation,
+            )
+        ],
+        return_annotation=return_annotation,
+    )
+    provide.__annotations__ = {param_name: annotation, "return": return_annotation}
+    return provide
+
+
+def _build_null_provider(field_name: str, *, negated: bool) -> Callable[..., Any]:
+    """Build a per-field ``IS NULL`` / ``IS NOT NULL`` provider with a unique parameter name (issue #435)."""
+    suffix = "is_not_null" if negated else "is_null"
+    param_name = f"{field_name}_{suffix}"
+    alias = camelize(f"{field_name}_{suffix}")
+    filter_cls: type[Any] = NotNullFilter if negated else NullFilter
+    annotation = bool | None
+    return_annotation = filter_cls | None
+
+    def provide(**kwargs: Any) -> Any:
+        flag = kwargs.get(param_name)
+        return filter_cls(field_name=field_name) if flag else None
+
+    provide.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
+        parameters=[
+            inspect.Parameter(
+                param_name,
+                kind=inspect.Parameter.KEYWORD_ONLY,
+                default=Parameter(query=alias, default=None, required=False),
+                annotation=annotation,
+            )
+        ],
+        return_annotation=return_annotation,
+    )
+    provide.__annotations__ = {param_name: annotation, "return": return_annotation}
+    return provide
+
+
+def _build_before_after_provider(field_name: str, before_alias: str, after_alias: str) -> Callable[..., Any]:
+    """Build a ``BeforeAfterFilter`` provider with unique ``before``/``after`` parameter names (issue #435).
+
+    ``created_at`` and ``updated_at`` providers both used ``before``/``after``, so when
+    enabled together they cross-bound to whichever query alias Litestar resolved first.
+    """
+    before_param = f"{field_name}_before"
+    after_param = f"{field_name}_after"
+
+    def provide(**kwargs: Any) -> BeforeAfterFilter:
+        return BeforeAfterFilter(field_name, kwargs.get(before_param), kwargs.get(after_param))
+
+    provide.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
+        parameters=[
+            inspect.Parameter(
+                before_param,
+                kind=inspect.Parameter.KEYWORD_ONLY,
+                default=Parameter(query=before_alias, default=None, required=False),
+                annotation=DTorNone,
+            ),
+            inspect.Parameter(
+                after_param,
+                kind=inspect.Parameter.KEYWORD_ONLY,
+                default=Parameter(query=after_alias, default=None, required=False),
+                annotation=DTorNone,
+            ),
+        ],
+        return_annotation=BeforeAfterFilter,
+    )
+    provide.__annotations__ = {before_param: DTorNone, after_param: DTorNone, "return": BeforeAfterFilter}
+    return provide
+
+
+def _create_statement_filters(
     config: FilterConfig, dep_defaults: DependencyDefaults = DEPENDENCY_DEFAULTS
 ) -> dict[str, Provide]:
     """Create filter dependencies based on configuration.
@@ -195,24 +291,14 @@ def _create_statement_filters(  # noqa: C901
         filters[dep_defaults.ID_FILTER_DEPENDENCY_KEY] = Provide(provide_id_filter, sync_to_thread=False)  # pyright: ignore[reportUnknownArgumentType]
 
     if config.get("created_at", False):
-
-        def provide_created_filter(
-            before: DTorNone = Parameter(query="createdBefore", default=None, required=False),
-            after: DTorNone = Parameter(query="createdAfter", default=None, required=False),
-        ) -> BeforeAfterFilter:
-            return BeforeAfterFilter("created_at", before, after)
-
-        filters[dep_defaults.CREATED_FILTER_DEPENDENCY_KEY] = Provide(provide_created_filter, sync_to_thread=False)
+        filters[dep_defaults.CREATED_FILTER_DEPENDENCY_KEY] = Provide(
+            _build_before_after_provider("created_at", "createdBefore", "createdAfter"), sync_to_thread=False
+        )
 
     if config.get("updated_at", False):
-
-        def provide_updated_filter(
-            before: DTorNone = Parameter(query="updatedBefore", default=None, required=False),
-            after: DTorNone = Parameter(query="updatedAfter", default=None, required=False),
-        ) -> BeforeAfterFilter:
-            return BeforeAfterFilter("updated_at", before, after)
-
-        filters[dep_defaults.UPDATED_FILTER_DEPENDENCY_KEY] = Provide(provide_updated_filter, sync_to_thread=False)
+        filters[dep_defaults.UPDATED_FILTER_DEPENDENCY_KEY] = Provide(
+            _build_before_after_provider("updated_at", "updatedBefore", "updatedAfter"), sync_to_thread=False
+        )
 
     if config.get("pagination_type") == "limit_offset":
 
@@ -276,85 +362,33 @@ def _create_statement_filters(  # noqa: C901
         not_in_fields = {not_in_fields} if isinstance(not_in_fields, (str, FieldNameType)) else not_in_fields
 
         for field_def in not_in_fields:
-            field_def = FieldNameType(name=field_def, type_hint=str) if isinstance(field_def, str) else field_def
-
-            def create_not_in_filter_provider(  # pyright: ignore
-                field_name: FieldNameType,
-            ) -> Callable[..., NotInCollectionFilter[field_def.type_hint] | None]:  # type: ignore
-                def provide_not_in_filter(  # pyright: ignore
-                    values: list[field_name.type_hint] | None = Parameter(  # type: ignore
-                        query=camelize(f"{field_name.name}_not_in"), default=None, required=False
-                    ),
-                ) -> NotInCollectionFilter[field_name.type_hint] | None:  # type: ignore
-                    return (
-                        NotInCollectionFilter[field_name.type_hint](field_name=field_name.name, values=values)  # type: ignore
-                        if values
-                        else None
-                    )
-
-                return provide_not_in_filter  # pyright: ignore
-
-            provider = create_not_in_filter_provider(field_def)  # pyright: ignore
-            filters[f"{field_def.name}_not_in_filter"] = Provide(provider, sync_to_thread=False)  # pyright: ignore
+            resolved = FieldNameType(name=field_def, type_hint=str) if isinstance(field_def, str) else field_def
+            filters[f"{resolved.name}_not_in_filter"] = Provide(
+                _build_in_collection_provider(resolved, negated=True), sync_to_thread=False
+            )
 
     if in_fields := config.get("in_fields"):
         in_fields = {in_fields} if isinstance(in_fields, (str, FieldNameType)) else in_fields
 
         for field_def in in_fields:
-            field_def = FieldNameType(name=field_def, type_hint=str) if isinstance(field_def, str) else field_def
-
-            def create_in_filter_provider(  # pyright: ignore
-                field_name: FieldNameType,
-            ) -> Callable[..., InCollectionFilter[field_def.type_hint] | None]:  # type: ignore # pyright: ignore
-                def provide_in_filter(  # pyright: ignore
-                    values: list[field_name.type_hint] | None = Parameter(  # type: ignore # pyright: ignore
-                        query=camelize(f"{field_name.name}_in"), default=None, required=False
-                    ),
-                ) -> InCollectionFilter[field_name.type_hint] | None:  # type: ignore # pyright: ignore
-                    return (
-                        InCollectionFilter[field_name.type_hint](field_name=field_name.name, values=values)  # type: ignore  # pyright: ignore
-                        if values
-                        else None
-                    )
-
-                return provide_in_filter  # pyright: ignore
-
-            provider = create_in_filter_provider(field_def)  # type: ignore
-            filters[f"{field_def.name}_in_filter"] = Provide(provider, sync_to_thread=False)  # pyright: ignore
+            resolved = FieldNameType(name=field_def, type_hint=str) if isinstance(field_def, str) else field_def
+            filters[f"{resolved.name}_in_filter"] = Provide(
+                _build_in_collection_provider(resolved, negated=False), sync_to_thread=False
+            )
 
     if null_fields := config.get("null_fields"):
         null_fields = {null_fields} if isinstance(null_fields, str) else set(null_fields)
-
         for field_name in null_fields:
-
-            def create_null_filter_provider(fname: str) -> Callable[..., NullFilter | None]:
-                def provide_null_filter(
-                    is_null: bool | None = Parameter(query=camelize(f"{fname}_is_null"), default=None, required=False),
-                ) -> NullFilter | None:
-                    return NullFilter(field_name=fname) if is_null else None
-
-                return provide_null_filter
-
-            null_provider = create_null_filter_provider(field_name)
-            filters[f"{field_name}_null_filter"] = Provide(null_provider, sync_to_thread=False)
+            filters[f"{field_name}_null_filter"] = Provide(
+                _build_null_provider(field_name, negated=False), sync_to_thread=False
+            )
 
     if not_null_fields := config.get("not_null_fields"):
         not_null_fields = {not_null_fields} if isinstance(not_null_fields, str) else set(not_null_fields)
-
         for field_name in not_null_fields:
-
-            def create_not_null_filter_provider(fname: str) -> Callable[..., NotNullFilter | None]:
-                def provide_not_null_filter(
-                    is_not_null: bool | None = Parameter(
-                        query=camelize(f"{fname}_is_not_null"), default=None, required=False
-                    ),
-                ) -> NotNullFilter | None:
-                    return NotNullFilter(field_name=fname) if is_not_null else None
-
-                return provide_not_null_filter
-
-            not_null_provider = create_not_null_filter_provider(field_name)
-            filters[f"{field_name}_not_null_filter"] = Provide(not_null_provider, sync_to_thread=False)
+            filters[f"{field_name}_not_null_filter"] = Provide(
+                _build_null_provider(field_name, negated=True), sync_to_thread=False
+            )
 
     if filters:
         filters[dep_defaults.FILTERS_DEPENDENCY_KEY] = Provide(

--- a/tests/integration/extensions/fastapi/test_filters_integration.py
+++ b/tests/integration/extensions/fastapi/test_filters_integration.py
@@ -486,6 +486,40 @@ def test_fastapi_not_in_fields_filter_dependency() -> None:
         assert set(data["values"]) == {"deleted", "archived"}
 
 
+def test_fastapi_multi_in_fields_mixed_types_do_not_cross_bind() -> None:
+    """FastAPI sub-`Depends()` are scoped, so siblings with overlapping inner param names must not collide (#435)."""
+    sqlspec = SQLSpec()
+    config = AiosqliteConfig(
+        connection_config={"database": ":memory:"}, extension_config={"fastapi": {"commit_mode": "manual"}}
+    )
+    sqlspec.add_config(config)
+
+    app = FastAPI()
+    db_ext = SQLSpecPlugin(sqlspec, app=app)
+
+    from sqlspec.extensions.fastapi.providers import FieldNameType, InCollectionFilter
+
+    @app.get("/x")
+    async def handler(
+        filters: Annotated[
+            list[FilterTypes],
+            Depends(
+                db_ext.provide_filters({"in_fields": [FieldNameType("role", str), FieldNameType("owner_id", UUID)]})
+            ),
+        ],
+    ) -> dict[str, Any]:
+        return {
+            "got": [(f.field_name, [str(v) for v in f.values]) for f in filters if isinstance(f, InCollectionFilter)]
+        }
+
+    valid_uuid = "11111111-2222-3333-4444-555555555555"
+    with TestClient(app) as client:
+        response = client.get("/x", params={"roleIn": "HR", "ownerIdIn": valid_uuid})
+        assert response.status_code == 200, response.text
+        got = dict(response.json()["got"])
+        assert got == {"role": ["HR"], "owner_id": [valid_uuid]}
+
+
 def test_fastapi_in_fields_with_query_execution() -> None:
     """Test in_fields filter applied to actual SQL query execution (issue #405)."""
     sqlspec = SQLSpec()

--- a/tests/integration/extensions/fastapi/test_filters_integration.py
+++ b/tests/integration/extensions/fastapi/test_filters_integration.py
@@ -509,7 +509,9 @@ def test_fastapi_multi_in_fields_mixed_types_do_not_cross_bind() -> None:
         ],
     ) -> dict[str, Any]:
         return {
-            "got": [(f.field_name, [str(v) for v in f.values]) for f in filters if isinstance(f, InCollectionFilter)]
+            "got": [
+                (f.field_name, [str(v) for v in (f.values or ())]) for f in filters if isinstance(f, InCollectionFilter)
+            ]
         }
 
     valid_uuid = "11111111-2222-3333-4444-555555555555"

--- a/tests/integration/extensions/litestar/test_in_fields_filters.py
+++ b/tests/integration/extensions/litestar/test_in_fields_filters.py
@@ -2,6 +2,7 @@
 
 import tempfile
 from typing import Any
+from uuid import UUID
 
 import pytest
 from litestar import Litestar, get
@@ -11,7 +12,14 @@ from litestar.testing import AsyncTestClient, TestClient
 from sqlspec import sql as sql_builder
 from sqlspec.adapters.aiosqlite import AiosqliteConfig
 from sqlspec.base import SQLSpec
-from sqlspec.core import FilterTypes, InCollectionFilter, NotInCollectionFilter
+from sqlspec.core import (
+    BeforeAfterFilter,
+    FilterTypes,
+    InCollectionFilter,
+    NotInCollectionFilter,
+    NotNullFilter,
+    NullFilter,
+)
 from sqlspec.extensions.litestar import SQLSpecPlugin
 from sqlspec.extensions.litestar.providers import FieldNameType, create_filter_dependencies, dep_cache
 from sqlspec.typing import LITESTAR_INSTALLED
@@ -306,3 +314,134 @@ def test_litestar_order_by_openapi_schema() -> None:
     sort_order_param = _named_param("sortOrder")
     assert sort_order_param is not None
     assert is_string_type(sort_order_param.schema)
+
+
+# Regression tests for issue #435 (cross-binding across providers in the same family).
+
+
+def test_litestar_in_fields_two_str_fields_do_not_cross_bind() -> None:
+    """Two `in_fields` with matching `str` types must not share a value (issue #435)."""
+    filter_deps = create_filter_dependencies({"in_fields": [FieldNameType("a", str), FieldNameType("b", str)]})
+
+    @get("/x", dependencies=filter_deps)
+    async def handler(filters: list[FilterTypes] = Dependency(skip_validation=True)) -> dict[str, Any]:
+        return {"got": [(f.field_name, sorted(f.values)) for f in filters if isinstance(f, InCollectionFilter)]}
+
+    app = Litestar(route_handlers=[handler])
+    with TestClient(app=app) as client:
+        response = client.get("/x", params={"aIn": "HR,SYSTEM", "bIn": "ADMIN"})
+        assert response.status_code == 200
+        got = dict(response.json()["got"])
+        assert got == {"a": sorted(["HR,SYSTEM"]), "b": sorted(["ADMIN"])}
+
+
+def test_litestar_in_fields_mixed_types_do_not_400() -> None:
+    """`in_fields` with mixed (`str`, `UUID`) types must bind separately, not 400 (issue #435)."""
+    filter_deps = create_filter_dependencies({
+        "in_fields": [FieldNameType("role", str), FieldNameType("owner_id", UUID)]
+    })
+
+    @get("/x", dependencies=filter_deps)
+    async def handler(filters: list[FilterTypes] = Dependency(skip_validation=True)) -> dict[str, Any]:
+        return {
+            "got": [(f.field_name, [str(v) for v in f.values]) for f in filters if isinstance(f, InCollectionFilter)]
+        }
+
+    app = Litestar(route_handlers=[handler])
+    valid_uuid = "11111111-2222-3333-4444-555555555555"
+    with TestClient(app=app) as client:
+        response = client.get("/x", params={"roleIn": "HR", "ownerIdIn": valid_uuid})
+        assert response.status_code == 200, response.text
+        got = dict(response.json()["got"])
+        assert got == {"role": ["HR"], "owner_id": [valid_uuid]}
+
+        # Sending only the str field should not trigger UUID validation on the other.
+        response = client.get("/x", params={"roleIn": "HR"})
+        assert response.status_code == 200, response.text
+        got = dict(response.json()["got"])
+        assert got == {"role": ["HR"]}
+
+
+def test_litestar_not_in_fields_two_fields_do_not_cross_bind() -> None:
+    """Two `not_in_fields` providers must not share their `values` parameter (issue #435)."""
+    filter_deps = create_filter_dependencies({"not_in_fields": [FieldNameType("a", str), FieldNameType("b", str)]})
+
+    @get("/x", dependencies=filter_deps)
+    async def handler(filters: list[FilterTypes] = Dependency(skip_validation=True)) -> dict[str, Any]:
+        return {"got": [(f.field_name, sorted(f.values)) for f in filters if isinstance(f, NotInCollectionFilter)]}
+
+    app = Litestar(route_handlers=[handler])
+    with TestClient(app=app) as client:
+        response = client.get("/x", params={"aNotIn": "HR", "bNotIn": "ADMIN"})
+        assert response.status_code == 200
+        got = dict(response.json()["got"])
+        assert got == {"a": ["HR"], "b": ["ADMIN"]}
+
+
+def test_litestar_null_fields_two_fields_do_not_cross_bind() -> None:
+    """Two `null_fields` providers must not share their `is_null` parameter (issue #435)."""
+    filter_deps = create_filter_dependencies({"null_fields": ["a", "b"]})
+
+    @get("/x", dependencies=filter_deps)
+    async def handler(filters: list[FilterTypes] = Dependency(skip_validation=True)) -> dict[str, Any]:
+        return {"fields": sorted(f.field_name for f in filters if isinstance(f, NullFilter))}
+
+    app = Litestar(route_handlers=[handler])
+    with TestClient(app=app) as client:
+        response = client.get("/x", params={"aIsNull": "true"})
+        assert response.status_code == 200
+        assert response.json() == {"fields": ["a"]}
+
+        response = client.get("/x", params={"bIsNull": "true"})
+        assert response.status_code == 200
+        assert response.json() == {"fields": ["b"]}
+
+        response = client.get("/x", params={"aIsNull": "true", "bIsNull": "true"})
+        assert response.status_code == 200
+        assert response.json() == {"fields": ["a", "b"]}
+
+
+def test_litestar_not_null_fields_two_fields_do_not_cross_bind() -> None:
+    """Two `not_null_fields` providers must not share their `is_not_null` parameter (issue #435)."""
+    filter_deps = create_filter_dependencies({"not_null_fields": ["a", "b"]})
+
+    @get("/x", dependencies=filter_deps)
+    async def handler(filters: list[FilterTypes] = Dependency(skip_validation=True)) -> dict[str, Any]:
+        return {"fields": sorted(f.field_name for f in filters if isinstance(f, NotNullFilter))}
+
+    app = Litestar(route_handlers=[handler])
+    with TestClient(app=app) as client:
+        response = client.get("/x", params={"aIsNotNull": "true", "bIsNotNull": "true"})
+        assert response.status_code == 200
+        assert response.json() == {"fields": ["a", "b"]}
+
+
+def test_litestar_created_at_and_updated_at_do_not_cross_bind() -> None:
+    """`created_at` + `updated_at` providers share `before`/`after` names; aliases must still be honored."""
+    filter_deps = create_filter_dependencies({"created_at": True, "updated_at": True})
+
+    @get("/x", dependencies=filter_deps)
+    async def handler(filters: list[FilterTypes] = Dependency(skip_validation=True)) -> dict[str, Any]:
+        return {
+            "got": [
+                (f.field_name, f.before.isoformat() if f.before else None, f.after.isoformat() if f.after else None)
+                for f in filters
+                if isinstance(f, BeforeAfterFilter)
+            ]
+        }
+
+    app = Litestar(route_handlers=[handler])
+    with TestClient(app=app) as client:
+        response = client.get(
+            "/x",
+            params={
+                "createdBefore": "2025-01-01T00:00:00",
+                "createdAfter": "2024-01-01T00:00:00",
+                "updatedBefore": "2025-06-01T00:00:00",
+                "updatedAfter": "2024-06-01T00:00:00",
+            },
+        )
+        assert response.status_code == 200, response.text
+        got = {field: (before, after) for field, before, after in response.json()["got"]}
+        assert got["created_at"] == ("2025-01-01T00:00:00", "2024-01-01T00:00:00")
+        assert got["updated_at"] == ("2025-06-01T00:00:00", "2024-06-01T00:00:00")

--- a/tests/integration/extensions/litestar/test_in_fields_filters.py
+++ b/tests/integration/extensions/litestar/test_in_fields_filters.py
@@ -325,7 +325,7 @@ def test_litestar_in_fields_two_str_fields_do_not_cross_bind() -> None:
 
     @get("/x", dependencies=filter_deps)
     async def handler(filters: list[FilterTypes] = Dependency(skip_validation=True)) -> dict[str, Any]:
-        return {"got": [(f.field_name, sorted(f.values)) for f in filters if isinstance(f, InCollectionFilter)]}
+        return {"got": [(f.field_name, sorted(f.values or ())) for f in filters if isinstance(f, InCollectionFilter)]}
 
     app = Litestar(route_handlers=[handler])
     with TestClient(app=app) as client:
@@ -344,7 +344,9 @@ def test_litestar_in_fields_mixed_types_do_not_400() -> None:
     @get("/x", dependencies=filter_deps)
     async def handler(filters: list[FilterTypes] = Dependency(skip_validation=True)) -> dict[str, Any]:
         return {
-            "got": [(f.field_name, [str(v) for v in f.values]) for f in filters if isinstance(f, InCollectionFilter)]
+            "got": [
+                (f.field_name, [str(v) for v in (f.values or ())]) for f in filters if isinstance(f, InCollectionFilter)
+            ]
         }
 
     app = Litestar(route_handlers=[handler])
@@ -368,7 +370,9 @@ def test_litestar_not_in_fields_two_fields_do_not_cross_bind() -> None:
 
     @get("/x", dependencies=filter_deps)
     async def handler(filters: list[FilterTypes] = Dependency(skip_validation=True)) -> dict[str, Any]:
-        return {"got": [(f.field_name, sorted(f.values)) for f in filters if isinstance(f, NotInCollectionFilter)]}
+        return {
+            "got": [(f.field_name, sorted(f.values or ())) for f in filters if isinstance(f, NotInCollectionFilter)]
+        }
 
     app = Litestar(route_handlers=[handler])
     with TestClient(app=app) as client:
@@ -384,7 +388,7 @@ def test_litestar_null_fields_two_fields_do_not_cross_bind() -> None:
 
     @get("/x", dependencies=filter_deps)
     async def handler(filters: list[FilterTypes] = Dependency(skip_validation=True)) -> dict[str, Any]:
-        return {"fields": sorted(f.field_name for f in filters if isinstance(f, NullFilter))}
+        return {"fields": sorted(str(f.field_name) for f in filters if isinstance(f, NullFilter))}
 
     app = Litestar(route_handlers=[handler])
     with TestClient(app=app) as client:
@@ -407,7 +411,7 @@ def test_litestar_not_null_fields_two_fields_do_not_cross_bind() -> None:
 
     @get("/x", dependencies=filter_deps)
     async def handler(filters: list[FilterTypes] = Dependency(skip_validation=True)) -> dict[str, Any]:
-        return {"fields": sorted(f.field_name for f in filters if isinstance(f, NotNullFilter))}
+        return {"fields": sorted(str(f.field_name) for f in filters if isinstance(f, NotNullFilter))}
 
     app = Litestar(route_handlers=[handler])
     with TestClient(app=app) as client:

--- a/tests/unit/extensions/test_litestar/test_providers.py
+++ b/tests/unit/extensions/test_litestar/test_providers.py
@@ -41,7 +41,7 @@ def test_in_fields_provider_returns_filter_when_values_present() -> None:
     deps = _create_statement_filters(config)
 
     provider = deps["status_in_filter"]
-    result = provider.dependency(values=["active", "archived"])
+    result = provider.dependency(**{"status_values": ["active", "archived"]})
 
     assert isinstance(result, InCollectionFilter)
     assert result.field_name == "status"
@@ -54,8 +54,24 @@ def test_in_fields_provider_returns_none_when_no_values() -> None:
     deps = _create_statement_filters(config)
 
     provider = deps["status_in_filter"]
-    result = provider.dependency(values=None)
+    result = provider.dependency(**{"status_values": None})
     assert result is None
+
+
+def test_in_fields_provider_uses_unique_signature_param_per_field() -> None:
+    """Each in_fields provider exposes a unique parameter name to prevent cross-binding (issue #435)."""
+    import inspect as _inspect
+
+    config = FilterConfig(
+        in_fields={FieldNameType(name="status", type_hint=str), FieldNameType(name="role", type_hint=str)}
+    )
+    deps = _create_statement_filters(config)
+
+    status_params = list(_inspect.signature(deps["status_in_filter"].dependency).parameters)
+    role_params = list(_inspect.signature(deps["role_in_filter"].dependency).parameters)
+
+    assert status_params == ["status_values"]
+    assert role_params == ["role_values"]
 
 
 def test_not_in_fields_provider_returns_filter_when_values_present() -> None:
@@ -64,7 +80,7 @@ def test_not_in_fields_provider_returns_filter_when_values_present() -> None:
     deps = _create_statement_filters(config)
 
     provider = deps["status_not_in_filter"]
-    result = provider.dependency(values=["deleted", "archived"])
+    result = provider.dependency(**{"status_values": ["deleted", "archived"]})
 
     assert isinstance(result, NotInCollectionFilter)
     assert result.field_name == "status"
@@ -119,7 +135,7 @@ def test_in_fields_with_string_config() -> None:
     assert "filters" in deps
 
     provider = deps["status_in_filter"]
-    result = provider.dependency(values=["active"])
+    result = provider.dependency(**{"status_values": ["active"]})
     assert isinstance(result, InCollectionFilter)
     assert result.field_name == "status"
 

--- a/uv.lock
+++ b/uv.lock
@@ -6922,7 +6922,7 @@ wheels = [
 
 [[package]]
 name = "sqlspec"
-version = "0.46.0"
+version = "0.46.1"
 source = { editable = "." }
 dependencies = [
     { name = "mypy-extensions" },


### PR DESCRIPTION
## Summary

- Filter providers in `create_filter_dependencies()` shared Python parameter names (`values`, `is_null`, `is_not_null`, `before`, `after`) across distinct `Provide()` instances. Litestar collapses bindings by parameter name across providers, ignoring per-instance `Parameter(query=...)` aliases — so siblings in the same family cross-bound (silent value bleed when types matched, `400 Invalid UUID` when they didn't). Reported as #435.
- Each affected closure (`in_fields`, `not_in_fields`, `null_fields`, `not_null_fields`, `created_at`+`updated_at`) is now built via small helpers that synthesize a unique `__signature__` per field (`{field}_values`, `{field}_is_null`, `{field}_is_not_null`, `{field}_before`/`{field}_after`).
- FastAPI extension was already correct — `Depends()` creates isolated sub-dependency scopes — confirmed with a new mixed-type regression test.
- Sanic / Flask / Starlette extensions ship no filter providers, so nothing to fix there.
- Patch bump to 0.46.1.

## Test plan

- [x] `uv run pytest tests/unit/extensions/ tests/integration/extensions/litestar/ tests/integration/extensions/fastapi/` → 587 passed.
- [x] New Litestar regression coverage:
  - mixed-type `in_fields` (`str` + `UUID`) does not 400 and binds aliases independently
  - same-type two-field `in_fields` does not silently cross-bind
  - `not_in_fields` two-field
  - `null_fields` / `not_null_fields` two-field
  - `created_at` + `updated_at` enabled together don't collide on `before`/`after`
- [x] FastAPI sibling-isolation regression (`test_fastapi_multi_in_fields_mixed_types_do_not_cross_bind`)
- [x] `uv run ruff check` and `uv run mypy sqlspec/extensions/litestar/providers.py` clean
- [ ] CI green

Closes #435.