### PR TITLE
feat: struct-aware schema_dump default + values_from / set_from builder methods

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,23 @@ v0.46.2 - Framework Filter ``orderBy`` Aliases (Unreleased)
   emitted camelCase column names for snake_case database tables. The kwarg
   remains a no-op for non-msgspec inputs.
 
+**Added:**
+
+* ``Insert.values_from(data, *, exclude_unset=True)``,
+  ``Insert.values_from_many(items, *, exclude_unset=True)``, and
+  ``Update.set_from(data, *, exclude_unset=True)`` builder methods. Each accepts
+  any schema kind (dict, dataclass, ``msgspec.Struct``, ``pydantic.BaseModel``,
+  attrs class) and dispatches through ``schema_dump(wire_format=False)`` so SQL
+  column names are always Python attribute names regardless of any wire-rename
+  meta on the source schema.
+
+**Deprecated:**
+
+* ``Insert.values_from_dict`` and ``Insert.values_from_dicts`` now emit a
+  ``DeprecationWarning`` pointing at ``Insert.values_from`` /
+  ``Insert.values_from_many`` respectively. The dict-shaped methods continue to
+  work; they are scheduled for removal in 0.48.0.
+
 **Fixed:**
 
 * Missing named SQL statements now raise ``SQLStatementNotFoundError``, a

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,19 @@ Recent Updates
 v0.46.2 - Framework Filter ``orderBy`` Aliases (Unreleased)
 -----------------------------------------------------------
 
+**Changed (breaking default):**
+
+* ``sqlspec.utils.serializers.schema_dump`` (and its helpers
+  ``serialize_collection`` / ``get_collection_serializer``) now default
+  ``wire_format=False``. Calling ``schema_dump(struct)`` on a ``msgspec.Struct``
+  declared with ``rename=`` now returns Python attribute names by default
+  (matching Pydantic, dataclass, and attrs output) instead of wire-aligned
+  ``field.encode_name`` keys. Pass ``wire_format=True`` explicitly to restore
+  the prior wire-aligned output for JSON / API payloads. This default flip
+  closes the silent footgun where ``sql.update(t).set(**schema_dump(struct))``
+  emitted camelCase column names for snake_case database tables. The kwarg
+  remains a no-op for non-msgspec inputs.
+
 **Fixed:**
 
 * Missing named SQL statements now raise ``SQLStatementNotFoundError``, a

--- a/sqlspec/builder/_dml.py
+++ b/sqlspec/builder/_dml.py
@@ -11,6 +11,7 @@ from sqlspec.builder._base import BuiltQuery, QueryBuilder
 from sqlspec.builder._parsing_utils import extract_sql_object_expression
 from sqlspec.exceptions import SQLBuilderError
 from sqlspec.protocols import SQLBuilderProtocol
+from sqlspec.utils.serializers import schema_dump
 from sqlspec.utils.type_guards import has_expression_and_sql, has_parameter_builder, is_dict
 
 __all__ = (
@@ -321,6 +322,26 @@ class UpdateSetClauseMixin:
         existing = current_expr.args.get("expressions", [])
         current_expr.set("expressions", existing + assignments)
         return self
+
+    def set_from(self, data: Any, *, exclude_unset: bool = True) -> Self:
+        """Set columns from a dict, dataclass, msgspec.Struct, Pydantic model, or attrs class.
+
+        Schema instances are normalised via :func:`sqlspec.utils.serializers.schema_dump`
+        with ``wire_format=False`` and dispatched to :meth:`set` via keyword unpack. The
+        dict shape uses Python attribute names regardless of msgspec ``rename=`` or
+        Pydantic ``Field(alias=...)``.
+
+        Args:
+            data: A dict, dataclass instance, ``msgspec.Struct``, ``pydantic.BaseModel``,
+                or ``attrs``-decorated class instance.
+            exclude_unset: If True, exclude fields that were never set (msgspec UNSET,
+                Pydantic ``model_fields_set``, dataclass empty defaults). No-op for attrs.
+
+        Returns:
+            The current builder instance for method chaining.
+        """
+        payload = schema_dump(data, exclude_unset=exclude_unset, wire_format=False)
+        return self.set(**payload)
 
 
 @trait

--- a/sqlspec/builder/_insert.py
+++ b/sqlspec/builder/_insert.py
@@ -16,6 +16,7 @@ from sqlspec.builder._parsing_utils import extract_sql_object_expression
 from sqlspec.builder._select import ReturningClauseMixin
 from sqlspec.core import SQLResult
 from sqlspec.exceptions import SQLBuilderError
+from sqlspec.utils.serializers import schema_dump
 from sqlspec.utils.type_guards import has_expression_and_sql
 
 if TYPE_CHECKING:
@@ -167,6 +168,56 @@ class Insert(
             self.values(*[row_dict[col] for col in self._columns])
 
         return self
+
+    def values_from(self, data: Any, *, exclude_unset: bool = True) -> "Self":
+        """Add a row of values from a dict, dataclass, msgspec.Struct, Pydantic model, or attrs class.
+
+        Schema instances are normalised via :func:`sqlspec.utils.serializers.schema_dump`
+        with ``wire_format=False`` and dispatched to :meth:`values_from_dict`. The dict
+        shape uses Python attribute names regardless of msgspec ``rename=`` or Pydantic
+        ``Field(alias=...)``; wire-aligned names never make sense for SQL column binding.
+
+        Args:
+            data: A dict, dataclass instance, ``msgspec.Struct``, ``pydantic.BaseModel``,
+                or ``attrs``-decorated class instance.
+            exclude_unset: If True, exclude fields that were never set. Honoured by
+                msgspec (UNSET fields), Pydantic (``model_fields_set``), and dataclass
+                (via empty default-field semantics). No-op for attrs.
+
+        Returns:
+            The current builder instance for method chaining.
+
+        Raises:
+            SQLBuilderError: If ``into()`` has not been called or the dict shape is
+                incompatible with previously set columns.
+        """
+        payload = schema_dump(data, exclude_unset=exclude_unset, wire_format=False)
+        return self.values_from_dict(payload)
+
+    def values_from_many(self, items: "Sequence[Any]", *, exclude_unset: bool = True) -> "Self":
+        """Add multiple rows from a sequence of dicts, dataclasses, msgspec Structs, Pydantic models, or attrs classes.
+
+        Each item is normalised via :func:`sqlspec.utils.serializers.schema_dump` with
+        ``wire_format=False`` and dispatched to :meth:`values_from_dicts`. Mixed schema
+        kinds in the same sequence are supported (each item dispatches independently);
+        however, the resulting dict shapes must agree on key sets.
+
+        Args:
+            items: A sequence of schema instances or dicts.
+            exclude_unset: See :meth:`values_from` for per-library semantics.
+
+        Returns:
+            The current builder instance for method chaining. Empty input returns the
+            builder unchanged.
+
+        Raises:
+            SQLBuilderError: If ``into()`` has not been called or item dict shapes
+                disagree on key sets.
+        """
+        if not items:
+            return self
+        payload = [schema_dump(item, exclude_unset=exclude_unset, wire_format=False) for item in items]
+        return self.values_from_dicts(payload)
 
     def on_conflict(self, *columns: str) -> "ConflictBuilder":
         """Adds an ON CONFLICT clause with specified columns.

--- a/sqlspec/builder/_insert.py
+++ b/sqlspec/builder/_insert.py
@@ -17,7 +17,7 @@ from sqlspec.builder._select import ReturningClauseMixin
 from sqlspec.core import SQLResult
 from sqlspec.exceptions import SQLBuilderError
 from sqlspec.utils.deprecation import warn_deprecation
-from sqlspec.utils.serializers import schema_dump
+from sqlspec.utils.serializers import schema_dump, serialize_collection
 from sqlspec.utils.type_guards import has_expression_and_sql
 
 if TYPE_CHECKING:
@@ -242,7 +242,7 @@ class Insert(
         """
         if not items:
             return self
-        payload = [schema_dump(item, exclude_unset=exclude_unset, wire_format=False) for item in items]
+        payload = serialize_collection(items, exclude_unset=exclude_unset, wire_format=False)
         return self._bind_values_from_dicts(payload)
 
     def on_conflict(self, *columns: str) -> "ConflictBuilder":

--- a/sqlspec/builder/_insert.py
+++ b/sqlspec/builder/_insert.py
@@ -16,6 +16,7 @@ from sqlspec.builder._parsing_utils import extract_sql_object_expression
 from sqlspec.builder._select import ReturningClauseMixin
 from sqlspec.core import SQLResult
 from sqlspec.exceptions import SQLBuilderError
+from sqlspec.utils.deprecation import warn_deprecation
 from sqlspec.utils.serializers import schema_dump
 from sqlspec.utils.type_guards import has_expression_and_sql
 
@@ -105,21 +106,8 @@ class Insert(
         """Get the insert expression (public API)."""
         return self._get_insert_expression()
 
-    def values_from_dict(self, data: "Mapping[str, Any]") -> "Self":
-        """Adds a row of values from a dictionary.
-
-        This is a convenience method that automatically sets columns based on
-        the dictionary keys and values based on the dictionary values.
-
-        Args:
-            data: A mapping of column names to values.
-
-        Returns:
-            The current builder instance for method chaining.
-
-        Raises:
-            SQLBuilderError: If `into()` has not been called to set the table.
-        """
+    def _bind_values_from_dict(self, data: "Mapping[str, Any]") -> "Self":
+        """Bind a single dict row without deprecation warnings (internal)."""
         insert_expr = self._get_insert_expression()
         if insert_expr.args.get("this") is None:
             raise SQLBuilderError(ERR_MSG_TABLE_NOT_SET)
@@ -133,21 +121,8 @@ class Insert(
 
         return self.values(*[data[col] for col in self._columns])
 
-    def values_from_dicts(self, data: "Sequence[Mapping[str, Any]]") -> "Self":
-        """Adds multiple rows of values from a sequence of dictionaries.
-
-        This is a convenience method for bulk inserts from structured data.
-
-        Args:
-            data: A sequence of mappings, each representing a row of data.
-
-        Returns:
-            The current builder instance for method chaining.
-
-        Raises:
-            SQLBuilderError: If `into()` has not been called to set the table,
-                           or if dictionaries have inconsistent keys.
-        """
+    def _bind_values_from_dicts(self, data: "Sequence[Mapping[str, Any]]") -> "Self":
+        """Bind many dict rows without deprecation warnings (internal)."""
         if not data:
             return self
 
@@ -169,13 +144,64 @@ class Insert(
 
         return self
 
+    def values_from_dict(self, data: "Mapping[str, Any]") -> "Self":
+        """Adds a row of values from a dictionary.
+
+        .. deprecated:: 0.46.2
+            Use :meth:`values_from` instead — it accepts dicts, msgspec Structs,
+            Pydantic models, dataclasses, and attrs classes.
+
+        Args:
+            data: A mapping of column names to values.
+
+        Returns:
+            The current builder instance for method chaining.
+
+        Raises:
+            SQLBuilderError: If `into()` has not been called to set the table.
+        """
+        warn_deprecation(
+            version="0.46.2",
+            deprecated_name="Insert.values_from_dict",
+            kind="method",
+            alternative="Insert.values_from() — accepts dicts, msgspec Structs, Pydantic models, dataclasses, and attrs classes",
+            removal_in="0.48.0",
+        )
+        return self._bind_values_from_dict(data)
+
+    def values_from_dicts(self, data: "Sequence[Mapping[str, Any]]") -> "Self":
+        """Adds multiple rows of values from a sequence of dictionaries.
+
+        .. deprecated:: 0.46.2
+            Use :meth:`values_from_many` instead — it accepts dicts, msgspec Structs,
+            Pydantic models, dataclasses, and attrs classes.
+
+        Args:
+            data: A sequence of mappings, each representing a row of data.
+
+        Returns:
+            The current builder instance for method chaining.
+
+        Raises:
+            SQLBuilderError: If `into()` has not been called to set the table,
+                           or if dictionaries have inconsistent keys.
+        """
+        warn_deprecation(
+            version="0.46.2",
+            deprecated_name="Insert.values_from_dicts",
+            kind="method",
+            alternative="Insert.values_from_many() — accepts dicts, msgspec Structs, Pydantic models, dataclasses, and attrs classes",
+            removal_in="0.48.0",
+        )
+        return self._bind_values_from_dicts(data)
+
     def values_from(self, data: Any, *, exclude_unset: bool = True) -> "Self":
         """Add a row of values from a dict, dataclass, msgspec.Struct, Pydantic model, or attrs class.
 
         Schema instances are normalised via :func:`sqlspec.utils.serializers.schema_dump`
-        with ``wire_format=False`` and dispatched to :meth:`values_from_dict`. The dict
-        shape uses Python attribute names regardless of msgspec ``rename=`` or Pydantic
-        ``Field(alias=...)``; wire-aligned names never make sense for SQL column binding.
+        with ``wire_format=False`` then bound as a single row. The dict shape uses Python
+        attribute names regardless of msgspec ``rename=`` or Pydantic ``Field(alias=...)``;
+        wire-aligned names never make sense for SQL column binding.
 
         Args:
             data: A dict, dataclass instance, ``msgspec.Struct``, ``pydantic.BaseModel``,
@@ -192,15 +218,15 @@ class Insert(
                 incompatible with previously set columns.
         """
         payload = schema_dump(data, exclude_unset=exclude_unset, wire_format=False)
-        return self.values_from_dict(payload)
+        return self._bind_values_from_dict(payload)
 
     def values_from_many(self, items: "Sequence[Any]", *, exclude_unset: bool = True) -> "Self":
         """Add multiple rows from a sequence of dicts, dataclasses, msgspec Structs, Pydantic models, or attrs classes.
 
         Each item is normalised via :func:`sqlspec.utils.serializers.schema_dump` with
-        ``wire_format=False`` and dispatched to :meth:`values_from_dicts`. Mixed schema
-        kinds in the same sequence are supported (each item dispatches independently);
-        however, the resulting dict shapes must agree on key sets.
+        ``wire_format=False`` then bound as a multi-row INSERT. Mixed schema kinds in the
+        same sequence are supported (each item normalises independently); however, the
+        resulting dict shapes must agree on key sets.
 
         Args:
             items: A sequence of schema instances or dicts.
@@ -217,7 +243,7 @@ class Insert(
         if not items:
             return self
         payload = [schema_dump(item, exclude_unset=exclude_unset, wire_format=False) for item in items]
-        return self.values_from_dicts(payload)
+        return self._bind_values_from_dicts(payload)
 
     def on_conflict(self, *columns: str) -> "ConflictBuilder":
         """Adds an ON CONFLICT clause with specified columns.

--- a/sqlspec/utils/serializers/_schema.py
+++ b/sqlspec/utils/serializers/_schema.py
@@ -201,7 +201,7 @@ def _build_dump_function(sample: Any, exclude_unset: bool, wire_format: bool) ->
 
 
 def get_collection_serializer(
-    sample: Any, *, exclude_unset: bool = True, wire_format: bool = True
+    sample: Any, *, exclude_unset: bool = True, wire_format: bool = False
 ) -> "SchemaSerializer":
     """Return cached serializer pipeline for the provided sample object."""
     key = _make_serializer_key(sample, exclude_unset, wire_format)
@@ -219,7 +219,7 @@ def get_collection_serializer(
 
 
 def serialize_collection(
-    items: "Iterable[Any]", *, exclude_unset: bool = True, wire_format: bool = True
+    items: "Iterable[Any]", *, exclude_unset: bool = True, wire_format: bool = False
 ) -> "list[Any]":
     """Serialize a collection using cached pipelines keyed by item type."""
     serialized: list[Any] = []
@@ -254,7 +254,7 @@ def get_serializer_metrics() -> "dict[str, int]":
         return metrics
 
 
-def schema_dump(data: Any, *, exclude_unset: bool = True, wire_format: bool = True) -> Any:
+def schema_dump(data: Any, *, exclude_unset: bool = True, wire_format: bool = False) -> Any:
     """Dump a schema model or dict to a plain representation.
 
     Args:
@@ -262,11 +262,12 @@ def schema_dump(data: Any, *, exclude_unset: bool = True, wire_format: bool = Tr
             or plain dict / primitive.
         exclude_unset: If True, exclude fields that were never set (msgspec UNSET, Pydantic
             model_fields_set semantics). No-op for attrs (attrs has no unset concept).
-        wire_format: msgspec-only knob. Default True keeps the historical behavior of
-            emitting ``field.encode_name`` (honours ``rename=`` on the Struct). Pass
-            ``wire_format=False`` to opt msgspec into Python attribute names (``field.name``)
-            for cross-library consistency. Pydantic, dataclass, and attrs branches always
-            use Python attribute names regardless of this flag.
+        wire_format: msgspec-only knob. Default ``False`` emits Python attribute names
+            (``field.name``) for cross-library consistency — keys match Pydantic, dataclass,
+            and attrs output regardless of the Struct's ``rename=`` meta. Pass
+            ``wire_format=True`` to emit ``field.encode_name`` (honours ``rename=`` on the
+            Struct) for wire-aligned JSON / API payloads. Pydantic, dataclass, and attrs
+            branches always use Python attribute names regardless of this flag.
     """
     if is_dict(data):
         return data

--- a/tests/unit/builder/test_insert_builder.py
+++ b/tests/unit/builder/test_insert_builder.py
@@ -33,9 +33,10 @@ def test_insert_with_table_in_constructor() -> None:
 
 
 def test_insert_values_from_dict() -> None:
-    """Test INSERT using values_from_dict method."""
+    """Test INSERT using values_from_dict method (deprecated; emits DeprecationWarning)."""
     data = {"id": 1, "name": "John", "status": "active"}
-    query = sql.insert("users").values_from_dict(data)
+    with pytest.warns(DeprecationWarning, match=r"values_from"):
+        query = sql.insert("users").values_from_dict(data)
     stmt = query.build()
 
     assert "INSERT INTO" in stmt.sql
@@ -46,9 +47,10 @@ def test_insert_values_from_dict() -> None:
 
 
 def test_insert_values_from_dicts_multiple_rows() -> None:
-    """Test INSERT using values_from_dicts for multiple rows."""
+    """Test INSERT using values_from_dicts for multiple rows (deprecated; emits DeprecationWarning)."""
     data = [{"id": 1, "name": "John"}, {"id": 2, "name": "Jane"}, {"id": 3, "name": "Bob"}]
-    query = sql.insert("users").values_from_dicts(data)
+    with pytest.warns(DeprecationWarning, match=r"values_from"):
+        query = sql.insert("users").values_from_dicts(data)
     stmt = query.build()
 
     assert "INSERT INTO" in stmt.sql
@@ -130,9 +132,12 @@ def test_insert_columns_and_values_consistency() -> None:
 
 
 def test_insert_inconsistent_dict_keys_error() -> None:
-    """Test that inconsistent dictionary keys in values_from_dicts raises error."""
+    """Test that inconsistent dictionary keys in values_from_dicts raises error (deprecated method)."""
     data = [{"id": 1, "name": "John"}, {"id": 2, "email": "jane@test.com"}]
-    with pytest.raises(SQLBuilderError, match="do not match expected keys"):
+    with (
+        pytest.warns(DeprecationWarning, match=r"values_from"),
+        pytest.raises(SQLBuilderError, match="do not match expected keys"),
+    ):
         sql.insert("users").values_from_dicts(data).build()
 
 
@@ -310,12 +315,42 @@ def test_on_conflict_parameter_merging() -> None:
 
 
 def test_on_conflict_with_values_from_dict() -> None:
-    """Test ON CONFLICT with values_from_dict."""
+    """Test ON CONFLICT with values_from_dict (deprecated method emits DeprecationWarning)."""
     data = {"id": 1, "name": "John", "email": "john@test.com"}
-    query = sql.insert("users").values_from_dict(data).on_conflict("id").do_update(name="Updated")
+    with pytest.warns(DeprecationWarning, match=r"values_from"):
+        query = sql.insert("users").values_from_dict(data).on_conflict("id").do_update(name="Updated")
     stmt = query.build()
 
     assert "ON CONFLICT" in stmt.sql
     assert "DO UPDATE" in stmt.sql
     assert "name_1" in stmt.parameters
     assert stmt.parameters["name_1"] == "Updated"
+
+
+def test_values_from_dict_warning_message_contains_migration_pointer() -> None:
+    """Warning text must name the replacement API explicitly."""
+    import warnings
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        sql.insert("users").values_from_dict({"id": 1})
+
+    deprecation_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(deprecation_warnings) == 1
+    msg = str(deprecation_warnings[0].message)
+    assert "values_from" in msg
+    assert "msgspec" in msg or "Pydantic" in msg or "dataclass" in msg
+
+
+def test_values_from_dicts_warning_message_contains_migration_pointer() -> None:
+    """values_from_dicts warning must point at values_from_many()."""
+    import warnings
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        sql.insert("users").values_from_dicts([{"id": 1}])
+
+    deprecation_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert len(deprecation_warnings) == 1
+    msg = str(deprecation_warnings[0].message)
+    assert "values_from_many" in msg

--- a/tests/unit/builder/test_parameter_naming.py
+++ b/tests/unit/builder/test_parameter_naming.py
@@ -173,8 +173,8 @@ def test_insert_with_columns_uses_column_names() -> None:
 
 
 def test_insert_values_from_dict_preserves_keys() -> None:
-    """Test that INSERT values_from_dict preserves dictionary keys."""
-    query = sql.insert("orders").values_from_dict({
+    """Test that INSERT values_from preserves dictionary keys."""
+    query = sql.insert("orders").values_from({
         "customer_id": 12345,
         "product_name": "Widget",
         "quantity": 3,
@@ -314,7 +314,7 @@ def test_no_generic_param_names_in_update_operations() -> None:
 def test_no_generic_param_names_in_insert_operations() -> None:
     """Test that INSERT operations use descriptive parameter names."""
     test_cases = [
-        sql.insert("users").values_from_dict({"name": "John", "email": "john@test.com"}),
+        sql.insert("users").values_from({"name": "John", "email": "john@test.com"}),
         sql.insert("posts").columns("title", "content").values("Hello", "World"),
     ]
 

--- a/tests/unit/builder/test_sql_factory.py
+++ b/tests/unit/builder/test_sql_factory.py
@@ -307,7 +307,7 @@ def test_select_method() -> None:
 
 def test_insert_method() -> None:
     """Test sql.insert() method."""
-    query = sql.insert("users").values_from_dict({"name": "John", "email": "john@test.com"})
+    query = sql.insert("users").values_from({"name": "John", "email": "john@test.com"})
     stmt = query.build()
 
     assert "INSERT INTO" in stmt.sql
@@ -1289,9 +1289,9 @@ def test_legacy_on_duplicate_key_update_method() -> None:
 
 
 def test_on_conflict_with_insert_from_dict() -> None:
-    """Test ON CONFLICT with insert using from_dict methods."""
+    """Test ON CONFLICT with insert built from a dict via values_from."""
     data = {"id": 1, "name": "John", "email": "john@test.com"}
-    query = sql.insert("users").values_from_dict(data).on_conflict("id").do_update(name="Updated John")
+    query = sql.insert("users").values_from(data).on_conflict("id").do_update(name="Updated John")
     stmt = query.build()
 
     assert "INSERT INTO" in stmt.sql

--- a/tests/unit/builder/test_struct_aware_values.py
+++ b/tests/unit/builder/test_struct_aware_values.py
@@ -1,0 +1,203 @@
+"""Struct-aware INSERT/UPDATE builder tests (chapter 2 of struct-aware-serialization-builder).
+
+Covers ``Insert.values_from``, ``Insert.values_from_many``, ``Update.set_from`` against
+dicts, dataclasses, msgspec Structs (with ``rename=``), Pydantic models (with ``Field(alias=)``),
+and attrs classes (with ``field(alias=)``). The contract is that all five schema kinds
+produce identical Python-attribute-name keys regardless of any wire-rename meta.
+"""
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from sqlspec import sql
+from sqlspec.utils.serializers import reset_serializer_cache
+
+if TYPE_CHECKING:
+    pass
+
+
+pytestmark = pytest.mark.xdist_group("builder")
+
+
+@pytest.fixture(autouse=True)
+def _reset_serializer_cache() -> "Any":
+    reset_serializer_cache()
+    yield
+    reset_serializer_cache()
+
+
+def test_insert_values_from_msgspec_struct_with_rename_uses_python_names() -> None:
+    """Regression: msgspec Struct with rename="camel" must NOT leak camelCase column names."""
+    msgspec = pytest.importorskip("msgspec")
+
+    class _User(msgspec.Struct, rename="camel"):
+        user_id: str
+        display_name: str
+
+    obj = _User(user_id="abc-123", display_name="Cody")
+    stmt = sql.insert("users").values_from(obj).build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert "userId" not in stmt.sql
+    assert "displayName" not in stmt.sql
+
+    assert stmt.parameters["user_id"] == "abc-123"
+    assert stmt.parameters["display_name"] == "Cody"
+
+
+def test_insert_values_from_many_dataclasses_emits_multi_row() -> None:
+    """values_from_many must produce a multi-row INSERT keyed by Python attribute names."""
+    from dataclasses import dataclass
+
+    @dataclass
+    class _User:
+        user_id: str
+        name: str
+
+    users = [_User("u1", "Alice"), _User("u2", "Bob"), _User("u3", "Carol")]
+    stmt = sql.insert("users").values_from_many(users).build()
+
+    assert "INSERT INTO" in stmt.sql
+    assert stmt.parameters["user_id"] == "u1"
+    assert stmt.parameters["user_id_1"] == "u2"
+    assert stmt.parameters["user_id_2"] == "u3"
+    assert stmt.parameters["name"] == "Alice"
+    assert stmt.parameters["name_1"] == "Bob"
+    assert stmt.parameters["name_2"] == "Carol"
+
+
+def test_insert_values_from_many_empty_list_returns_self_unchanged() -> None:
+    """Empty input must return the builder unchanged (matches values_from_dicts contract)."""
+    builder = sql.insert("users")
+    result = builder.values_from_many([])
+    assert result is builder
+
+
+def test_update_set_from_msgspec_struct_with_rename_uses_python_names() -> None:
+    """set_from must emit Python attribute names regardless of msgspec rename meta."""
+    msgspec = pytest.importorskip("msgspec")
+
+    class _UserPatch(msgspec.Struct, rename="camel"):
+        display_name: str
+        email: str
+
+    patch = _UserPatch(display_name="Updated", email="new@example.com")
+    stmt = sql.update("users").set_from(patch).where_eq("id", 42).build()
+
+    assert "UPDATE" in stmt.sql
+    assert "displayName" not in stmt.sql
+    assert stmt.parameters["display_name"] == "Updated"
+    assert stmt.parameters["email"] == "new@example.com"
+    assert stmt.parameters["id"] == 42
+
+
+# --- Schema-kind matrix factories ---
+
+
+def _make_dict() -> "dict[str, str]":
+    return {"user_id": "u1", "display_name": "Cody"}
+
+
+def _make_dataclass() -> "Any":
+    from dataclasses import dataclass
+
+    @dataclass
+    class _User:
+        user_id: str
+        display_name: str
+
+    return _User(user_id="u1", display_name="Cody")
+
+
+def _make_msgspec_struct_with_rename() -> "Any":
+    msgspec = pytest.importorskip("msgspec")
+
+    class _User(msgspec.Struct, rename="camel"):
+        user_id: str
+        display_name: str
+
+    return _User(user_id="u1", display_name="Cody")
+
+
+def _make_pydantic_model_with_alias() -> "Any":
+    pytest.importorskip("pydantic")
+    import pydantic
+
+    class _User(pydantic.BaseModel):
+        user_id: str = pydantic.Field(alias="userId")
+        display_name: str = pydantic.Field(alias="displayName")
+
+        model_config = pydantic.ConfigDict(populate_by_name=True)
+
+    return _User(userId="u1", displayName="Cody")
+
+
+def _make_attrs_instance() -> "Any":
+    pytest.importorskip("attrs")
+    import attrs
+
+    @attrs.define
+    class _User:
+        user_id: str = attrs.field(alias="userId")
+        display_name: str = attrs.field(alias="displayName")
+
+    return _User(userId="u1", displayName="Cody")
+
+
+SCHEMA_FACTORIES: "list[pytest.ParameterSet]" = [
+    pytest.param(_make_dict, id="dict"),
+    pytest.param(_make_dataclass, id="dataclass"),
+    pytest.param(_make_msgspec_struct_with_rename, id="msgspec_rename"),
+    pytest.param(_make_pydantic_model_with_alias, id="pydantic_alias"),
+    pytest.param(_make_attrs_instance, id="attrs_alias"),
+]
+
+
+@pytest.mark.parametrize("factory", SCHEMA_FACTORIES)
+def test_insert_values_from_uses_python_names_for_all_schema_kinds(factory: "Callable[[], Any]") -> None:
+    obj = factory()
+    stmt = sql.insert("users").values_from(obj, exclude_unset=False).build()
+
+    assert stmt.parameters["user_id"] == "u1"
+    assert stmt.parameters["display_name"] == "Cody"
+    assert "userId" not in stmt.parameters
+    assert "displayName" not in stmt.parameters
+
+
+@pytest.mark.parametrize("factory", SCHEMA_FACTORIES)
+def test_update_set_from_uses_python_names_for_all_schema_kinds(factory: "Callable[[], Any]") -> None:
+    obj = factory()
+    stmt = sql.update("users").set_from(obj, exclude_unset=False).where_eq("id", 42).build()
+
+    assert stmt.parameters["user_id"] == "u1"
+    assert stmt.parameters["display_name"] == "Cody"
+
+
+@pytest.mark.parametrize("factory", SCHEMA_FACTORIES)
+def test_insert_values_from_many_uses_python_names_for_all_schema_kinds(factory: "Callable[[], Any]") -> None:
+    obj1 = factory()
+    obj2 = factory()
+    stmt = sql.insert("users").values_from_many([obj1, obj2], exclude_unset=False).build()
+
+    assert stmt.parameters["user_id"] == "u1"
+    assert stmt.parameters["display_name"] == "Cody"
+    assert stmt.parameters["user_id_1"] == "u1"
+    assert stmt.parameters["display_name_1"] == "Cody"
+
+
+def test_insert_values_from_msgspec_exclude_unset_filters_unset_fields() -> None:
+    """exclude_unset=True must drop UNSET msgspec fields from the resulting INSERT."""
+    msgspec = pytest.importorskip("msgspec")
+    from msgspec import UNSET
+
+    class _UserPatch(msgspec.Struct, rename="camel", omit_defaults=False):
+        user_id: str = UNSET  # type: ignore[assignment]
+        display_name: str = UNSET  # type: ignore[assignment]
+
+    patch = _UserPatch(user_id="u1")
+    stmt = sql.insert("users").values_from(patch, exclude_unset=True).build()
+
+    assert stmt.parameters["user_id"] == "u1"
+    assert "display_name" not in stmt.parameters

--- a/tests/unit/builder/test_struct_aware_values.py
+++ b/tests/unit/builder/test_struct_aware_values.py
@@ -7,16 +7,12 @@ produce identical Python-attribute-name keys regardless of any wire-rename meta.
 """
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import pytest
 
 from sqlspec import sql
 from sqlspec.utils.serializers import reset_serializer_cache
-
-if TYPE_CHECKING:
-    pass
-
 
 pytestmark = pytest.mark.xdist_group("builder")
 
@@ -30,7 +26,7 @@ def _reset_serializer_cache() -> "Any":
 
 def test_insert_values_from_msgspec_struct_with_rename_uses_python_names() -> None:
     """Regression: msgspec Struct with rename="camel" must NOT leak camelCase column names."""
-    msgspec = pytest.importorskip("msgspec")
+    import msgspec
 
     class _User(msgspec.Struct, rename="camel"):
         user_id: str
@@ -77,7 +73,7 @@ def test_insert_values_from_many_empty_list_returns_self_unchanged() -> None:
 
 def test_update_set_from_msgspec_struct_with_rename_uses_python_names() -> None:
     """set_from must emit Python attribute names regardless of msgspec rename meta."""
-    msgspec = pytest.importorskip("msgspec")
+    import msgspec
 
     class _UserPatch(msgspec.Struct, rename="camel"):
         display_name: str
@@ -112,7 +108,7 @@ def _make_dataclass() -> "Any":
 
 
 def _make_msgspec_struct_with_rename() -> "Any":
-    msgspec = pytest.importorskip("msgspec")
+    import msgspec
 
     class _User(msgspec.Struct, rename="camel"):
         user_id: str
@@ -146,7 +142,7 @@ def _make_attrs_instance() -> "Any":
     return _User(userId="u1", displayName="Cody")
 
 
-SCHEMA_FACTORIES: "list[pytest.ParameterSet]" = [
+SCHEMA_FACTORIES = [
     pytest.param(_make_dict, id="dict"),
     pytest.param(_make_dataclass, id="dataclass"),
     pytest.param(_make_msgspec_struct_with_rename, id="msgspec_rename"),
@@ -189,7 +185,7 @@ def test_insert_values_from_many_uses_python_names_for_all_schema_kinds(factory:
 
 def test_insert_values_from_msgspec_exclude_unset_filters_unset_fields() -> None:
     """exclude_unset=True must drop UNSET msgspec fields from the resulting INSERT."""
-    msgspec = pytest.importorskip("msgspec")
+    import msgspec
     from msgspec import UNSET
 
     class _UserPatch(msgspec.Struct, rename="camel", omit_defaults=False):

--- a/tests/unit/utils/test_serializers.py
+++ b/tests/unit/utils/test_serializers.py
@@ -744,9 +744,10 @@ class TestSchemaDumpWireFormatOptOut:
             user_id: str
 
         obj = _User(user_id="abc")
-        assert schema_dump(obj) == {"userId": "abc"}
+        assert schema_dump(obj, wire_format=True) == {"userId": "abc"}
         assert schema_dump(obj, wire_format=False) == {"user_id": "abc"}
-        assert schema_dump(obj) == {"userId": "abc"}
+        assert schema_dump(obj, wire_format=True) == {"userId": "abc"}
+        assert schema_dump(obj) == {"user_id": "abc"}  # default is wire_format=False
 
     def test_pydantic_unaffected_by_wire_format(self) -> None:
         pytest.importorskip("pydantic")
@@ -786,7 +787,7 @@ class TestSchemaDumpWireFormatOptOut:
 
 
 class TestSchemaDumpRename:
-    """Regression suite for GitHub #418 — schema_dump must honor msgspec rename meta."""
+    """Regression suite for GitHub #418 — schema_dump honors msgspec rename meta when ``wire_format=True``."""
 
     @pytest.fixture(autouse=True)
     def _reset_cache(self) -> "Any":
@@ -802,7 +803,7 @@ class TestSchemaDumpRename:
             display_name: str
 
         obj = _User(user_id="abc-123", display_name="Cody")
-        assert schema_dump(obj) == {"userId": "abc-123", "displayName": "Cody"}
+        assert schema_dump(obj, wire_format=True) == {"userId": "abc-123", "displayName": "Cody"}
 
     def test_rename_kebab(self) -> None:
         import msgspec
@@ -812,7 +813,7 @@ class TestSchemaDumpRename:
             display_name: str
 
         obj = _User(user_id="abc", display_name="Cody")
-        assert schema_dump(obj) == {"user-id": "abc", "display-name": "Cody"}
+        assert schema_dump(obj, wire_format=True) == {"user-id": "abc", "display-name": "Cody"}
 
     def test_rename_pascal(self) -> None:
         import msgspec
@@ -822,7 +823,7 @@ class TestSchemaDumpRename:
             display_name: str
 
         obj = _User(user_id="abc", display_name="Cody")
-        assert schema_dump(obj) == {"UserId": "abc", "DisplayName": "Cody"}
+        assert schema_dump(obj, wire_format=True) == {"UserId": "abc", "DisplayName": "Cody"}
 
     def test_rename_callable(self) -> None:
         import msgspec
@@ -835,7 +836,7 @@ class TestSchemaDumpRename:
             display_name: str
 
         obj = _User(user_id="abc", display_name="Cody")
-        assert schema_dump(obj) == {"USER_ID": "abc", "DISPLAY_NAME": "Cody"}
+        assert schema_dump(obj, wire_format=True) == {"USER_ID": "abc", "DISPLAY_NAME": "Cody"}
 
     def test_no_rename_preserved(self) -> None:
         import msgspec
@@ -856,4 +857,71 @@ class TestSchemaDumpRename:
             display_name: str = UNSET  # type: ignore[assignment]
 
         obj = _User(user_id="abc")
-        assert schema_dump(obj, exclude_unset=True) == {"userId": "abc"}
+        assert schema_dump(obj, exclude_unset=True, wire_format=True) == {"userId": "abc"}
+
+
+class TestSchemaDumpDefaultIsPythonNames:
+    """Default ``schema_dump(struct)`` emits Python attribute names regardless of ``rename=`` meta.
+
+    Cross-library consistency contract: the same call shape on every supported schema kind
+    (msgspec, Pydantic, dataclass, attrs, dict) returns Python-attribute-name keys. Wire-aligned
+    output requires explicit ``wire_format=True``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_cache(self) -> "Any":
+        reset_serializer_cache()
+        yield
+        reset_serializer_cache()
+
+    def test_msgspec_rename_camel_default_emits_python_names(self) -> None:
+        import msgspec
+
+        class _User(msgspec.Struct, rename="camel"):
+            user_id: str
+            display_name: str
+
+        obj = _User(user_id="abc", display_name="Cody")
+        assert schema_dump(obj) == {"user_id": "abc", "display_name": "Cody"}
+
+    def test_msgspec_rename_kebab_default_emits_python_names(self) -> None:
+        import msgspec
+
+        class _User(msgspec.Struct, rename="kebab"):
+            user_id: str
+
+        obj = _User(user_id="abc")
+        assert schema_dump(obj) == {"user_id": "abc"}
+
+    def test_pydantic_alias_default_emits_python_names(self) -> None:
+        pytest.importorskip("pydantic")
+        import pydantic
+
+        class _User(pydantic.BaseModel):
+            user_id: str = pydantic.Field(alias="userId")
+
+            model_config = pydantic.ConfigDict(populate_by_name=True)
+
+        obj = _User(userId="abc")
+        assert schema_dump(obj, exclude_unset=False) == {"user_id": "abc"}
+
+    def test_dataclass_default_emits_python_names(self) -> None:
+        from dataclasses import dataclass
+
+        @dataclass
+        class _User:
+            user_id: str
+
+        obj = _User(user_id="abc")
+        assert schema_dump(obj, exclude_unset=False) == {"user_id": "abc"}
+
+    def test_attrs_default_emits_python_names(self) -> None:
+        pytest.importorskip("attrs")
+        import attrs
+
+        @attrs.define
+        class _User:
+            user_id: str = attrs.field(alias="userId")
+
+        obj = _User(userId="abc")
+        assert schema_dump(obj, exclude_unset=False) == {"user_id": "abc"}


### PR DESCRIPTION
## Summary

- Flip `schema_dump` `wire_format` default from `True` to `False`. Cross-library consistency: `msgspec.Struct` now matches Pydantic / dataclass / attrs by default. Wire-aligned output (camelCase via `field.encode_name`) requires explicit `wire_format=True`.
- Add `Insert.values_from`, `Insert.values_from_many`, `Update.set_from`. Each accepts any schema kind (dict, dataclass, msgspec, Pydantic, attrs) and dispatches through `schema_dump(wire_format=False)`.
- Deprecate `Insert.values_from_dict` / `Insert.values_from_dicts`. Both emit `DeprecationWarning` pointing at the new methods. Removal target: 0.48.0.
- `values_from_many` now uses `serialize_collection` (per-batch type-keyed cache) instead of a per-item `schema_dump` loop.

## Why

`schema_dump`'s prior default (`wire_format=True`) silently emitted `field.encode_name` keys for `msgspec.Struct(rename=...)` instances — meaning `sql.insert(t).columns(*schema_dump(struct).keys()).values(...)` against snake_case Postgres tables blew up with `column "userId" does not exist` whenever the source schema declared `rename="camel"`.

## Behavior change

| Caller pattern | Before | After |
|---|---|---|
| `schema_dump(struct)` on `msgspec.Struct(rename="camel")` | `{"userId": ...}` | `{"user_id": ...}` |
| `schema_dump(struct, wire_format=True)` | `{"userId": ...}` | `{"userId": ...}` (unchanged) |
| `schema_dump(pydantic_model)` / `dataclass` / `attrs` | Python names | Python names (unchanged) |
| `Insert.values_from_dict({...})` | Silent | Emits `DeprecationWarning` |