### PR TITLE
fix: repair Litestar NumPy serializer integration

### DIFF
--- a/sqlspec/extensions/litestar/plugin.py
+++ b/sqlspec/extensions/litestar/plugin.py
@@ -106,141 +106,6 @@ def not_found_error_handler(_request: "Request[Any, Any, Any]", exc: NotFoundErr
     raise NotFoundException(detail=detail) from exc
 
 
-class _OffsetPaginationSchemaPlugin(OpenAPISchemaPlugin):
-    """OpenAPI schema plugin expanding OffsetPagination[T] into a concrete schema.
-
-    Defense-in-depth for sqlspec.core.filters.OffsetPagination. The msgspec.Struct
-    conversion already lets Litestar's default generator produce a correct schema;
-    this plugin guarantees the shape even if future Litestar or msgspec changes
-    break auto-detection.
-    """
-
-    @staticmethod
-    def is_plugin_supported_type(value: Any) -> bool:
-        origin = getattr(value, "__origin__", value)
-        return isinstance(origin, type) and issubclass(origin, OffsetPagination)
-
-    def to_openapi_schema(self, field_definition: "FieldDefinition", schema_creator: "SchemaCreator") -> "Schema":
-        from litestar.openapi.spec import OpenAPIType, Schema
-        from litestar.typing import FieldDefinition
-
-        inner_type: Any = Any
-        inner_args = getattr(field_definition, "inner_types", ())
-        if inner_args:
-            inner_type = inner_args[0].annotation
-
-        item_schema = schema_creator.for_field_definition(FieldDefinition.from_annotation(inner_type))
-
-        return Schema(
-            type=OpenAPIType.OBJECT,
-            properties={
-                "items": Schema(type=OpenAPIType.ARRAY, items=item_schema),
-                "limit": Schema(type=OpenAPIType.INTEGER),
-                "offset": Schema(type=OpenAPIType.INTEGER),
-                "total": Schema(type=OpenAPIType.INTEGER),
-            },
-            required=["items", "limit", "offset", "total"],
-        )
-
-
-class _NumpySignatureNamespace:
-    """Proxy ``numpy`` module namespace that maps ``ndarray`` to SQLSpec's decoder-safe subclass."""
-
-    __slots__ = ("_numpy", "ndarray")
-
-    def __init__(self, numpy_module: Any, ndarray_type: type[Any]) -> None:
-        self._numpy = numpy_module
-        self.ndarray = ndarray_type
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._numpy, name)
-
-
-def _get_litestar_numpy_array_type() -> type[Any] | None:
-    """Return a mutable ndarray subclass Litestar can attach a decoder to."""
-    if not NUMPY_INSTALLED:
-        return None
-
-    global _LITESTAR_NUMPY_ARRAY_TYPE
-    if _LITESTAR_NUMPY_ARRAY_TYPE is None:
-        import numpy as np
-
-        class SQLSpecNumpyArray(np.ndarray):
-            pass
-
-        _LITESTAR_NUMPY_ARRAY_TYPE = SQLSpecNumpyArray
-    return _LITESTAR_NUMPY_ARRAY_TYPE
-
-
-def _litestar_numpy_array_predicate(target_type: Any) -> bool:
-    ndarray_type = _get_litestar_numpy_array_type()
-    return ndarray_type is not None and target_type is ndarray_type
-
-
-def _litestar_numpy_array_dec_hook(target_type: type[Any], value: Any) -> Any:
-    decoded = numpy_array_dec_hook(target_type, value)
-    if NUMPY_INSTALLED:
-        import numpy as np
-
-        if isinstance(decoded, np.ndarray) and isinstance(target_type, type) and not isinstance(decoded, target_type):
-            return decoded.view(target_type)
-    return decoded
-
-
-def _normalize_header_list(headers: Any) -> list[str]:
-    if headers is None:
-        return []
-    if isinstance(headers, str):
-        return [headers.lower()]
-    if isinstance(headers, Iterable):
-        normalized: list[str] = []
-        for header in headers:
-            if not isinstance(header, str):
-                msg = "litestar correlation headers must be strings"
-                raise ImproperConfigurationError(msg)
-            normalized.append(header.lower())
-        return normalized
-    msg = "litestar correlation_headers must be a string or iterable of strings"
-    raise ImproperConfigurationError(msg)
-
-
-def _dedupe_headers(headers: Iterable[str]) -> list[str]:
-    seen: set[str] = set()
-    ordered: list[str] = []
-    for header in headers:
-        lowered = header.lower()
-        if lowered in seen or not lowered:
-            continue
-        seen.add(lowered)
-        ordered.append(lowered)
-    return ordered
-
-
-def _build_correlation_headers(*, primary: str, configured: list[str], auto_trace_headers: bool) -> tuple[str, ...]:
-    header_order: list[str] = [primary.lower()]
-    header_order.extend(configured)
-    if auto_trace_headers:
-        header_order.extend(TRACE_CONTEXT_FALLBACK_HEADERS)
-    return tuple(_dedupe_headers(header_order))
-
-
-def _build_litestar_type_decoders() -> "list[tuple[Callable[[Any], bool], Callable[[type, Any], Any]]]":
-    """Build the Litestar-specific ``type_decoders`` list.
-
-    Decoders are predicate-tuples consumed by Litestar's request-body parsing,
-    not part of sqlspec's serializer registry — so they live here rather than
-    in :data:`sqlspec.utils.serializers.DEFAULT_TYPE_ENCODERS`.
-    """
-    decoders: list[tuple[Callable[[Any], bool], Callable[[type, Any], Any]]] = []
-    if NUMPY_INSTALLED:
-        decoders.append((_litestar_numpy_array_predicate, _litestar_numpy_array_dec_hook))
-    with suppress(ImportError):
-        import uuid_utils  # pyright: ignore[reportMissingImports]
-
-        decoders.append((lambda t: t is uuid_utils.UUID, lambda t, v: t(str(v))))
-    return decoders
-
-
 class CorrelationMiddleware:
     __slots__ = ("_app", "_headers")
 
@@ -1064,3 +929,138 @@ class SQLCommenterMiddleware:
             await self.app(scope, receive, send)
         finally:
             SQLCommenterContext.set(previous)
+
+
+class _OffsetPaginationSchemaPlugin(OpenAPISchemaPlugin):
+    """OpenAPI schema plugin expanding OffsetPagination[T] into a concrete schema.
+
+    Defense-in-depth for sqlspec.core.filters.OffsetPagination. The msgspec.Struct
+    conversion already lets Litestar's default generator produce a correct schema;
+    this plugin guarantees the shape even if future Litestar or msgspec changes
+    break auto-detection.
+    """
+
+    @staticmethod
+    def is_plugin_supported_type(value: Any) -> bool:
+        origin = getattr(value, "__origin__", value)
+        return isinstance(origin, type) and issubclass(origin, OffsetPagination)
+
+    def to_openapi_schema(self, field_definition: "FieldDefinition", schema_creator: "SchemaCreator") -> "Schema":
+        from litestar.openapi.spec import OpenAPIType, Schema
+        from litestar.typing import FieldDefinition
+
+        inner_type: Any = Any
+        inner_args = getattr(field_definition, "inner_types", ())
+        if inner_args:
+            inner_type = inner_args[0].annotation
+
+        item_schema = schema_creator.for_field_definition(FieldDefinition.from_annotation(inner_type))
+
+        return Schema(
+            type=OpenAPIType.OBJECT,
+            properties={
+                "items": Schema(type=OpenAPIType.ARRAY, items=item_schema),
+                "limit": Schema(type=OpenAPIType.INTEGER),
+                "offset": Schema(type=OpenAPIType.INTEGER),
+                "total": Schema(type=OpenAPIType.INTEGER),
+            },
+            required=["items", "limit", "offset", "total"],
+        )
+
+
+class _NumpySignatureNamespace:
+    """Proxy ``numpy`` module namespace that maps ``ndarray`` to SQLSpec's decoder-safe subclass."""
+
+    __slots__ = ("_numpy", "ndarray")
+
+    def __init__(self, numpy_module: Any, ndarray_type: type[Any]) -> None:
+        self._numpy = numpy_module
+        self.ndarray = ndarray_type
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._numpy, name)
+
+
+def _normalize_header_list(headers: Any) -> list[str]:
+    if headers is None:
+        return []
+    if isinstance(headers, str):
+        return [headers.lower()]
+    if isinstance(headers, Iterable):
+        normalized: list[str] = []
+        for header in headers:
+            if not isinstance(header, str):
+                msg = "litestar correlation headers must be strings"
+                raise ImproperConfigurationError(msg)
+            normalized.append(header.lower())
+        return normalized
+    msg = "litestar correlation_headers must be a string or iterable of strings"
+    raise ImproperConfigurationError(msg)
+
+
+def _dedupe_headers(headers: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for header in headers:
+        lowered = header.lower()
+        if lowered in seen or not lowered:
+            continue
+        seen.add(lowered)
+        ordered.append(lowered)
+    return ordered
+
+
+def _build_correlation_headers(*, primary: str, configured: list[str], auto_trace_headers: bool) -> tuple[str, ...]:
+    header_order: list[str] = [primary.lower()]
+    header_order.extend(configured)
+    if auto_trace_headers:
+        header_order.extend(TRACE_CONTEXT_FALLBACK_HEADERS)
+    return tuple(_dedupe_headers(header_order))
+
+
+def _get_litestar_numpy_array_type() -> type[Any] | None:
+    """Return a mutable ndarray subclass Litestar can attach a decoder to."""
+    if not NUMPY_INSTALLED:
+        return None
+
+    global _LITESTAR_NUMPY_ARRAY_TYPE
+    if _LITESTAR_NUMPY_ARRAY_TYPE is None:
+        import numpy as np
+
+        class SQLSpecNumpyArray(np.ndarray):
+            pass
+
+        _LITESTAR_NUMPY_ARRAY_TYPE = SQLSpecNumpyArray
+    return _LITESTAR_NUMPY_ARRAY_TYPE
+
+
+def _litestar_numpy_array_predicate(target_type: Any) -> bool:
+    ndarray_type = _get_litestar_numpy_array_type()
+    return ndarray_type is not None and target_type is ndarray_type
+
+
+def _litestar_numpy_array_dec_hook(target_type: type[Any], value: Any) -> Any:
+    decoded = numpy_array_dec_hook(target_type, value)
+    if NUMPY_INSTALLED:
+        import numpy as np
+
+        if isinstance(decoded, np.ndarray) and isinstance(target_type, type) and not isinstance(decoded, target_type):
+            return decoded.view(target_type)
+    return decoded
+
+
+def _build_litestar_type_decoders() -> "list[tuple[Callable[[Any], bool], Callable[[type, Any], Any]]]":
+    """Build the Litestar-specific ``type_decoders`` list.
+
+    Decoders are predicate-tuples consumed by Litestar's request-body parsing,
+    not part of sqlspec's serializer registry — so they live here rather than
+    in :data:`sqlspec.utils.serializers.DEFAULT_TYPE_ENCODERS`.
+    """
+    decoders: list[tuple[Callable[[Any], bool], Callable[[type, Any], Any]]] = []
+    if NUMPY_INSTALLED:
+        decoders.append((_litestar_numpy_array_predicate, _litestar_numpy_array_dec_hook))
+    with suppress(ImportError):
+        import uuid_utils  # pyright: ignore[reportMissingImports]
+
+        decoders.append((lambda t: t is uuid_utils.UUID, lambda t, v: t(str(v))))
+    return decoders

--- a/sqlspec/extensions/litestar/plugin.py
+++ b/sqlspec/extensions/litestar/plugin.py
@@ -39,7 +39,7 @@ from sqlspec.extensions.litestar.handlers import (
 from sqlspec.typing import NUMPY_INSTALLED, ConnectionT, PoolT, SchemaT
 from sqlspec.utils.correlation import CorrelationContext
 from sqlspec.utils.logging import get_logger, log_with_context
-from sqlspec.utils.serializers import DEFAULT_TYPE_ENCODERS, numpy_array_dec_hook, numpy_array_predicate
+from sqlspec.utils.serializers import DEFAULT_TYPE_ENCODERS, numpy_array_dec_hook
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Callable
@@ -76,6 +76,7 @@ TRACE_CONTEXT_FALLBACK_HEADERS: tuple[str, ...] = (
     "x-client-trace-id",
 )
 CORRELATION_STATE_KEY = "sqlspec_correlation_id"
+_LITESTAR_NUMPY_ARRAY_TYPE: type[Any] | None = None
 
 __all__ = (
     "CORRELATION_STATE_KEY",
@@ -142,6 +143,50 @@ class _OffsetPaginationSchemaPlugin(OpenAPISchemaPlugin):
         )
 
 
+class _NumpySignatureNamespace:
+    """Proxy ``numpy`` module namespace that maps ``ndarray`` to SQLSpec's decoder-safe subclass."""
+
+    __slots__ = ("_numpy", "ndarray")
+
+    def __init__(self, numpy_module: Any, ndarray_type: type[Any]) -> None:
+        self._numpy = numpy_module
+        self.ndarray = ndarray_type
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._numpy, name)
+
+
+def _get_litestar_numpy_array_type() -> type[Any] | None:
+    """Return a mutable ndarray subclass Litestar can attach a decoder to."""
+    if not NUMPY_INSTALLED:
+        return None
+
+    global _LITESTAR_NUMPY_ARRAY_TYPE
+    if _LITESTAR_NUMPY_ARRAY_TYPE is None:
+        import numpy as np
+
+        class SQLSpecNumpyArray(np.ndarray):
+            pass
+
+        _LITESTAR_NUMPY_ARRAY_TYPE = SQLSpecNumpyArray
+    return _LITESTAR_NUMPY_ARRAY_TYPE
+
+
+def _litestar_numpy_array_predicate(target_type: Any) -> bool:
+    ndarray_type = _get_litestar_numpy_array_type()
+    return ndarray_type is not None and target_type is ndarray_type
+
+
+def _litestar_numpy_array_dec_hook(target_type: type[Any], value: Any) -> Any:
+    decoded = numpy_array_dec_hook(target_type, value)
+    if NUMPY_INSTALLED:
+        import numpy as np
+
+        if isinstance(decoded, np.ndarray) and isinstance(target_type, type) and not isinstance(decoded, target_type):
+            return decoded.view(target_type)
+    return decoded
+
+
 def _normalize_header_list(headers: Any) -> list[str]:
     if headers is None:
         return []
@@ -188,7 +233,7 @@ def _build_litestar_type_decoders() -> "list[tuple[Callable[[Any], bool], Callab
     """
     decoders: list[tuple[Callable[[Any], bool], Callable[[type, Any], Any]]] = []
     if NUMPY_INSTALLED:
-        decoders.append((numpy_array_predicate, numpy_array_dec_hook))
+        decoders.append((_litestar_numpy_array_predicate, _litestar_numpy_array_dec_hook))
     with suppress(ImportError):
         import uuid_utils  # pyright: ignore[reportMissingImports]
 
@@ -480,6 +525,16 @@ class SQLSpecPlugin(InitPluginProtocol, CLIPlugin):
 
         if signature_namespace:
             app_config.signature_namespace.update(signature_namespace)
+
+        if NUMPY_INSTALLED and (ndarray_type := _get_litestar_numpy_array_type()) is not None:
+            import numpy as np
+
+            numpy_namespace = _NumpySignatureNamespace(np, ndarray_type)
+            app_config.signature_namespace.update({
+                "np": numpy_namespace,
+                "numpy": numpy_namespace,
+                "ndarray": ndarray_type,
+            })
 
         if not any(isinstance(p, _OffsetPaginationSchemaPlugin) for p in app_config.plugins):
             app_config.plugins.append(_OffsetPaginationSchemaPlugin())

--- a/tests/integration/adapters/aiosqlite/extensions/litestar/test_numpy_serialization.py
+++ b/tests/integration/adapters/aiosqlite/extensions/litestar/test_numpy_serialization.py
@@ -4,6 +4,7 @@ Tests automatic NumPy array encoding/decoding in HTTP request/response cycles.
 """
 
 import tempfile
+from typing import Any
 
 import pytest
 
@@ -55,6 +56,24 @@ def test_litestar_numpy_decoder_registered() -> None:
         assert len(app.type_decoders) > 0
 
 
+def test_litestar_numpy_direct_annotation_registration() -> None:
+    """The decoder predicate must not make Litestar mutate immutable ``np.ndarray`` during registration."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=True) as tmp:
+        sql = SQLSpec()
+        config = AiosqliteConfig(
+            connection_config={"database": tmp.name}, extension_config={"litestar": {"commit_mode": "manual"}}
+        )
+        sql.add_config(config)
+
+        @post("/vector")
+        def create_vector(data: np.ndarray, state: State) -> dict[str, bool]:
+            return {"success": isinstance(data, np.ndarray)}
+
+        app = Litestar(route_handlers=[create_vector], plugins=[SQLSpecPlugin(sql)])
+
+        assert app.routes
+
+
 def test_litestar_numpy_response_encoding() -> None:
     """Test that NumPy arrays in responses are automatically encoded to JSON."""
     with tempfile.NamedTemporaryFile(suffix=".db", delete=True) as tmp:
@@ -80,6 +99,29 @@ def test_litestar_numpy_response_encoding() -> None:
             assert data["id"] == 1
             assert data["embedding"] == [0.1, 0.2, 0.3, 0.4, 0.5]
             assert data["dimensions"] == 5
+
+
+def test_litestar_numpy_typed_request_decoding() -> None:
+    """Test NumPy array decoding at a Litestar typed request boundary."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=True) as tmp:
+        sql = SQLSpec()
+        config = AiosqliteConfig(
+            connection_config={"database": tmp.name}, extension_config={"litestar": {"commit_mode": "manual"}}
+        )
+        sql.add_config(config)
+
+        @post("/vector")
+        def create_vector(data: "np.ndarray", state: State) -> dict[str, Any]:
+            assert isinstance(data, np.ndarray)
+            return {"success": True, "dimensions": len(data), "embedding": data}
+
+        app = Litestar(route_handlers=[create_vector], plugins=[SQLSpecPlugin(sql)])
+
+        with TestClient(app) as client:
+            response = client.post("/vector", json=[1.0, 2.0, 3.0])
+
+            assert response.status_code == HTTP_201_CREATED
+            assert response.json() == {"success": True, "dimensions": 3, "embedding": [1.0, 2.0, 3.0]}
 
 
 def test_litestar_numpy_request_decoding() -> None:

--- a/tests/unit/extensions/test_litestar/test_serialization_plugin.py
+++ b/tests/unit/extensions/test_litestar/test_serialization_plugin.py
@@ -18,6 +18,7 @@ from litestar.config.app import AppConfig
 from sqlspec.adapters.aiosqlite.config import AiosqliteConfig
 from sqlspec.base import SQLSpec
 from sqlspec.extensions.litestar.plugin import SQLSpecPlugin
+from sqlspec.typing import NUMPY_INSTALLED
 from sqlspec.utils.serializers import DEFAULT_TYPE_ENCODERS
 
 pytestmark = pytest.mark.xdist_group("extensions_litestar")
@@ -71,6 +72,25 @@ def test_user_decoders_take_precedence_in_list_order() -> None:
 
     assert app_config.type_decoders is not None
     assert app_config.type_decoders[0] == (user_predicate, user_decoder)
+
+
+@pytest.mark.skipif(not NUMPY_INSTALLED, reason="NumPy not installed")
+def test_numpy_decoder_targets_signature_namespace_alias_not_ndarray() -> None:
+    """The NumPy decoder must not match immutable ``np.ndarray`` during Litestar signature construction."""
+    import numpy as np
+
+    plugin = _build_plugin()
+    app_config = AppConfig()
+
+    plugin.on_app_init(app_config)
+
+    ndarray_type = app_config.signature_namespace["ndarray"]
+    assert ndarray_type is not np.ndarray
+    assert issubclass(ndarray_type, np.ndarray)
+    assert app_config.signature_namespace["np"].ndarray is ndarray_type
+    assert app_config.type_decoders is not None
+    assert any(predicate(ndarray_type) for predicate, _ in app_config.type_decoders)
+    assert not any(predicate(np.ndarray) for predicate, _ in app_config.type_decoders)
 
 
 def test_plugin_does_not_set_before_or_after_response_hooks() -> None:


### PR DESCRIPTION
## Summary

- Repair Litestar typed NumPy request decoding by routing `np.ndarray` annotations through the SQLSpecPlugin signature namespace and a Litestar-safe type decoder.
- Keep the serializer parity scope to the accepted surface: `DEFAULT_TYPE_ENCODERS` plus Litestar `SQLSpecPlugin` wiring, without provider/response re-exports.
- Reorganize `sqlspec/extensions/litestar/plugin.py` so public plugin/middleware code comes first and private helpers sit at the bottom.