### PR TITLE
ci: bump GitHub Actions to Node 24 majors + add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: ci
+
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: deps

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         run: uv run python tools/build_docs.py docs-build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs-build
 
@@ -47,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pgo-validate.yml
+++ b/.github/workflows/pgo-validate.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,6 +15,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
         run: uv build --sdist
 
       - name: Upload source artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: source-dist
           path: dist/*.tar.gz
@@ -51,7 +51,7 @@ jobs:
         run: uv build --wheel
 
       - name: Upload wheel artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-standard
           path: dist/*.whl
@@ -67,12 +67,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: all
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -164,7 +164,7 @@ jobs:
             MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
 
       - name: Upload wheel artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-mypyc-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
@@ -191,13 +191,13 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Download standard wheel artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wheels-standard
           path: dist-standard/
 
       - name: Download mypyc wheel artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: wheels-mypyc-*
           merge-multiple: true
@@ -230,7 +230,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: "*"
           merge-multiple: true

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -43,7 +43,7 @@ jobs:
         run: uv build --sdist
 
       - name: Upload source artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: source-dist
           path: dist/*.tar.gz
@@ -68,7 +68,7 @@ jobs:
         run: uv build --wheel
 
       - name: Upload wheel artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-standard
           path: dist/*.whl
@@ -85,12 +85,12 @@ jobs:
 
       - name: Set up QEMU
         if: github.event.inputs.test_matrix == 'full'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: all
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -151,7 +151,7 @@ jobs:
             CFLAGS="-fprofile-use=/tmp/sqlspec-pgo -fprofile-correction -Wno-error=missing-profile -Wno-error=coverage-mismatch"
 
       - name: Upload wheel artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-mypyc-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
@@ -178,13 +178,13 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Download standard wheel artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: wheels-standard
           path: dist-standard/
 
       - name: Download mypyc wheel artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: wheels-mypyc-*
           merge-multiple: true
@@ -211,7 +211,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: "*"
           merge-multiple: true


### PR DESCRIPTION
## Summary

Pre-empts the 2026-06-02 Node 24 cutover and 2026-09-16 Node 20 removal on GitHub-hosted runners. Last release emitted Node 20 deprecation warnings on every `actions/upload-artifact@v4` invocation in `publish.yml` ("Build standard pure Python wheel", "Build source distribution"). Full audit of every workflow follows; ships with a dependabot config so the next cutover comes as an automated PR instead of a release-day warning.

###  `ci: bump actions to Node 24 majors`

20 line edits across 5 workflow files. `ci.yml` already on Node 24 actions; untouched.

| Action | Current | Target | Notes |
| --- | --- | --- | --- |
| `actions/upload-artifact` | v4 | **v7** | v6 first Node 24 default; v7 adds opt-in direct uploads (default behavior unchanged for our usage) |
| `actions/download-artifact` | v4 | **v7** | Skips v8 — v8 makes hash-mismatch errors the default; behavior change we don't need |
| `actions/setup-python` | v5 | **v6** | v6.0.0 = Node 24 (Sep 2025) |
| `actions/upload-pages-artifact` | v4 | **v5** | v5.0.0 = Node 24 (Apr 2026) |
| `actions/deploy-pages` | v4 | **v5** | v5.0.0 = Node 24 (Mar 2026) |
| `docker/setup-qemu-action` | v3 | **v4** | v4.0.0 = Node 24 (Mar 2026) |
| `amannn/action-semantic-pull-request` | v5 | **v6** | v6.0.0 = Node 24 (Aug 2025) |

Untouched (already current / auto-tracking): `actions/checkout@v6`, `actions/cache@v5`, `astral-sh/setup-uv@v7`, `pypa/gh-action-pypi-publish@release/v1`.

###  `ci: add dependabot config for github-actions + python security`

New `.github/dependabot.yml`:

- **`github-actions`**: weekly version updates, all actions grouped into one PR. Catches the next Node-version cutover and any action-side security advisories with low review burden.
- **`uv`**: security advisories only via `open-pull-requests-limit: 0`. Avoids weekly version churn across the ~25 optional dependency groups (asyncpg, oracledb, bigquery, spanner, adbc, ...) while keeping a security floor.

## Risks & mitigations

| Risk | Mitigation |
| --- | --- |
| `upload-artifact@v7` rejects an input we use | All call sites use only `name` + `path` — stable across v5/v6/v7. |
| `download-artifact@v7` changes merge-multiple semantics | `merge-multiple: true` + `pattern:` inputs unchanged across v4–v7. |
| `setup-python@v6` drops a feature | Only `python-version` used; stable. |
| `docker/setup-qemu-action@v4` QEMU regression | Used only in mypyc cibuildwheel matrix; pin to `v4.0.x` minor if needed. |
| Dependabot floods inbox | Actions grouped to one PR; uv restricted to security-only. |

Beads: epic `sqlspec-bo94`; tasks `sqlspec-rbfr` (T1) + `sqlspec-vfgl` (T2) implemented here; `sqlspec-40qj` (T3 verification) follows post-merge.