### PR TITLE
fix(build): version-gate Traversable import for Py 3.11+ typeshed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,6 +76,12 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Export build constraints from uv.lock
+        run: uv export --frozen --no-emit-project --no-hashes --format requirements.txt --output-file build-constraints.txt
+
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
 
@@ -94,8 +100,10 @@ jobs:
           # Skip problematic combinations
           CIBW_SKIP: "cp39-win_arm64 *-musllinux*"
 
-          # Install build dependencies (base, overridden per-platform below)
-          CIBW_BEFORE_BUILD: "pip install hatch-mypyc hatchling"
+          # Install build dependencies (base, overridden per-platform below).
+          # build-constraints.txt is produced from uv.lock so hatch-mypyc / mypy / hatchling
+          # versions match the locked dev environment and can't drift on each cibw run.
+          CIBW_BEFORE_BUILD: "pip install -c /project/build-constraints.txt hatch-mypyc hatchling"
 
           # Test the built wheels
           CIBW_TEST_REQUIRES: "cloud-sql-python-connector google-cloud-alloydb-connector"
@@ -107,7 +115,7 @@ jobs:
           # Stage 3 (optimized build) is the main cibuildwheel build with -fprofile-use.
           # HATCH_MYPYC_BUILD_DIR pins the build directory so profile data paths match.
           CIBW_BEFORE_BUILD_LINUX: >-
-            pip install hatch-mypyc hatchling &&
+            pip install -c /project/build-constraints.txt hatch-mypyc hatchling &&
             PGO_DIR=/tmp/sqlspec-pgo &&
             BUILD_DIR=/tmp/sqlspec-mypyc-build &&
             mkdir -p "$PGO_DIR" "$BUILD_DIR" &&
@@ -129,7 +137,7 @@ jobs:
 
           # ── macOS (Clang): PGO three-stage build ──
           CIBW_BEFORE_BUILD_MACOS: >-
-            pip install hatch-mypyc hatchling &&
+            pip install -c /project/build-constraints.txt hatch-mypyc hatchling &&
             PGO_DIR=/tmp/sqlspec-pgo &&
             BUILD_DIR=/tmp/sqlspec-mypyc-build &&
             mkdir -p "$PGO_DIR" "$BUILD_DIR" &&

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -17,7 +17,10 @@ on:
       - '.github/workflows/pgo-validate.yml'
       - '.github/workflows/publish.yml'
       - 'pyproject.toml'
+      - 'uv.lock'
       - 'tools/scripts/pgo_training.py'
+      - 'sqlspec/**'
+      - 'tools/scripts/mypyc_smoke.py'
 
 jobs:
   build-source:
@@ -91,6 +94,12 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Export build constraints from uv.lock
+        run: uv export --frozen --no-emit-project --no-hashes --format requirements.txt --output-file build-constraints.txt
+
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
 
@@ -109,8 +118,10 @@ jobs:
           # Skip problematic combinations
           CIBW_SKIP: "cp39-win_arm64 *-musllinux*"
 
-          # Install build dependencies (base, overridden per-platform below)
-          CIBW_BEFORE_BUILD: "pip install hatch-mypyc hatchling"
+          # Install build dependencies (base, overridden per-platform below).
+          # build-constraints.txt is produced from uv.lock so hatch-mypyc / mypy / hatchling
+          # versions match the locked dev environment and can't drift on each cibw run.
+          CIBW_BEFORE_BUILD: "pip install -c /project/build-constraints.txt hatch-mypyc hatchling"
 
           # Test the built wheels
           CIBW_TEST_REQUIRES: "cloud-sql-python-connector google-cloud-alloydb-connector"
@@ -119,7 +130,7 @@ jobs:
 
           # Linux PR validation should exercise the same three-stage PGO path as publish.yml.
           CIBW_BEFORE_BUILD_LINUX: >-
-            pip install hatch-mypyc hatchling &&
+            pip install -c /project/build-constraints.txt hatch-mypyc hatchling &&
             PGO_DIR=/tmp/sqlspec-pgo &&
             BUILD_DIR=/tmp/sqlspec-mypyc-build &&
             mkdir -p "$PGO_DIR" "$BUILD_DIR" &&

--- a/sqlspec/data_dictionary/_loader.py
+++ b/sqlspec/data_dictionary/_loader.py
@@ -7,7 +7,12 @@ from sqlspec.exceptions import SQLFileNotFoundError
 from sqlspec.loader import SQLFileLoader
 
 if TYPE_CHECKING:
-    from importlib.abc import Traversable
+    import sys
+
+    if sys.version_info >= (3, 11):
+        from importlib.resources.abc import Traversable
+    else:
+        from importlib.abc import Traversable
 
     from sqlspec.core.statement import SQL
     from sqlspec.data_dictionary._types import DialectConfig


### PR DESCRIPTION
## Summary
- **Hot fix (commit 1):** version-gate the `Traversable` import in `sqlspec/data_dictionary/_loader.py`. The current mypy/typeshed removed `Traversable` from `importlib.abc`; it lives in `importlib.resources.abc` for Py 3.11+. Mypyc strips `TYPE_CHECKING` blocks before compilation, so this is type-checker-only — zero runtime impact. Failing run for reference: https://github.com/litestar-org/sqlspec/actions/runs/26344367739/job/77551706326
- **Hardening (commit 2):** the release wheel build was broken by an unpinned `pip install hatch-mypyc hatchling` in `CIBW_BEFORE_BUILD`, which pulled mypy 2.1.0 + its new typeshed. Two follow-ups:
  - Export a `build-constraints.txt` from `uv.lock` in the runner before cibw, then reference it via `pip install -c` in `CIBW_BEFORE_BUILD` (plus the Linux + macOS PGO overrides) in both `publish.yml` and `test-build.yml`. Build-time `hatch-mypyc` / `mypy` / `hatchling` versions now track the locked dev environment.
  - Broaden `test-build.yml` PR triggers to include `sqlspec/**`, `uv.lock`, and `tools/scripts/mypyc_smoke.py` so the mypyc + PGO wheel build runs on the PR that introduces source changes, instead of only surfacing at release time.

## Test plan
- [ ] CI: `mypy`, `pyright`, `test-linux (3.10/3.11/3.12/3.13/3.14)` stay green with the new version-gated import.
- [ ] CI: `Test Build Configuration` now runs on this PR (workflow trigger broadened) and the mypyc / PGO wheel build completes without the `Traversable` attr-defined error.
- [ ] Confirm `build-constraints.txt` is generated in the runner, mounted at `/project/build-constraints.txt`, and that `pip install -c ... hatch-mypyc hatchling` resolves to the versions pinned in `uv.lock` (currently hatch-mypyc 0.16.0 / mypy 2.1.0 / hatchling 1.29.0).
- [ ] Re-trigger the release workflow once merged.