### PR TITLE
test: use rustfs for s3 integration fixtures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ test = [
   "pytest>=8.0.0",
 
   "pytest-cov>=5.0.0",
-  "pytest-databases[postgres,oracle,mysql,bigquery,spanner,minio]>=0.17.0",
+  "pytest-databases[postgres,oracle,bigquery,spanner]>=0.18.0",
   "pytest-mock>=3.14.0",
   "pytest-sugar>=1.0.0",
   "pytest-xdist>=3.6.1",
@@ -164,7 +164,7 @@ sqlspec-light = "tools.sphinx_ext.pygments_styles:SQLSpecLightStyle"
 # mysql-connector-python 9.7.0 dropped cp312/cp313/cp314 wheels (regression vs 9.6.0).
 # Override dependency metadata for every source that requests mysql-connector-python.
 # Keep the uncapped dependency on Python <3.12, and force the cap on Python >=3.12
-# so transitive pulls (e.g., pytest-databases[mysql]) resolve to an existing wheel.
+# so the SQLSpec mysql-connector extra resolves to an existing wheel.
 override-dependencies = [
   "mysql-connector-python; python_version < '3.12'",
   "mysql-connector-python<9.7.0; python_version >= '3.12'",
@@ -469,7 +469,6 @@ module = [
   "fsspec.*",
   "sqlglot",
   "sqlglot.*",
-  "minio",
 ]
 
 [[tool.mypy.overrides]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,13 +8,8 @@ warnings.filterwarnings(
 
 from collections.abc import Generator  # noqa: E402
 from pathlib import Path  # noqa: E402
-from typing import TYPE_CHECKING  # noqa: E402
 
 import pytest  # noqa: E402
-from minio import Minio  # noqa: E402
-
-if TYPE_CHECKING:
-    from pytest_databases.docker.minio import MinioService
 
 
 def is_compiled() -> bool:
@@ -45,7 +40,6 @@ pytest_plugins = [
     "pytest_databases.docker.mysql",
     "pytest_databases.docker.bigquery",
     "pytest_databases.docker.spanner",
-    "pytest_databases.docker.minio",
     "pytest_databases.docker.cockroachdb",
 ]
 
@@ -82,24 +76,6 @@ def suppress_noisy_test_loggers() -> "Generator[None, None, None]":
     finally:
         for name, level in original_levels.items():
             logging.getLogger(name).setLevel(level)
-
-
-@pytest.fixture(scope="session")
-def minio_client(minio_service: "MinioService", minio_default_bucket_name: str) -> Generator[Minio, None, None]:
-    """Override pytest-databases minio_client to use new minio API with keyword arguments."""
-    client = Minio(
-        endpoint=minio_service.endpoint,
-        access_key=minio_service.access_key,
-        secret_key=minio_service.secret_key,
-        secure=minio_service.secure,
-    )
-    try:
-        if not client.bucket_exists(bucket_name=minio_default_bucket_name):
-            client.make_bucket(bucket_name=minio_default_bucket_name)
-    except Exception as e:
-        msg = f"Failed to create bucket {minio_default_bucket_name}"
-        raise RuntimeError(msg) from e
-    yield client
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/tests/fixtures/rustfs.py
+++ b/tests/fixtures/rustfs.py
@@ -1,0 +1,62 @@
+"""RustFS-backed S3-compatible test helpers."""
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from pytest_databases.docker.rustfs import RustfsService
+
+
+def rustfs_endpoint_url(rustfs_service: "RustfsService") -> str:
+    """Return the S3 endpoint URL for a pytest-databases RustFS service."""
+    scheme = "https" if rustfs_service.secure else "http"
+    return f"{scheme}://{rustfs_service.endpoint}"
+
+
+def rustfs_fsspec_kwargs(rustfs_service: "RustfsService") -> dict[str, Any]:
+    """Return FSSpec S3 options for a pytest-databases RustFS service."""
+    endpoint_url = rustfs_endpoint_url(rustfs_service)
+    return {
+        "endpoint_url": endpoint_url,
+        "key": rustfs_service.access_key,
+        "secret": rustfs_service.secret_key,
+        "use_ssl": rustfs_service.secure,
+        "client_kwargs": {"endpoint_url": endpoint_url, "verify": False},
+        "config_kwargs": {"s3": {"addressing_style": "path"}},
+    }
+
+
+def rustfs_obstore_kwargs(rustfs_service: "RustfsService") -> dict[str, Any]:
+    """Return ObStore S3 options for a pytest-databases RustFS service."""
+    return {
+        "aws_endpoint": rustfs_endpoint_url(rustfs_service),
+        "aws_access_key_id": rustfs_service.access_key,
+        "aws_secret_access_key": rustfs_service.secret_key,
+        "aws_virtual_hosted_style_request": False,
+        "client_options": {"allow_http": not rustfs_service.secure},
+    }
+
+
+def rustfs_filesystem(rustfs_service: "RustfsService") -> Any:
+    """Create an S3 filesystem connected to the RustFS service."""
+    pytest.importorskip("s3fs", reason="s3fs is required for RustFS S3 test setup")
+    fsspec = pytest.importorskip("fsspec", reason="fsspec is required for RustFS S3 test setup")
+    return fsspec.filesystem("s3", anon=False, **rustfs_fsspec_kwargs(rustfs_service))
+
+
+def ensure_rustfs_bucket(rustfs_service: "RustfsService", bucket_name: str) -> str:
+    """Ensure the default RustFS bucket exists and return its name."""
+    fs = rustfs_filesystem(rustfs_service)
+    if not fs.exists(bucket_name):
+        fs.mkdir(bucket_name)
+    return bucket_name
+
+
+def rustfs_object_size(rustfs_service: "RustfsService", bucket_name: str, object_name: str) -> int:
+    """Return the size of an object stored in RustFS."""
+    info = rustfs_filesystem(rustfs_service).info(f"{bucket_name}/{object_name}")
+    size = info.get("size")
+    if isinstance(size, int):
+        return size
+    return 0

--- a/tests/integration/adapters/_storage_bridge_helpers.py
+++ b/tests/integration/adapters/_storage_bridge_helpers.py
@@ -3,26 +3,20 @@
 from typing import TYPE_CHECKING
 
 from sqlspec.storage.registry import storage_registry
+from tests.fixtures.rustfs import rustfs_fsspec_kwargs
 
 if TYPE_CHECKING:  # pragma: no cover
-    from pytest_databases.docker.minio import MinioService
+    from pytest_databases.docker.rustfs import RustfsService
 
-__all__ = ("register_minio_alias",)
+__all__ = ("register_rustfs_alias",)
 
 
-def register_minio_alias(
-    alias: str, minio_service: "MinioService", bucket: str, *, prefix: str = "storage-bridge"
+def register_rustfs_alias(
+    alias: str, rustfs_service: "RustfsService", bucket: str, *, prefix: str = "storage-bridge"
 ) -> str:
-    """Register a storage registry alias backed by the pytest-databases MinIO service."""
+    """Register a storage registry alias backed by the pytest-databases RustFS service."""
 
     storage_registry.register_alias(
-        alias,
-        f"s3://{bucket}/{prefix}",
-        backend="fsspec",
-        endpoint_url=f"http://{minio_service.endpoint}",
-        key=minio_service.access_key,
-        secret=minio_service.secret_key,
-        use_ssl=False,
-        client_kwargs={"endpoint_url": f"http://{minio_service.endpoint}", "verify": False},
+        alias, f"s3://{bucket}/{prefix}", backend="fsspec", **rustfs_fsspec_kwargs(rustfs_service)
     )
     return prefix

--- a/tests/integration/adapters/asyncpg/test_storage_bridge.py
+++ b/tests/integration/adapters/asyncpg/test_storage_bridge.py
@@ -1,4 +1,4 @@
-"""Storage bridge integration tests for AsyncPG using MinIO."""
+"""Storage bridge integration tests for AsyncPG using RustFS."""
 
 from typing import TYPE_CHECKING
 
@@ -7,11 +7,11 @@ import pytest
 from sqlspec.adapters.asyncpg import AsyncpgDriver
 from sqlspec.storage.registry import storage_registry
 from sqlspec.typing import FSSPEC_INSTALLED, PYARROW_INSTALLED
-from tests.integration.adapters._storage_bridge_helpers import register_minio_alias
+from tests.fixtures.rustfs import rustfs_object_size
+from tests.integration.adapters._storage_bridge_helpers import register_rustfs_alias
 
 if TYPE_CHECKING:  # pragma: no cover
-    from minio import Minio
-    from pytest_databases.docker.minio import MinioService
+    from pytest_databases.docker.rustfs import RustfsService
 
 pytestmark = [
     pytest.mark.asyncpg,
@@ -21,11 +21,8 @@ pytestmark = [
 ]
 
 
-async def test_asyncpg_storage_bridge_with_minio(
-    asyncpg_async_driver: AsyncpgDriver,
-    minio_service: "MinioService",
-    minio_client: "Minio",
-    minio_default_bucket_name: str,
+async def test_asyncpg_storage_bridge_with_rustfs(
+    asyncpg_async_driver: AsyncpgDriver, rustfs_service: "RustfsService", rustfs_bucket_name: str
 ) -> None:
     alias = "storage_bridge_asyncpg"
     destination_path = "alias://storage_bridge_asyncpg/asyncpg/export.parquet"
@@ -34,7 +31,7 @@ async def test_asyncpg_storage_bridge_with_minio(
 
     storage_registry.clear()
     try:
-        prefix = register_minio_alias(alias, minio_service, minio_default_bucket_name)
+        prefix = register_rustfs_alias(alias, rustfs_service, rustfs_bucket_name)
 
         await asyncpg_async_driver.execute(f"DROP TABLE IF EXISTS {source_table} CASCADE")
         await asyncpg_async_driver.execute(f"DROP TABLE IF EXISTS {target_table} CASCADE")
@@ -59,9 +56,7 @@ async def test_asyncpg_storage_bridge_with_minio(
         assert rows == [(1, "north"), (2, "south"), (3, "east")]
 
         object_name = f"{prefix}/asyncpg/export.parquet"
-        stat = minio_client.stat_object(bucket_name=minio_default_bucket_name, object_name=object_name)
-        object_size = stat.size if stat.size is not None else 0
-        assert object_size > 0
+        assert rustfs_object_size(rustfs_service, rustfs_bucket_name, object_name) > 0
     finally:
         storage_registry.clear()
         await asyncpg_async_driver.execute(f"DROP TABLE IF EXISTS {source_table} CASCADE")

--- a/tests/integration/adapters/duckdb/test_storage_bridge.py
+++ b/tests/integration/adapters/duckdb/test_storage_bridge.py
@@ -1,4 +1,4 @@
-"""Storage bridge integration tests for DuckDB using MinIO."""
+"""Storage bridge integration tests for DuckDB using RustFS."""
 
 from typing import TYPE_CHECKING
 
@@ -7,11 +7,11 @@ import pytest
 from sqlspec.adapters.duckdb import DuckDBDriver
 from sqlspec.storage.registry import storage_registry
 from sqlspec.typing import FSSPEC_INSTALLED, PYARROW_INSTALLED
-from tests.integration.adapters._storage_bridge_helpers import register_minio_alias
+from tests.fixtures.rustfs import rustfs_object_size
+from tests.integration.adapters._storage_bridge_helpers import register_rustfs_alias
 
 if TYPE_CHECKING:  # pragma: no cover
-    from minio import Minio
-    from pytest_databases.docker.minio import MinioService
+    from pytest_databases.docker.rustfs import RustfsService
 
 pytestmark = [
     pytest.mark.xdist_group("storage"),
@@ -20,18 +20,15 @@ pytestmark = [
 ]
 
 
-def test_duckdb_storage_bridge_with_minio(
-    duckdb_basic_session: DuckDBDriver,
-    minio_service: "MinioService",
-    minio_client: "Minio",
-    minio_default_bucket_name: str,
+def test_duckdb_storage_bridge_with_rustfs(
+    duckdb_basic_session: DuckDBDriver, rustfs_service: "RustfsService", rustfs_bucket_name: str
 ) -> None:
     alias = "storage_bridge_duckdb"
     destination_path = "alias://storage_bridge_duckdb/duckdb/export.parquet"
 
     storage_registry.clear()
     try:
-        prefix = register_minio_alias(alias, minio_service, minio_default_bucket_name)
+        prefix = register_rustfs_alias(alias, rustfs_service, rustfs_bucket_name)
 
         duckdb_basic_session.execute("DROP TABLE IF EXISTS storage_bridge_duckdb_source")
         duckdb_basic_session.execute("DROP TABLE IF EXISTS storage_bridge_duckdb_target")
@@ -60,9 +57,7 @@ def test_duckdb_storage_bridge_with_minio(
         assert rows == [(1, "alpha"), (2, "beta"), (3, "gamma")]
 
         object_name = f"{prefix}/duckdb/export.parquet"
-        stat = minio_client.stat_object(bucket_name=minio_default_bucket_name, object_name=object_name)
-        object_size = stat.size if stat.size is not None else 0
-        assert object_size > 0
+        assert rustfs_object_size(rustfs_service, rustfs_bucket_name, object_name) > 0
     finally:
         storage_registry.clear()
         duckdb_basic_session.execute("DROP TABLE IF EXISTS storage_bridge_duckdb_source")

--- a/tests/integration/adapters/psqlpy/test_storage_bridge.py
+++ b/tests/integration/adapters/psqlpy/test_storage_bridge.py
@@ -7,11 +7,11 @@ import pytest
 from sqlspec.adapters.psqlpy import PsqlpyDriver
 from sqlspec.storage.registry import storage_registry
 from sqlspec.typing import FSSPEC_INSTALLED, PYARROW_INSTALLED
-from tests.integration.adapters._storage_bridge_helpers import register_minio_alias
+from tests.fixtures.rustfs import rustfs_object_size
+from tests.integration.adapters._storage_bridge_helpers import register_rustfs_alias
 
 if TYPE_CHECKING:  # pragma: no cover
-    from minio import Minio
-    from pytest_databases.docker.minio import MinioService
+    from pytest_databases.docker.rustfs import RustfsService
 
 pytestmark = [
     pytest.mark.xdist_group("postgres"),
@@ -21,8 +21,8 @@ pytestmark = [
 
 
 @pytest.mark.anyio
-async def test_psqlpy_storage_bridge_with_minio(
-    psqlpy_driver: PsqlpyDriver, minio_service: "MinioService", minio_client: "Minio", minio_default_bucket_name: str
+async def test_psqlpy_storage_bridge_with_rustfs(
+    psqlpy_driver: PsqlpyDriver, rustfs_service: "RustfsService", rustfs_bucket_name: str
 ) -> None:
     alias = "storage_bridge_psqlpy"
     destination = f"alias://{alias}/psqlpy/export.parquet"
@@ -31,7 +31,7 @@ async def test_psqlpy_storage_bridge_with_minio(
 
     storage_registry.clear()
     try:
-        prefix = register_minio_alias(alias, minio_service, minio_default_bucket_name)
+        prefix = register_rustfs_alias(alias, rustfs_service, rustfs_bucket_name)
 
         await psqlpy_driver.execute(f"DROP TABLE IF EXISTS {source_table}")
         await psqlpy_driver.execute(f"DROP TABLE IF EXISTS {target_table}")
@@ -54,9 +54,7 @@ async def test_psqlpy_storage_bridge_with_minio(
         assert rows == [{"id": 1, "label": "delta"}, {"id": 2, "label": "omega"}, {"id": 3, "label": "zeta"}]
 
         object_name = f"{prefix}/psqlpy/export.parquet"
-        stat = minio_client.stat_object(bucket_name=minio_default_bucket_name, object_name=object_name)
-        object_size = stat.size if stat.size is not None else 0
-        assert object_size > 0
+        assert rustfs_object_size(rustfs_service, rustfs_bucket_name, object_name) > 0
     finally:
         storage_registry.clear()
         await psqlpy_driver.execute(f"DROP TABLE IF EXISTS {source_table}")

--- a/tests/integration/adapters/psycopg/test_storage_bridge.py
+++ b/tests/integration/adapters/psycopg/test_storage_bridge.py
@@ -9,11 +9,11 @@ from sqlspec.adapters.psycopg import PsycopgAsyncConfig, PsycopgAsyncDriver, Psy
 from sqlspec.core import SQLResult
 from sqlspec.storage.registry import storage_registry
 from sqlspec.typing import FSSPEC_INSTALLED, PYARROW_INSTALLED
-from tests.integration.adapters._storage_bridge_helpers import register_minio_alias
+from tests.fixtures.rustfs import rustfs_object_size
+from tests.integration.adapters._storage_bridge_helpers import register_rustfs_alias
 
 if TYPE_CHECKING:  # pragma: no cover
-    from minio import Minio
-    from pytest_databases.docker.minio import MinioService
+    from pytest_databases.docker.rustfs import RustfsService
 
 pytestmark = [
     pytest.mark.xdist_group("postgres"),
@@ -34,11 +34,8 @@ async def psycopg_async_session(psycopg_async_config: PsycopgAsyncConfig) -> Asy
         yield session
 
 
-def test_psycopg_sync_storage_bridge_with_minio(
-    psycopg_sync_config: PsycopgSyncConfig,
-    minio_service: "MinioService",
-    minio_client: "Minio",
-    minio_default_bucket_name: str,
+def test_psycopg_sync_storage_bridge_with_rustfs(
+    psycopg_sync_config: PsycopgSyncConfig, rustfs_service: "RustfsService", rustfs_bucket_name: str
 ) -> None:
     alias = "storage_bridge_psycopg_sync"
     destination = f"alias://{alias}/psycopg_sync/export.parquet"
@@ -47,7 +44,7 @@ def test_psycopg_sync_storage_bridge_with_minio(
 
     storage_registry.clear()
     try:
-        prefix = register_minio_alias(alias, minio_service, minio_default_bucket_name)
+        prefix = register_rustfs_alias(alias, rustfs_service, rustfs_bucket_name)
 
         with psycopg_sync_config.provide_session() as session:
             session.execute_script(f"DROP TABLE IF EXISTS {source_table} CASCADE")
@@ -89,9 +86,7 @@ def test_psycopg_sync_storage_bridge_with_minio(
             ]
 
         object_name = f"{prefix}/psycopg_sync/export.parquet"
-        stat = minio_client.stat_object(bucket_name=minio_default_bucket_name, object_name=object_name)
-        object_size = stat.size if stat.size is not None else 0
-        assert object_size > 0
+        assert rustfs_object_size(rustfs_service, rustfs_bucket_name, object_name) > 0
     finally:
         storage_registry.clear()
         with psycopg_sync_config.provide_session() as cleanup:
@@ -101,11 +96,8 @@ def test_psycopg_sync_storage_bridge_with_minio(
 
 
 @pytest.mark.anyio
-async def test_psycopg_async_storage_bridge_with_minio(
-    psycopg_async_session: PsycopgAsyncDriver,
-    minio_service: "MinioService",
-    minio_client: "Minio",
-    minio_default_bucket_name: str,
+async def test_psycopg_async_storage_bridge_with_rustfs(
+    psycopg_async_session: PsycopgAsyncDriver, rustfs_service: "RustfsService", rustfs_bucket_name: str
 ) -> None:
     alias = "storage_bridge_psycopg_async"
     destination = f"alias://{alias}/psycopg_async/export.parquet"
@@ -114,7 +106,7 @@ async def test_psycopg_async_storage_bridge_with_minio(
 
     storage_registry.clear()
     try:
-        prefix = register_minio_alias(alias, minio_service, minio_default_bucket_name)
+        prefix = register_rustfs_alias(alias, rustfs_service, rustfs_bucket_name)
 
         await psycopg_async_session.execute_script(f"DROP TABLE IF EXISTS {source_table} CASCADE")
         await psycopg_async_session.execute_script(f"DROP TABLE IF EXISTS {target_table} CASCADE")
@@ -146,9 +138,7 @@ async def test_psycopg_async_storage_bridge_with_minio(
         assert rows == [{"id": 1, "label": "north"}, {"id": 2, "label": "south"}, {"id": 3, "label": "east"}]
 
         object_name = f"{prefix}/psycopg_async/export.parquet"
-        stat = minio_client.stat_object(bucket_name=minio_default_bucket_name, object_name=object_name)
-        object_size = stat.size if stat.size is not None else 0
-        assert object_size > 0
+        assert rustfs_object_size(rustfs_service, rustfs_bucket_name, object_name) > 0
     finally:
         storage_registry.clear()
         await psycopg_async_session.execute_script(f"DROP TABLE IF EXISTS {source_table} CASCADE")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,8 +1,19 @@
 """Pytest configuration and fixtures for integration tests."""
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
+from pytest_databases.docker.rustfs import rustfs_access_key as rustfs_access_key
+from pytest_databases.docker.rustfs import rustfs_default_bucket_name as rustfs_default_bucket_name
+from pytest_databases.docker.rustfs import rustfs_secret_key as rustfs_secret_key
+from pytest_databases.docker.rustfs import rustfs_secure as rustfs_secure
+from pytest_databases.docker.rustfs import rustfs_service as rustfs_service
+from pytest_databases.docker.rustfs import xdist_rustfs_isolation_level as xdist_rustfs_isolation_level
+
+from tests.fixtures.rustfs import ensure_rustfs_bucket
+
+if TYPE_CHECKING:
+    from pytest_databases.docker.rustfs import RustfsService
 
 
 @pytest.fixture
@@ -25,3 +36,9 @@ def complex_data() -> list[dict[str, Any]]:
         {"name": "test2", "value": 200, "data": {"key": "value2"}, "tags": ["tag2", "tag3"]},
         {"name": "test3", "value": 300, "data": None, "tags": None},
     ]
+
+
+@pytest.fixture(scope="session")
+def rustfs_bucket_name(rustfs_service: "RustfsService", rustfs_default_bucket_name: str) -> str:
+    """Return the verified RustFS bucket used by S3-compatible integration tests."""
+    return ensure_rustfs_bucket(rustfs_service, rustfs_default_bucket_name)

--- a/tests/integration/storage/test_integration.py
+++ b/tests/integration/storage/test_integration.py
@@ -1,6 +1,6 @@
-"""Integration tests for storage backends using minio fixtures.
+"""Integration tests for storage backends using RustFS fixtures.
 
-Tests storage backend operations against S3-compatible storage using pytest-databases minio fixtures.
+Tests storage backend operations against S3-compatible storage using pytest-databases RustFS fixtures.
 Follows Advanced Alchemy patterns for comprehensive storage testing.
 """
 
@@ -9,14 +9,14 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from minio import Minio
-from pytest_databases.docker.minio import MinioService
+from pytest_databases.docker.rustfs import RustfsService
 
 from sqlspec.exceptions import FileNotFoundInStorageError
 from sqlspec.protocols import ObjectStoreProtocol
 from sqlspec.storage.errors import execute_sync_storage_operation
 from sqlspec.storage.registry import storage_registry
 from sqlspec.typing import FSSPEC_INSTALLED, OBSTORE_INSTALLED, PYARROW_INSTALLED
+from tests.fixtures.rustfs import rustfs_fsspec_kwargs, rustfs_obstore_kwargs
 
 # Test data
 TEST_TEXT_CONTENT = "Hello, SQLSpec storage integration test!"
@@ -58,40 +58,20 @@ def local_test_setup(tmp_path: "Path") -> "Path":
 
 
 @pytest.fixture
-def fsspec_s3_backend(
-    minio_service: "MinioService", minio_client: "Minio", minio_default_bucket_name: str
-) -> "ObjectStoreProtocol":
+def fsspec_s3_backend(rustfs_service: "RustfsService", rustfs_bucket_name: str) -> "ObjectStoreProtocol":
     """Set up FSSpec S3 backend for testing."""
-    _ = minio_client  # Ensures bucket is created
     from sqlspec.storage.backends.fsspec import FSSpecBackend
 
-    return FSSpecBackend(
-        uri=f"s3://{minio_default_bucket_name}/",
-        endpoint_url=f"http://{minio_service.endpoint}",
-        key=minio_service.access_key,
-        secret=minio_service.secret_key,
-        use_ssl=False,
-        client_kwargs={"verify": False, "use_ssl": False},
-    )
+    return FSSpecBackend(uri=f"s3://{rustfs_bucket_name}/", **rustfs_fsspec_kwargs(rustfs_service))
 
 
 @pytest.fixture
-def obstore_s3_backend(
-    minio_service: "MinioService", minio_client: "Minio", minio_default_bucket_name: str
-) -> "ObjectStoreProtocol":
+def obstore_s3_backend(rustfs_service: "RustfsService", rustfs_bucket_name: str) -> "ObjectStoreProtocol":
     """Set up ObStore S3 backend for testing."""
-    _ = minio_client  # Ensures bucket is created
     from sqlspec.storage.backends.obstore import ObStoreBackend
 
-    s3_uri = f"s3://{minio_default_bucket_name}"
-    return ObStoreBackend(
-        s3_uri,
-        aws_endpoint=f"http://{minio_service.endpoint}",
-        aws_access_key_id=minio_service.access_key,
-        aws_secret_access_key=minio_service.secret_key,
-        aws_virtual_hosted_style_request=False,
-        client_options={"allow_http": True},
-    )
+    s3_uri = f"s3://{rustfs_bucket_name}"
+    return ObStoreBackend(s3_uri, **rustfs_obstore_kwargs(rustfs_service))
 
 
 # Local storage tests
@@ -207,15 +187,8 @@ def test_storage_missing_logging_format(caplog) -> None:
 
 @pytest.mark.xdist_group("storage")
 @pytest.mark.skipif(not FSSPEC_INSTALLED, reason="fsspec missing")
-def test_fsspec_s3_basic_operations(
-    fsspec_s3_backend: "ObjectStoreProtocol", minio_client: "Minio", minio_default_bucket_name: str
-) -> None:
+def test_fsspec_s3_basic_operations(fsspec_s3_backend: "ObjectStoreProtocol") -> None:
     """Test FSSpec S3 backend basic operations."""
-    # Ensure bucket exists (following Advanced Alchemy pattern)
-    assert minio_client.bucket_exists(bucket_name=minio_default_bucket_name), (
-        f"Bucket {minio_default_bucket_name} does not exist"
-    )
-
     # Test write and read text
     test_path = "integration_test/test.txt"
     fsspec_s3_backend.write_text_sync(test_path, TEST_TEXT_CONTENT)
@@ -303,15 +276,8 @@ def test_fsspec_s3_copy_move_operations(fsspec_s3_backend: "ObjectStoreProtocol"
 
 @pytest.mark.xdist_group("storage")
 @pytest.mark.skipif(not OBSTORE_INSTALLED, reason="obstore missing")
-def test_obstore_s3_basic_operations(
-    obstore_s3_backend: "ObjectStoreProtocol", minio_client: "Minio", minio_default_bucket_name: str
-) -> None:
+def test_obstore_s3_basic_operations(obstore_s3_backend: "ObjectStoreProtocol") -> None:
     """Test ObStore S3 backend basic operations."""
-    # Ensure bucket exists (following Advanced Alchemy pattern)
-    assert minio_client.bucket_exists(bucket_name=minio_default_bucket_name), (
-        f"Bucket {minio_default_bucket_name} does not exist"
-    )
-
     test_path = "integration_test/obstore_test.txt"
 
     # Test write and read
@@ -408,24 +374,13 @@ def test_registry_path_resolution(tmp_path: "Path") -> None:
 
 @pytest.mark.xdist_group("storage")
 @pytest.mark.skipif(not FSSPEC_INSTALLED, reason="fsspec missing")
-def test_registry_s3_fsspec_resolution(
-    minio_service: "MinioService", minio_client: "Minio", minio_default_bucket_name: str
-) -> None:
+def test_registry_s3_fsspec_resolution(rustfs_service: "RustfsService", rustfs_bucket_name: str) -> None:
     """Test storage registry S3 resolution with FSSpec backend."""
-    _ = minio_client  # Ensures bucket is created
     from sqlspec.storage.backends.fsspec import FSSpecBackend
 
-    s3_uri = f"s3://{minio_default_bucket_name}/registry_test/"
+    s3_uri = f"s3://{rustfs_bucket_name}/registry_test/"
 
-    backend = storage_registry.get(
-        s3_uri,
-        backend="fsspec",
-        endpoint_url=f"http://{minio_service.endpoint}",
-        key=minio_service.access_key,
-        secret=minio_service.secret_key,
-        use_ssl=False,
-        client_kwargs={"verify": False, "use_ssl": False},
-    )
+    backend = storage_registry.get(s3_uri, backend="fsspec", **rustfs_fsspec_kwargs(rustfs_service))
 
     # Should get FSSpec backend for S3
     assert isinstance(backend, FSSpecBackend)
@@ -439,10 +394,9 @@ def test_registry_s3_fsspec_resolution(
 
 @pytest.mark.xdist_group("storage")
 def test_registry_alias_registration(
-    minio_service: "MinioService", minio_client: "Minio", minio_default_bucket_name: str, tmp_path: "Path"
+    rustfs_service: "RustfsService", rustfs_bucket_name: str, tmp_path: "Path"
 ) -> None:
     """Test storage registry alias registration and usage."""
-    _ = minio_client  # Ensures bucket is created
     from sqlspec.storage.backends.local import LocalStore
     from sqlspec.storage.backends.obstore import ObStoreBackend
 
@@ -468,14 +422,7 @@ def test_registry_alias_registration(
             from sqlspec.storage.backends.fsspec import FSSpecBackend
 
             storage_registry.register_alias(
-                "test-s3",
-                uri=f"s3://{minio_default_bucket_name}/",
-                backend="fsspec",
-                endpoint_url=f"http://{minio_service.endpoint}",
-                key=minio_service.access_key,
-                secret=minio_service.secret_key,
-                use_ssl=False,
-                client_kwargs={"verify": False, "use_ssl": False},
+                "test-s3", uri=f"s3://{rustfs_bucket_name}/", backend="fsspec", **rustfs_fsspec_kwargs(rustfs_service)
             )
 
             s3_backend = storage_registry.get("test-s3")
@@ -503,11 +450,8 @@ def local_backend(tmp_path: "Path") -> "ObjectStoreProtocol":
 
 
 @pytest.fixture
-def fsspec_s3_backend_optional(
-    minio_service: "MinioService", minio_client: "Minio", minio_default_bucket_name: str
-) -> "ObjectStoreProtocol":
+def fsspec_s3_backend_optional(rustfs_service: "RustfsService", rustfs_bucket_name: str) -> "ObjectStoreProtocol":
     """Create FSSpec S3 backend if available."""
-    _ = minio_client  # Ensures bucket is created
     if not FSSPEC_INSTALLED:
         pytest.skip("fsspec missing")
 
@@ -515,35 +459,21 @@ def fsspec_s3_backend_optional(
 
     return FSSpecBackend.from_config({
         "protocol": "s3",
-        "fs_config": {
-            "endpoint_url": f"http://{minio_service.host}:{minio_service.port}",
-            "key": minio_service.access_key,
-            "secret": minio_service.secret_key,
-        },
-        "base_path": minio_default_bucket_name,
+        "fs_config": rustfs_fsspec_kwargs(rustfs_service),
+        "base_path": rustfs_bucket_name,
     })
 
 
 @pytest.fixture
-def obstore_s3_backend_optional(
-    minio_service: "MinioService", minio_client: "Minio", minio_default_bucket_name: str
-) -> "ObjectStoreProtocol":
+def obstore_s3_backend_optional(rustfs_service: "RustfsService", rustfs_bucket_name: str) -> "ObjectStoreProtocol":
     """Create ObStore S3 backend if available."""
-    _ = minio_client  # Ensures bucket is created
     if not OBSTORE_INSTALLED:
         pytest.skip("obstore missing")
 
     from sqlspec.storage.backends.obstore import ObStoreBackend
 
-    s3_uri = f"s3://{minio_default_bucket_name}"
-    return ObStoreBackend(
-        s3_uri,
-        aws_endpoint=f"http://{minio_service.endpoint}",
-        aws_access_key_id=minio_service.access_key,
-        aws_secret_access_key=minio_service.secret_key,
-        aws_virtual_hosted_style_request=False,
-        client_options={"allow_http": True},
-    )
+    s3_uri = f"s3://{rustfs_bucket_name}"
+    return ObStoreBackend(s3_uri, **rustfs_obstore_kwargs(rustfs_service))
 
 
 @pytest.mark.xdist_group("storage")
@@ -614,21 +544,14 @@ def test_local_backend_error_handling(tmp_path: "Path") -> None:
 
 @pytest.mark.xdist_group("storage")
 @pytest.mark.skipif(not FSSPEC_INSTALLED, reason="fsspec missing")
-def test_fsspec_s3_error_handling(
-    minio_service: "MinioService", minio_client: "Minio", minio_default_bucket_name: str
-) -> None:
+def test_fsspec_s3_error_handling(rustfs_service: "RustfsService", rustfs_bucket_name: str) -> None:
     """Test FSSpec S3 backend error handling."""
-    _ = minio_client  # Ensures bucket is created
     from sqlspec.storage.backends.fsspec import FSSpecBackend
 
     backend = FSSpecBackend.from_config({
         "protocol": "s3",
-        "fs_config": {
-            "endpoint_url": f"http://{minio_service.host}:{minio_service.port}",
-            "key": minio_service.access_key,
-            "secret": minio_service.secret_key,
-        },
-        "base_path": minio_default_bucket_name,
+        "fs_config": rustfs_fsspec_kwargs(rustfs_service),
+        "base_path": rustfs_bucket_name,
     })
 
     # Test reading nonexistent file
@@ -708,10 +631,9 @@ def test_registry_alias_management(tmp_path: "Path") -> None:
 
 @pytest.mark.xdist_group("storage")
 def test_registry_backend_fallback_order(
-    tmp_path: "Path", minio_service: "MinioService", minio_client: "Minio", minio_default_bucket_name: str
+    tmp_path: "Path", rustfs_service: "RustfsService", rustfs_bucket_name: str
 ) -> None:
     """Test that registry follows correct backend fallback order."""
-    _ = minio_client  # Ensures bucket is created
     from sqlspec.storage.backends.local import LocalStore
     from sqlspec.storage.backends.obstore import ObStoreBackend
 
@@ -725,13 +647,11 @@ def test_registry_backend_fallback_order(
         assert isinstance(local_backend, (ObStoreBackend, LocalStore))
 
         # Test S3 resolution (should prefer ObStore > FSSpec if available)
-        s3_uri = f"s3://{minio_default_bucket_name}"
-        s3_backend = storage_registry.get(
-            s3_uri,
-            endpoint_url=f"http://{minio_service.host}:{minio_service.port}",
-            aws_access_key_id=minio_service.access_key,
-            aws_secret_access_key=minio_service.secret_key,
+        s3_uri = f"s3://{rustfs_bucket_name}"
+        storage_kwargs = (
+            rustfs_obstore_kwargs(rustfs_service) if OBSTORE_INSTALLED else rustfs_fsspec_kwargs(rustfs_service)
         )
+        s3_backend = storage_registry.get(s3_uri, **storage_kwargs)
 
         # Should get ObStore if available, else FSSpec, else error
         if OBSTORE_INSTALLED:
@@ -781,21 +701,14 @@ def test_local_arrow_operations(tmp_path: "Path") -> None:
 @pytest.mark.xdist_group("storage")
 @pytest.mark.skipif(not FSSPEC_INSTALLED, reason="fsspec missing")
 @pytest.mark.skipif(not PYARROW_INSTALLED, reason="pyarrow missing")
-def test_fsspec_s3_arrow_operations(
-    minio_service: "MinioService", minio_client: "Minio", minio_default_bucket_name: str
-) -> None:
+def test_fsspec_s3_arrow_operations(rustfs_service: "RustfsService", rustfs_bucket_name: str) -> None:
     """Test FSSpec S3 backend Arrow operations if pyarrow is available."""
-    _ = minio_client  # Ensures bucket is created
     from sqlspec.storage.backends.fsspec import FSSpecBackend
 
     backend = FSSpecBackend.from_config({
         "protocol": "s3",
-        "fs_config": {
-            "endpoint_url": f"http://{minio_service.host}:{minio_service.port}",
-            "key": minio_service.access_key,
-            "secret": minio_service.secret_key,
-        },
-        "base_path": minio_default_bucket_name,
+        "fs_config": rustfs_fsspec_kwargs(rustfs_service),
+        "base_path": rustfs_bucket_name,
     })
 
     import pyarrow as pa
@@ -905,21 +818,14 @@ def test_local_metadata_operations(tmp_path: "Path") -> None:
 
 @pytest.mark.xdist_group("storage")
 @pytest.mark.skipif(not FSSPEC_INSTALLED, reason="fsspec missing")
-def test_fsspec_s3_metadata_operations(
-    minio_service: "MinioService", minio_client: "Minio", minio_default_bucket_name: str
-) -> None:
+def test_fsspec_s3_metadata_operations(rustfs_service: "RustfsService", rustfs_bucket_name: str) -> None:
     """Test FSSpec S3 backend metadata operations."""
-    _ = minio_client  # Ensures bucket is created
     from sqlspec.storage.backends.fsspec import FSSpecBackend
 
     backend = FSSpecBackend.from_config({
         "protocol": "s3",
-        "fs_config": {
-            "endpoint_url": f"http://{minio_service.host}:{minio_service.port}",
-            "key": minio_service.access_key,
-            "secret": minio_service.secret_key,
-        },
-        "base_path": minio_default_bucket_name,
+        "fs_config": rustfs_fsspec_kwargs(rustfs_service),
+        "base_path": rustfs_bucket_name,
     })
 
     # Test S3 metadata

--- a/tests/integration/storage/test_signing.py
+++ b/tests/integration/storage/test_signing.py
@@ -1,6 +1,6 @@
 """Integration tests for storage backend URL signing with real cloud services.
 
-Tests URL signing functionality against S3-compatible storage (MinIO) using
+Tests URL signing functionality against S3-compatible storage (RustFS) using
 pytest-databases fixtures. These tests verify that actual signed URLs are
 generated and can be used for download/upload operations.
 """
@@ -8,12 +8,12 @@ generated and can be used for download/upload operations.
 from typing import TYPE_CHECKING
 
 import pytest
-from minio import Minio
 
 from sqlspec.typing import OBSTORE_INSTALLED
+from tests.fixtures.rustfs import rustfs_obstore_kwargs
 
 if TYPE_CHECKING:
-    from pytest_databases.docker.minio import MinioService
+    from pytest_databases.docker.rustfs import RustfsService
 
     from sqlspec.protocols import ObjectStoreProtocol
 
@@ -22,22 +22,12 @@ TEST_TEXT_CONTENT = "Hello, SQLSpec URL signing test!"
 
 
 @pytest.fixture
-def obstore_s3_backend(
-    minio_service: "MinioService", minio_client: "Minio", minio_default_bucket_name: str
-) -> "ObjectStoreProtocol":
+def obstore_s3_backend(rustfs_service: "RustfsService", rustfs_bucket_name: str) -> "ObjectStoreProtocol":
     """Set up ObStore S3 backend for signing tests."""
-    _ = minio_client
     from sqlspec.storage.backends.obstore import ObStoreBackend
 
-    s3_uri = f"s3://{minio_default_bucket_name}"
-    return ObStoreBackend(
-        s3_uri,
-        aws_endpoint=f"http://{minio_service.endpoint}",
-        aws_access_key_id=minio_service.access_key,
-        aws_secret_access_key=minio_service.secret_key,
-        aws_virtual_hosted_style_request=False,
-        client_options={"allow_http": True},
-    )
+    s3_uri = f"s3://{rustfs_bucket_name}"
+    return ObStoreBackend(s3_uri, **rustfs_obstore_kwargs(rustfs_service))
 
 
 @pytest.mark.xdist_group("storage")

--- a/tests/integration/test_rustfs_fixture_contract.py
+++ b/tests/integration/test_rustfs_fixture_contract.py
@@ -1,0 +1,57 @@
+"""Tests for the RustFS-backed S3 integration fixture contract."""
+
+from pathlib import Path
+
+import tomli
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+ROOT_CONFTEST = PROJECT_ROOT / "tests" / "conftest.py"
+INTEGRATION_CONFTEST = PROJECT_ROOT / "tests" / "integration" / "conftest.py"
+LIVE_TEST_PATHS = (
+    ROOT_CONFTEST,
+    INTEGRATION_CONFTEST,
+    PROJECT_ROOT / "tests" / "integration" / "storage",
+    PROJECT_ROOT / "tests" / "integration" / "adapters" / "_storage_bridge_helpers.py",
+    PROJECT_ROOT / "tests" / "integration" / "adapters" / "asyncpg" / "test_storage_bridge.py",
+    PROJECT_ROOT / "tests" / "integration" / "adapters" / "duckdb" / "test_storage_bridge.py",
+    PROJECT_ROOT / "tests" / "integration" / "adapters" / "psqlpy" / "test_storage_bridge.py",
+    PROJECT_ROOT / "tests" / "integration" / "adapters" / "psycopg" / "test_storage_bridge.py",
+)
+STALE_MINIO_MARKERS = (
+    "from minio import",
+    "MinioService",
+    "minio_client",
+    "minio_default_bucket_name",
+    "pytest_databases.docker.minio",
+    "register_minio_alias",
+)
+
+
+def _read_live_test_text() -> str:
+    parts: list[str] = []
+    for path in LIVE_TEST_PATHS:
+        if path.is_dir():
+            parts.extend(child.read_text(encoding="utf-8") for child in sorted(path.rglob("*.py")))
+        else:
+            parts.append(path.read_text(encoding="utf-8"))
+    return "\n".join(parts)
+
+
+def test_pytest_databases_test_extra_uses_rustfs_capable_release() -> None:
+    pyproject = tomli.loads((PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    test_deps = pyproject["dependency-groups"]["test"]
+    pytest_databases_deps = [dep for dep in test_deps if dep.startswith("pytest-databases")]
+
+    assert pytest_databases_deps == ["pytest-databases[postgres,oracle,bigquery,spanner]>=0.18.0"]
+
+
+def test_live_tests_use_rustfs_fixture_instead_of_minio_client() -> None:
+    live_test_text = _read_live_test_text()
+    root_conftest_text = ROOT_CONFTEST.read_text(encoding="utf-8")
+
+    assert "rustfs" not in root_conftest_text.lower()
+    assert "pytest_databases.docker.rustfs" in live_test_text
+    assert "rustfs_service" in live_test_text
+    assert "rustfs_default_bucket_name" in live_test_text
+    for marker in STALE_MINIO_MARKERS:
+        assert marker not in live_test_text

--- a/uv.lock
+++ b/uv.lock
@@ -417,54 +417,6 @@ wheels = [
 ]
 
 [[package]]
-name = "argon2-cffi"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "argon2-cffi-bindings" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
-]
-
-[[package]]
-name = "argon2-cffi-bindings"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
-    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
-    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
-    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
-    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
-    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
-    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
-    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
-    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
-    { url = "https://files.pythonhosted.org/packages/11/2d/ba4e4ca8d149f8dcc0d952ac0967089e1d759c7e5fcf0865a317eb680fbb/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:6dca33a9859abf613e22733131fc9194091c1fa7cb3e131c143056b4856aa47e", size = 24549, upload-time = "2025-07-30T10:02:00.101Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/82/9b2386cc75ac0bd3210e12a44bfc7fd1632065ed8b80d573036eecb10442/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:21378b40e1b8d1655dd5310c84a40fc19a9aa5e6366e835ceb8576bf0fea716d", size = 25539, upload-time = "2025-07-30T10:02:00.929Z" },
-    { url = "https://files.pythonhosted.org/packages/31/db/740de99a37aa727623730c90d92c22c9e12585b3c98c54b7960f7810289f/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d588dec224e2a83edbdc785a5e6f3c6cd736f46bfd4b441bbb5aa1f5085e584", size = 28467, upload-time = "2025-07-30T10:02:02.08Z" },
-    { url = "https://files.pythonhosted.org/packages/71/7a/47c4509ea18d755f44e2b92b7178914f0c113946d11e16e626df8eaa2b0b/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5acb4e41090d53f17ca1110c3427f0a130f944b896fc8c83973219c97f57b690", size = 27355, upload-time = "2025-07-30T10:02:02.867Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/82/82745642d3c46e7cea25e1885b014b033f4693346ce46b7f47483cf5d448/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:da0c79c23a63723aa5d782250fbf51b768abca630285262fb5144ba5ae01e520", size = 29187, upload-time = "2025-07-30T10:02:03.674Z" },
-]
-
-[[package]]
 name = "ast-serialize"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1498,7 +1450,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1952,7 +1904,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-aiplatform"
-version = "1.151.0"
+version = "1.152.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
@@ -1968,9 +1920,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/f6/e2fbe175a011f5080da8c1f7d9169a6875a00ea2c7bee4193d952b097400/google_cloud_aiplatform-1.151.0.tar.gz", hash = "sha256:2f29b1853f790a7371a746c747bf1f664380b534254682441acd4b5ee26fafd2", size = 10617421, upload-time = "2026-05-07T21:56:52.91Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/a7/71de0f281e6040c70c3ead54b8c92f1c11f45361461b238c94836887bd10/google_cloud_aiplatform-1.152.0.tar.gz", hash = "sha256:1b77d3ca4e7a5c4996d2da28ac2bed1007a1fdea10a882750f51f5b1119a02a6", size = 10625966, upload-time = "2026-05-12T17:19:51.533Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/4a/cd35f8ba622d563b1335222284d2838aa789b953b40516b1b997e50fe5b6/google_cloud_aiplatform-1.151.0-py2.py3-none-any.whl", hash = "sha256:61372bb0923b14b8027f45b83393452df3a85bf4ea86fa48e08844fb5ec50049", size = 8732627, upload-time = "2026-05-07T21:56:49.014Z" },
+    { url = "https://files.pythonhosted.org/packages/23/a0/cc370743763ea3a09aa57bd0ea7678803a0247dc5de60ddd3ebc69dfb53d/google_cloud_aiplatform-1.152.0-py2.py3-none-any.whl", hash = "sha256:ebf5709913490d9007f358d0ef6f36f92db25390df3a12221c4c54db4cf36da4", size = 8739877, upload-time = "2026-05-12T17:19:47.721Z" },
 ]
 
 [package.optional-dependencies]
@@ -3375,22 +3327,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
-name = "minio"
-version = "7.2.20"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "argon2-cffi" },
-    { name = "certifi" },
-    { name = "pycryptodome" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/40/df/6dfc6540f96a74125a11653cce717603fd5b7d0001a8e847b3e54e72d238/minio-7.2.20.tar.gz", hash = "sha256:95898b7a023fbbfde375985aa77e2cd6a0762268db79cf886f002a9ea8e68598", size = 136113, upload-time = "2025-11-27T00:37:15.569Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/9a/b697530a882588a84db616580f2ba5d1d515c815e11c30d219145afeec87/minio-7.2.20-py3-none-any.whl", hash = "sha256:eb33dd2fb80e04c3726a76b13241c6be3c4c46f8d81e1d58e757786f6501897e", size = 93751, upload-time = "2025-11-27T00:37:13.993Z" },
 ]
 
 [[package]]
@@ -5325,41 +5261,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pycryptodome"
-version = "3.23.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/a6/8452177684d5e906854776276ddd34eca30d1b1e15aa1ee9cefc289a33f5/pycryptodome-3.23.0.tar.gz", hash = "sha256:447700a657182d60338bab09fdb27518f8856aecd80ae4c6bdddb67ff5da44ef", size = 4921276, upload-time = "2025-05-17T17:21:45.242Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/5d/bdb09489b63cd34a976cc9e2a8d938114f7a53a74d3dd4f125ffa49dce82/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0011f7f00cdb74879142011f95133274741778abba114ceca229adbf8e62c3e4", size = 2495152, upload-time = "2025-05-17T17:20:20.833Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/ce/7840250ed4cc0039c433cd41715536f926d6e86ce84e904068eb3244b6a6/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:90460fc9e088ce095f9ee8356722d4f10f86e5be06e2354230a9880b9c549aae", size = 1639348, upload-time = "2025-05-17T17:20:23.171Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/f0/991da24c55c1f688d6a3b5a11940567353f74590734ee4a64294834ae472/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4764e64b269fc83b00f682c47443c2e6e85b18273712b98aa43bcb77f8570477", size = 2184033, upload-time = "2025-05-17T17:20:25.424Z" },
-    { url = "https://files.pythonhosted.org/packages/54/16/0e11882deddf00f68b68dd4e8e442ddc30641f31afeb2bc25588124ac8de/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb8f24adb74984aa0e5d07a2368ad95276cf38051fe2dc6605cbcf482e04f2a7", size = 2270142, upload-time = "2025-05-17T17:20:27.808Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/fc/4347fea23a3f95ffb931f383ff28b3f7b1fe868739182cb76718c0da86a1/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d97618c9c6684a97ef7637ba43bdf6663a2e2e77efe0f863cce97a76af396446", size = 2309384, upload-time = "2025-05-17T17:20:30.765Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/d9/c5261780b69ce66d8cfab25d2797bd6e82ba0241804694cd48be41add5eb/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9a53a4fe5cb075075d515797d6ce2f56772ea7e6a1e5e4b96cf78a14bac3d265", size = 2183237, upload-time = "2025-05-17T17:20:33.736Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/6f/3af2ffedd5cfa08c631f89452c6648c4d779e7772dfc388c77c920ca6bbf/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:763d1d74f56f031788e5d307029caef067febf890cd1f8bf61183ae142f1a77b", size = 2343898, upload-time = "2025-05-17T17:20:36.086Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/dc/9060d807039ee5de6e2f260f72f3d70ac213993a804f5e67e0a73a56dd2f/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:954af0e2bd7cea83ce72243b14e4fb518b18f0c1649b576d114973e2073b273d", size = 2269197, upload-time = "2025-05-17T17:20:38.414Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/34/e6c8ca177cb29dcc4967fef73f5de445912f93bd0343c9c33c8e5bf8cde8/pycryptodome-3.23.0-cp313-cp313t-win32.whl", hash = "sha256:257bb3572c63ad8ba40b89f6fc9d63a2a628e9f9708d31ee26560925ebe0210a", size = 1768600, upload-time = "2025-05-17T17:20:40.688Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/1d/89756b8d7ff623ad0160f4539da571d1f594d21ee6d68be130a6eccb39a4/pycryptodome-3.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6501790c5b62a29fcb227bd6b62012181d886a767ce9ed03b303d1f22eb5c625", size = 1799740, upload-time = "2025-05-17T17:20:42.413Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/61/35a64f0feaea9fd07f0d91209e7be91726eb48c0f1bfc6720647194071e4/pycryptodome-3.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9a77627a330ab23ca43b48b130e202582e91cc69619947840ea4d2d1be21eb39", size = 1703685, upload-time = "2025-05-17T17:20:44.388Z" },
-    { url = "https://files.pythonhosted.org/packages/db/6c/a1f71542c969912bb0e106f64f60a56cc1f0fabecf9396f45accbe63fa68/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:187058ab80b3281b1de11c2e6842a357a1f71b42cb1e15bce373f3d238135c27", size = 2495627, upload-time = "2025-05-17T17:20:47.139Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/4e/a066527e079fc5002390c8acdd3aca431e6ea0a50ffd7201551175b47323/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:cfb5cd445280c5b0a4e6187a7ce8de5a07b5f3f897f235caa11f1f435f182843", size = 1640362, upload-time = "2025-05-17T17:20:50.392Z" },
-    { url = "https://files.pythonhosted.org/packages/50/52/adaf4c8c100a8c49d2bd058e5b551f73dfd8cb89eb4911e25a0c469b6b4e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67bd81fcbe34f43ad9422ee8fd4843c8e7198dd88dd3d40e6de42ee65fbe1490", size = 2182625, upload-time = "2025-05-17T17:20:52.866Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/e9/a09476d436d0ff1402ac3867d933c61805ec2326c6ea557aeeac3825604e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8987bd3307a39bc03df5c8e0e3d8be0c4c3518b7f044b0f4c15d1aa78f52575", size = 2268954, upload-time = "2025-05-17T17:20:55.027Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/c5/ffe6474e0c551d54cab931918127c46d70cab8f114e0c2b5a3c071c2f484/pycryptodome-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa0698f65e5b570426fc31b8162ed4603b0c2841cbb9088e2b01641e3065915b", size = 2308534, upload-time = "2025-05-17T17:20:57.279Z" },
-    { url = "https://files.pythonhosted.org/packages/18/28/e199677fc15ecf43010f2463fde4c1a53015d1fe95fb03bca2890836603a/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:53ecbafc2b55353edcebd64bf5da94a2a2cdf5090a6915bcca6eca6cc452585a", size = 2181853, upload-time = "2025-05-17T17:20:59.322Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/ea/4fdb09f2165ce1365c9eaefef36625583371ee514db58dc9b65d3a255c4c/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:156df9667ad9f2ad26255926524e1c136d6664b741547deb0a86a9acf5ea631f", size = 2342465, upload-time = "2025-05-17T17:21:03.83Z" },
-    { url = "https://files.pythonhosted.org/packages/22/82/6edc3fc42fe9284aead511394bac167693fb2b0e0395b28b8bedaa07ef04/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:dea827b4d55ee390dc89b2afe5927d4308a8b538ae91d9c6f7a5090f397af1aa", size = 2267414, upload-time = "2025-05-17T17:21:06.72Z" },
-    { url = "https://files.pythonhosted.org/packages/59/fe/aae679b64363eb78326c7fdc9d06ec3de18bac68be4b612fc1fe8902693c/pycryptodome-3.23.0-cp37-abi3-win32.whl", hash = "sha256:507dbead45474b62b2bbe318eb1c4c8ee641077532067fec9c1aa82c31f84886", size = 1768484, upload-time = "2025-05-17T17:21:08.535Z" },
-    { url = "https://files.pythonhosted.org/packages/54/2f/e97a1b8294db0daaa87012c24a7bb714147c7ade7656973fd6c736b484ff/pycryptodome-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:c75b52aacc6c0c260f204cbdd834f76edc9fb0d8e0da9fbf8352ef58202564e2", size = 1799636, upload-time = "2025-05-17T17:21:10.393Z" },
-    { url = "https://files.pythonhosted.org/packages/18/3d/f9441a0d798bf2b1e645adc3265e55706aead1255ccdad3856dbdcffec14/pycryptodome-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:11eeeb6917903876f134b56ba11abe95c0b0fd5e3330def218083c7d98bbcb3c", size = 1703675, upload-time = "2025-05-17T17:21:13.146Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/12/e33935a0709c07de084d7d58d330ec3f4daf7910a18e77937affdb728452/pycryptodome-3.23.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:ddb95b49df036ddd264a0ad246d1be5b672000f12d6961ea2c267083a5e19379", size = 1623886, upload-time = "2025-05-17T17:21:20.614Z" },
-    { url = "https://files.pythonhosted.org/packages/22/0b/aa8f9419f25870889bebf0b26b223c6986652bdf071f000623df11212c90/pycryptodome-3.23.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e95564beb8782abfd9e431c974e14563a794a4944c29d6d3b7b5ea042110b4", size = 1672151, upload-time = "2025-05-17T17:21:22.666Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/5e/63f5cbde2342b7f70a39e591dbe75d9809d6338ce0b07c10406f1a140cdc/pycryptodome-3.23.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14e15c081e912c4b0d75632acd8382dfce45b258667aa3c67caf7a4d4c13f630", size = 1664461, upload-time = "2025-05-17T17:21:25.225Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/92/608fbdad566ebe499297a86aae5f2a5263818ceeecd16733006f1600403c/pycryptodome-3.23.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a7fc76bf273353dc7e5207d172b83f569540fc9a28d63171061c42e361d22353", size = 1702440, upload-time = "2025-05-17T17:21:27.991Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/92/2eadd1341abd2989cce2e2740b4423608ee2014acb8110438244ee97d7ff/pycryptodome-3.23.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:45c69ad715ca1a94f778215a11e66b7ff989d792a4d63b68dc586a1da1392ff5", size = 1803005, upload-time = "2025-05-17T17:21:31.37Z" },
-]
-
-[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -5738,27 +5639,21 @@ wheels = [
 
 [[package]]
 name = "pytest-databases"
-version = "0.17.0"
+version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docker" },
     { name = "filelock" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/7f/58e6de47d1c4c59c1c31a8c8fb181a50bfe2737bcce5fe85a896cfb09b0b/pytest_databases-0.17.0.tar.gz", hash = "sha256:3918c932877d0b4e1252084fcae98fd4ee0315a6adc7409510e4fea8af5adf47", size = 330299, upload-time = "2026-03-10T19:33:46.227Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ce/e0458cdb8d84b14156392b4bbc5575b6145b4ae6c3962a500e3d66002da3/pytest_databases-0.18.0.tar.gz", hash = "sha256:d49fa4e85494ec33dd6224affada1ddfdb83736b28f5ae40377220ad5dbbb658", size = 324907, upload-time = "2026-05-12T13:43:52.438Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/34/acedc8d44ac86a62f1e3576c1adeba92479bf115962b0925c8d87e664bfb/pytest_databases-0.17.0-py3-none-any.whl", hash = "sha256:d7831c0a5a4fd06b87902e95447b2e4b52ec8910d34ad94c6222e75db6950327", size = 33318, upload-time = "2026-03-10T19:33:43.824Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/129e2529248eceb422e9051f408f752a78c80628700ffde94cc9edbf2d9d/pytest_databases-0.18.0-py3-none-any.whl", hash = "sha256:e2114c9e36ec7f4ff118453e9511e5cffb85294214838a70a8dee36c40340bd1", size = 40309, upload-time = "2026-05-12T13:43:51.033Z" },
 ]
 
 [package.optional-dependencies]
 bigquery = [
     { name = "google-cloud-bigquery" },
-]
-minio = [
-    { name = "minio" },
-]
-mysql = [
-    { name = "mysql-connector-python" },
 ]
 oracle = [
     { name = "oracledb" },
@@ -7161,7 +7056,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-databases", extra = ["bigquery", "minio", "mysql", "oracle", "postgres", "spanner"] },
+    { name = "pytest-databases", extra = ["bigquery", "oracle", "postgres", "spanner"] },
     { name = "pytest-mock" },
     { name = "pytest-sugar" },
     { name = "pytest-timeout" },
@@ -7265,7 +7160,7 @@ test = [
     { name = "coverage" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-databases", extra = ["bigquery", "minio", "mysql", "oracle", "postgres", "spanner"] },
+    { name = "pytest-databases", extra = ["bigquery", "oracle", "postgres", "spanner"] },
     { name = "pytest-mock" },
     { name = "pytest-sugar" },
     { name = "pytest-timeout" },
@@ -7380,7 +7275,7 @@ dev = [
     { name = "pyright", specifier = ">=1.1.386" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
-    { name = "pytest-databases", extras = ["postgres", "oracle", "mysql", "bigquery", "spanner", "minio"], specifier = ">=0.17.0" },
+    { name = "pytest-databases", extras = ["postgres", "oracle", "bigquery", "spanner"], specifier = ">=0.18.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "pytest-sugar", specifier = ">=1.0.0" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
@@ -7470,7 +7365,7 @@ test = [
     { name = "coverage", specifier = ">=7.6.1" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
-    { name = "pytest-databases", extras = ["postgres", "oracle", "mysql", "bigquery", "spanner", "minio"], specifier = ">=0.17.0" },
+    { name = "pytest-databases", extras = ["postgres", "oracle", "bigquery", "spanner"], specifier = ">=0.18.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "pytest-sugar", specifier = ">=1.0.0" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
@@ -8057,7 +7952,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.3.1"
+version = "21.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -8066,9 +7961,9 @@ dependencies = [
     { name = "python-discovery" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/0d/915c02c94d207b85580eb09bffab54438a709e7288524094fe781da526c2/virtualenv-21.3.1.tar.gz", hash = "sha256:c2305bc1fddeec40699b8370d13f8d431b0701f00ce895061ce493aeded4426b", size = 7613791, upload-time = "2026-05-05T01:34:31.402Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/e1/665267cea4767debd19f584667a9197c2098b5e7f67a502da9f3a086ab37/virtualenv-21.3.2.tar.gz", hash = "sha256:3ecda97894a6fc1c53106356f488690e5c86278c1f693f3fc0805ac85a513686", size = 7613810, upload-time = "2026-05-12T14:44:18.01Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/4f/f71e641e504111a5a74e3a20bc52d01bd86788b22699dd3fee1c63253cf6/virtualenv-21.3.1-py3-none-any.whl", hash = "sha256:d1a71cf58f2f9228fff23a1f6ec15d39785c6b32e03658d104974247145edd35", size = 7594539, upload-time = "2026-05-05T01:34:28.98Z" },
+    { url = "https://files.pythonhosted.org/packages/20/5b/885f479093f6627669d39b57bc3d4e674da532e1a4b247d473a61d8d2118/virtualenv-21.3.2-py3-none-any.whl", hash = "sha256:c58ea748fa50bb2a4367da5ba3d30b02458ed40b4ea888faad94021f3309f764", size = 7594558, upload-time = "2026-05-12T14:44:15.193Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- upgrade pytest-databases test dependency to 0.18.0 and drop removed mysql/minio extras
- move S3-compatible integration fixtures from MinIO to RustFS, scoped under tests/integration instead of the root conftest
- add RustFS bucket readiness/helpers and retarget storage plus adapter bridge tests