### PR TITLE
fix(ci): improve `mypyc` build testing and failure detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
     branches:
       - main
 
+# Cancel in-flight runs of this workflow on the same ref when a newer
+# commit lands. Saves runner minutes during a churn of PR pushes. Not
+# applied to publish.yml — releases must never be cancelled mid-upload.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python
         run: uv python install 3.11
@@ -41,6 +44,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python
         run: uv python install 3.11
@@ -58,6 +64,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python
         run: uv python install 3.11
@@ -75,6 +84,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python
         run: uv python install 3.11
@@ -98,6 +110,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python
         run: uv python install ${{ matrix.python-version }}
@@ -105,7 +120,19 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev
 
+      - name: Cache docker images
+        id: docker-image-cache
+        uses: actions/cache@v5
+        with:
+          path: /tmp/docker-images
+          key: docker-images-v1-${{ hashFiles('.github/workflows/ci.yml') }}
+
+      - name: Load cached docker images
+        if: steps.docker-image-cache.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/docker-images/sqlspec-test-images.tar
+
       - name: Pre-pull docker images
+        if: steps.docker-image-cache.outputs.cache-hit != 'true'
         run: |
           set -eu
           images=(
@@ -121,6 +148,8 @@ jobs:
             rustfs/rc:latest
           )
           printf '%s\n' "${images[@]}" | xargs -P 4 -I{} docker pull {}
+          mkdir -p /tmp/docker-images
+          docker save "${images[@]}" -o /tmp/docker-images/sqlspec-test-images.tar
 
       - name: Test
         id: pytest
@@ -230,6 +259,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,13 @@ on:
 permissions:
   contents: read
 
+# Cancel in-flight runs of this workflow on the same ref when a newer
+# commit lands. Saves runner minutes during a churn of PR pushes. Not
+# applied to publish.yml — releases must never be cancelled mid-upload.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -149,7 +149,7 @@ jobs:
           # Stage 3 (optimized build) is the main cibuildwheel build with -fprofile-use.
           # HATCH_MYPYC_BUILD_DIR pins the build directory so profile data paths match.
           CIBW_BEFORE_BUILD_LINUX: >-
-            pip install -c /project/build-constraints.txt hatch-mypyc hatchling &&
+            pip install -c {project}/build-constraints.txt hatch-mypyc hatchling &&
             PGO_DIR=/tmp/sqlspec-pgo &&
             BUILD_DIR=/tmp/sqlspec-mypyc-build &&
             mkdir -p "$PGO_DIR" "$BUILD_DIR" &&
@@ -159,7 +159,7 @@ jobs:
             MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
             pip install {package} --no-build-isolation &&
             pip install anyio pyarrow aiosqlite duckdb adbc-driver-sqlite adbc-driver-manager &&
-            python /project/tools/scripts/pgo_training.py &&
+            python {project}/tools/scripts/pgo_training.py &&
             pip uninstall -y sqlspec &&
             rm -rf "$BUILD_DIR/build" "$BUILD_DIR/tmp"
 
@@ -173,7 +173,7 @@ jobs:
           # Activated for the first time by the per-OS matrix split — the blocks
           # below were authored previously but never ran (job had been ubuntu-only).
           CIBW_BEFORE_BUILD_MACOS: >-
-            pip install -c /project/build-constraints.txt hatch-mypyc hatchling &&
+            pip install -c {project}/build-constraints.txt hatch-mypyc hatchling &&
             PGO_DIR=/tmp/sqlspec-pgo &&
             BUILD_DIR=/tmp/sqlspec-mypyc-build &&
             mkdir -p "$PGO_DIR" "$BUILD_DIR" &&
@@ -183,7 +183,7 @@ jobs:
             MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
             pip install {package} --no-build-isolation &&
             pip install anyio pyarrow aiosqlite duckdb adbc-driver-sqlite adbc-driver-manager &&
-            python /project/tools/scripts/pgo_training.py &&
+            python {project}/tools/scripts/pgo_training.py &&
             xcrun llvm-profdata merge -o "$PGO_DIR/merged.profdata" "$PGO_DIR"/*.profraw &&
             pip uninstall -y sqlspec &&
             rm -rf "$BUILD_DIR/build" "$BUILD_DIR/tmp"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -169,33 +169,19 @@ jobs:
             MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
             CFLAGS="-fprofile-use=/tmp/sqlspec-pgo -fprofile-correction -Wno-error=missing-profile -Wno-error=coverage-mismatch"
 
-          # ── macOS (Clang): PGO three-stage build ──
-          # Activated for the first time by the per-OS matrix split — the blocks
-          # below were authored previously but never ran (job had been ubuntu-only).
-          CIBW_BEFORE_BUILD_MACOS: >-
-            pip install -c {project}/build-constraints.txt hatch-mypyc hatchling &&
-            PGO_DIR=/tmp/sqlspec-pgo &&
-            BUILD_DIR=/tmp/sqlspec-mypyc-build &&
-            mkdir -p "$PGO_DIR" "$BUILD_DIR" &&
-            CFLAGS="-fprofile-instr-generate=$PGO_DIR/default_%m.profraw"
-            HATCH_BUILD_HOOKS_ENABLE=1
-            HATCH_MYPYC_BUILD_DIR="$BUILD_DIR"
-            MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
-            pip install {package} --no-build-isolation &&
-            pip install anyio pyarrow aiosqlite duckdb adbc-driver-sqlite adbc-driver-manager &&
-            python {project}/tools/scripts/pgo_training.py &&
-            xcrun llvm-profdata merge -o "$PGO_DIR/merged.profdata" "$PGO_DIR"/*.profraw &&
-            pip uninstall -y sqlspec &&
-            rm -rf "$BUILD_DIR/build" "$BUILD_DIR/tmp"
-
+          # ── macOS (Clang): plain mypyc, no PGO ──
+          # PGO was attempted but pgo_training.py needs optional filter deps
+          # that are absent in the cibuildwheel BEFORE_BUILD env (every workload
+          # logs "skipped (filters not installed)" → no .profraw files emitted
+          # → llvm-profdata merge fails). Falls back to the base CIBW_BEFORE_BUILD,
+          # which just installs hatch-mypyc + hatchling and lets cibuildwheel
+          # run the normal frontend build with the mypyc env below.
           CIBW_ENVIRONMENT_MACOS: >-
             HATCH_BUILD_HOOKS_ENABLE=1
             HATCH_MYPYC_BUILD_DIR=/tmp/sqlspec-mypyc-build
             MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
-            CFLAGS="-fprofile-instr-use=/tmp/sqlspec-pgo/merged.profdata"
 
           # ── Windows (MSVC): plain mypyc, no PGO ──
-          # MSVC PGO with hatch-mypyc is not validated. Track separately if needed.
           CIBW_ENVIRONMENT_WINDOWS: >-
             HATCH_BUILD_HOOKS_ENABLE=1
             MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -221,14 +221,19 @@ jobs:
         uses: actions/checkout@v6
 
       # Route untrusted release tag through an env var (not direct ${{ … }}
-      # interpolation into the shell) to avoid command injection.
+      # interpolation into the shell) to avoid command injection. Fall back
+      # to pyproject.toml when triggered via workflow_dispatch (no release
+      # context) so manual reruns still have a version to assert against.
       - name: Resolve expected version
         shell: bash
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          # Strip optional leading 'v' (e.g. 'v0.47.0' → '0.47.0').
-          echo "SQLSPEC_EXPECTED_VERSION=${RELEASE_TAG#v}" >> "$GITHUB_ENV"
+          tag="${RELEASE_TAG#v}"
+          if [ -z "$tag" ]; then
+            tag=$(grep -m1 '^version = ' pyproject.toml | sed -E 's/version = "(.*)"/\1/')
+          fi
+          echo "SQLSPEC_EXPECTED_VERSION=$tag" >> "$GITHUB_ENV"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,19 +68,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
-
-      # Linux is the only host that cross-builds an additional arch (aarch64)
-      # under QEMU. macOS arm64 and Windows AMD64 are native to their runners.
-      - name: Set up QEMU
-        if: matrix.os == 'ubuntu-latest'
-        uses: docker/setup-qemu-action@v4
-        with:
-          platforms: arm64
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -108,9 +100,9 @@ jobs:
             pip-${{ runner.os }}-py${{ matrix.python-version }}-
 
       # mypyc compile cache only useful on PGO hosts where HATCH_MYPYC_BUILD_DIR
-      # is pinned. Windows builds without PGO and without a pinned build dir.
+      # is pinned. Windows + macOS build without PGO and without a pinned build dir.
       - name: Cache mypyc build dir
-        if: matrix.os == 'ubuntu-latest'
+        if: startsWith(matrix.os, 'ubuntu')
         uses: actions/cache@v5
         with:
           path: /tmp/sqlspec-mypyc-build
@@ -139,10 +131,10 @@ jobs:
           CIBW_BUILD: "cp${{ matrix.python-version == '3.10' && '310' || matrix.python-version == '3.11' && '311' || matrix.python-version == '3.12' && '312' || matrix.python-version == '3.13' && '313' || matrix.python-version == '3.14' && '314' }}-*"
           CIBW_BUILD_VERBOSITY: 1
 
-          # cibuildwheel reads only the *_ARCHS_<HOST> var matching the current
-          # runner OS; leaving all three set documents intent without side effects.
-          CIBW_ARCHS_LINUX: "x86_64 aarch64"
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          # Native host arch only — Linux aarch64 builds on ubuntu-24.04-arm,
+          # macOS arm64 on macos-latest (Apple Silicon). No QEMU emulation.
+          CIBW_ARCHS_LINUX: ${{ matrix.os == 'ubuntu-24.04-arm' && 'aarch64' || 'x86_64' }}
+          CIBW_ARCHS_MACOS: "arm64"
           CIBW_ARCHS_WINDOWS: "AMD64"
 
           CIBW_SKIP: "cp39-win_arm64 *-musllinux*"
@@ -209,7 +201,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
         python-version: ["3.10", "3.12", "3.14"]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,13 +110,23 @@ jobs:
       # mypyc compile cache only useful on PGO hosts where HATCH_MYPYC_BUILD_DIR
       # is pinned. Windows builds without PGO and without a pinned build dir.
       - name: Cache mypyc build dir
-        if: matrix.os != 'windows-latest'
+        if: matrix.os == 'ubuntu-latest'
         uses: actions/cache@v5
         with:
           path: /tmp/sqlspec-mypyc-build
           key: mypyc-${{ matrix.os }}-py${{ matrix.python-version }}-${{ hashFiles('sqlspec/**/*.py', 'pyproject.toml') }}
           restore-keys: |
             mypyc-${{ matrix.os }}-py${{ matrix.python-version }}-
+
+      - name: Pre-warm Windows Defender exclusions
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          # Defender's real-time scan on the freshly-extracted nuget-cpython
+          # python.exe blocks virtualenv discovery past its 10s timeout.
+          Add-MpPreference -ExclusionPath "$env:LOCALAPPDATA\pypa\cibuildwheel" -ErrorAction SilentlyContinue
+          Add-MpPreference -ExclusionPath "$env:TEMP" -ErrorAction SilentlyContinue
+          Add-MpPreference -ExclusionProcess "python.exe" -ErrorAction SilentlyContinue
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
@@ -178,7 +188,6 @@ jobs:
           # run the normal frontend build with the mypyc env below.
           CIBW_ENVIRONMENT_MACOS: >-
             HATCH_BUILD_HOOKS_ENABLE=1
-            HATCH_MYPYC_BUILD_DIR=/tmp/sqlspec-mypyc-build
             MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
 
           # ── Windows (MSVC): plain mypyc, no PGO ──

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python
         run: uv python install 3.12
@@ -40,6 +43,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python 3.12
         run: uv python install 3.12
@@ -57,19 +63,24 @@ jobs:
           path: dist/*.whl
 
   build-wheels-mypyc:
-    name: Build MyPyC+PGO wheels for all platforms
-    runs-on: ubuntu-latest
+    name: Build MyPyC wheels (${{ matrix.os }} py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      # Linux is the only host that cross-builds an additional arch (aarch64)
+      # under QEMU. macOS arm64 and Windows AMD64 are native to their runners.
       - name: Set up QEMU
+        if: matrix.os == 'ubuntu-latest'
         uses: docker/setup-qemu-action@v4
         with:
-          platforms: all
+          platforms: arm64
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -78,9 +89,34 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Export build constraints from uv.lock
         run: uv export --frozen --no-emit-project --no-hashes --format requirements.txt --output-file build-constraints.txt
+
+      - name: Cache pip downloads
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/pip
+            ~/Library/Caches/pip
+            ~\AppData\Local\pip\Cache
+          key: pip-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('build-constraints.txt') }}
+          restore-keys: |
+            pip-${{ runner.os }}-py${{ matrix.python-version }}-
+
+      # mypyc compile cache only useful on PGO hosts where HATCH_MYPYC_BUILD_DIR
+      # is pinned. Windows builds without PGO and without a pinned build dir.
+      - name: Cache mypyc build dir
+        if: matrix.os != 'windows-latest'
+        uses: actions/cache@v5
+        with:
+          path: /tmp/sqlspec-mypyc-build
+          key: mypyc-${{ matrix.os }}-py${{ matrix.python-version }}-${{ hashFiles('sqlspec/**/*.py', 'pyproject.toml') }}
+          restore-keys: |
+            mypyc-${{ matrix.os }}-py${{ matrix.python-version }}-
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
@@ -88,27 +124,25 @@ jobs:
       - name: Build wheels with cibuildwheel
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          # Configure cibuildwheel
           CIBW_BUILD: "cp${{ matrix.python-version == '3.10' && '310' || matrix.python-version == '3.11' && '311' || matrix.python-version == '3.12' && '312' || matrix.python-version == '3.13' && '313' || matrix.python-version == '3.14' && '314' }}-*"
           CIBW_BUILD_VERBOSITY: 1
 
-          # Platform configuration - comprehensive coverage with QEMU emulation
+          # cibuildwheel reads only the *_ARCHS_<HOST> var matching the current
+          # runner OS; leaving all three set documents intent without side effects.
           CIBW_ARCHS_LINUX: "x86_64 aarch64"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_WINDOWS: "AMD64"
 
-          # Skip problematic combinations
           CIBW_SKIP: "cp39-win_arm64 *-musllinux*"
 
-          # Install build dependencies (base, overridden per-platform below).
-          # build-constraints.txt is produced from uv.lock so hatch-mypyc / mypy / hatchling
-          # versions match the locked dev environment and can't drift on each cibw run.
-          CIBW_BEFORE_BUILD: "pip install -c /project/build-constraints.txt hatch-mypyc hatchling"
+          # Base build deps; PGO blocks below override on Linux + macOS.
+          # build-constraints.txt is produced from uv.lock so hatch-mypyc / mypy /
+          # hatchling versions track the locked dev environment.
+          CIBW_BEFORE_BUILD: "pip install -c {project}/build-constraints.txt hatch-mypyc hatchling"
 
-          # Test the built wheels
           CIBW_TEST_REQUIRES: "cloud-sql-python-connector google-cloud-alloydb-connector"
           CIBW_TEST_COMMAND: >-
-            python /project/tools/scripts/mypyc_smoke.py --require-compiled
+            python {project}/tools/scripts/mypyc_smoke.py --require-compiled
 
           # ── Linux (GCC): PGO three-stage build ──
           # Stage 1 (instrumented build) + Stage 2 (training) run in BEFORE_BUILD.
@@ -136,6 +170,8 @@ jobs:
             CFLAGS="-fprofile-use=/tmp/sqlspec-pgo -fprofile-correction -Wno-error=missing-profile -Wno-error=coverage-mismatch"
 
           # ── macOS (Clang): PGO three-stage build ──
+          # Activated for the first time by the per-OS matrix split — the blocks
+          # below were authored previously but never ran (job had been ubuntu-only).
           CIBW_BEFORE_BUILD_MACOS: >-
             pip install -c /project/build-constraints.txt hatch-mypyc hatchling &&
             PGO_DIR=/tmp/sqlspec-pgo &&
@@ -158,7 +194,8 @@ jobs:
             MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
             CFLAGS="-fprofile-instr-use=/tmp/sqlspec-pgo/merged.profdata"
 
-          # ── Windows (MSVC): No PGO, standard mypyc build ──
+          # ── Windows (MSVC): plain mypyc, no PGO ──
+          # MSVC PGO with hatch-mypyc is not validated. Track separately if needed.
           CIBW_ENVIRONMENT_WINDOWS: >-
             HATCH_BUILD_HOOKS_ENABLE=1
             MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
@@ -166,9 +203,8 @@ jobs:
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-mypyc-py${{ matrix.python-version }}
+          name: wheels-mypyc-${{ matrix.os }}-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
-
 
   test-wheels:
     name: Test ${{ matrix.os }} py${{ matrix.python-version }}
@@ -184,8 +220,21 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      # Route untrusted release tag through an env var (not direct ${{ … }}
+      # interpolation into the shell) to avoid command injection.
+      - name: Resolve expected version
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          # Strip optional leading 'v' (e.g. 'v0.47.0' → '0.47.0').
+          echo "SQLSPEC_EXPECTED_VERSION=${RELEASE_TAG#v}" >> "$GITHUB_ENV"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -203,16 +252,24 @@ jobs:
           merge-multiple: true
           path: dist-mypyc/
 
+      # --no-index forbids PyPI fallback so any missing wheel for the current
+      # host fails the install loudly instead of silently grabbing a stale
+      # pure-Python release. The version assert catches drift between
+      # pyproject.toml and the built wheel.
       - name: Test standard wheel installation
+        shell: bash
         run: |
           uv venv test-standard --python ${{ matrix.python-version }}
-          uv pip install --python test-standard --find-links dist-standard/ sqlspec
+          uv pip install --python test-standard --no-index --find-links dist-standard/ "sqlspec==${SQLSPEC_EXPECTED_VERSION}"
+          uv run --no-project --python test-standard python -I -c "import sqlspec, os, sys; v=sqlspec.__version__; e=os.environ['SQLSPEC_EXPECTED_VERSION']; sys.exit(0 if v == e else (sys.stderr.write(f'version mismatch: got {v}, expected {e}\n') or 1))"
           uv run --no-project --python test-standard python -I -c "import sqlspec; print('Standard wheel OK')"
 
       - name: Test mypyc wheel installation
+        shell: bash
         run: |
           uv venv test-mypyc --python ${{ matrix.python-version }}
-          uv pip install --python test-mypyc --find-links dist-mypyc/ sqlspec
+          uv pip install --python test-mypyc --no-index --find-links dist-mypyc/ "sqlspec==${SQLSPEC_EXPECTED_VERSION}"
+          uv run --no-project --python test-mypyc python -I -c "import sqlspec, os, sys; v=sqlspec.__version__; e=os.environ['SQLSPEC_EXPECTED_VERSION']; sys.exit(0 if v == e else (sys.stderr.write(f'version mismatch: got {v}, expected {e}\n') or 1))"
           uv run --no-project --python test-mypyc python -I tools/scripts/mypyc_smoke.py --require-compiled
 
   publish-release:
@@ -228,6 +285,9 @@ jobs:
     steps:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Download all artifacts
         uses: actions/download-artifact@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -126,6 +126,8 @@ jobs:
           # python.exe blocks virtualenv discovery past its 10s timeout.
           Add-MpPreference -ExclusionPath "$env:LOCALAPPDATA\pypa\cibuildwheel" -ErrorAction SilentlyContinue
           Add-MpPreference -ExclusionPath "$env:TEMP" -ErrorAction SilentlyContinue
+          Add-MpPreference -ExclusionPath "$env:GITHUB_WORKSPACE" -ErrorAction SilentlyContinue
+          Add-MpPreference -ExclusionPath "$env:GITHUB_WORKSPACE\wheelhouse" -ErrorAction SilentlyContinue
           Add-MpPreference -ExclusionProcess "python.exe" -ErrorAction SilentlyContinue
 
       - name: Install cibuildwheel

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -208,7 +208,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.12", "3.14"]
+        python-version: ["3.12"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -246,15 +246,16 @@ jobs:
           merge-multiple: true
           path: dist-mypyc/
 
-      # --no-index forbids PyPI fallback so any missing wheel for the current
-      # host fails the install loudly instead of silently grabbing a stale
-      # pure-Python release. The version assert catches drift between
-      # pyproject.toml and the built wheel.
+      # Install sqlspec from local wheels only (--no-index + --no-deps) so any
+      # missing host wheel fails loudly instead of silently grabbing a stale
+      # PyPI release. Transitive deps resolve from PyPI in a separate step.
+      # The version assert catches drift between pyproject.toml and the wheel.
       - name: Test standard wheel installation
         shell: bash
         run: |
           uv venv test-standard --python ${{ matrix.python-version }}
-          uv pip install --python test-standard --no-index --find-links dist-standard/ "sqlspec==${SQLSPEC_EXPECTED_VERSION}"
+          uv pip install --python test-standard --no-index --no-deps --find-links dist-standard/ "sqlspec==${SQLSPEC_EXPECTED_VERSION}"
+          uv pip install --python test-standard "sqlspec==${SQLSPEC_EXPECTED_VERSION}" --find-links dist-standard/
           uv run --no-project --python test-standard python -I -c "import sqlspec, os, sys; v=sqlspec.__version__; e=os.environ['SQLSPEC_EXPECTED_VERSION']; sys.exit(0 if v == e else (sys.stderr.write(f'version mismatch: got {v}, expected {e}\n') or 1))"
           uv run --no-project --python test-standard python -I -c "import sqlspec; print('Standard wheel OK')"
 
@@ -262,7 +263,8 @@ jobs:
         shell: bash
         run: |
           uv venv test-mypyc --python ${{ matrix.python-version }}
-          uv pip install --python test-mypyc --no-index --find-links dist-mypyc/ "sqlspec==${SQLSPEC_EXPECTED_VERSION}"
+          uv pip install --python test-mypyc --no-index --no-deps --find-links dist-mypyc/ "sqlspec==${SQLSPEC_EXPECTED_VERSION}"
+          uv pip install --python test-mypyc "sqlspec==${SQLSPEC_EXPECTED_VERSION}" --find-links dist-mypyc/
           uv run --no-project --python test-mypyc python -I -c "import sqlspec, os, sys; v=sqlspec.__version__; e=os.environ['SQLSPEC_EXPECTED_VERSION']; sys.exit(0 if v == e else (sys.stderr.write(f'version mismatch: got {v}, expected {e}\n') or 1))"
           uv run --no-project --python test-mypyc python -I tools/scripts/mypyc_smoke.py --require-compiled
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -208,7 +208,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.12"]
+        python-version: ["3.10", "3.12", "3.14"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -197,7 +197,7 @@ jobs:
 
           # Linux PR validation exercises the same three-stage PGO path as publish.yml.
           CIBW_BEFORE_BUILD_LINUX: >-
-            pip install -c /project/build-constraints.txt hatch-mypyc hatchling &&
+            pip install -c {project}/build-constraints.txt hatch-mypyc hatchling &&
             PGO_DIR=/tmp/sqlspec-pgo &&
             BUILD_DIR=/tmp/sqlspec-mypyc-build &&
             mkdir -p "$PGO_DIR" "$BUILD_DIR" &&
@@ -207,7 +207,7 @@ jobs:
             MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
             pip install {package} --no-build-isolation &&
             pip install anyio pyarrow aiosqlite duckdb adbc-driver-sqlite adbc-driver-manager &&
-            python /project/tools/scripts/pgo_training.py &&
+            python {project}/tools/scripts/pgo_training.py &&
             pip uninstall -y sqlspec &&
             rm -rf "$BUILD_DIR/build" "$BUILD_DIR/tmp"
 
@@ -218,7 +218,7 @@ jobs:
             CFLAGS="-fprofile-use=/tmp/sqlspec-pgo -fprofile-correction -Wno-error=missing-profile -Wno-error=coverage-mismatch"
 
           CIBW_BEFORE_BUILD_MACOS: >-
-            pip install -c /project/build-constraints.txt hatch-mypyc hatchling &&
+            pip install -c {project}/build-constraints.txt hatch-mypyc hatchling &&
             PGO_DIR=/tmp/sqlspec-pgo &&
             BUILD_DIR=/tmp/sqlspec-mypyc-build &&
             mkdir -p "$PGO_DIR" "$BUILD_DIR" &&
@@ -228,7 +228,7 @@ jobs:
             MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
             pip install {package} --no-build-isolation &&
             pip install anyio pyarrow aiosqlite duckdb adbc-driver-sqlite adbc-driver-manager &&
-            python /project/tools/scripts/pgo_training.py &&
+            python {project}/tools/scripts/pgo_training.py &&
             xcrun llvm-profdata merge -o "$PGO_DIR/merged.profdata" "$PGO_DIR"/*.profraw &&
             pip uninstall -y sqlspec &&
             rm -rf "$BUILD_DIR/build" "$BUILD_DIR/tmp"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -200,6 +200,8 @@ jobs:
           # python.exe blocks virtualenv discovery past its 10s timeout.
           Add-MpPreference -ExclusionPath "$env:LOCALAPPDATA\pypa\cibuildwheel" -ErrorAction SilentlyContinue
           Add-MpPreference -ExclusionPath "$env:TEMP" -ErrorAction SilentlyContinue
+          Add-MpPreference -ExclusionPath "$env:GITHUB_WORKSPACE" -ErrorAction SilentlyContinue
+          Add-MpPreference -ExclusionPath "$env:GITHUB_WORKSPACE\wheelhouse" -ErrorAction SilentlyContinue
           Add-MpPreference -ExclusionProcess "python.exe" -ErrorAction SilentlyContinue
 
       - name: Install cibuildwheel

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -32,6 +32,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python
         run: uv python install 3.12
@@ -57,6 +60,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python 3.12
         run: uv python install 3.12
@@ -74,20 +80,22 @@ jobs:
           path: dist/*.whl
 
   build-wheels-mypyc:
-    name: Build MyPyC wheels for all platforms
-    runs-on: ubuntu-latest
+    name: Build MyPyC wheels (${{ matrix.os }} py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        os: ${{ github.event.inputs.test_matrix == 'full' && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
         python-version: ${{ github.event.inputs.test_matrix == 'full' && fromJSON('["3.10", "3.11", "3.12", "3.13", "3.14"]') || fromJSON('["3.12"]') }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
       - name: Set up QEMU
-        if: github.event.inputs.test_matrix == 'full'
+        if: matrix.os == 'ubuntu-latest' && github.event.inputs.test_matrix == 'full'
         uses: docker/setup-qemu-action@v4
         with:
-          platforms: all
+          platforms: arm64
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -96,9 +104,32 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Export build constraints from uv.lock
         run: uv export --frozen --no-emit-project --no-hashes --format requirements.txt --output-file build-constraints.txt
+
+      - name: Cache pip downloads
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/pip
+            ~/Library/Caches/pip
+            ~\AppData\Local\pip\Cache
+          key: pip-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('build-constraints.txt') }}
+          restore-keys: |
+            pip-${{ runner.os }}-py${{ matrix.python-version }}-
+
+      - name: Cache mypyc build dir
+        if: matrix.os != 'windows-latest'
+        uses: actions/cache@v5
+        with:
+          path: /tmp/sqlspec-mypyc-build
+          key: mypyc-${{ matrix.os }}-py${{ matrix.python-version }}-${{ hashFiles('sqlspec/**/*.py', 'pyproject.toml') }}
+          restore-keys: |
+            mypyc-${{ matrix.os }}-py${{ matrix.python-version }}-
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
@@ -106,29 +137,23 @@ jobs:
       - name: Build wheels with cibuildwheel
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          # Configure cibuildwheel
           CIBW_BUILD: "cp${{ matrix.python-version == '3.10' && '310' || matrix.python-version == '3.11' && '311' || matrix.python-version == '3.12' && '312' || matrix.python-version == '3.13' && '313' || matrix.python-version == '3.14' && '314' }}-*"
           CIBW_BUILD_VERBOSITY: 1
 
-          # Platform configuration - conditional ARM64 support with QEMU
+          # Conditional aarch64 cross-build only in 'full' mode (QEMU enabled).
           CIBW_ARCHS_LINUX: ${{ github.event.inputs.test_matrix == 'full' && 'x86_64 aarch64' || 'x86_64' }}
           CIBW_ARCHS_MACOS: ${{ github.event.inputs.test_matrix == 'full' && 'x86_64 arm64' || 'x86_64' }}
           CIBW_ARCHS_WINDOWS: "AMD64"
 
-          # Skip problematic combinations
           CIBW_SKIP: "cp39-win_arm64 *-musllinux*"
 
-          # Install build dependencies (base, overridden per-platform below).
-          # build-constraints.txt is produced from uv.lock so hatch-mypyc / mypy / hatchling
-          # versions match the locked dev environment and can't drift on each cibw run.
-          CIBW_BEFORE_BUILD: "pip install -c /project/build-constraints.txt hatch-mypyc hatchling"
+          CIBW_BEFORE_BUILD: "pip install -c {project}/build-constraints.txt hatch-mypyc hatchling"
 
-          # Test the built wheels
           CIBW_TEST_REQUIRES: "cloud-sql-python-connector google-cloud-alloydb-connector"
           CIBW_TEST_COMMAND: >-
-            python /project/tools/scripts/mypyc_smoke.py --require-compiled
+            python {project}/tools/scripts/mypyc_smoke.py --require-compiled
 
-          # Linux PR validation should exercise the same three-stage PGO path as publish.yml.
+          # Linux PR validation exercises the same three-stage PGO path as publish.yml.
           CIBW_BEFORE_BUILD_LINUX: >-
             pip install -c /project/build-constraints.txt hatch-mypyc hatchling &&
             PGO_DIR=/tmp/sqlspec-pgo &&
@@ -150,10 +175,36 @@ jobs:
             MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
             CFLAGS="-fprofile-use=/tmp/sqlspec-pgo -fprofile-correction -Wno-error=missing-profile -Wno-error=coverage-mismatch"
 
+          CIBW_BEFORE_BUILD_MACOS: >-
+            pip install -c /project/build-constraints.txt hatch-mypyc hatchling &&
+            PGO_DIR=/tmp/sqlspec-pgo &&
+            BUILD_DIR=/tmp/sqlspec-mypyc-build &&
+            mkdir -p "$PGO_DIR" "$BUILD_DIR" &&
+            CFLAGS="-fprofile-instr-generate=$PGO_DIR/default_%m.profraw"
+            HATCH_BUILD_HOOKS_ENABLE=1
+            HATCH_MYPYC_BUILD_DIR="$BUILD_DIR"
+            MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
+            pip install {package} --no-build-isolation &&
+            pip install anyio pyarrow aiosqlite duckdb adbc-driver-sqlite adbc-driver-manager &&
+            python /project/tools/scripts/pgo_training.py &&
+            xcrun llvm-profdata merge -o "$PGO_DIR/merged.profdata" "$PGO_DIR"/*.profraw &&
+            pip uninstall -y sqlspec &&
+            rm -rf "$BUILD_DIR/build" "$BUILD_DIR/tmp"
+
+          CIBW_ENVIRONMENT_MACOS: >-
+            HATCH_BUILD_HOOKS_ENABLE=1
+            HATCH_MYPYC_BUILD_DIR=/tmp/sqlspec-mypyc-build
+            MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
+            CFLAGS="-fprofile-instr-use=/tmp/sqlspec-pgo/merged.profdata"
+
+          CIBW_ENVIRONMENT_WINDOWS: >-
+            HATCH_BUILD_HOOKS_ENABLE=1
+            MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
+
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-mypyc-py${{ matrix.python-version }}
+          name: wheels-mypyc-${{ matrix.os }}-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
 
 
@@ -171,8 +222,19 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      # PR builds have no release tag — derive expected version from
+      # pyproject.toml so the version assertion below has something to check.
+      - name: Resolve expected version
+        shell: bash
+        run: |
+          v=$(grep -m1 '^version = ' pyproject.toml | sed -E 's/version = "(.*)"/\1/')
+          echo "SQLSPEC_EXPECTED_VERSION=$v" >> "$GITHUB_ENV"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -191,15 +253,19 @@ jobs:
           path: dist-mypyc/
 
       - name: Test standard wheel installation
+        shell: bash
         run: |
           uv venv test-standard --python ${{ matrix.python-version }}
-          uv pip install --python test-standard --find-links dist-standard/ sqlspec
+          uv pip install --python test-standard --no-index --find-links dist-standard/ "sqlspec==${SQLSPEC_EXPECTED_VERSION}"
+          uv run --no-project --python test-standard python -I -c "import sqlspec, os, sys; v=sqlspec.__version__; e=os.environ['SQLSPEC_EXPECTED_VERSION']; sys.exit(0 if v == e else (sys.stderr.write(f'version mismatch: got {v}, expected {e}\n') or 1))"
           uv run --no-project --python test-standard python -I -c "import sqlspec; print('Standard wheel OK')"
 
       - name: Test mypyc wheel installation
+        shell: bash
         run: |
           uv venv test-mypyc --python ${{ matrix.python-version }}
-          uv pip install --python test-mypyc --find-links dist-mypyc/ sqlspec
+          uv pip install --python test-mypyc --no-index --find-links dist-mypyc/ "sqlspec==${SQLSPEC_EXPECTED_VERSION}"
+          uv run --no-project --python test-mypyc python -I -c "import sqlspec, os, sys; v=sqlspec.__version__; e=os.environ['SQLSPEC_EXPECTED_VERSION']; sys.exit(0 if v == e else (sys.stderr.write(f'version mismatch: got {v}, expected {e}\n') or 1))"
           uv run --no-project --python test-mypyc python -I tools/scripts/mypyc_smoke.py --require-compiled
 
   verify-packages:
@@ -209,6 +275,9 @@ jobs:
     steps:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Download all artifacts
         uses: actions/download-artifact@v7

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -152,12 +152,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Set up QEMU
-        if: matrix.os == 'ubuntu-latest' && needs.detect-mode.outputs.matrix_mode == 'full'
-        uses: docker/setup-qemu-action@v4
-        with:
-          platforms: arm64
-
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -213,9 +207,9 @@ jobs:
           CIBW_BUILD: "cp${{ matrix.python-version == '3.10' && '310' || matrix.python-version == '3.11' && '311' || matrix.python-version == '3.12' && '312' || matrix.python-version == '3.13' && '313' || matrix.python-version == '3.14' && '314' }}-*"
           CIBW_BUILD_VERBOSITY: 1
 
-          # Conditional aarch64 cross-build only in 'full' mode (QEMU enabled).
-          CIBW_ARCHS_LINUX: ${{ needs.detect-mode.outputs.matrix_mode == 'full' && 'x86_64 aarch64' || 'x86_64' }}
-          CIBW_ARCHS_MACOS: ${{ needs.detect-mode.outputs.matrix_mode == 'full' && 'x86_64 arm64' || 'x86_64' }}
+          # PR validation builds host arch only — release covers full cross-arch matrix.
+          CIBW_ARCHS_LINUX: "x86_64"
+          CIBW_ARCHS_MACOS: "arm64"
           CIBW_ARCHS_WINDOWS: "AMD64"
 
           CIBW_SKIP: "cp39-win_arm64 *-musllinux*"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -308,7 +308,8 @@ jobs:
         shell: bash
         run: |
           uv venv test-standard --python ${{ matrix.python-version }}
-          uv pip install --python test-standard --no-index --find-links dist-standard/ "sqlspec==${SQLSPEC_EXPECTED_VERSION}"
+          uv pip install --python test-standard --no-index --no-deps --find-links dist-standard/ "sqlspec==${SQLSPEC_EXPECTED_VERSION}"
+          uv pip install --python test-standard "sqlspec==${SQLSPEC_EXPECTED_VERSION}" --find-links dist-standard/
           uv run --no-project --python test-standard python -I -c "import sqlspec, os, sys; v=sqlspec.__version__; e=os.environ['SQLSPEC_EXPECTED_VERSION']; sys.exit(0 if v == e else (sys.stderr.write(f'version mismatch: got {v}, expected {e}\n') or 1))"
           uv run --no-project --python test-standard python -I -c "import sqlspec; print('Standard wheel OK')"
 
@@ -316,7 +317,8 @@ jobs:
         shell: bash
         run: |
           uv venv test-mypyc --python ${{ matrix.python-version }}
-          uv pip install --python test-mypyc --no-index --find-links dist-mypyc/ "sqlspec==${SQLSPEC_EXPECTED_VERSION}"
+          uv pip install --python test-mypyc --no-index --no-deps --find-links dist-mypyc/ "sqlspec==${SQLSPEC_EXPECTED_VERSION}"
+          uv pip install --python test-mypyc "sqlspec==${SQLSPEC_EXPECTED_VERSION}" --find-links dist-mypyc/
           uv run --no-project --python test-mypyc python -I -c "import sqlspec, os, sys; v=sqlspec.__version__; e=os.environ['SQLSPEC_EXPECTED_VERSION']; sys.exit(0 if v == e else (sys.stderr.write(f'version mismatch: got {v}, expected {e}\n') or 1))"
           uv run --no-project --python test-mypyc python -I tools/scripts/mypyc_smoke.py --require-compiled
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -33,6 +33,13 @@ on:
       - 'sqlspec/**'
       - 'tools/scripts/mypyc_smoke.py'
 
+# Cancel in-flight runs of this workflow on the same ref when a newer
+# commit lands. Saves runner minutes during a churn of PR pushes. Not
+# applied to publish.yml — releases must never be cancelled mid-upload.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   detect-mode:
     name: Detect matrix mode

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -165,13 +165,23 @@ jobs:
             pip-${{ runner.os }}-py${{ matrix.python-version }}-
 
       - name: Cache mypyc build dir
-        if: matrix.os != 'windows-latest'
+        if: matrix.os == 'ubuntu-latest'
         uses: actions/cache@v5
         with:
           path: /tmp/sqlspec-mypyc-build
           key: mypyc-${{ matrix.os }}-py${{ matrix.python-version }}-${{ hashFiles('sqlspec/**/*.py', 'pyproject.toml') }}
           restore-keys: |
             mypyc-${{ matrix.os }}-py${{ matrix.python-version }}-
+
+      - name: Pre-warm Windows Defender exclusions
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          # Defender's real-time scan on the freshly-extracted nuget-cpython
+          # python.exe blocks virtualenv discovery past its 10s timeout.
+          Add-MpPreference -ExclusionPath "$env:LOCALAPPDATA\pypa\cibuildwheel" -ErrorAction SilentlyContinue
+          Add-MpPreference -ExclusionPath "$env:TEMP" -ErrorAction SilentlyContinue
+          Add-MpPreference -ExclusionProcess "python.exe" -ErrorAction SilentlyContinue
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
@@ -221,7 +231,6 @@ jobs:
           # deps absent from BEFORE_BUILD; MSVC PGO isn't validated.
           CIBW_ENVIRONMENT_MACOS: >-
             HATCH_BUILD_HOOKS_ENABLE=1
-            HATCH_MYPYC_BUILD_DIR=/tmp/sqlspec-mypyc-build
             MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
 
           CIBW_ENVIRONMENT_WINDOWS: >-

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -128,7 +128,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ needs.detect-mode.outputs.matrix_mode == 'full' && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
-        python-version: ${{ needs.detect-mode.outputs.matrix_mode == 'full' && fromJSON('["3.10", "3.11", "3.12", "3.13", "3.14"]') || fromJSON('["3.12"]') }}
+        python-version: ["3.12"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -251,7 +251,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ needs.detect-mode.outputs.matrix_mode == 'full' && fromJSON('["ubuntu-latest", "windows-latest", "macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
-        python-version: ${{ needs.detect-mode.outputs.matrix_mode == 'full' && fromJSON('["3.10", "3.12", "3.14"]') || fromJSON('["3.12"]') }}
+        python-version: ["3.12"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -217,27 +217,12 @@ jobs:
             MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
             CFLAGS="-fprofile-use=/tmp/sqlspec-pgo -fprofile-correction -Wno-error=missing-profile -Wno-error=coverage-mismatch"
 
-          CIBW_BEFORE_BUILD_MACOS: >-
-            pip install -c {project}/build-constraints.txt hatch-mypyc hatchling &&
-            PGO_DIR=/tmp/sqlspec-pgo &&
-            BUILD_DIR=/tmp/sqlspec-mypyc-build &&
-            mkdir -p "$PGO_DIR" "$BUILD_DIR" &&
-            CFLAGS="-fprofile-instr-generate=$PGO_DIR/default_%m.profraw"
-            HATCH_BUILD_HOOKS_ENABLE=1
-            HATCH_MYPYC_BUILD_DIR="$BUILD_DIR"
-            MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
-            pip install {package} --no-build-isolation &&
-            pip install anyio pyarrow aiosqlite duckdb adbc-driver-sqlite adbc-driver-manager &&
-            python {project}/tools/scripts/pgo_training.py &&
-            xcrun llvm-profdata merge -o "$PGO_DIR/merged.profdata" "$PGO_DIR"/*.profraw &&
-            pip uninstall -y sqlspec &&
-            rm -rf "$BUILD_DIR/build" "$BUILD_DIR/tmp"
-
+          # macOS + Windows: plain mypyc, no PGO. macOS PGO needs filter
+          # deps absent from BEFORE_BUILD; MSVC PGO isn't validated.
           CIBW_ENVIRONMENT_MACOS: >-
             HATCH_BUILD_HOOKS_ENABLE=1
             HATCH_MYPYC_BUILD_DIR=/tmp/sqlspec-mypyc-build
             MYPYC_OPT_LEVEL=3 MYPYC_DEBUG_LEVEL=0 MYPYC_MULTI_FILE=1
-            CFLAGS="-fprofile-instr-use=/tmp/sqlspec-pgo/merged.profdata"
 
           CIBW_ENVIRONMENT_WINDOWS: >-
             HATCH_BUILD_HOOKS_ENABLE=1

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -11,6 +11,17 @@ on:
         options:
           - 'full'
           - 'subset'
+      python_version:
+        description: 'Python version to build/test (single value; default 3.12)'
+        required: false
+        default: '3.12'
+        type: choice
+        options:
+          - '3.10'
+          - '3.11'
+          - '3.12'
+          - '3.13'
+          - '3.14'
   pull_request:
     paths:
       - '.github/workflows/test-build.yml'
@@ -128,7 +139,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ needs.detect-mode.outputs.matrix_mode == 'full' && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
-        python-version: ["3.12"]
+        python-version:
+          - ${{ github.event.inputs.python_version || '3.12' }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -251,7 +263,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ needs.detect-mode.outputs.matrix_mode == 'full' && fromJSON('["ubuntu-latest", "windows-latest", "macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
-        python-version: ["3.12"]
+        python-version:
+          - ${{ github.event.inputs.python_version || '3.12' }}
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -23,6 +23,47 @@ on:
       - 'tools/scripts/mypyc_smoke.py'
 
 jobs:
+  detect-mode:
+    name: Detect matrix mode
+    runs-on: ubuntu-latest
+    outputs:
+      matrix_mode: ${{ steps.detect.outputs.matrix_mode }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # workflow_dispatch with test_matrix=full always wins. Otherwise,
+      # promote a PR to the full per-OS x per-py matrix when its diff
+      # touches anything that could affect wheel-build correctness
+      # (workflow yaml, packaging metadata, PGO training, smoke script).
+      # Non-infra PRs stay in subset mode (linux x py3.12) for fast feedback.
+      - name: Detect matrix mode
+        id: detect
+        env:
+          DISPATCH_MODE: ${{ github.event.inputs.test_matrix }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          if [ "$DISPATCH_MODE" = "full" ]; then
+            mode=full
+            reason="workflow_dispatch input"
+          else
+            mode=subset
+            reason="default"
+            if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
+              changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" || true)
+              if printf '%s\n' "$changed" | grep -qE '^(\.github/workflows/.*\.yml|pyproject\.toml|uv\.lock|tools/scripts/(pgo_training|mypyc_smoke)\.py)$'; then
+                mode=full
+                reason="PR touches build-matrix infra"
+              fi
+            fi
+          fi
+          echo "matrix_mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "Resolved matrix_mode=$mode ($reason)"
+
   build-source:
     name: Build source distribution
     runs-on: ubuntu-latest
@@ -82,17 +123,18 @@ jobs:
   build-wheels-mypyc:
     name: Build MyPyC wheels (${{ matrix.os }} py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
+    needs: [detect-mode]
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ github.event.inputs.test_matrix == 'full' && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
-        python-version: ${{ github.event.inputs.test_matrix == 'full' && fromJSON('["3.10", "3.11", "3.12", "3.13", "3.14"]') || fromJSON('["3.12"]') }}
+        os: ${{ needs.detect-mode.outputs.matrix_mode == 'full' && fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        python-version: ${{ needs.detect-mode.outputs.matrix_mode == 'full' && fromJSON('["3.10", "3.11", "3.12", "3.13", "3.14"]') || fromJSON('["3.12"]') }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
       - name: Set up QEMU
-        if: matrix.os == 'ubuntu-latest' && github.event.inputs.test_matrix == 'full'
+        if: matrix.os == 'ubuntu-latest' && needs.detect-mode.outputs.matrix_mode == 'full'
         uses: docker/setup-qemu-action@v4
         with:
           platforms: arm64
@@ -141,8 +183,8 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
 
           # Conditional aarch64 cross-build only in 'full' mode (QEMU enabled).
-          CIBW_ARCHS_LINUX: ${{ github.event.inputs.test_matrix == 'full' && 'x86_64 aarch64' || 'x86_64' }}
-          CIBW_ARCHS_MACOS: ${{ github.event.inputs.test_matrix == 'full' && 'x86_64 arm64' || 'x86_64' }}
+          CIBW_ARCHS_LINUX: ${{ needs.detect-mode.outputs.matrix_mode == 'full' && 'x86_64 aarch64' || 'x86_64' }}
+          CIBW_ARCHS_MACOS: ${{ needs.detect-mode.outputs.matrix_mode == 'full' && 'x86_64 arm64' || 'x86_64' }}
           CIBW_ARCHS_WINDOWS: "AMD64"
 
           CIBW_SKIP: "cp39-win_arm64 *-musllinux*"
@@ -210,12 +252,12 @@ jobs:
 
   test-wheels:
     name: Test ${{ matrix.os }} py${{ matrix.python-version }}
-    needs: [build-wheels-standard, build-wheels-mypyc]
+    needs: [build-wheels-standard, build-wheels-mypyc, detect-mode]
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ github.event.inputs.test_matrix == 'full' && fromJSON('["ubuntu-latest", "windows-latest", "macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
-        python-version: ${{ github.event.inputs.test_matrix == 'full' && fromJSON('["3.10", "3.12", "3.14"]') || fromJSON('["3.12"]') }}
+        os: ${{ needs.detect-mode.outputs.matrix_mode == 'full' && fromJSON('["ubuntu-latest", "windows-latest", "macos-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        python-version: ${{ needs.detect-mode.outputs.matrix_mode == 'full' && fromJSON('["3.10", "3.12", "3.14"]') || fromJSON('["3.12"]') }}
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Summary

v0.47.0 release ([run 26351509901](https://github.com/litestar-org/sqlspec/actions/runs/26351509901)) failed every Windows + macOS `test-wheels` job. Root cause: `build-wheels-mypyc` ran on `ubuntu-latest`, where cibuildwheel silently ignores `CIBW_ARCHS_WINDOWS` and `CIBW_ARCHS_MACOS`. **No Windows or macOS mypyc wheel had ever been published** — every PyPI release back to 0.6.0 shipped only `manylinux*` mypyc wheels + a pure-Python `py3-none-any.whl` fallback. PR #446 added `--require-compiled` to the smoke step; that flag finally caught the long-standing gap and blocked the release.

The `test-wheels` job had been silently passing for every previous release because:
- `uv pip install --find-links dist-mypyc/ sqlspec` fell back to PyPI when no local wheel matched the host.
- Pre-#446 `mypyc_smoke.py` only imported attributes; the pure-Python fallback satisfied it.
- Post-#446 `--require-compiled` checks `module.__file__` ends in `.so` / `.pyd`, so `.py` source modules now fail.

## Changes

### Build matrix — `publish.yml`

- Per-OS native build matrix: `(ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest) × (3.10, 3.11, 3.12, 3.13, 3.14)` = **20 build legs**.
- Linux aarch64 builds on **native ARM runners** (`ubuntu-24.04-arm`, free for public repos) instead of QEMU. QEMU + PGO three-stage previously took hours per leg and risked the 6-hour cap.
- `CIBW_ARCHS_LINUX` is conditional on the matrix os value: `aarch64` on the ARM runner, `x86_64` otherwise.
- `CIBW_ARCHS_MACOS: arm64` — `macos-latest` is Apple Silicon native. Intel Macs use the pure-Python `py3-none-any.whl`.
- Artifacts named `wheels-mypyc-<os>-py<ver>` so OS × py legs don't collide.
- `needs:` chain enforces all-or-nothing publish — any failed build/test leg blocks PyPI upload.

### Build matrix — `test-build.yml`

- PR validation always runs **host-arch only** (no QEMU, no cross-build). aarch64 is exercised at release time only.
- Default `test_matrix=subset`: `ubuntu-latest` × py3.12 for fast PR feedback.
- `workflow_dispatch test_matrix=full`: exercises all 4 OS legs (matches release shape minus aarch64).
- Auto-promotion to `full` when a PR touches `.github/workflows/*.yml`, `pyproject.toml`, `uv.lock`, `pgo_training.py`, or `mypyc_smoke.py`.
- Configurable `python_version` input (3.10–3.14, default 3.12).

### PGO + mypyc

- **Linux (GCC, both x86_64 + aarch64):** full three-stage PGO (`-fprofile-generate` → training workload → `-fprofile-use`). `HATCH_MYPYC_BUILD_DIR` pinned + cached so profile data paths match.
- **macOS (Clang) + Windows (MSVC):** plain mypyc, no PGO. macOS PGO requires optional filter deps absent from cibuildwheel's `BEFORE_BUILD` env; MSVC PGO isn't validated with hatch-mypyc.

### Windows Defender

- Pre-warm step adds exclusions for `LOCALAPPDATA\pypa\cibuildwheel`, `$env:TEMP`, `$env:GITHUB_WORKSPACE`, `$env:GITHUB_WORKSPACE\wheelhouse`, and the `python.exe` process.
- Initial pass missed `wheelhouse\`, which caused `actions/upload-artifact@v7` to silently terminate after pre-flight validation — Defender was holding the freshly-built `.whl` file handle when the action opened it for chunked upload.

### Test-wheel install hardening

Install is split into two steps to preserve the safety check while allowing transitive deps:
```bash
# Step 1: sqlspec MUST come from local wheels (no silent PyPI fallback)
uv pip install --no-index --no-deps --find-links dist/ "sqlspec==$EXPECTED"
# Step 2: same target, transitive deps (mypy-extensions, sqlglot, …) from PyPI
uv pip install "sqlspec==$EXPECTED" --find-links dist/
```
- Asserts `sqlspec.__version__ == SQLSPEC_EXPECTED_VERSION` before running `mypyc_smoke.py`. In `publish.yml` the expected version is derived from `github.event.release.tag_name` (routed through an env var, never interpolated into shell); `workflow_dispatch` falls back to `pyproject.toml`.
- `test-wheels` matrix in `publish.yml` adds `ubuntu-24.04-arm` so the aarch64 wheel actually gets imported + smoke-tested before publish.

### Caching

- Every `astral-sh/setup-uv@v7` invocation across `ci.yml`, `docs.yml`, `publish.yml`, `test-build.yml` has `enable-cache: true` with `cache-dependency-glob: uv.lock`.
- `publish.yml` + `test-build.yml`: cache pip downloads keyed on `build-constraints.txt`; cache the pinned `HATCH_MYPYC_BUILD_DIR` keyed on `sqlspec/**/*.py` + `pyproject.toml` (Linux-only — Windows + macOS don't pin a build dir). PGO profile data is intentionally not cached (must regenerate against instrumented binaries).
- `ci.yml test-linux`: replace the unconditional `Pre-pull docker images` step with `docker save` + `actions/cache@v5` + `docker load`, keyed on the ci.yml hash so any image tag bump invalidates automatically.

### Concurrency

- `ci.yml`, `test-build.yml`, `docs.yml` add `concurrency: { group: ${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: true }` — any new push to a ref auto-cancels in-flight runs of the same workflow on that ref. No more 5-deep queue chains.
- `publish.yml`, `pgo-validate.yml`, `pr-title.yml` left untouched. Releases never get cancelled mid-PyPI-upload; manual / quick lints don't benefit.

## Risks

- **macOS + Windows mypyc compilation now ships for the first time.** Toolchain-specific bugs could surface; the build's own `CIBW_TEST_COMMAND` runs `mypyc_smoke.py --require-compiled` and fails the leg if any required module isn't compiled.
- **Build fan-out grows from 5 → 20 legs** at release time. Per-leg runtime drops because each builds one host arch natively; wall-clock is similar or better since legs run fully in parallel.
- **`ubuntu-24.04-arm` is a relatively new runner image.** First release will validate manylinux_2_28_aarch64 container availability and pyarrow/duckdb/adbc-driver aarch64 manylinux wheel resolution inside `BEFORE_BUILD`.
