### PR TITLE
fix: harden Arrow JSON ingest (#452)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -45,6 +45,12 @@ v0.46.2 - Framework Filter ``orderBy`` Aliases (Unreleased)
 
 **Fixed:**
 
+* AsyncPG and CockroachDB AsyncPG connections now register binary ``json`` and
+  ``jsonb`` codecs by default. ``load_from_arrow()`` can bulk load Arrow tables
+  into PostgreSQL ``JSON`` / ``JSONB`` columns without asyncpg rejecting binary
+  ``jsonb`` payloads. (`#452
+  <https://github.com/litestar-org/sqlspec/issues/452>`_)
+
 * Missing named SQL statements now raise ``SQLStatementNotFoundError``, a
   ``SQLFileNotFoundError`` subclass with structured lookup context and bounded
   messages that report the loaded statement count instead of dumping available

--- a/docs/reference/adapters/asyncpg.rst
+++ b/docs/reference/adapters/asyncpg.rst
@@ -12,6 +12,16 @@ Configuration
    :members:
    :show-inheritance:
 
+JSON and JSONB Codecs
+=====================
+
+AsyncPG connections register binary ``json`` and ``jsonb`` codecs by default.
+This lets regular statement execution and ``load_from_arrow()`` pass Python
+``dict`` and ``list`` values into PostgreSQL ``JSON`` / ``JSONB`` columns while
+preserving asyncpg's binary COPY protocol expectations for ``jsonb`` payloads.
+Set ``driver_features={"enable_json_codecs": False}`` when an application needs
+to manage asyncpg JSON codecs manually.
+
 .. autoclass:: sqlspec.adapters.asyncpg.config.AsyncpgPoolConfig
    :members:
    :show-inheritance:

--- a/sqlspec/adapters/aiomysql/driver.py
+++ b/sqlspec/adapters/aiomysql/driver.py
@@ -306,9 +306,14 @@ class AiomysqlDriver(AsyncDriverAdapterBase):
         columns, records = self._arrow_table_to_rows(arrow_table)
         if records:
             insert_sql = build_insert_statement(table, columns)
+            prepared_records = (
+                self.prepare_driver_parameters(records, self.statement_config, is_many=True)
+                if self._arrow_table_needs_parameter_preparation(arrow_table)
+                else records
+            )
             exc_handler = self.handle_database_exceptions()
             async with exc_handler, self.with_cursor(self.connection) as cursor:
-                await cursor.executemany(insert_sql, records)
+                await cursor.executemany(insert_sql, prepared_records)
             if exc_handler.pending_exception is not None:
                 raise exc_handler.pending_exception from None
 

--- a/sqlspec/adapters/aiosqlite/driver.py
+++ b/sqlspec/adapters/aiosqlite/driver.py
@@ -240,9 +240,14 @@ class AiosqliteDriver(AsyncDriverAdapterBase):
         columns, records = self._arrow_table_to_rows(arrow_table)
         if records:
             insert_sql = build_insert_statement(table, columns)
+            prepared_records = (
+                self.prepare_driver_parameters(records, self.statement_config, is_many=True)
+                if self._arrow_table_needs_parameter_preparation(arrow_table)
+                else records
+            )
             try:
                 async with self.with_cursor(self.connection) as cursor:
-                    await cursor.executemany(insert_sql, records)
+                    await cursor.executemany(insert_sql, cast("Any", prepared_records))
             except (aiosqlite.Error, sqlite3.Error) as exc:
                 raise create_mapped_exception(exc) from exc
 

--- a/sqlspec/adapters/asyncmy/driver.py
+++ b/sqlspec/adapters/asyncmy/driver.py
@@ -311,9 +311,14 @@ class AsyncmyDriver(AsyncDriverAdapterBase):
         columns, records = self._arrow_table_to_rows(arrow_table)
         if records:
             insert_sql = build_insert_statement(table, columns)
+            prepared_records = (
+                self.prepare_driver_parameters(records, self.statement_config, is_many=True)
+                if self._arrow_table_needs_parameter_preparation(arrow_table)
+                else records
+            )
             exc_handler = self.handle_database_exceptions()
             async with exc_handler, self.with_cursor(self.connection) as cursor:
-                await cursor.executemany(insert_sql, records)
+                await cursor.executemany(insert_sql, prepared_records)
             if exc_handler.pending_exception is not None:
                 raise exc_handler.pending_exception from None
 

--- a/sqlspec/adapters/asyncpg/core.py
+++ b/sqlspec/adapters/asyncpg/core.py
@@ -67,6 +67,7 @@ EXPECTED_REGEX_GROUPS = 3
 
 logger = get_logger("sqlspec.adapters.asyncpg.core")
 _PGVECTOR_MISSING_LOGGED = False
+_JSONB_BINARY_VERSION = b"\x01"
 
 
 class NormalizedStackOperation(NamedTuple):
@@ -221,11 +222,69 @@ def build_statement_config(
 default_statement_config = build_statement_config()
 
 
+def _encode_json_payload(value: Any, encoder: "Callable[[Any], str]") -> bytes:
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, bytearray):
+        return bytes(value)
+    if isinstance(value, memoryview):
+        return value.tobytes()
+    if isinstance(value, str):
+        return value.encode("utf-8")
+
+    encoded = encoder(value)
+    if isinstance(encoded, bytes):
+        return encoded
+    if isinstance(encoded, bytearray):
+        return bytes(encoded)
+    if isinstance(encoded, memoryview):
+        return encoded.tobytes()
+    return str(encoded).encode("utf-8")
+
+
+def _decode_json_payload(value: Any, decoder: "Callable[[str], Any]") -> Any:
+    if isinstance(value, str):
+        return decoder(value)
+    if isinstance(value, memoryview):
+        value = value.tobytes()
+    return decoder(bytes(value).decode("utf-8"))
+
+
+def _encode_jsonb_payload(value: Any, encoder: "Callable[[Any], str]") -> bytes:
+    payload = _encode_json_payload(value, encoder)
+    if payload.startswith(_JSONB_BINARY_VERSION):
+        return payload
+    return _JSONB_BINARY_VERSION + payload
+
+
+def _decode_jsonb_payload(value: Any, decoder: "Callable[[str], Any]") -> Any:
+    if isinstance(value, str):
+        return decoder(value)
+    if isinstance(value, memoryview):
+        value = value.tobytes()
+    payload = bytes(value)
+    if payload.startswith(_JSONB_BINARY_VERSION):
+        payload = payload[1:]
+    return decoder(payload.decode("utf-8"))
+
+
 async def register_json_codecs(connection: Any, encoder: Any, decoder: Any) -> None:
     """Register JSON type codecs on asyncpg connection."""
     try:
-        await connection.set_type_codec("json", encoder=encoder, decoder=decoder, schema="pg_catalog")
-        await connection.set_type_codec("jsonb", encoder=encoder, decoder=decoder, schema="pg_catalog")
+        await connection.set_type_codec(
+            "json",
+            encoder=lambda value: _encode_json_payload(value, encoder),
+            decoder=lambda value: _decode_json_payload(value, decoder),
+            schema="pg_catalog",
+            format="binary",
+        )
+        await connection.set_type_codec(
+            "jsonb",
+            encoder=lambda value: _encode_jsonb_payload(value, encoder),
+            decoder=lambda value: _decode_jsonb_payload(value, decoder),
+            schema="pg_catalog",
+            format="binary",
+        )
     except Exception:
         logger.exception("Failed to register JSON type codecs")
 

--- a/sqlspec/adapters/cockroach_asyncpg/config.py
+++ b/sqlspec/adapters/cockroach_asyncpg/config.py
@@ -5,7 +5,12 @@ from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 from asyncpg import create_pool as asyncpg_create_pool
 from typing_extensions import NotRequired
 
-from sqlspec.adapters.asyncpg.core import apply_driver_features, build_connection_config, default_statement_config
+from sqlspec.adapters.asyncpg.core import (
+    apply_driver_features,
+    build_connection_config,
+    default_statement_config,
+    register_json_codecs,
+)
 from sqlspec.adapters.cockroach_asyncpg._typing import (
     CockroachAsyncpgConnection,
     CockroachAsyncpgPool,
@@ -16,6 +21,7 @@ from sqlspec.config import AsyncDatabaseConfig, ExtensionConfigs
 from sqlspec.driver._async import AsyncPoolConnectionContext, AsyncPoolSessionFactory
 from sqlspec.extensions.events import EventRuntimeHints
 from sqlspec.utils.config_tools import normalize_connection_config
+from sqlspec.utils.serializers import from_json, to_json
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -177,7 +183,14 @@ class CockroachAsyncpgConfig(
         return await asyncpg_create_pool(**config)
 
     async def _init_connection(self, connection: "CockroachAsyncpgConnection") -> None:
-        """Initialize connection with user callback if provided."""
+        """Initialize connection with JSON codecs and user callback."""
+        if self.driver_features.get("enable_json_codecs", True):
+            await register_json_codecs(
+                connection,
+                encoder=self.driver_features.get("json_serializer", to_json),
+                decoder=self.driver_features.get("json_deserializer", from_json),
+            )
+
         if self._user_connection_hook is not None:
             await self._user_connection_hook(connection)
 

--- a/sqlspec/adapters/mysqlconnector/driver.py
+++ b/sqlspec/adapters/mysqlconnector/driver.py
@@ -233,9 +233,14 @@ class MysqlConnectorSyncDriver(SyncDriverAdapterBase):
         columns, records = self._arrow_table_to_rows(arrow_table)
         if records:
             insert_sql = build_insert_statement(table, columns)
+            prepared_records = (
+                self.prepare_driver_parameters(records, self.statement_config, is_many=True)
+                if self._arrow_table_needs_parameter_preparation(arrow_table)
+                else records
+            )
             exc_handler = self.handle_database_exceptions()
             with exc_handler, self.with_cursor(self.connection) as cursor:
-                cursor.executemany(insert_sql, records)
+                cursor.executemany(insert_sql, cast("Any", prepared_records))
             if exc_handler.pending_exception is not None:
                 raise exc_handler.pending_exception from None
 
@@ -447,9 +452,14 @@ class MysqlConnectorAsyncDriver(AsyncDriverAdapterBase):
         columns, records = self._arrow_table_to_rows(arrow_table)
         if records:
             insert_sql = build_insert_statement(table, columns)
+            prepared_records = (
+                self.prepare_driver_parameters(records, self.statement_config, is_many=True)
+                if self._arrow_table_needs_parameter_preparation(arrow_table)
+                else records
+            )
             exc_handler = self.handle_database_exceptions()
             async with exc_handler, self.with_cursor(self.connection) as cursor:
-                await cursor.executemany(insert_sql, records)
+                await cursor.executemany(insert_sql, cast("Any", prepared_records))
             if exc_handler.pending_exception is not None:
                 raise exc_handler.pending_exception from None
 

--- a/sqlspec/adapters/psqlpy/core.py
+++ b/sqlspec/adapters/psqlpy/core.py
@@ -31,7 +31,7 @@ from sqlspec.exceptions import (
 from sqlspec.typing import PGVECTOR_INSTALLED, Empty
 from sqlspec.utils.dispatch import TypeDispatcher
 from sqlspec.utils.logging import get_logger
-from sqlspec.utils.serializers import to_json
+from sqlspec.utils.serializers import from_json, to_json
 from sqlspec.utils.type_converters import build_nested_decimal_normalizer, build_uuid_coercions
 from sqlspec.utils.type_guards import has_query_result_metadata
 
@@ -653,5 +653,42 @@ def format_execute_many_parameters(parameters: Any, *, coerce_numeric: bool) -> 
     return [_format_execute_many_param_set(parameters, coerce_numeric=coerce_numeric)]
 
 
-def coerce_records_for_execute_many(records: "list[tuple[Any, ...]]") -> "list[list[Any]]":
-    return format_execute_many_parameters(records, coerce_numeric=True)
+def _coerce_json_text_for_execute_many(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    stripped = value.lstrip()
+    if not stripped or stripped[0] not in "{[":
+        return value
+    try:
+        decoded = from_json(value)
+    except Exception:
+        return value
+    return decoded if isinstance(decoded, (dict, list, tuple)) else value
+
+
+def _coerce_json_text_rows(rows: "list[list[Any]]") -> "list[list[Any]]":
+    coerced_rows: list[list[Any]] | None = None
+    for row_index, row in enumerate(rows):
+        coerced_row: list[Any] | None = None
+        for value_index, value in enumerate(row):
+            coerced_value = _coerce_json_text_for_execute_many(value)
+            if coerced_row is None:
+                if coerced_value is value:
+                    continue
+                coerced_row = list(row)
+            coerced_row[value_index] = coerced_value
+        if coerced_row is None:
+            if coerced_rows is not None:
+                coerced_rows.append(row)
+            continue
+        if coerced_rows is None:
+            coerced_rows = list(rows[:row_index])
+        coerced_rows.append(coerced_row)
+    return rows if coerced_rows is None else coerced_rows
+
+
+def coerce_records_for_execute_many(
+    records: "list[tuple[Any, ...]]", *, parse_json_text: bool = False
+) -> "list[list[Any]]":
+    formatted = format_execute_many_parameters(records, coerce_numeric=True)
+    return _coerce_json_text_rows(formatted) if parse_json_text else formatted

--- a/sqlspec/adapters/psqlpy/driver.py
+++ b/sqlspec/adapters/psqlpy/driver.py
@@ -303,9 +303,17 @@ class PsqlpyDriver(AsyncDriverAdapterBase):
                     logger.debug("Binary COPY not available for psqlpy; falling back to INSERT statements: %s", exc)
                     insert_sql = build_insert_statement(table, columns)
                     formatted_records = coerce_records_for_execute_many(records)
-                    insert_operation = cursor.execute_many(insert_sql, formatted_records)
-                    if inspect.isawaitable(insert_operation):
-                        await insert_operation
+                    try:
+                        insert_operation = cursor.execute_many(insert_sql, formatted_records)
+                        if inspect.isawaitable(insert_operation):
+                            await insert_operation
+                    except (psqlpy.exceptions.DatabaseError, psqlpy.exceptions.Error) as fallback_exc:
+                        if "PyJSON must be dict, list, or tuple" not in str(fallback_exc):
+                            raise
+                        formatted_records = coerce_records_for_execute_many(records, parse_json_text=True)
+                        insert_operation = cursor.execute_many(insert_sql, formatted_records)
+                        if inspect.isawaitable(insert_operation):
+                            await insert_operation
             if exc_handler.pending_exception is not None:
                 raise exc_handler.pending_exception from None
 

--- a/sqlspec/adapters/pymysql/driver.py
+++ b/sqlspec/adapters/pymysql/driver.py
@@ -206,9 +206,14 @@ class PyMysqlDriver(SyncDriverAdapterBase):
         columns, records = self._arrow_table_to_rows(arrow_table)
         if records:
             insert_sql = build_insert_statement(table, columns)
+            prepared_records = (
+                self.prepare_driver_parameters(records, self.statement_config, is_many=True)
+                if self._arrow_table_needs_parameter_preparation(arrow_table)
+                else records
+            )
             exc_handler = self.handle_database_exceptions()
             with exc_handler, self.with_cursor(self.connection) as cursor:
-                cursor.executemany(insert_sql, records)
+                cursor.executemany(insert_sql, cast("Any", prepared_records))
             if exc_handler.pending_exception is not None:
                 raise exc_handler.pending_exception from None
 

--- a/sqlspec/adapters/spanner/driver.py
+++ b/sqlspec/adapters/spanner/driver.py
@@ -313,10 +313,20 @@ class SpannerSyncDriver(SyncDriverAdapterBase):
         if records:
             insert_sql = f"INSERT INTO {table} ({', '.join(columns)}) VALUES ({', '.join('@p' + str(i) for i in range(len(columns)))})"
             batch_args: list[tuple[str, dict[str, Any] | None, dict[str, Any]]] = []
+            param_types_cache: dict[tuple[tuple[str, type[Any]], ...], dict[str, Any]] = {}
+            empty_param_types: dict[str, Any] = {}
             for record in records:
                 params = {f"p{i}": val for i, val in enumerate(record)}
                 coerced = self._coerce_params(params)
-                batch_args.append((insert_sql, coerced, self._infer_param_types(coerced)))
+                if not coerced:
+                    batch_args.append((insert_sql, {}, empty_param_types))
+                    continue
+                signature = build_param_type_signature(coerced)
+                param_types = param_types_cache.get(signature)
+                if param_types is None:
+                    param_types = self._infer_param_types(coerced)
+                    param_types_cache[signature] = param_types
+                batch_args.append((insert_sql, coerced, param_types))
 
             conn = self.connection
             if not isinstance(conn, Transaction):

--- a/sqlspec/adapters/sqlite/driver.py
+++ b/sqlspec/adapters/sqlite/driver.py
@@ -1,7 +1,7 @@
 """SQLite driver implementation."""
 
 import sqlite3
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from sqlspec.adapters.sqlite._typing import SqliteCursor, SqliteSessionContext
 from sqlspec.adapters.sqlite.core import (
@@ -458,9 +458,14 @@ class SqliteDriver(SyncDriverAdapterBase):
         columns, records = self._arrow_table_to_rows(arrow_table)
         if records:
             insert_sql = build_insert_statement(table, columns)
+            prepared_records = (
+                self.prepare_driver_parameters(records, self.statement_config, is_many=True)
+                if self._arrow_table_needs_parameter_preparation(arrow_table)
+                else records
+            )
             try:
                 with self.with_cursor(self.connection) as cursor:
-                    cursor.executemany(insert_sql, records)
+                    cursor.executemany(insert_sql, cast("Any", prepared_records))
             except sqlite3.Error as exc:
                 raise create_mapped_exception(exc) from exc
 

--- a/sqlspec/driver/_common.py
+++ b/sqlspec/driver/_common.py
@@ -36,6 +36,7 @@ from sqlspec.data_dictionary._registry import get_dialect_config
 from sqlspec.driver._query_cache import STMT_CACHE_MAX_SIZE, CachedQuery, QueryCache
 from sqlspec.driver._storage_helpers import (
     CAPABILITY_HINTS,
+    arrow_table_needs_parameter_preparation,
     arrow_table_to_rows,
     attach_partition_telemetry,
     build_ingest_telemetry,
@@ -2267,6 +2268,11 @@ class CommonDriverAttributesMixin:
     ) -> "tuple[list[str], list[tuple[Any, ...]]]":
         """Convert Arrow table to column names and row tuples."""
         return arrow_table_to_rows(table, columns)
+
+    @staticmethod
+    def _arrow_table_needs_parameter_preparation(table: "ArrowTable") -> bool:
+        """Return whether Arrow rows may contain nested values needing preparation."""
+        return arrow_table_needs_parameter_preparation(table)
 
     @staticmethod
     def _build_ingest_telemetry(table: "ArrowTable", *, format_label: str = "arrow") -> "StorageTelemetry":

--- a/sqlspec/driver/_storage_helpers.py
+++ b/sqlspec/driver/_storage_helpers.py
@@ -8,6 +8,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final, cast
 
 from sqlspec.storage import StorageBridgeJob, StorageTelemetry, create_storage_bridge_job
+from sqlspec.utils.arrow_helpers import (
+    arrow_table_needs_parameter_preparation as _arrow_table_needs_parameter_preparation,
+)
 from sqlspec.utils.arrow_helpers import arrow_table_to_rows as _arrow_table_to_rows_impl
 from sqlspec.utils.arrow_helpers import build_ingest_telemetry as _build_ingest_telemetry_impl
 from sqlspec.utils.arrow_helpers import coerce_arrow_table as _coerce_arrow_table_impl
@@ -20,6 +23,7 @@ if TYPE_CHECKING:
 
 __all__ = (
     "CAPABILITY_HINTS",
+    "arrow_table_needs_parameter_preparation",
     "arrow_table_to_rows",
     "attach_partition_telemetry",
     "build_ingest_telemetry",
@@ -87,6 +91,11 @@ def arrow_table_to_rows(
 
     """
     return _arrow_table_to_rows_impl(table, columns)
+
+
+def arrow_table_needs_parameter_preparation(table: "ArrowTable") -> bool:
+    """Return whether Arrow rows may contain nested values needing preparation."""
+    return _arrow_table_needs_parameter_preparation(table)
 
 
 def build_ingest_telemetry(table: "ArrowTable", *, format_label: str = "arrow") -> "StorageTelemetry":

--- a/sqlspec/utils/arrow_helpers.py
+++ b/sqlspec/utils/arrow_helpers.py
@@ -8,6 +8,7 @@ when compiled drivers touch Arrow objects.
 """
 
 from collections.abc import Iterable
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 from sqlspec.utils.dispatch import TypeDispatcher
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
 
 __all__ = (
     "arrow_table_column_names",
+    "arrow_table_needs_parameter_preparation",
     "arrow_table_num_columns",
     "arrow_table_num_rows",
     "arrow_table_to_pandas",
@@ -35,6 +37,7 @@ __all__ = (
     "ensure_arrow_table",
 )
 _ARROW_TABLE_COERCER: "TypeDispatcher[Any] | None" = None
+_ARROW_SCHEMA_DECISION_CACHE_SIZE = 512
 
 
 @overload
@@ -290,6 +293,40 @@ def arrow_table_to_rows(
     # Transpose columns to rows using zip
     records: list[tuple[Any, ...]] = [tuple(row) for row in zip(*col_data, strict=False)]
     return resolved_columns, records
+
+
+def _arrow_type_needs_parameter_preparation(data_type: Any) -> bool:
+    ensure_pyarrow()
+    import pyarrow as pa
+
+    if pa.types.is_dictionary(data_type):
+        return _arrow_type_needs_parameter_preparation(data_type.value_type)
+
+    is_extension = getattr(pa.types, "is_extension", None)
+    if is_extension is not None and is_extension(data_type):
+        return _arrow_type_needs_parameter_preparation(data_type.storage_type)
+
+    nested_type_checks = (
+        "is_struct",
+        "is_list",
+        "is_large_list",
+        "is_fixed_size_list",
+        "is_map",
+        "is_union",
+        "is_list_view",
+        "is_large_list_view",
+    )
+    return any(getattr(pa.types, check, lambda _: False)(data_type) for check in nested_type_checks)
+
+
+@lru_cache(maxsize=_ARROW_SCHEMA_DECISION_CACHE_SIZE)
+def _arrow_schema_needs_parameter_preparation(schema: Any) -> bool:
+    return any(_arrow_type_needs_parameter_preparation(field.type) for field in schema)
+
+
+def arrow_table_needs_parameter_preparation(table: "ArrowTable") -> bool:
+    """Return whether Arrow rows may emit nested values needing driver preparation."""
+    return _arrow_schema_needs_parameter_preparation(table.schema)
 
 
 def arrow_table_to_pylist(table: "ArrowTable") -> "list[dict[str, Any]]":

--- a/tests/integration/adapters/asyncpg/test_arrow.py
+++ b/tests/integration/adapters/asyncpg/test_arrow.py
@@ -204,3 +204,43 @@ async def test_select_to_arrow_postgres_array(asyncpg_async_driver: AsyncpgDrive
     assert isinstance(df["tags"].iloc[0], (list, object))
 
     await asyncpg_async_driver.execute("DROP TABLE IF EXISTS arrow_array_test CASCADE")
+
+
+async def test_load_from_arrow_json_and_jsonb(asyncpg_async_driver: AsyncpgDriver) -> None:
+    """Test Arrow import into PostgreSQL JSON and JSONB columns."""
+    import pyarrow as pa
+
+    table_name = "arrow_json_ingest_asyncpg"
+    await asyncpg_async_driver.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
+    await asyncpg_async_driver.execute(
+        f"""
+        CREATE TABLE {table_name} (
+            id INTEGER PRIMARY KEY,
+            payload_json JSON NOT NULL,
+            payload_jsonb JSONB NOT NULL
+        )
+        """
+    )
+
+    try:
+        arrow_table = pa.table({
+            "id": [1, 2],
+            "payload_json": ['{"name":"alpha","items":[1,2]}', '{"name":"beta","items":[3]}'],
+            "payload_jsonb": ['{"status":"ready","count":1}', '{"status":"done","count":2}'],
+        })
+
+        job = await asyncpg_async_driver.load_from_arrow(table_name, arrow_table)
+
+        result = await asyncpg_async_driver.execute(f"SELECT * FROM {table_name} ORDER BY id")
+        rows = result.get_data()
+        assert rows == [
+            {
+                "id": 1,
+                "payload_json": {"name": "alpha", "items": [1, 2]},
+                "payload_jsonb": {"count": 1, "status": "ready"},
+            },
+            {"id": 2, "payload_json": {"name": "beta", "items": [3]}, "payload_jsonb": {"count": 2, "status": "done"}},
+        ]
+        assert job.telemetry["rows_processed"] == 2
+    finally:
+        await asyncpg_async_driver.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")

--- a/tests/integration/adapters/duckdb/test_arrow.py
+++ b/tests/integration/adapters/duckdb/test_arrow.py
@@ -193,3 +193,22 @@ def test_select_to_arrow_type_preservation(duckdb_basic_session: "DuckDBDriver")
         assert df["active"].dtype == "bool"
     finally:
         _drop_table(driver, "arrow_types_test")
+
+
+def test_load_from_arrow_json(duckdb_basic_session: "DuckDBDriver") -> None:
+    """Test Arrow import into DuckDB JSON columns."""
+    import pyarrow as pa
+
+    driver = duckdb_basic_session
+    table_name = "arrow_json_ingest_duckdb"
+    driver.execute(f"CREATE TABLE {table_name} (id INTEGER, payload JSON)")
+    try:
+        arrow_table = pa.table({"id": [1, 2], "payload": ['{"name":"alpha"}', '{"name":"beta"}']})
+
+        job = driver.load_from_arrow(table_name, arrow_table)
+
+        result = driver.execute(f"SELECT id, payload::VARCHAR AS payload FROM {table_name} ORDER BY id")
+        assert result.get_data() == [{"id": 1, "payload": '{"name":"alpha"}'}, {"id": 2, "payload": '{"name":"beta"}'}]
+        assert job.telemetry["rows_processed"] == 2
+    finally:
+        _drop_table(driver, table_name)

--- a/tests/integration/adapters/oracledb/test_arrow.py
+++ b/tests/integration/adapters/oracledb/test_arrow.py
@@ -48,6 +48,29 @@ async def test_select_to_arrow_basic(oracle_async_session: "OracleAsyncDriver") 
         await _safe_drop_table(driver, "arrow_users_oracledb_async")
 
 
+async def test_load_from_arrow_json(oracle_async_session: "OracleAsyncDriver") -> None:
+    """Test Arrow import into Oracle JSON columns."""
+    import pyarrow as pa
+
+    driver = oracle_async_session
+    table_name = "arrow_json_test_oracledb_async"
+    await _safe_drop_table(driver, table_name)
+    await driver.execute(f"CREATE TABLE {table_name} (id NUMBER PRIMARY KEY, payload JSON)")
+    await driver.commit()
+
+    try:
+        payload = {"name": "alpha", "tags": ["north", "east"]}
+        arrow_table = pa.table({"id": [1], "payload": pa.array([payload])})
+
+        job = await driver.load_from_arrow(table_name, arrow_table)
+
+        row = await driver.select_one(f"SELECT payload FROM {table_name} WHERE id = 1")
+        assert row["payload"] == payload
+        assert job.telemetry["rows_processed"] == arrow_table.num_rows
+    finally:
+        await _safe_drop_table(driver, table_name)
+
+
 async def test_select_to_arrow_table_format(oracle_async_session: "OracleAsyncDriver") -> None:
     """Test select_to_arrow with table return format (default)."""
     import pyarrow as pa

--- a/tests/integration/adapters/psqlpy/test_arrow.py
+++ b/tests/integration/adapters/psqlpy/test_arrow.py
@@ -199,3 +199,23 @@ async def test_select_to_arrow_type_preservation(psqlpy_driver: "PsqlpyDriver") 
         assert list(df["name"]) == ["Item 1", "Item 2"]
     finally:
         await _drop_table(driver, "arrow_types_test_psqlpy")
+
+
+async def test_load_from_arrow_jsonb(psqlpy_driver: "PsqlpyDriver") -> None:
+    """Test Arrow import into PostgreSQL JSONB columns."""
+    import pyarrow as pa
+
+    driver = psqlpy_driver
+    table_name = "arrow_jsonb_ingest_psqlpy"
+    await driver.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
+    await driver.execute(f"CREATE TABLE {table_name} (id INTEGER PRIMARY KEY, payload JSONB NOT NULL)")
+    try:
+        arrow_table = pa.table({"id": [1, 2], "payload": ['{"name":"alpha"}', '{"name":"beta"}']})
+
+        job = await driver.load_from_arrow(table_name, arrow_table)
+
+        rows = await driver.select(f"SELECT id, payload FROM {table_name} ORDER BY id")
+        assert rows == [{"id": 1, "payload": {"name": "alpha"}}, {"id": 2, "payload": {"name": "beta"}}]
+        assert job.telemetry["rows_processed"] == 2
+    finally:
+        await _drop_table(driver, table_name)

--- a/tests/integration/adapters/psycopg/test_arrow.py
+++ b/tests/integration/adapters/psycopg/test_arrow.py
@@ -1,9 +1,14 @@
 """Integration tests for psycopg Arrow support."""
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 from sqlspec.adapters.psycopg import PsycopgAsyncConfig
 from sqlspec.typing import PYARROW_INSTALLED
+
+if TYPE_CHECKING:
+    from sqlspec.adapters.psycopg import PsycopgSyncConfig
 
 pytestmark = [
     pytest.mark.xdist_group("postgres"),
@@ -198,3 +203,49 @@ async def test_select_to_arrow_postgres_array(psycopg_config: PsycopgAsyncConfig
         df = result.to_pandas()
         assert len(df) == 2
         assert isinstance(df["tags"].iloc[0], (list, object))
+
+
+async def test_psycopg_async_load_from_arrow_jsonb(psycopg_config: PsycopgAsyncConfig) -> None:
+    """Test async Arrow import into PostgreSQL JSONB columns."""
+    import pyarrow as pa
+
+    async with psycopg_config.provide_session() as session:
+        table_name = "arrow_jsonb_ingest_psycopg_async"
+        await session.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
+        await session.execute(f"CREATE TABLE {table_name} (id INTEGER PRIMARY KEY, payload JSONB NOT NULL)")
+        try:
+            arrow_table = pa.table({"id": [1, 2], "payload": ['{"name":"alpha"}', '{"name":"beta"}']})
+
+            job = await session.load_from_arrow(table_name, arrow_table)
+
+            result = await session.execute(f"SELECT id, payload FROM {table_name} ORDER BY id")
+            assert result.get_data() == [
+                {"id": 1, "payload": {"name": "alpha"}},
+                {"id": 2, "payload": {"name": "beta"}},
+            ]
+            assert job.telemetry["rows_processed"] == 2
+        finally:
+            await session.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
+
+
+def test_psycopg_sync_load_from_arrow_jsonb(psycopg_sync_config: "PsycopgSyncConfig") -> None:
+    """Test sync Arrow import into PostgreSQL JSONB columns."""
+    import pyarrow as pa
+
+    with psycopg_sync_config.provide_session() as session:
+        table_name = "arrow_jsonb_ingest_psycopg_sync"
+        session.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
+        session.execute(f"CREATE TABLE {table_name} (id INTEGER PRIMARY KEY, payload JSONB NOT NULL)")
+        try:
+            arrow_table = pa.table({"id": [1, 2], "payload": ['{"name":"alpha"}', '{"name":"beta"}']})
+
+            job = session.load_from_arrow(table_name, arrow_table)
+
+            result = session.execute(f"SELECT id, payload FROM {table_name} ORDER BY id")
+            assert result.get_data() == [
+                {"id": 1, "payload": {"name": "alpha"}},
+                {"id": 2, "payload": {"name": "beta"}},
+            ]
+            assert job.telemetry["rows_processed"] == 2
+        finally:
+            session.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")

--- a/tests/unit/adapters/test_asyncpg/test_type_handlers.py
+++ b/tests/unit/adapters/test_asyncpg/test_type_handlers.py
@@ -8,14 +8,15 @@ import pytest
 from sqlspec.adapters.asyncpg.config import register_json_codecs, register_pgvector_support
 from sqlspec.adapters.asyncpg.core import create_mapped_exception
 from sqlspec.exceptions import PermissionDeniedError, UniqueViolationError
+from sqlspec.utils.serializers import from_json, to_json
 
 
 @pytest.mark.anyio
 async def test_register_json_codecs_success() -> None:
     """Test successful JSON codec registration."""
     connection = AsyncMock()
-    encoder = MagicMock()
-    decoder = MagicMock()
+    encoder = to_json
+    decoder = from_json
 
     await register_json_codecs(connection, encoder, decoder)
 
@@ -23,11 +24,27 @@ async def test_register_json_codecs_success() -> None:
 
     json_call = connection.set_type_codec.call_args_list[0]
     assert json_call.args == ("json",)
-    assert json_call.kwargs == {"encoder": encoder, "decoder": decoder, "schema": "pg_catalog"}
+    assert json_call.kwargs == {
+        "encoder": json_call.kwargs["encoder"],
+        "decoder": json_call.kwargs["decoder"],
+        "schema": "pg_catalog",
+        "format": "binary",
+    }
 
     jsonb_call = connection.set_type_codec.call_args_list[1]
     assert jsonb_call.args == ("jsonb",)
-    assert jsonb_call.kwargs == {"encoder": encoder, "decoder": decoder, "schema": "pg_catalog"}
+    assert jsonb_call.kwargs == {
+        "encoder": jsonb_call.kwargs["encoder"],
+        "decoder": jsonb_call.kwargs["decoder"],
+        "schema": "pg_catalog",
+        "format": "binary",
+    }
+
+    assert json_call.kwargs["encoder"]({"value": 1}) == b'{"value":1}'
+    assert json_call.kwargs["decoder"](b'{"value":1}') == {"value": 1}
+    assert jsonb_call.kwargs["encoder"]({"value": 1}) == b'\x01{"value":1}'
+    assert jsonb_call.kwargs["encoder"](b'\x01{"value":1}') == b'\x01{"value":1}'
+    assert jsonb_call.kwargs["decoder"](b'\x01{"value":1}') == {"value": 1}
 
 
 @pytest.mark.anyio

--- a/tests/unit/adapters/test_cockroach_asyncpg/test_config.py
+++ b/tests/unit/adapters/test_cockroach_asyncpg/test_config.py
@@ -6,6 +6,8 @@ Tests cover:
 - Connection config normalization
 """
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from sqlspec.adapters.cockroach_asyncpg import (
@@ -81,6 +83,49 @@ class TestCockroachAsyncpgConfig:
         """Bind key should be stored for multi-database setups."""
         config = CockroachAsyncpgConfig(bind_key="cockroach_primary")
         assert config.bind_key == "cockroach_primary"
+
+    async def test_init_connection_registers_json_codecs_before_user_hook(self) -> None:
+        """Connection init should install JSON codecs before user callbacks."""
+        events: list[str] = []
+
+        async def user_hook(connection: object) -> None:
+            events.append("user")
+
+        async def register_json(connection: object, **_: object) -> None:
+            events.append("json")
+
+        config = CockroachAsyncpgConfig(driver_features={"on_connection_create": user_hook})
+        connection = AsyncMock()
+
+        with patch(
+            "sqlspec.adapters.cockroach_asyncpg.config.register_json_codecs",
+            new=AsyncMock(side_effect=register_json),
+            create=True,
+        ) as register_mock:
+            await config._init_connection(connection)
+
+        register_mock.assert_awaited_once()
+        assert events == ["json", "user"]
+
+    async def test_init_connection_skips_json_codecs_when_disabled(self) -> None:
+        """Disabling JSON codecs should preserve the user callback."""
+        events: list[str] = []
+
+        async def user_hook(connection: object) -> None:
+            events.append("user")
+
+        config = CockroachAsyncpgConfig(
+            driver_features={"enable_json_codecs": False, "on_connection_create": user_hook}
+        )
+        connection = AsyncMock()
+
+        with patch(
+            "sqlspec.adapters.cockroach_asyncpg.config.register_json_codecs", new_callable=AsyncMock, create=True
+        ) as register_mock:
+            await config._init_connection(connection)
+
+        register_mock.assert_not_awaited()
+        assert events == ["user"]
 
 
 @pytest.mark.xdist_group("cockroachdb")

--- a/tests/unit/adapters/test_psqlpy/test_core.py
+++ b/tests/unit/adapters/test_psqlpy/test_core.py
@@ -93,6 +93,17 @@ def test_coerce_records_for_execute_many_delegates_to_formatter() -> None:
     assert formatted[1] == [3, "y"]
 
 
+def test_coerce_records_for_execute_many_parses_json_text_values() -> None:
+    """JSON object and array text from Arrow rows should become psqlpy JSON values."""
+    records = [(1, '{"name":"alpha"}', '["north","east"]', "plain")]
+
+    unparsed = coerce_records_for_execute_many(records)
+    formatted = coerce_records_for_execute_many(records, parse_json_text=True)
+
+    assert unparsed == [[1, '{"name":"alpha"}', '["north","east"]', "plain"]]
+    assert formatted == [[1, {"name": "alpha"}, ["north", "east"], "plain"]]
+
+
 def test_encode_records_for_binary_copy_preserves_copy_format() -> None:
     """The public copy encoder should keep the same escaped wire payload."""
     records = [("plain", "needs\tescape", "line\nbreak", None, True, b"bytes")]

--- a/tests/unit/adapters/test_spanner/test_driver.py
+++ b/tests/unit/adapters/test_spanner/test_driver.py
@@ -1,11 +1,22 @@
 from unittest.mock import MagicMock, Mock
 
+import pyarrow as pa
 import pytest
 from google.cloud.spanner_v1 import Transaction
 from google.cloud.spanner_v1.streamed import StreamedResultSet
 
 from sqlspec.adapters.spanner.driver import SpannerSyncDriver
 from sqlspec.exceptions import SQLConversionError
+
+CAPABILITIES = {
+    "arrow_export_enabled": True,
+    "arrow_import_enabled": True,
+    "parquet_export_enabled": True,
+    "parquet_import_enabled": True,
+    "requires_staging_for_load": False,
+    "staging_protocols": [],
+    "partition_strategies": ["fixed"],
+}
 
 
 @pytest.fixture
@@ -105,3 +116,28 @@ def test_execute_many_caches_inferred_param_types(mock_transaction: MagicMock, m
 
     assert result.rowcount_override == 2
     assert infer_call_count == 1
+
+
+def test_load_from_arrow_caches_inferred_param_types(
+    mock_transaction: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    driver = SpannerSyncDriver(mock_transaction, driver_features={"storage_capabilities": CAPABILITIES})
+
+    infer_call_count = 0
+
+    def _mock_infer_param_types(params: dict[str, object] | list[object] | tuple[object, ...] | None) -> dict[str, str]:
+        nonlocal infer_call_count
+        infer_call_count += 1
+        if not isinstance(params, dict):
+            return {}
+        return dict.fromkeys(params, "TYPE")
+
+    monkeypatch.setattr("sqlspec.adapters.spanner.driver.Transaction", type(mock_transaction))
+    monkeypatch.setattr("sqlspec.adapters.spanner.driver.infer_param_types", _mock_infer_param_types)
+    arrow_table = pa.table({"id": [1, 2], "name": ["alice", "bob"]})
+
+    result = driver.load_from_arrow("users", arrow_table)
+
+    assert result.telemetry["rows_processed"] == 2
+    assert infer_call_count == 1
+    mock_transaction.batch_update.assert_called_once()

--- a/tests/unit/storage/test_bridge.py
+++ b/tests/unit/storage/test_bridge.py
@@ -10,6 +10,9 @@ import duckdb
 import pyarrow as pa
 import pytest
 
+import sqlspec.utils.arrow_helpers as arrow_helpers
+from sqlspec.adapters.aiomysql import AiomysqlDriver
+from sqlspec.adapters.aiomysql import default_statement_config as aiomysql_statement_config
 from sqlspec.adapters.aiosqlite import AiosqliteDriver
 from sqlspec.adapters.aiosqlite import default_statement_config as aiosqlite_statement_config
 from sqlspec.adapters.asyncmy import AsyncmyConnection, AsyncmyDriver
@@ -18,8 +21,12 @@ from sqlspec.adapters.asyncpg import AsyncpgConnection, AsyncpgDriver
 from sqlspec.adapters.asyncpg import default_statement_config as asyncpg_statement_config
 from sqlspec.adapters.duckdb import DuckDBDriver
 from sqlspec.adapters.duckdb import default_statement_config as duckdb_statement_config
+from sqlspec.adapters.mysqlconnector import MysqlConnectorAsyncDriver, MysqlConnectorSyncDriver
+from sqlspec.adapters.mysqlconnector import default_statement_config as mysqlconnector_statement_config
 from sqlspec.adapters.psqlpy import PsqlpyConnection, PsqlpyDriver
 from sqlspec.adapters.psqlpy import default_statement_config as psqlpy_statement_config
+from sqlspec.adapters.pymysql import PyMysqlDriver
+from sqlspec.adapters.pymysql import default_statement_config as pymysql_statement_config
 from sqlspec.adapters.sqlite import SqliteDriver
 from sqlspec.adapters.sqlite import default_statement_config as sqlite_statement_config
 from sqlspec.storage import SyncStoragePipeline, get_storage_bridge_diagnostics, reset_storage_bridge_metrics
@@ -91,6 +98,43 @@ class DummyAsyncmyConnection:
 
     def cursor(self) -> DummyAsyncmyCursorImpl:
         return DummyAsyncmyCursorImpl(self.operations)
+
+
+class DummyAwaitableCursorConnection(DummyAsyncmyConnection):
+    async def cursor(self, *_args: Any, **_kwargs: Any) -> DummyAsyncmyCursorImpl:  # type: ignore[override]
+        return DummyAsyncmyCursorImpl(self.operations)
+
+
+class DummySyncCursorImpl:
+    def __init__(self, operations: "list[tuple[str, Any, Any | None]]") -> None:
+        self.operations = operations
+
+    def executemany(self, sql: str, params: Any) -> None:
+        self.operations.append(("executemany", sql, params))
+
+    def execute(self, sql: str, params: Any | None = None) -> None:
+        self.operations.append(("execute", sql, params))
+
+    def close(self) -> None:
+        return None
+
+
+class DummySyncConnection:
+    def __init__(self) -> None:
+        self.operations: list[tuple[str, Any, Any | None]] = []
+
+    def cursor(self) -> DummySyncCursorImpl:
+        return DummySyncCursorImpl(self.operations)
+
+
+class TrackingAsyncmyDriver(AsyncmyDriver):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.prepare_calls = 0
+
+    def prepare_driver_parameters(self, *args: Any, **kwargs: Any) -> Any:
+        self.prepare_calls += 1
+        return super().prepare_driver_parameters(*args, **kwargs)
 
 
 class _CountingStorageBackend:
@@ -248,6 +292,24 @@ async def test_psqlpy_load_from_arrow_overwrite() -> None:
     assert job.telemetry["rows_processed"] == arrow_table.num_rows
 
 
+async def test_psqlpy_load_from_arrow_serializes_nested_json_values() -> None:
+    arrow_table = pa.table({"id": [1], "payload": pa.array([{"name": "alpha"}]), "tags": pa.array([["north", "east"]])})
+    dummy_connection = DummyPsqlpyConnection()
+    driver = PsqlpyDriver(
+        connection=cast(PsqlpyConnection, dummy_connection),
+        statement_config=asyncpg_statement_config,
+        driver_features={"storage_capabilities": CAPABILITIES},
+    )
+
+    await driver.load_from_arrow("analytics.events", arrow_table)
+
+    payload = dummy_connection.copy_calls[0]["records"]
+    if isinstance(payload, bytes):
+        assert payload == b'1\t{"name":"alpha"}\t["north","east"]\n'
+    else:
+        assert payload == [(1, {"name": "alpha"}, ["north", "east"])]
+
+
 async def test_psqlpy_load_from_storage_merges_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
     arrow_table = pa.table({"id": [1, 2], "name": ["north", "south"]})
     dummy_connection = DummyPsqlpyConnection()
@@ -291,6 +353,31 @@ async def test_aiosqlite_load_from_arrow_overwrite() -> None:
         assert rows == [(1, "alpha"), (2, "beta")]  # type: ignore[comparison-overlap]
         assert job.telemetry["destination"] == "ingest"
         assert job.telemetry["rows_processed"] == arrow_table.num_rows
+    finally:
+        await connection.close()
+
+
+async def test_aiosqlite_load_from_arrow_serializes_nested_json_values() -> None:
+    connection = await aiosqlite.connect(":memory:")
+    try:
+        await connection.execute("CREATE TABLE events (id INTEGER, payload TEXT, tags TEXT)")
+        await connection.commit()
+        driver = AiosqliteDriver(
+            connection=connection,
+            statement_config=aiosqlite_statement_config,
+            driver_features={"storage_capabilities": CAPABILITIES},
+        )
+        arrow_table = pa.table({
+            "id": [1],
+            "payload": pa.array([{"name": "alpha"}]),
+            "tags": pa.array([["north", "east"]]),
+        })
+
+        await driver.load_from_arrow("events", arrow_table)
+
+        async with connection.execute("SELECT id, payload, tags FROM events") as cursor:
+            rows = await cursor.fetchall()
+        assert rows == [(1, '{"name":"alpha"}', '["north","east"]')]  # type: ignore[comparison-overlap]
     finally:
         await connection.close()
 
@@ -346,6 +433,29 @@ def test_sqlite_load_from_arrow_overwrite() -> None:
         connection.close()
 
 
+def test_sqlite_load_from_arrow_serializes_nested_json_values() -> None:
+    connection = sqlite3.connect(":memory:")
+    try:
+        connection.execute("CREATE TABLE events (id INTEGER, payload TEXT, tags TEXT)")
+        driver = SqliteDriver(
+            connection=connection,
+            statement_config=sqlite_statement_config,
+            driver_features={"storage_capabilities": CAPABILITIES},
+        )
+        arrow_table = pa.table({
+            "id": [1],
+            "payload": pa.array([{"name": "alpha"}]),
+            "tags": pa.array([["north", "east"]]),
+        })
+
+        driver.load_from_arrow("events", arrow_table)
+
+        rows = connection.execute("SELECT id, payload, tags FROM events").fetchall()
+        assert rows == [(1, '{"name":"alpha"}', '["north","east"]')]
+    finally:
+        connection.close()
+
+
 def test_sqlite_load_from_storage_merges_source(monkeypatch: pytest.MonkeyPatch) -> None:
     connection = sqlite3.connect(":memory:")
     try:
@@ -387,6 +497,104 @@ async def test_asyncmy_load_from_arrow_overwrite() -> None:
     assert connection.operations[0][1].startswith("TRUNCATE TABLE `analytics`.`scores`")
     assert connection.operations[1][0] == "executemany"
     assert job.telemetry["destination"] == "analytics.scores"
+
+
+async def test_asyncmy_load_from_arrow_serializes_nested_json_values() -> None:
+    connection = DummyAsyncmyConnection()
+    driver = TrackingAsyncmyDriver(
+        connection=cast(AsyncmyConnection, connection),
+        statement_config=asyncmy_statement_config,
+        driver_features={"storage_capabilities": CAPABILITIES},
+    )
+    arrow_table = pa.table({"id": [1], "payload": pa.array([{"name": "alpha"}]), "tags": pa.array([["north", "east"]])})
+
+    await driver.load_from_arrow("analytics.events", arrow_table)
+
+    assert connection.operations[0][0] == "executemany"
+    assert connection.operations[0][2] == [(1, '{"name":"alpha"}', '["north","east"]')]
+    assert driver.prepare_calls == 1
+
+
+async def test_asyncmy_load_from_arrow_skips_preparation_for_scalar_columns() -> None:
+    connection = DummyAsyncmyConnection()
+    driver = TrackingAsyncmyDriver(
+        connection=cast(AsyncmyConnection, connection),
+        statement_config=asyncmy_statement_config,
+        driver_features={"storage_capabilities": CAPABILITIES},
+    )
+    arrow_table = pa.table({"id": [1, 2], "name": ["alpha", "beta"]})
+
+    await driver.load_from_arrow("analytics.events", arrow_table)
+
+    assert connection.operations[0][0] == "executemany"
+    assert connection.operations[0][2] == [(1, "alpha"), (2, "beta")]
+    assert driver.prepare_calls == 0
+
+
+def test_arrow_parameter_preparation_decision_is_cached_by_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    arrow_helpers._arrow_schema_needs_parameter_preparation.cache_clear()
+    calls = 0
+    original = arrow_helpers._arrow_type_needs_parameter_preparation
+
+    def _spy(data_type: Any) -> bool:
+        nonlocal calls
+        calls += 1
+        return original(data_type)
+
+    monkeypatch.setattr(arrow_helpers, "_arrow_type_needs_parameter_preparation", _spy)
+    schema = pa.schema([("id", pa.int64()), ("payload", pa.struct([("name", pa.string())]))])
+    first_table = pa.Table.from_pylist([{"id": 1, "payload": {"name": "alpha"}}], schema=schema)
+    second_table = pa.Table.from_pylist([{"id": 2, "payload": {"name": "beta"}}], schema=schema)
+
+    try:
+        assert arrow_helpers.arrow_table_needs_parameter_preparation(first_table) is True
+        assert arrow_helpers.arrow_table_needs_parameter_preparation(second_table) is True
+        assert calls == 2
+        assert arrow_helpers._arrow_schema_needs_parameter_preparation.cache_info().hits == 1
+    finally:
+        arrow_helpers._arrow_schema_needs_parameter_preparation.cache_clear()
+
+
+@pytest.mark.parametrize(
+    ("driver_type", "statement_config"),
+    [(AiomysqlDriver, aiomysql_statement_config), (MysqlConnectorAsyncDriver, mysqlconnector_statement_config)],
+)
+async def test_async_mysql_load_from_arrow_serializes_nested_json_values(
+    driver_type: type[AiomysqlDriver | MysqlConnectorAsyncDriver], statement_config: Any
+) -> None:
+    connection = DummyAwaitableCursorConnection()
+    driver = driver_type(
+        connection=cast(Any, connection),
+        statement_config=statement_config,
+        driver_features={"storage_capabilities": CAPABILITIES},
+    )
+    arrow_table = pa.table({"id": [1], "payload": pa.array([{"name": "alpha"}]), "tags": pa.array([["north", "east"]])})
+
+    await driver.load_from_arrow("analytics.events", arrow_table)
+
+    assert connection.operations[0][0] == "executemany"
+    assert connection.operations[0][2] == [(1, '{"name":"alpha"}', '["north","east"]')]
+
+
+@pytest.mark.parametrize(
+    ("driver_type", "statement_config"),
+    [(PyMysqlDriver, pymysql_statement_config), (MysqlConnectorSyncDriver, mysqlconnector_statement_config)],
+)
+def test_sync_mysql_load_from_arrow_serializes_nested_json_values(
+    driver_type: type[PyMysqlDriver | MysqlConnectorSyncDriver], statement_config: Any
+) -> None:
+    connection = DummySyncConnection()
+    driver = driver_type(
+        connection=cast(Any, connection),
+        statement_config=statement_config,
+        driver_features={"storage_capabilities": CAPABILITIES},
+    )
+    arrow_table = pa.table({"id": [1], "payload": pa.array([{"name": "alpha"}]), "tags": pa.array([["north", "east"]])})
+
+    driver.load_from_arrow("analytics.events", arrow_table)
+
+    assert connection.operations[0][0] == "executemany"
+    assert connection.operations[0][2] == [(1, '{"name":"alpha"}', '["north","east"]')]
 
 
 async def test_asyncmy_load_from_storage_merges_source(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #452.

Summary:
- register asyncpg json/jsonb codecs in binary mode, including JSONB version-byte handling
- align cockroach_asyncpg connection init with asyncpg JSON codec registration
- prepare nested Arrow rows for SQLite/MySQL-family bridged loaders and cache Arrow schema prep decisions
- tighten psqlpy JSON fallback and Spanner Arrow parameter-type caching
- add Oracle, DuckDB, psycopg, psqlpy, asyncpg, Cockroach, SQLite, MySQL-family, and Spanner regression coverage