### PR TITLE
feat(adapters): add `arrow_odbc` and `mssql_python` adapters

### DIFF
--- a/docs/reference/adapters/arrow_odbc.rst
+++ b/docs/reference/adapters/arrow_odbc.rst
@@ -1,0 +1,37 @@
+==========
+arrow-odbc
+==========
+
+Sync Arrow-over-ODBC adapter built on `arrow-odbc <https://pypi.org/project/arrow-odbc/>`_.
+Streams ``pyarrow.RecordBatchReader`` results from any ODBC-compliant driver,
+making it a good fit for read-heavy analytical transfer between SQL Server,
+PostgreSQL, MySQL, or other ODBC sources and the Arrow ecosystem.
+
+Configuration
+=============
+
+.. autoclass:: sqlspec.adapters.arrow_odbc.ArrowOdbcConfig
+   :members:
+   :show-inheritance:
+
+.. autoclass:: sqlspec.adapters.arrow_odbc.ArrowOdbcConnectionParams
+   :members:
+   :show-inheritance:
+
+.. autoclass:: sqlspec.adapters.arrow_odbc.ArrowOdbcDriverFeatures
+   :members:
+   :show-inheritance:
+
+Driver
+======
+
+.. autoclass:: sqlspec.adapters.arrow_odbc.ArrowOdbcDriver
+   :members:
+   :show-inheritance:
+
+Data Dictionary
+===============
+
+.. autoclass:: sqlspec.adapters.arrow_odbc.data_dictionary.ArrowOdbcDataDictionary
+   :members:
+   :show-inheritance:

--- a/docs/reference/adapters/index.rst
+++ b/docs/reference/adapters/index.rst
@@ -109,6 +109,12 @@ exports a typed config class and a driver implementation.
 
       Sync Arrow-over-ODBC for any ODBC-compliant database.
 
+   .. grid-item-card:: mssql-python
+      :link: mssql_python
+      :link-type: doc
+
+      Sync + Async SQL Server via Microsoft's official mssql-python driver.
+
 Feature Comparison
 ==================
 
@@ -223,6 +229,12 @@ Feature Comparison
      -
      - Yes
      -
+   * - mssql_python
+     - Yes
+     - Yes
+     - Yes
+     -
+     -
 
 .. toctree::
    :hidden:
@@ -244,3 +256,4 @@ Feature Comparison
    cockroach_psycopg
    adbc
    arrow_odbc
+   mssql_python

--- a/docs/reference/adapters/index.rst
+++ b/docs/reference/adapters/index.rst
@@ -103,6 +103,12 @@ exports a typed config class and a driver implementation.
 
       Arrow Database Connectivity.
 
+   .. grid-item-card:: arrow-odbc
+      :link: arrow_odbc
+      :link-type: doc
+
+      Sync Arrow-over-ODBC for any ODBC-compliant database.
+
 Feature Comparison
 ==================
 
@@ -211,6 +217,12 @@ Feature Comparison
      -
      - Yes
      -
+   * - arrow_odbc
+     - Yes
+     -
+     -
+     - Yes
+     -
 
 .. toctree::
    :hidden:
@@ -231,3 +243,4 @@ Feature Comparison
    cockroach_asyncpg
    cockroach_psycopg
    adbc
+   arrow_odbc

--- a/docs/reference/adapters/mssql_python.rst
+++ b/docs/reference/adapters/mssql_python.rst
@@ -1,0 +1,78 @@
+============
+mssql-python
+============
+
+Sync + async SQL Server adapter built on Microsoft's official
+`mssql-python <https://pypi.org/project/mssql-python/>`_ driver. Ships a
+T-SQL data dictionary, a Litestar session store, an events queue store,
+and migrations tracker. The SQL splitter also gains ``GO`` batch-separator
+handling so multi-batch T-SQL scripts execute correctly.
+
+Sync Configuration
+==================
+
+.. autoclass:: sqlspec.adapters.mssql_python.MssqlPythonConfig
+   :members:
+   :show-inheritance:
+
+Async Configuration
+===================
+
+.. autoclass:: sqlspec.adapters.mssql_python.MssqlPythonAsyncConfig
+   :members:
+   :show-inheritance:
+
+.. autoclass:: sqlspec.adapters.mssql_python.MssqlPythonConnectionParams
+   :members:
+   :show-inheritance:
+
+.. autoclass:: sqlspec.adapters.mssql_python.MssqlPythonPoolParams
+   :members:
+   :show-inheritance:
+
+.. autoclass:: sqlspec.adapters.mssql_python.MssqlPythonDriverFeatures
+   :members:
+   :show-inheritance:
+
+Sync Driver
+===========
+
+.. autoclass:: sqlspec.adapters.mssql_python.MssqlPythonDriver
+   :members:
+   :show-inheritance:
+
+Async Driver
+============
+
+.. autoclass:: sqlspec.adapters.mssql_python.MssqlPythonAsyncDriver
+   :members:
+   :show-inheritance:
+
+Connection Pool
+===============
+
+.. autoclass:: sqlspec.adapters.mssql_python.MssqlPythonConnectionPool
+   :members:
+   :show-inheritance:
+
+Data Dictionaries
+=================
+
+.. autoclass:: sqlspec.adapters.mssql_python.MssqlPythonSyncDataDictionary
+   :members:
+   :show-inheritance:
+
+.. autoclass:: sqlspec.adapters.mssql_python.MssqlPythonAsyncDataDictionary
+   :members:
+   :show-inheritance:
+
+Migration Trackers
+==================
+
+.. autoclass:: sqlspec.adapters.mssql_python.MssqlPythonSyncMigrationTracker
+   :members:
+   :show-inheritance:
+
+.. autoclass:: sqlspec.adapters.mssql_python.MssqlPythonAsyncMigrationTracker
+   :members:
+   :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ aiomysql = ["aiomysql"]
 aioodbc = ["aioodbc"]
 aiosqlite = ["aiosqlite"]
 alloydb = ["google-cloud-alloydb-connector"]
+arrow-odbc = ["arrow-odbc>=10.4", "pyarrow"]
 asyncmy = ["asyncmy"]
 asyncpg = ["asyncpg"]
 attrs = ["attrs", "cattrs"]
@@ -415,6 +416,7 @@ markers = [
   "aiomysql: marks tests using aiomysql",
   "aioodbc: marks tests using aioodbc",
   "aiosqlite: marks tests using aiosqlite",
+  "arrow_odbc: marks tests using the arrow_odbc adapter",
   "asyncmy: marks tests using asyncmy",
   "asyncpg: marks tests using asyncpg",
   "duckdb_driver: marks tests using the duckdb driver",
@@ -460,6 +462,8 @@ module = [
   "uvloop.*",
   "aiomysql",
   "aiomysql.*",
+  "arrow_odbc",
+  "arrow_odbc.*",
   "asyncmy",
   "asyncmy.*",
   "pyarrow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ flask = ["flask"]
 fsspec = ["fsspec"]
 litestar = ["litestar>=2.22.0"]
 msgspec = ["msgspec"]
+mssql-python = ["mssql-python>=1.7"]
 mypyc = ["sqlglot[c]>=30.0.0"]
 mysql-connector = [
   "mysql-connector-python; python_version < '3.12'",
@@ -424,6 +425,7 @@ markers = [
   "google_spanner: marks tests using google-cloud-spanner",
   "oracledb: marks tests using oracledb",
   "psycopg: marks tests using psycopg",
+  "mssql_python: marks tests using the mssql-python driver",
   "pymssql: marks tests using pymssql",
   "mysql_connector: marks tests using mysql-connector",
   "pymysql: marks tests using pymysql",
@@ -466,6 +468,8 @@ module = [
   "arrow_odbc.*",
   "asyncmy",
   "asyncmy.*",
+  "mssql_python",
+  "mssql_python.*",
   "pyarrow",
   "pyarrow.*",
   "opentelemetry.*",

--- a/sqlspec/adapters/arrow_odbc/__init__.py
+++ b/sqlspec/adapters/arrow_odbc/__init__.py
@@ -1,0 +1,30 @@
+"""SQLSpec adapter for arrow-odbc."""
+
+from sqlspec.adapters.arrow_odbc.config import ArrowOdbcConfig, ArrowOdbcConnectionParams, ArrowOdbcDriverFeatures
+from sqlspec.adapters.arrow_odbc.core import (
+    apply_driver_features,
+    build_connection_config,
+    build_statement_config,
+    create_mapped_exception,
+    default_statement_config,
+    driver_profile,
+    resolve_dialect_from_dbms_name,
+)
+from sqlspec.adapters.arrow_odbc.data_dictionary import ArrowOdbcDataDictionary
+from sqlspec.adapters.arrow_odbc.driver import ArrowOdbcDriver, ArrowOdbcExceptionHandler
+
+__all__ = (
+    "ArrowOdbcConfig",
+    "ArrowOdbcConnectionParams",
+    "ArrowOdbcDataDictionary",
+    "ArrowOdbcDriver",
+    "ArrowOdbcDriverFeatures",
+    "ArrowOdbcExceptionHandler",
+    "apply_driver_features",
+    "build_connection_config",
+    "build_statement_config",
+    "create_mapped_exception",
+    "default_statement_config",
+    "driver_profile",
+    "resolve_dialect_from_dbms_name",
+)

--- a/sqlspec/adapters/arrow_odbc/_typing.py
+++ b/sqlspec/adapters/arrow_odbc/_typing.py
@@ -1,0 +1,94 @@
+# pyright: reportAttributeAccessIssue=false
+"""arrow-odbc adapter type definitions and mypyc-excluded context managers."""
+
+from typing import TYPE_CHECKING, Any
+
+import arrow_odbc as _arrow_odbc  # pyright: ignore[reportMissingImports]
+
+ARROW_ODBC_MODULE: Any = _arrow_odbc
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from types import TracebackType
+    from typing import TypeAlias
+
+    from sqlspec.adapters.arrow_odbc.driver import ArrowOdbcDriver
+    from sqlspec.core import StatementConfig
+
+    ArrowOdbcConnection: TypeAlias = _arrow_odbc.Connection
+    ArrowOdbcRawCursor: TypeAlias = _arrow_odbc.Connection
+
+if not TYPE_CHECKING:
+    ArrowOdbcConnection = _arrow_odbc.Connection
+    ArrowOdbcRawCursor = _arrow_odbc.Connection
+
+
+class ArrowOdbcCursor:
+    """Context manager yielding the arrow-odbc connection as its execution cursor."""
+
+    __slots__ = ("connection",)
+
+    def __init__(self, connection: "ArrowOdbcConnection") -> None:
+        self.connection = connection
+
+    def __enter__(self) -> "ArrowOdbcRawCursor":
+        return self.connection
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+
+class ArrowOdbcSessionContext:
+    """Sync session context bridging interpreted config and compiled driver code."""
+
+    __slots__ = (
+        "_acquire_connection",
+        "_connection",
+        "_driver",
+        "_driver_features",
+        "_prepare_driver",
+        "_release_connection",
+        "_statement_config",
+    )
+
+    def __init__(
+        self,
+        acquire_connection: "Callable[[], Any]",
+        release_connection: "Callable[[Any], Any]",
+        statement_config: "StatementConfig",
+        driver_features: "dict[str, Any]",
+        prepare_driver: "Callable[[ArrowOdbcDriver], ArrowOdbcDriver]",
+    ) -> None:
+        self._acquire_connection = acquire_connection
+        self._release_connection = release_connection
+        self._statement_config = statement_config
+        self._driver_features = driver_features
+        self._prepare_driver = prepare_driver
+        self._connection: Any = None
+        self._driver: ArrowOdbcDriver | None = None
+
+    def __enter__(self) -> "ArrowOdbcDriver":
+        from sqlspec.adapters.arrow_odbc.driver import ArrowOdbcDriver
+
+        self._connection = self._acquire_connection()
+        self._driver = ArrowOdbcDriver(
+            connection=self._connection, statement_config=self._statement_config, driver_features=self._driver_features
+        )
+        return self._prepare_driver(self._driver)
+
+    def __exit__(
+        self, exc_type: "type[BaseException] | None", exc_val: "BaseException | None", exc_tb: "TracebackType | None"
+    ) -> "bool | None":
+        if self._connection is not None:
+            self._release_connection(self._connection)
+            self._connection = None
+        return None
+
+
+__all__ = (
+    "ARROW_ODBC_MODULE",
+    "ArrowOdbcConnection",
+    "ArrowOdbcCursor",
+    "ArrowOdbcRawCursor",
+    "ArrowOdbcSessionContext",
+)

--- a/sqlspec/adapters/arrow_odbc/_typing.py
+++ b/sqlspec/adapters/arrow_odbc/_typing.py
@@ -4,8 +4,7 @@
 from typing import TYPE_CHECKING, Any
 
 import arrow_odbc as _arrow_odbc  # pyright: ignore[reportMissingImports]
-
-ARROW_ODBC_MODULE: Any = _arrow_odbc
+from arrow_odbc import connect as arrow_odbc_connect  # pyright: ignore[reportMissingImports]
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -21,6 +20,8 @@ if TYPE_CHECKING:
 if not TYPE_CHECKING:
     ArrowOdbcConnection = _arrow_odbc.Connection
     ArrowOdbcRawCursor = _arrow_odbc.Connection
+
+ArrowOdbcError: "type[Exception]" = getattr(_arrow_odbc, "Error", Exception)
 
 
 class ArrowOdbcCursor:
@@ -86,9 +87,10 @@ class ArrowOdbcSessionContext:
 
 
 __all__ = (
-    "ARROW_ODBC_MODULE",
     "ArrowOdbcConnection",
     "ArrowOdbcCursor",
+    "ArrowOdbcError",
     "ArrowOdbcRawCursor",
     "ArrowOdbcSessionContext",
+    "arrow_odbc_connect",
 )

--- a/sqlspec/adapters/arrow_odbc/config.py
+++ b/sqlspec/adapters/arrow_odbc/config.py
@@ -1,0 +1,202 @@
+"""arrow-odbc database configuration."""
+
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
+
+from typing_extensions import NotRequired
+
+from sqlspec.adapters.arrow_odbc._typing import ARROW_ODBC_MODULE, ArrowOdbcConnection, ArrowOdbcSessionContext
+from sqlspec.adapters.arrow_odbc.core import apply_driver_features, build_connection_config, default_statement_config
+from sqlspec.adapters.arrow_odbc.driver import ArrowOdbcDriver
+from sqlspec.config import ExtensionConfigs, NoPoolSyncConfig
+from sqlspec.driver._sync import SyncPoolConnectionContext, SyncPoolSessionFactory
+from sqlspec.exceptions import ImproperConfigurationError
+from sqlspec.extensions.events import EventRuntimeHints
+from sqlspec.utils.config_tools import normalize_connection_config
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    from sqlspec.core import StatementConfig
+    from sqlspec.observability import ObservabilityConfig
+
+__all__ = ("ArrowOdbcConfig", "ArrowOdbcConnectionParams", "ArrowOdbcDriverFeatures")
+
+
+class ArrowOdbcConnectionParams(TypedDict):
+    """arrow-odbc connection parameters."""
+
+    connection_string: NotRequired[str]
+    dsn: NotRequired[str]
+    driver: NotRequired[str]
+    server: NotRequired[str]
+    host: NotRequired[str]
+    database: NotRequired[str]
+    uid: NotRequired[str]
+    pwd: NotRequired[str]
+    user: NotRequired[str]
+    password: NotRequired[str]
+    login_timeout: NotRequired[int]
+    login_timeout_sec: NotRequired[int]
+    packet_size: NotRequired[int]
+    autocommit: NotRequired[bool]
+    extra: NotRequired[dict[str, Any]]
+
+
+class ArrowOdbcDriverFeatures(TypedDict):
+    """arrow-odbc driver feature flags."""
+
+    chunk_size: NotRequired[int]
+    max_bytes_per_batch: NotRequired[int]
+    max_text_size: NotRequired[int]
+    max_binary_size: NotRequired[int]
+    fetch_concurrently: NotRequired[bool]
+    query_timeout_sec: NotRequired[int]
+    connection_string: NotRequired[str]
+    dbms_name: NotRequired[str]
+    enable_events: NotRequired[bool]
+
+
+class ArrowOdbcConnectionContext(SyncPoolConnectionContext):
+    """Context manager for arrow-odbc connections."""
+
+    __slots__ = ("_connection",)
+
+    def __init__(self, config: "ArrowOdbcConfig") -> None:
+        super().__init__(config)
+        self._connection: ArrowOdbcConnection | None = None
+
+    def __enter__(self) -> "ArrowOdbcConnection":
+        self._connection = self._config.create_connection()
+        return cast("ArrowOdbcConnection", self._connection)
+
+    def __exit__(
+        self, exc_type: "type[BaseException] | None", exc_val: "BaseException | None", exc_tb: "TracebackType | None"
+    ) -> "bool | None":
+        if self._connection is not None:
+            _close_arrow_odbc_connection(self._connection)
+            self._connection = None
+        return None
+
+
+class _ArrowOdbcSessionConnectionHandler(SyncPoolSessionFactory):
+    """Session connection handler for no-pool arrow-odbc sessions."""
+
+    __slots__ = ("_connection",)
+
+    def __init__(self, config: "ArrowOdbcConfig") -> None:
+        super().__init__(config)
+        self._connection: ArrowOdbcConnection | None = None
+
+    def acquire_connection(self) -> "ArrowOdbcConnection":
+        self._connection = self._config.create_connection()
+        return cast("ArrowOdbcConnection", self._connection)
+
+    def release_connection(self, _conn: "ArrowOdbcConnection", **kwargs: Any) -> None:
+        if self._connection is None:
+            return
+        _close_arrow_odbc_connection(self._connection)
+        self._connection = None
+
+
+class ArrowOdbcConfig(NoPoolSyncConfig[ArrowOdbcConnection, ArrowOdbcDriver]):
+    """Configuration for synchronous arrow-odbc connections."""
+
+    driver_type: "ClassVar[type[ArrowOdbcDriver]]" = ArrowOdbcDriver
+    connection_type: "ClassVar[type[ArrowOdbcConnection]]" = ArrowOdbcConnection
+    supports_transactional_ddl: "ClassVar[bool]" = False
+    supports_native_arrow_export: "ClassVar[bool]" = True
+    supports_native_arrow_import: "ClassVar[bool]" = True
+    supports_native_parquet_export: "ClassVar[bool]" = False
+    supports_native_parquet_import: "ClassVar[bool]" = False
+    _connection_context_class: "ClassVar[type[ArrowOdbcConnectionContext]]" = ArrowOdbcConnectionContext
+    _session_factory_class: "ClassVar[type[_ArrowOdbcSessionConnectionHandler]]" = _ArrowOdbcSessionConnectionHandler
+    _session_context_class: "ClassVar[type[ArrowOdbcSessionContext]]" = ArrowOdbcSessionContext
+    _default_statement_config = default_statement_config
+
+    def __init__(
+        self,
+        *,
+        connection_config: "ArrowOdbcConnectionParams | dict[str, Any] | None" = None,
+        connection_instance: "Any" = None,
+        migration_config: "dict[str, Any] | None" = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "ArrowOdbcDriverFeatures | dict[str, Any] | None" = None,
+        bind_key: str | None = None,
+        extension_config: "ExtensionConfigs | None" = None,
+        observability_config: "ObservabilityConfig | None" = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize arrow-odbc configuration."""
+        self.connection_config = normalize_connection_config(connection_config)
+        features = apply_driver_features(dict(driver_features or {}))
+        connection_string = self.connection_config.get("connection_string")
+        if connection_string is not None:
+            features.setdefault("connection_string", str(connection_string))
+        elif self.connection_config.get("driver") is not None:
+            features.setdefault("dbms_name", str(self.connection_config["driver"]))
+
+        super().__init__(
+            connection_config=self.connection_config,
+            connection_instance=connection_instance,
+            migration_config=migration_config,
+            statement_config=statement_config or default_statement_config,
+            driver_features=features,
+            bind_key=bind_key,
+            extension_config=extension_config,
+            observability_config=observability_config,
+            **kwargs,
+        )
+
+    def create_connection(self) -> "ArrowOdbcConnection":
+        """Create and return a new arrow-odbc connection."""
+        if self.connection_instance is not None:
+            return cast("ArrowOdbcConnection", self.connection_instance)
+        connection_string, connect_kwargs = build_connection_config(self.connection_config)
+        try:
+            connection = cast("ArrowOdbcConnection", ARROW_ODBC_MODULE.connect(connection_string, **connect_kwargs))
+            return cast("ArrowOdbcConnection", connection)
+        except Exception as exc:
+            msg = f"Could not configure arrow-odbc connection. Error: {exc}"
+            raise ImproperConfigurationError(msg) from exc
+
+    def provide_connection(self, *args: Any, **kwargs: Any) -> "ArrowOdbcConnectionContext":
+        """Provide a connection context manager."""
+        return ArrowOdbcConnectionContext(self)
+
+    def provide_session(
+        self, *_args: Any, statement_config: "StatementConfig | None" = None, **_kwargs: Any
+    ) -> "ArrowOdbcSessionContext":
+        """Provide a driver session context manager."""
+        handler = _ArrowOdbcSessionConnectionHandler(self)
+        return ArrowOdbcSessionContext(
+            acquire_connection=handler.acquire_connection,
+            release_connection=handler.release_connection,
+            statement_config=statement_config or self.statement_config,
+            driver_features=self.driver_features,
+            prepare_driver=self._prepare_driver,
+        )
+
+    def get_signature_namespace(self) -> "dict[str, Any]":
+        """Get the signature namespace for ArrowOdbcConfig types."""
+        namespace = super().get_signature_namespace()
+        namespace.update({
+            "ArrowOdbcConfig": ArrowOdbcConfig,
+            "ArrowOdbcConnection": ArrowOdbcConnection,
+            "ArrowOdbcConnectionContext": ArrowOdbcConnectionContext,
+            "ArrowOdbcConnectionParams": ArrowOdbcConnectionParams,
+            "ArrowOdbcDriver": ArrowOdbcDriver,
+            "ArrowOdbcDriverFeatures": ArrowOdbcDriverFeatures,
+            "ArrowOdbcSessionContext": ArrowOdbcSessionContext,
+        })
+        return namespace
+
+    def get_event_runtime_hints(self) -> "EventRuntimeHints":
+        """Return polling defaults suitable for generic ODBC sources."""
+        return EventRuntimeHints(poll_interval=2.0, lease_seconds=60, retention_seconds=172_800)
+
+
+def _close_arrow_odbc_connection(connection: "ArrowOdbcConnection") -> None:
+    """Close connection objects from compatible wrappers when they expose close()."""
+    close = getattr(connection, "close", None)
+    if close is not None:
+        close()

--- a/sqlspec/adapters/arrow_odbc/config.py
+++ b/sqlspec/adapters/arrow_odbc/config.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 
 from typing_extensions import NotRequired
 
-from sqlspec.adapters.arrow_odbc._typing import ARROW_ODBC_MODULE, ArrowOdbcConnection, ArrowOdbcSessionContext
+from sqlspec.adapters.arrow_odbc._typing import ArrowOdbcConnection, ArrowOdbcSessionContext, arrow_odbc_connect
 from sqlspec.adapters.arrow_odbc.core import apply_driver_features, build_connection_config, default_statement_config
 from sqlspec.adapters.arrow_odbc.driver import ArrowOdbcDriver
 from sqlspec.config import ExtensionConfigs, NoPoolSyncConfig
@@ -153,7 +153,7 @@ class ArrowOdbcConfig(NoPoolSyncConfig[ArrowOdbcConnection, ArrowOdbcDriver]):
             return cast("ArrowOdbcConnection", self.connection_instance)
         connection_string, connect_kwargs = build_connection_config(self.connection_config)
         try:
-            connection = cast("ArrowOdbcConnection", ARROW_ODBC_MODULE.connect(connection_string, **connect_kwargs))
+            connection = cast("ArrowOdbcConnection", arrow_odbc_connect(connection_string, **connect_kwargs))
             return cast("ArrowOdbcConnection", connection)
         except Exception as exc:
             msg = f"Could not configure arrow-odbc connection. Error: {exc}"

--- a/sqlspec/adapters/arrow_odbc/core.py
+++ b/sqlspec/adapters/arrow_odbc/core.py
@@ -1,0 +1,164 @@
+"""arrow-odbc adapter core helpers."""
+
+from typing import TYPE_CHECKING, Any, Final
+
+from sqlspec.core.parameters import ParameterStyle
+from sqlspec.core.parameters._registry import build_statement_config_from_profile
+from sqlspec.core.parameters._types import DriverParameterProfile
+from sqlspec.exceptions import ImproperConfigurationError, SQLSpecError
+from sqlspec.utils.serializers import from_json, to_json
+from sqlspec.utils.type_converters import build_uuid_coercions
+
+if TYPE_CHECKING:
+    from sqlspec.core import StatementConfig
+
+__all__ = (
+    "apply_driver_features",
+    "build_connection_config",
+    "build_profile",
+    "build_statement_config",
+    "create_mapped_exception",
+    "default_statement_config",
+    "driver_profile",
+    "resolve_dialect_from_dbms_name",
+)
+
+
+_CONNECT_KWARG_KEYS: Final[set[str]] = {"user", "password", "login_timeout_sec", "packet_size", "autocommit"}
+_CONNECTION_STRING_KEYS: Final[tuple[tuple[str, str], ...]] = (
+    ("dsn", "DSN"),
+    ("driver", "Driver"),
+    ("server", "Server"),
+    ("host", "Server"),
+    ("database", "Database"),
+    ("uid", "UID"),
+    ("pwd", "PWD"),
+    ("trusted_connection", "Trusted_Connection"),
+    ("trust_server_certificate", "TrustServerCertificate"),
+    ("encrypt", "Encrypt"),
+)
+_DIALECT_PATTERNS: Final[tuple[tuple[str, tuple[str, ...]], ...]] = (
+    ("mssql", ("sql server", "sqlserver", "microsoft sql", "msodbcsql")),
+    ("oracle", ("oracle",)),
+    ("mysql", ("mysql", "mariadb")),
+    ("postgres", ("postgres", "postgresql")),
+    ("sqlite", ("sqlite",)),
+    ("duckdb", ("duckdb",)),
+    ("snowflake", ("snowflake",)),
+)
+
+
+def resolve_dialect_from_dbms_name(dbms_name: str | None) -> str:
+    """Resolve an ODBC DBMS or driver name to a SQLSpec dialect name."""
+    if not dbms_name:
+        return "sqlite"
+    lowered = dbms_name.lower()
+    for dialect, patterns in _DIALECT_PATTERNS:
+        if any(pattern in lowered for pattern in patterns):
+            return dialect
+    return "sqlite"
+
+
+def create_mapped_exception(exc: Exception) -> Exception:
+    """Map an arrow-odbc exception to SQLSpec's exception hierarchy."""
+    return SQLSpecError(f"ODBC database error. Original error: {exc}")
+
+
+def apply_driver_features(features: "dict[str, Any] | None") -> dict[str, Any]:
+    """Merge arrow-odbc driver feature defaults with caller overrides."""
+    defaults: dict[str, Any] = {
+        "chunk_size": 65_536,
+        "max_bytes_per_batch": 512 * 1024 * 1024,
+        "max_text_size": 1024 * 1024,
+        "max_binary_size": 1024 * 1024,
+        "fetch_concurrently": True,
+        "query_timeout_sec": None,
+        "json_serializer": to_json,
+        "json_deserializer": from_json,
+    }
+    defaults.update(features or {})
+    return defaults
+
+
+def build_connection_config(params: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    """Build arrow-odbc connection arguments using the 10.4 keyword names."""
+    config = dict(params)
+    extra = config.pop("extra", None)
+    if isinstance(extra, dict):
+        config.update(extra)
+
+    login_timeout = config.pop("login_timeout", None)
+    if login_timeout is not None and "login_timeout_sec" not in config:
+        config["login_timeout_sec"] = login_timeout
+
+    connect_kwargs = {key: config.pop(key) for key in tuple(config) if key in _CONNECT_KWARG_KEYS}
+    connection_string = config.pop("connection_string", None)
+    if connection_string is not None:
+        return str(connection_string), connect_kwargs
+
+    parts: list[str] = []
+    consumed: set[str] = set()
+    for key, option_name in _CONNECTION_STRING_KEYS:
+        value = config.get(key)
+        if value is None:
+            continue
+        parts.append(f"{option_name}={_format_connection_value(value)}")
+        consumed.add(key)
+
+    for key, value in config.items():
+        if key in consumed or value is None:
+            continue
+        parts.append(f"{key}={_format_connection_value(value)}")
+
+    if not parts:
+        msg = "arrow-odbc connection_config requires 'connection_string' or ODBC connection fields."
+        raise ImproperConfigurationError(msg)
+
+    return ";".join(parts) + ";", connect_kwargs
+
+
+def build_profile() -> "DriverParameterProfile":
+    """Create the arrow-odbc driver parameter profile."""
+    return DriverParameterProfile(
+        name="arrow_odbc",
+        default_style=ParameterStyle.QMARK,
+        supported_styles={ParameterStyle.QMARK, ParameterStyle.NAMED_COLON},
+        default_execution_style=ParameterStyle.QMARK,
+        supported_execution_styles={ParameterStyle.QMARK},
+        has_native_list_expansion=False,
+        preserve_parameter_format=True,
+        needs_static_script_compilation=False,
+        allow_mixed_parameter_styles=False,
+        preserve_original_params_for_many=False,
+        json_serializer_strategy="helper",
+        custom_type_coercions={
+            bool: _identity,
+            int: _identity,
+            float: _identity,
+            str: _identity,
+            bytes: _identity,
+            **build_uuid_coercions(native=False),
+        },
+        default_dialect="sqlite",
+    )
+
+
+def build_statement_config(*, dialect: str = "sqlite", json_serializer: "Any" = to_json) -> "StatementConfig":
+    """Construct the arrow-odbc statement configuration."""
+    return build_statement_config_from_profile(
+        driver_profile, statement_overrides={"dialect": dialect}, json_serializer=json_serializer
+    )
+
+
+def _identity(value: Any) -> Any:
+    return value
+
+
+def _format_connection_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    return str(value)
+
+
+driver_profile = build_profile()
+default_statement_config = build_statement_config()

--- a/sqlspec/adapters/arrow_odbc/core.py
+++ b/sqlspec/adapters/arrow_odbc/core.py
@@ -2,9 +2,7 @@
 
 from typing import TYPE_CHECKING, Any, Final
 
-from sqlspec.core.parameters import ParameterStyle
-from sqlspec.core.parameters._registry import build_statement_config_from_profile
-from sqlspec.core.parameters._types import DriverParameterProfile
+from sqlspec.core import DriverParameterProfile, ParameterStyle, build_statement_config_from_profile
 from sqlspec.exceptions import ImproperConfigurationError, SQLSpecError
 from sqlspec.utils.serializers import from_json, to_json
 from sqlspec.utils.type_converters import build_uuid_coercions

--- a/sqlspec/adapters/arrow_odbc/core.py
+++ b/sqlspec/adapters/arrow_odbc/core.py
@@ -8,6 +8,8 @@ from sqlspec.utils.serializers import from_json, to_json
 from sqlspec.utils.type_converters import build_uuid_coercions
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from sqlspec.core import StatementConfig
 
 __all__ = (
@@ -115,6 +117,18 @@ def build_connection_config(params: dict[str, Any]) -> tuple[str, dict[str, Any]
     return ";".join(parts) + ";", connect_kwargs
 
 
+def _build_arrow_odbc_custom_type_coercions() -> "dict[type, Callable[[Any], Any]]":
+    """Return custom type coercions for arrow-odbc."""
+    return {
+        bool: _identity,
+        int: _identity,
+        float: _identity,
+        str: _identity,
+        bytes: _identity,
+        **build_uuid_coercions(native=False),
+    }
+
+
 def build_profile() -> "DriverParameterProfile":
     """Create the arrow-odbc driver parameter profile."""
     return DriverParameterProfile(
@@ -129,14 +143,7 @@ def build_profile() -> "DriverParameterProfile":
         allow_mixed_parameter_styles=False,
         preserve_original_params_for_many=False,
         json_serializer_strategy="helper",
-        custom_type_coercions={
-            bool: _identity,
-            int: _identity,
-            float: _identity,
-            str: _identity,
-            bytes: _identity,
-            **build_uuid_coercions(native=False),
-        },
+        custom_type_coercions=_build_arrow_odbc_custom_type_coercions(),
         default_dialect="sqlite",
     )
 

--- a/sqlspec/adapters/arrow_odbc/data_dictionary.py
+++ b/sqlspec/adapters/arrow_odbc/data_dictionary.py
@@ -56,15 +56,25 @@ class ArrowOdbcDataDictionary(SyncDataDictionaryBase):
         try:
             version_value = driver.select_value_or_none(self.get_query("version"))
         except SQLFileNotFoundError:
+            self._log_version_unavailable(self._dialect, "no_query")
+            self.cache_version(driver_id, None)
+            return None
+        except Exception:
+            self._log_version_unavailable(self._dialect, "query_failed")
             self.cache_version(driver_id, None)
             return None
 
         if not version_value:
+            self._log_version_unavailable(self._dialect, "missing")
             self.cache_version(driver_id, None)
             return None
 
         config = self.get_dialect_config()
         version_info = self.parse_version_with_pattern(config.version_pattern, str(version_value))
+        if version_info is None:
+            self._log_version_unavailable(self._dialect, "parse_failed")
+        else:
+            self._log_version_detected(self._dialect, version_info)
         self.cache_version(driver_id, version_info)
         return version_info
 

--- a/sqlspec/adapters/arrow_odbc/data_dictionary.py
+++ b/sqlspec/adapters/arrow_odbc/data_dictionary.py
@@ -21,8 +21,6 @@ __all__ = ("ArrowOdbcDataDictionary",)
 class ArrowOdbcDataDictionary(SyncDataDictionaryBase):
     """Runtime-dialect data dictionary for generic ODBC connections."""
 
-    __slots__ = ("_dialect",)
-
     dialect: ClassVar[str] = "sqlite"
 
     def __init__(self, dialect: str = "sqlite") -> None:

--- a/sqlspec/adapters/arrow_odbc/data_dictionary.py
+++ b/sqlspec/adapters/arrow_odbc/data_dictionary.py
@@ -1,0 +1,128 @@
+"""Generic data dictionary for arrow-odbc connections."""
+
+from typing import TYPE_CHECKING, Any, ClassVar, cast
+
+from mypy_extensions import mypyc_attr
+
+from sqlspec.data_dictionary import get_data_dictionary_loader, get_dialect_config
+from sqlspec.driver import SyncDataDictionaryBase
+from sqlspec.exceptions import SQLFileNotFoundError
+from sqlspec.typing import ColumnMetadata, ForeignKeyMetadata, IndexMetadata, TableMetadata, VersionInfo
+
+if TYPE_CHECKING:
+    from sqlspec.adapters.arrow_odbc.driver import ArrowOdbcDriver
+    from sqlspec.core import SQL
+    from sqlspec.data_dictionary._types import DialectConfig
+
+__all__ = ("ArrowOdbcDataDictionary",)
+
+
+@mypyc_attr(allow_interpreted_subclasses=True, native_class=False)
+class ArrowOdbcDataDictionary(SyncDataDictionaryBase):
+    """Runtime-dialect data dictionary for generic ODBC connections."""
+
+    __slots__ = ("_dialect",)
+
+    dialect: ClassVar[str] = "sqlite"
+
+    def __init__(self, dialect: str = "sqlite") -> None:
+        super().__init__()
+        self._dialect = dialect
+
+    def get_dialect_config(self) -> "DialectConfig":
+        """Return the runtime dialect configuration for this data dictionary."""
+        return get_dialect_config(self._dialect)
+
+    def get_query(self, name: str) -> "SQL":
+        """Return a named SQL query for the runtime dialect."""
+        loader = get_data_dictionary_loader()
+        return loader.get_query(self._dialect, name)
+
+    def get_query_text(self, name: str) -> str:
+        """Return raw SQL text for a named runtime dialect query."""
+        loader = get_data_dictionary_loader()
+        return loader.get_query_text(self._dialect, name)
+
+    def resolve_schema(self, schema: str | None) -> str | None:
+        """Return a schema name using runtime dialect defaults when missing."""
+        if schema is not None:
+            return schema
+        return self.get_dialect_config().default_schema
+
+    def get_version(self, driver: "ArrowOdbcDriver") -> VersionInfo | None:
+        """Get database version information when the runtime dialect provides a query."""
+        driver_id = id(driver)
+        if driver_id in self._version_fetch_attempted:
+            return self._version_cache.get(driver_id)
+
+        try:
+            version_value = driver.select_value_or_none(self.get_query("version"))
+        except SQLFileNotFoundError:
+            self.cache_version(driver_id, None)
+            return None
+
+        if not version_value:
+            self.cache_version(driver_id, None)
+            return None
+
+        config = self.get_dialect_config()
+        version_info = self.parse_version_with_pattern(config.version_pattern, str(version_value))
+        self.cache_version(driver_id, version_info)
+        return version_info
+
+    def get_feature_flag(self, driver: "ArrowOdbcDriver", feature: str) -> bool:
+        """Check whether the runtime dialect supports a feature."""
+        return self.resolve_feature_flag(feature, self.get_version(driver))
+
+    def get_optimal_type(self, driver: "ArrowOdbcDriver", type_category: str) -> str:
+        """Get the optimal runtime dialect type for a category."""
+        return self.get_dialect_config().get_optimal_type(type_category)
+
+    def get_tables(self, driver: "ArrowOdbcDriver", schema: str | None = None) -> list[TableMetadata]:
+        """Get table metadata for dialects with bundled catalog queries."""
+        try:
+            return cast(
+                "list[TableMetadata]",
+                driver.select(self.get_query("tables_by_schema"), schema_name=self.resolve_schema(schema)),
+            )
+        except SQLFileNotFoundError:
+            return []
+
+    def get_columns(
+        self, driver: "ArrowOdbcDriver", table: str | None = None, schema: str | None = None
+    ) -> list[ColumnMetadata]:
+        """Get column metadata for dialects with bundled catalog queries."""
+        query_name = "columns_by_table" if table is not None else "columns_by_schema"
+        parameters: dict[str, Any] = {"schema_name": self.resolve_schema(schema)}
+        if table is not None:
+            parameters["table_name"] = table
+        try:
+            return cast("list[ColumnMetadata]", driver.select(self.get_query(query_name), **parameters))
+        except SQLFileNotFoundError:
+            return []
+
+    def get_indexes(
+        self, driver: "ArrowOdbcDriver", table: str | None = None, schema: str | None = None
+    ) -> list[IndexMetadata]:
+        """Get index metadata for dialects with bundled catalog queries."""
+        query_name = "indexes_by_table" if table is not None else "indexes_by_schema"
+        parameters: dict[str, Any] = {"schema_name": self.resolve_schema(schema)}
+        if table is not None:
+            parameters["table_name"] = table
+        try:
+            return cast("list[IndexMetadata]", driver.select(self.get_query(query_name), **parameters))
+        except SQLFileNotFoundError:
+            return []
+
+    def get_foreign_keys(
+        self, driver: "ArrowOdbcDriver", table: str | None = None, schema: str | None = None
+    ) -> list[ForeignKeyMetadata]:
+        """Get foreign-key metadata for dialects with bundled catalog queries."""
+        query_name = "foreign_keys_by_table" if table is not None else "foreign_keys_by_schema"
+        parameters: dict[str, Any] = {"schema_name": self.resolve_schema(schema)}
+        if table is not None:
+            parameters["table_name"] = table
+        try:
+            return cast("list[ForeignKeyMetadata]", driver.select(self.get_query(query_name), **parameters))
+        except SQLFileNotFoundError:
+            return []

--- a/sqlspec/adapters/arrow_odbc/data_dictionary.py
+++ b/sqlspec/adapters/arrow_odbc/data_dictionary.py
@@ -1,6 +1,6 @@
 """Generic data dictionary for arrow-odbc connections."""
 
-from typing import TYPE_CHECKING, Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from mypy_extensions import mypyc_attr
 
@@ -84,14 +84,14 @@ class ArrowOdbcDataDictionary(SyncDataDictionaryBase):
 
     def get_optimal_type(self, driver: "ArrowOdbcDriver", type_category: str) -> str:
         """Get the optimal runtime dialect type for a category."""
+        _ = driver
         return self.get_dialect_config().get_optimal_type(type_category)
 
     def get_tables(self, driver: "ArrowOdbcDriver", schema: str | None = None) -> list[TableMetadata]:
         """Get table metadata for dialects with bundled catalog queries."""
         try:
-            return cast(
-                "list[TableMetadata]",
-                driver.select(self.get_query("tables_by_schema"), schema_name=self.resolve_schema(schema)),
+            return driver.select(
+                self.get_query("tables_by_schema"), schema_name=self.resolve_schema(schema), schema_type=TableMetadata
             )
         except SQLFileNotFoundError:
             return []
@@ -105,7 +105,7 @@ class ArrowOdbcDataDictionary(SyncDataDictionaryBase):
         if table is not None:
             parameters["table_name"] = table
         try:
-            return cast("list[ColumnMetadata]", driver.select(self.get_query(query_name), **parameters))
+            return driver.select(self.get_query(query_name), schema_type=ColumnMetadata, **parameters)
         except SQLFileNotFoundError:
             return []
 
@@ -118,7 +118,7 @@ class ArrowOdbcDataDictionary(SyncDataDictionaryBase):
         if table is not None:
             parameters["table_name"] = table
         try:
-            return cast("list[IndexMetadata]", driver.select(self.get_query(query_name), **parameters))
+            return driver.select(self.get_query(query_name), schema_type=IndexMetadata, **parameters)
         except SQLFileNotFoundError:
             return []
 
@@ -131,6 +131,6 @@ class ArrowOdbcDataDictionary(SyncDataDictionaryBase):
         if table is not None:
             parameters["table_name"] = table
         try:
-            return cast("list[ForeignKeyMetadata]", driver.select(self.get_query(query_name), **parameters))
+            return driver.select(self.get_query(query_name), schema_type=ForeignKeyMetadata, **parameters)
         except SQLFileNotFoundError:
             return []

--- a/sqlspec/adapters/arrow_odbc/driver.py
+++ b/sqlspec/adapters/arrow_odbc/driver.py
@@ -1,14 +1,9 @@
 """arrow-odbc sync driver."""
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
-from sqlspec.adapters.arrow_odbc._typing import (
-    ARROW_ODBC_MODULE,
-    ArrowOdbcConnection,
-    ArrowOdbcCursor,
-    ArrowOdbcRawCursor,
-)
+from sqlspec.adapters.arrow_odbc._typing import ArrowOdbcConnection, ArrowOdbcCursor, ArrowOdbcError, ArrowOdbcRawCursor
 from sqlspec.adapters.arrow_odbc.core import (
     build_statement_config,
     create_mapped_exception,
@@ -38,9 +33,8 @@ class ArrowOdbcExceptionHandler(BaseSyncExceptionHandler):
     def _handle_exception(self, exc_type: "type[BaseException] | None", exc_val: "BaseException") -> bool:
         if exc_type is None:
             return False
-        error_type = getattr(ARROW_ODBC_MODULE, "Error", Exception)
-        if isinstance(exc_val, error_type):
-            self.pending_exception = create_mapped_exception(cast("Exception", exc_val))
+        if isinstance(exc_val, ArrowOdbcError):
+            self.pending_exception = create_mapped_exception(exc_val)
             return True
         return False
 
@@ -297,4 +291,4 @@ def _table_to_reader(table: Any, chunk_size: int) -> Any:
     return pa.RecordBatchReader.from_batches(table.schema, table.to_batches(max_chunksize=chunk_size))
 
 
-register_driver_profile("arrow_odbc", driver_profile, allow_override=True)
+register_driver_profile("arrow_odbc", driver_profile)

--- a/sqlspec/adapters/arrow_odbc/driver.py
+++ b/sqlspec/adapters/arrow_odbc/driver.py
@@ -1,0 +1,300 @@
+"""arrow-odbc sync driver."""
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, cast
+
+from sqlspec.adapters.arrow_odbc._typing import (
+    ARROW_ODBC_MODULE,
+    ArrowOdbcConnection,
+    ArrowOdbcCursor,
+    ArrowOdbcRawCursor,
+)
+from sqlspec.adapters.arrow_odbc.core import (
+    build_statement_config,
+    create_mapped_exception,
+    driver_profile,
+    resolve_dialect_from_dbms_name,
+)
+from sqlspec.adapters.arrow_odbc.data_dictionary import ArrowOdbcDataDictionary
+from sqlspec.core import SQL, build_arrow_result_from_table, get_cache_config, register_driver_profile
+from sqlspec.driver import BaseSyncExceptionHandler, SyncDriverAdapterBase
+from sqlspec.exceptions import ImproperConfigurationError, SQLSpecError
+from sqlspec.utils.module_loader import ensure_pyarrow
+
+if TYPE_CHECKING:
+    from sqlspec.builder import QueryBuilder
+    from sqlspec.core import ArrowResult, Statement, StatementConfig, StatementFilter
+    from sqlspec.driver import ExecutionResult
+    from sqlspec.typing import ArrowReturnFormat, StatementParameters
+
+__all__ = ("ArrowOdbcCursor", "ArrowOdbcDriver", "ArrowOdbcExceptionHandler", "resolve_dialect_from_dbms_name")
+
+
+class ArrowOdbcExceptionHandler(BaseSyncExceptionHandler):
+    """Sync context manager handling arrow-odbc exceptions."""
+
+    __slots__ = ()
+
+    def _handle_exception(self, exc_type: "type[BaseException] | None", exc_val: "BaseException") -> bool:
+        if exc_type is None:
+            return False
+        error_type = getattr(ARROW_ODBC_MODULE, "Error", Exception)
+        if isinstance(exc_val, error_type):
+            self.pending_exception = create_mapped_exception(cast("Exception", exc_val))
+            return True
+        return False
+
+
+class ArrowOdbcDriver(SyncDriverAdapterBase):
+    """Sync driver for generic ODBC connections with Arrow-native transfer."""
+
+    __slots__ = ("_data_dictionary", "_dbms_name", "_dialect", "_statement_dialect", "dialect")
+
+    def __init__(
+        self,
+        connection: "ArrowOdbcConnection",
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "dict[str, Any] | None" = None,
+    ) -> None:
+        features = dict(driver_features or {})
+        self._dbms_name = self._resolve_dbms_name(connection, features)
+        self._dialect = resolve_dialect_from_dbms_name(self._dbms_name)
+        self._statement_dialect = _statement_dialect_for(self._dialect)
+        if statement_config is None:
+            statement_config = build_statement_config(dialect=self._statement_dialect).replace(
+                enable_caching=get_cache_config().compiled_cache_enabled
+            )
+        else:
+            statement_config = statement_config.replace(dialect=self._statement_dialect)
+
+        super().__init__(connection=connection, statement_config=statement_config, driver_features=features)
+        self.dialect = self._statement_dialect
+        self._data_dictionary: ArrowOdbcDataDictionary | None = None
+
+    @property
+    def data_dictionary(self) -> "ArrowOdbcDataDictionary":
+        if self._data_dictionary is None:
+            self._data_dictionary = ArrowOdbcDataDictionary(self._dialect)
+        return self._data_dictionary
+
+    def dispatch_execute(self, cursor: "ArrowOdbcRawCursor", statement: "SQL") -> "ExecutionResult":
+        sql, prepared_parameters = self._get_compiled_sql(statement, self.statement_config)
+        parameters = _odbc_parameters(prepared_parameters)
+
+        if statement.returns_rows():
+            reader = self._read_arrow_batches(sql, parameters, self._chunk_size())
+            table = _reader_to_table(reader)
+            rows = table.to_pylist()
+            column_names = table.column_names
+            return self.create_execution_result(
+                cursor,
+                selected_data=rows,
+                column_names=column_names,
+                data_row_count=table.num_rows,
+                is_select_result=True,
+                row_format="dict",
+            )
+
+        cursor.execute(query=sql, parameters=parameters)
+        return self.create_execution_result(cursor, rowcount_override=0)
+
+    def dispatch_execute_many(self, cursor: "ArrowOdbcRawCursor", statement: "SQL") -> "ExecutionResult":
+        msg = "arrow-odbc does not expose a row-oriented executemany API; use bulk_insert_arrow() for Arrow ingestion."
+        raise NotImplementedError(msg)
+
+    def dispatch_execute_script(self, cursor: "ArrowOdbcRawCursor", statement: "SQL") -> "ExecutionResult":
+        sql, prepared_parameters = self._get_compiled_sql(statement, self.statement_config)
+        statements = self.split_script_statements(sql, statement.statement_config, strip_trailing_semicolon=True)
+        parameters = _odbc_parameters(prepared_parameters)
+        successful_count = 0
+        for stmt in statements:
+            cursor.execute(query=stmt, parameters=parameters)
+            successful_count += 1
+        return self.create_execution_result(
+            cursor, statement_count=len(statements), successful_statements=successful_count, is_script_result=True
+        )
+
+    def collect_rows(self, cursor: "ArrowOdbcRawCursor", fetched: "list[Any]") -> "tuple[list[Any], list[str], int]":
+        return fetched, [], len(fetched)
+
+    def resolve_rowcount(self, cursor: "ArrowOdbcRawCursor") -> int:
+        return 0
+
+    def begin(self) -> None:
+        statement = "BEGIN TRANSACTION" if self._dialect == "mssql" else "BEGIN"
+        self.connection.execute(statement)
+
+    def commit(self) -> None:
+        try:
+            self.connection.commit()
+        except Exception as exc:
+            msg = f"Failed to commit transaction: {exc}"
+            raise SQLSpecError(msg) from exc
+
+    def rollback(self) -> None:
+        try:
+            self.connection.rollback()
+        except Exception as exc:
+            msg = f"Failed to rollback transaction: {exc}"
+            raise SQLSpecError(msg) from exc
+
+    def with_cursor(self, connection: "ArrowOdbcConnection") -> "ArrowOdbcCursor":
+        return ArrowOdbcCursor(connection)
+
+    def handle_database_exceptions(self) -> "ArrowOdbcExceptionHandler":
+        return ArrowOdbcExceptionHandler()
+
+    def create_savepoint(self, name: str) -> None:
+        if self._dialect == "mssql":
+            self.execute_script(f"SAVE TRANSACTION {name}")
+            return
+        self.execute_script(f"SAVEPOINT {name}")
+
+    def release_savepoint(self, name: str) -> None:
+        if self._dialect == "mssql":
+            return
+        self.execute_script(f"RELEASE SAVEPOINT {name}")
+
+    def rollback_to_savepoint(self, name: str) -> None:
+        if self._dialect == "mssql":
+            self.execute_script(f"ROLLBACK TRANSACTION {name}")
+            return
+        self.execute_script(f"ROLLBACK TO SAVEPOINT {name}")
+
+    def select_to_arrow(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        statement_config: "StatementConfig | None" = None,
+        return_format: "ArrowReturnFormat" = "table",
+        native_only: bool = False,
+        batch_size: int | None = None,
+        arrow_schema: Any = None,
+        **kwargs: Any,
+    ) -> "ArrowResult":
+        """Execute a query and return native Arrow results."""
+        ensure_pyarrow()
+        config = statement_config or self.statement_config
+        prepared_statement = self.prepare_statement(statement, parameters, statement_config=config, kwargs=kwargs)
+        sql, prepared_parameters = self._get_compiled_sql(prepared_statement, config)
+        resolved_batch_size = batch_size or self._chunk_size()
+        table: Any | None = None
+
+        exc_handler = self.handle_database_exceptions()
+        with exc_handler, self.with_cursor(self.connection):
+            reader = self._read_arrow_batches(sql, _odbc_parameters(prepared_parameters), resolved_batch_size)
+            table = _reader_to_table(reader)
+        self._check_pending_exception(exc_handler)
+
+        if table is None:
+            msg = "arrow-odbc did not return an Arrow table."
+            raise SQLSpecError(msg)
+        return build_arrow_result_from_table(
+            prepared_statement,
+            table,
+            return_format=return_format,
+            batch_size=resolved_batch_size,
+            arrow_schema=arrow_schema,
+        )
+
+    def bulk_insert_arrow(self, target_table: str, source: Any, *, chunk_size: int | None = None) -> None:
+        """Insert an Arrow table or reader into a database table."""
+        ensure_pyarrow()
+        import pyarrow as pa
+
+        resolved_chunk_size = chunk_size or self._chunk_size()
+        exc_handler = self.handle_database_exceptions()
+        with exc_handler, self.with_cursor(self.connection):
+            if isinstance(source, pa.Table) and hasattr(self.connection, "from_table_to_db"):
+                self.connection.from_table_to_db(source=source, target=target_table, chunk_size=resolved_chunk_size)
+                self._check_pending_exception(exc_handler)
+                return
+
+            reader = _table_to_reader(source, resolved_chunk_size) if isinstance(source, pa.Table) else source
+            if hasattr(self.connection, "insert_into_table"):
+                self.connection.insert_into_table(reader=reader, table=target_table, chunk_size=resolved_chunk_size)
+                self._check_pending_exception(exc_handler)
+                return
+        self._check_pending_exception(exc_handler)
+
+        msg = "arrow-odbc connection does not expose table import APIs."
+        raise ImproperConfigurationError(msg)
+
+    def _read_arrow_batches(self, sql: str, parameters: "list[str | None] | None", batch_size: int) -> Any:
+        kwargs: dict[str, Any] = {
+            "query": sql,
+            "batch_size": batch_size,
+            "parameters": parameters,
+            "max_bytes_per_batch": self.driver_features.get("max_bytes_per_batch"),
+            "max_text_size": self.driver_features.get("max_text_size"),
+            "max_binary_size": self.driver_features.get("max_binary_size"),
+            "fetch_concurrently": self.driver_features.get("fetch_concurrently", True),
+        }
+        query_timeout_sec = self.driver_features.get("query_timeout_sec")
+        if query_timeout_sec is not None:
+            kwargs["query_timeout_sec"] = query_timeout_sec
+        return self.connection.read_arrow_batches(**kwargs)
+
+    def _chunk_size(self) -> int:
+        return int(self.driver_features.get("chunk_size") or 65_536)
+
+    @staticmethod
+    def _resolve_dbms_name(connection: "ArrowOdbcConnection", features: "dict[str, Any]") -> str | None:
+        dbms_name = getattr(connection, "dbms_name", None)
+        if dbms_name:
+            return str(dbms_name)
+        dbms_name = features.get("dbms_name")
+        if dbms_name:
+            return str(dbms_name)
+        connection_string = features.get("connection_string")
+        if connection_string:
+            return str(connection_string)
+        return None
+
+
+def _statement_dialect_for(dialect: str) -> str:
+    if dialect == "mssql":
+        return "tsql"
+    return dialect
+
+
+def _unwrap_parameter(value: Any) -> Any:
+    wrapped = getattr(value, "value", value)
+    return None if wrapped is None else str(wrapped)
+
+
+def _odbc_parameters(parameters: Any) -> "list[str | None] | None":
+    if parameters is None:
+        return None
+    if isinstance(parameters, Mapping):
+        return [_unwrap_parameter(value) for value in parameters.values()]
+    if isinstance(parameters, (list, tuple)):
+        if not parameters:
+            return None
+        return [_unwrap_parameter(value) for value in parameters]
+    return [_unwrap_parameter(parameters)]
+
+
+def _reader_to_table(reader: Any) -> Any:
+    ensure_pyarrow()
+    import pyarrow as pa
+
+    if isinstance(reader, pa.Table):
+        return reader
+    if hasattr(reader, "read_all"):
+        return reader.read_all()
+    batches = list(reader)
+    if not batches:
+        return pa.table({})
+    return pa.Table.from_batches(batches)
+
+
+def _table_to_reader(table: Any, chunk_size: int) -> Any:
+    ensure_pyarrow()
+    import pyarrow as pa
+
+    return pa.RecordBatchReader.from_batches(table.schema, table.to_batches(max_chunksize=chunk_size))
+
+
+register_driver_profile("arrow_odbc", driver_profile, allow_override=True)

--- a/sqlspec/adapters/arrow_odbc/type_converter.py
+++ b/sqlspec/adapters/arrow_odbc/type_converter.py
@@ -1,0 +1,83 @@
+"""Arrow type helpers for generic ODBC result sets."""
+
+from typing import TYPE_CHECKING, Any, Final, cast
+
+from sqlspec.utils.module_loader import ensure_pyarrow
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+__all__ = ("ArrowOdbcTypeConverter", "odbc_type_to_arrow")
+
+_ODBC_ARROW_TYPE_SPECS: Final[dict[str, tuple[str, tuple[Any, ...], dict[str, Any]]]] = {
+    "bit": ("bool_", (), {}),
+    "boolean": ("bool_", (), {}),
+    "bool": ("bool_", (), {}),
+    "tinyint": ("uint8", (), {}),
+    "smallint": ("int16", (), {}),
+    "integer": ("int32", (), {}),
+    "int": ("int32", (), {}),
+    "bigint": ("int64", (), {}),
+    "float": ("float64", (), {}),
+    "double": ("float64", (), {}),
+    "real": ("float32", (), {}),
+    "smallmoney": ("decimal128", (10, 4), {}),
+    "money": ("decimal128", (19, 4), {}),
+    "decimal": ("decimal128", (38, 10), {}),
+    "numeric": ("decimal128", (38, 10), {}),
+    "date": ("date32", (), {}),
+    "time": ("time64", ("us",), {}),
+    "timestamp": ("timestamp", ("us",), {}),
+    "datetime": ("timestamp", ("us",), {}),
+    "datetime2": ("timestamp", ("us",), {}),
+    "smalldatetime": ("timestamp", ("s",), {}),
+    "datetimeoffset": ("timestamp", ("us",), {"tz": "UTC"}),
+    "char": ("string", (), {}),
+    "varchar": ("string", (), {}),
+    "nchar": ("string", (), {}),
+    "nvarchar": ("string", (), {}),
+    "text": ("string", (), {}),
+    "ntext": ("string", (), {}),
+    "clob": ("string", (), {}),
+    "xml": ("string", (), {}),
+    "blob": ("binary", (), {}),
+    "image": ("binary", (), {}),
+    "binary": ("binary", (), {}),
+    "varbinary": ("binary", (), {}),
+    "rowversion": ("binary", (), {}),
+    "uuid": ("string", (), {}),
+    "uniqueidentifier": ("string", (), {}),
+}
+
+
+class ArrowOdbcTypeConverter:
+    """Small bind/read converter surface for arrow-odbc."""
+
+    __slots__ = ()
+
+    def coerce_bind_value(self, value: "Any") -> "Any":
+        """Coerce values before arrow-odbc parameter binding."""
+        return None if value is None else str(value)
+
+    def coerce_read_value(self, value: "Any") -> "Any":
+        """Return arrow-odbc result values unchanged."""
+        return value
+
+
+def odbc_type_to_arrow(sql_type: str, *, precision: int | None = None, scale: int | None = None) -> "pa.DataType":
+    """Resolve an ODBC SQL type name to an Arrow data type."""
+    normalized_type = sql_type.lower().split("(", 1)[0].strip()
+    if normalized_type in {"decimal", "numeric"} and precision is not None and scale is not None:
+        return _arrow_type("decimal128", (precision, scale))
+    spec = _ODBC_ARROW_TYPE_SPECS.get(normalized_type)
+    if spec is None:
+        return _arrow_type("string")
+    name, args, kwargs = spec
+    return _arrow_type(name, args, kwargs)
+
+
+def _arrow_type(name: str, args: tuple[Any, ...] = (), kwargs: dict[str, Any] | None = None) -> "pa.DataType":
+    ensure_pyarrow()
+    import pyarrow as pa
+
+    return cast("pa.DataType", getattr(pa, name)(*args, **(kwargs or {})))

--- a/sqlspec/adapters/arrow_odbc/type_converter.py
+++ b/sqlspec/adapters/arrow_odbc/type_converter.py
@@ -49,6 +49,8 @@ _ODBC_ARROW_TYPE_SPECS: Final[dict[str, tuple[str, tuple[Any, ...], dict[str, An
     "uniqueidentifier": ("string", (), {}),
 }
 
+_ARROW_TYPE_CACHE: "dict[tuple[str, tuple[Any, ...], tuple[tuple[str, Any], ...]], Any]" = {}
+
 
 class ArrowOdbcTypeConverter:
     """Small bind/read converter surface for arrow-odbc."""
@@ -77,7 +79,15 @@ def odbc_type_to_arrow(sql_type: str, *, precision: int | None = None, scale: in
 
 
 def _arrow_type(name: str, args: tuple[Any, ...] = (), kwargs: dict[str, Any] | None = None) -> "pa.DataType":
+    kwargs_key = tuple(sorted((kwargs or {}).items()))
+    cache_key = (name, args, kwargs_key)
+    cached = _ARROW_TYPE_CACHE.get(cache_key)
+    if cached is not None:
+        return cast("pa.DataType", cached)
+
     ensure_pyarrow()
     import pyarrow as pa
 
-    return cast("pa.DataType", getattr(pa, name)(*args, **(kwargs or {})))
+    resolved = getattr(pa, name)(*args, **(kwargs or {}))
+    _ARROW_TYPE_CACHE[cache_key] = resolved
+    return cast("pa.DataType", resolved)

--- a/sqlspec/adapters/mssql_python/__init__.py
+++ b/sqlspec/adapters/mssql_python/__init__.py
@@ -1,0 +1,55 @@
+"""sqlspec adapter for Microsoft mssql-python driver."""
+
+from sqlspec.adapters.mssql_python._typing import (
+    MssqlPythonAsyncCursor,
+    MssqlPythonAsyncSessionContext,
+    MssqlPythonConnection,
+    MssqlPythonCursor,
+    MssqlPythonSessionContext,
+)
+from sqlspec.adapters.mssql_python.config import (
+    MssqlPythonAsyncConfig,
+    MssqlPythonConfig,
+    MssqlPythonConnectionParams,
+    MssqlPythonConnectionPool,
+    MssqlPythonDriverFeatures,
+    MssqlPythonPoolParams,
+)
+from sqlspec.adapters.mssql_python.core import default_statement_config, driver_profile
+from sqlspec.adapters.mssql_python.data_dictionary import (
+    MssqlPythonAsyncDataDictionary,
+    MssqlPythonSyncDataDictionary,
+    MssqlVersionInfo,
+)
+from sqlspec.adapters.mssql_python.driver import (
+    MssqlPythonAsyncDriver,
+    MssqlPythonAsyncExceptionHandler,
+    MssqlPythonDriver,
+    MssqlPythonExceptionHandler,
+)
+from sqlspec.adapters.mssql_python.migrations import MssqlPythonAsyncMigrationTracker, MssqlPythonSyncMigrationTracker
+
+__all__ = (
+    "MssqlPythonAsyncConfig",
+    "MssqlPythonAsyncCursor",
+    "MssqlPythonAsyncDataDictionary",
+    "MssqlPythonAsyncDriver",
+    "MssqlPythonAsyncExceptionHandler",
+    "MssqlPythonAsyncMigrationTracker",
+    "MssqlPythonAsyncSessionContext",
+    "MssqlPythonConfig",
+    "MssqlPythonConnection",
+    "MssqlPythonConnectionParams",
+    "MssqlPythonConnectionPool",
+    "MssqlPythonCursor",
+    "MssqlPythonDriver",
+    "MssqlPythonDriverFeatures",
+    "MssqlPythonExceptionHandler",
+    "MssqlPythonPoolParams",
+    "MssqlPythonSessionContext",
+    "MssqlPythonSyncDataDictionary",
+    "MssqlPythonSyncMigrationTracker",
+    "MssqlVersionInfo",
+    "default_statement_config",
+    "driver_profile",
+)

--- a/sqlspec/adapters/mssql_python/_typing.py
+++ b/sqlspec/adapters/mssql_python/_typing.py
@@ -1,0 +1,166 @@
+"""mssql-python adapter type definitions and mypyc-excluded context managers."""
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+import mssql_python as _mssql_python  # pyright: ignore[reportMissingImports]
+from mssql_python.connection import Connection  # pyright: ignore
+from mssql_python.cursor import Cursor  # pyright: ignore
+
+MSSQL_PYTHON_MODULE: Any = _mssql_python
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from types import TracebackType
+    from typing import TypeAlias
+
+    from sqlspec.adapters.mssql_python.driver import MssqlPythonAsyncDriver, MssqlPythonDriver
+    from sqlspec.core import StatementConfig
+
+    MssqlPythonConnection: TypeAlias = Connection
+    MssqlPythonRawCursor: TypeAlias = Cursor
+
+if not TYPE_CHECKING:
+    MssqlPythonConnection = Connection
+    MssqlPythonRawCursor = Cursor
+
+
+class MssqlPythonCursor:
+    """Sync context manager for mssql-python cursor management."""
+
+    __slots__ = ("connection", "cursor")
+
+    def __init__(self, connection: "MssqlPythonConnection") -> None:
+        self.connection = connection
+        self.cursor: MssqlPythonRawCursor | None = None
+
+    def __enter__(self) -> "MssqlPythonRawCursor":
+        self.cursor = self.connection.cursor()
+        return self.cursor
+
+    def __exit__(self, *_: object) -> None:
+        if self.cursor is not None:
+            self.cursor.close()
+
+
+class MssqlPythonAsyncCursor:
+    """Async context manager for mssql-python cursor management."""
+
+    __slots__ = ("connection", "cursor")
+
+    def __init__(self, connection: "MssqlPythonConnection") -> None:
+        self.connection = connection
+        self.cursor: MssqlPythonRawCursor | None = None
+
+    async def __aenter__(self) -> "MssqlPythonRawCursor":
+        self.cursor = await asyncio.to_thread(self.connection.cursor)
+        return self.cursor
+
+    async def __aexit__(self, *_: object) -> None:
+        if self.cursor is not None:
+            await asyncio.to_thread(self.cursor.close)
+
+
+class MssqlPythonSessionContext:
+    """Sync session context bridging compiled driver and interpreted config."""
+
+    __slots__ = (
+        "_acquire_connection",
+        "_connection",
+        "_driver",
+        "_driver_features",
+        "_prepare_driver",
+        "_release_connection",
+        "_statement_config",
+    )
+
+    def __init__(
+        self,
+        acquire_connection: "Callable[[], Any]",
+        release_connection: "Callable[[Any], Any]",
+        statement_config: "StatementConfig",
+        driver_features: "dict[str, Any]",
+        prepare_driver: "Callable[[MssqlPythonDriver], MssqlPythonDriver]",
+    ) -> None:
+        self._acquire_connection = acquire_connection
+        self._release_connection = release_connection
+        self._statement_config = statement_config
+        self._driver_features = driver_features
+        self._prepare_driver = prepare_driver
+        self._connection: Any = None
+        self._driver: MssqlPythonDriver | None = None
+
+    def __enter__(self) -> "MssqlPythonDriver":
+        from sqlspec.adapters.mssql_python.driver import MssqlPythonDriver
+
+        self._connection = self._acquire_connection()
+        self._driver = MssqlPythonDriver(
+            connection=self._connection, statement_config=self._statement_config, driver_features=self._driver_features
+        )
+        return self._prepare_driver(self._driver)
+
+    def __exit__(
+        self, exc_type: "type[BaseException] | None", exc_val: "BaseException | None", exc_tb: "TracebackType | None"
+    ) -> "bool | None":
+        if self._connection is not None:
+            self._release_connection(self._connection)
+            self._connection = None
+        return None
+
+
+class MssqlPythonAsyncSessionContext:
+    """Async session context bridging compiled driver and interpreted config."""
+
+    __slots__ = (
+        "_acquire_connection",
+        "_connection",
+        "_driver",
+        "_driver_features",
+        "_prepare_driver",
+        "_release_connection",
+        "_statement_config",
+    )
+
+    def __init__(
+        self,
+        acquire_connection: "Callable[[], Any]",
+        release_connection: "Callable[[Any], Any]",
+        statement_config: "StatementConfig",
+        driver_features: "dict[str, Any]",
+        prepare_driver: "Callable[[MssqlPythonAsyncDriver], MssqlPythonAsyncDriver]",
+    ) -> None:
+        self._acquire_connection = acquire_connection
+        self._release_connection = release_connection
+        self._statement_config = statement_config
+        self._driver_features = driver_features
+        self._prepare_driver = prepare_driver
+        self._connection: Any = None
+        self._driver: MssqlPythonAsyncDriver | None = None
+
+    async def __aenter__(self) -> "MssqlPythonAsyncDriver":
+        from sqlspec.adapters.mssql_python.driver import MssqlPythonAsyncDriver
+
+        self._connection = await self._acquire_connection()
+        self._driver = MssqlPythonAsyncDriver(
+            connection=self._connection, statement_config=self._statement_config, driver_features=self._driver_features
+        )
+        return self._prepare_driver(self._driver)
+
+    async def __aexit__(
+        self, exc_type: "type[BaseException] | None", exc_val: "BaseException | None", exc_tb: "TracebackType | None"
+    ) -> "bool | None":
+        if self._connection is not None:
+            await self._release_connection(self._connection)
+            self._connection = None
+        return None
+
+
+__all__ = (
+    "MSSQL_PYTHON_MODULE",
+    "MssqlPythonAsyncCursor",
+    "MssqlPythonAsyncSessionContext",
+    "MssqlPythonConnection",
+    "MssqlPythonCursor",
+    "MssqlPythonRawCursor",
+    "MssqlPythonSessionContext",
+)

--- a/sqlspec/adapters/mssql_python/config.py
+++ b/sqlspec/adapters/mssql_python/config.py
@@ -1,0 +1,401 @@
+"""mssql-python database configuration."""
+
+import asyncio
+from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
+
+from typing_extensions import NotRequired
+
+from sqlspec.adapters.mssql_python._typing import (
+    MSSQL_PYTHON_MODULE,
+    MssqlPythonAsyncSessionContext,
+    MssqlPythonConnection,
+    MssqlPythonSessionContext,
+)
+from sqlspec.adapters.mssql_python.core import apply_driver_features, build_connection_config, default_statement_config
+from sqlspec.adapters.mssql_python.driver import MssqlPythonAsyncDriver, MssqlPythonDriver
+from sqlspec.adapters.mssql_python.migrations import MssqlPythonAsyncMigrationTracker, MssqlPythonSyncMigrationTracker
+from sqlspec.config import AsyncDatabaseConfig, ExtensionConfigs, SyncDatabaseConfig
+from sqlspec.driver._async import AsyncPoolConnectionContext, AsyncPoolSessionFactory
+from sqlspec.driver._sync import SyncPoolConnectionContext, SyncPoolSessionFactory
+from sqlspec.utils.config_tools import normalize_connection_config
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from types import TracebackType
+
+    from sqlspec.core import StatementConfig
+    from sqlspec.observability import ObservabilityConfig
+
+__all__ = (
+    "MssqlPythonAsyncConfig",
+    "MssqlPythonConfig",
+    "MssqlPythonConnectionParams",
+    "MssqlPythonConnectionPool",
+    "MssqlPythonDriverFeatures",
+    "MssqlPythonPoolParams",
+)
+
+
+class MssqlPythonConnectionParams(TypedDict):
+    """mssql-python connection parameters."""
+
+    connection_string: NotRequired[str]
+    server: NotRequired[str]
+    port: NotRequired[int]
+    database: NotRequired[str]
+    uid: NotRequired[str]
+    user: NotRequired[str]
+    pwd: NotRequired[str]
+    password: NotRequired[str]
+    authentication: NotRequired[str]
+    trust_server_certificate: NotRequired[bool]
+    encrypt: NotRequired[bool]
+    connection_timeout: NotRequired[int]
+    command_timeout: NotRequired[int]
+    application_name: NotRequired[str]
+    workstation_id: NotRequired[str]
+    multiple_active_result_sets: NotRequired[bool]
+    application_intent: NotRequired[str]
+    autocommit: NotRequired[bool]
+    attrs_before: NotRequired[dict[int, int | str | bytes]]
+    timeout: NotRequired[int]
+    native_uuid: NotRequired[bool]
+    extra: NotRequired[dict[str, Any]]
+
+
+class MssqlPythonPoolParams(MssqlPythonConnectionParams):
+    """mssql-python driver-level pooling parameters."""
+
+    pool_size: NotRequired[int]
+    pool_idle_timeout: NotRequired[int]
+    pool_enabled: NotRequired[bool]
+
+
+class MssqlPythonDriverFeatures(TypedDict):
+    """mssql-python driver feature flags."""
+
+    use_pool: NotRequired[bool]
+    json_serializer: "NotRequired[Callable[[Any], str]]"
+    json_deserializer: "NotRequired[Callable[[str], Any]]"
+    on_connection_create: "NotRequired[Callable[[MssqlPythonConnection], None]]"
+    enable_events: NotRequired[bool]
+
+
+class MssqlPythonConnectionPool:
+    """Small SQLSpec pool facade over mssql-python's driver-level pooling."""
+
+    __slots__ = (
+        "_closed",
+        "connect_kwargs",
+        "connection_string",
+        "enabled",
+        "idle_timeout",
+        "max_size",
+        "on_connection_create",
+    )
+
+    def __init__(
+        self,
+        *,
+        connection_string: str,
+        connect_kwargs: "dict[str, Any] | None" = None,
+        max_size: int = 100,
+        idle_timeout: int = 600,
+        enabled: bool = True,
+        on_connection_create: "Callable[[MssqlPythonConnection], None] | None" = None,
+    ) -> None:
+        self.connection_string = connection_string
+        self.connect_kwargs = connect_kwargs or {}
+        self.max_size = max_size
+        self.idle_timeout = idle_timeout
+        self.enabled = enabled
+        self.on_connection_create = on_connection_create
+        self._closed = False
+        MSSQL_PYTHON_MODULE.pooling(max_size=max_size, idle_timeout=idle_timeout, enabled=enabled)
+
+    def acquire(self) -> "MssqlPythonConnection":
+        if self._closed:
+            msg = "Cannot acquire a connection from a closed mssql-python pool."
+            raise RuntimeError(msg)
+        connection = cast(
+            "MssqlPythonConnection", MSSQL_PYTHON_MODULE.connect(self.connection_string, **self.connect_kwargs)
+        )
+        if self.on_connection_create is not None:
+            self.on_connection_create(connection)
+        return connection
+
+    def release(self, connection: "MssqlPythonConnection") -> None:
+        connection.close()
+
+    def close(self) -> None:
+        self._closed = True
+
+
+class MssqlPythonConnectionContext(SyncPoolConnectionContext):
+    """Context manager for mssql-python sync connections."""
+
+    __slots__ = ("_conn",)
+
+    def __init__(self, config: "MssqlPythonConfig") -> None:
+        super().__init__(config)
+        self._conn: MssqlPythonConnection | None = None
+
+    def __enter__(self) -> "MssqlPythonConnection":
+        pool = self._config.provide_pool()
+        conn = pool.acquire()
+        self._conn = conn
+        return cast("MssqlPythonConnection", conn)
+
+    def __exit__(
+        self, exc_type: "type[BaseException] | None", exc_val: "BaseException | None", exc_tb: "TracebackType | None"
+    ) -> "bool | None":
+        if self._conn is not None:
+            self._config.provide_pool().release(self._conn)
+            self._conn = None
+        return None
+
+
+class MssqlPythonAsyncConnectionContext(AsyncPoolConnectionContext):
+    """Async context manager for mssql-python connections via to_thread."""
+
+    __slots__ = ("_conn",)
+
+    def __init__(self, config: "MssqlPythonAsyncConfig") -> None:
+        super().__init__(config)
+        self._conn: MssqlPythonConnection | None = None
+
+    async def __aenter__(self) -> "MssqlPythonConnection":
+        pool = await self._config.provide_pool()
+        conn = await asyncio.to_thread(pool.acquire)
+        self._conn = conn
+        return cast("MssqlPythonConnection", conn)
+
+    async def __aexit__(
+        self, exc_type: "type[BaseException] | None", exc_val: "BaseException | None", exc_tb: "TracebackType | None"
+    ) -> "bool | None":
+        if self._conn is not None:
+            pool = await self._config.provide_pool()
+            await asyncio.to_thread(pool.release, self._conn)
+            self._conn = None
+        return None
+
+
+class _MssqlPythonSyncSessionConnectionHandler(SyncPoolSessionFactory):
+    __slots__ = ("_conn",)
+
+    def __init__(self, config: "MssqlPythonConfig") -> None:
+        super().__init__(config)
+        self._conn: MssqlPythonConnection | None = None
+
+    def acquire_connection(self) -> "MssqlPythonConnection":
+        pool = self._config.provide_pool()
+        conn = pool.acquire()
+        self._conn = conn
+        return cast("MssqlPythonConnection", conn)
+
+    def release_connection(self, _conn: "MssqlPythonConnection", **kwargs: Any) -> None:
+        if self._conn is None:
+            return
+        self._config.provide_pool().release(self._conn)
+        self._conn = None
+
+
+class _MssqlPythonAsyncSessionConnectionHandler(AsyncPoolSessionFactory):
+    __slots__ = ("_conn",)
+
+    def __init__(self, config: "MssqlPythonAsyncConfig") -> None:
+        super().__init__(config)
+        self._conn: MssqlPythonConnection | None = None
+
+    async def acquire_connection(self) -> "MssqlPythonConnection":
+        pool = await self._config.provide_pool()
+        conn = await asyncio.to_thread(pool.acquire)
+        self._conn = conn
+        return cast("MssqlPythonConnection", conn)
+
+    async def release_connection(self, _conn: "MssqlPythonConnection", **kwargs: Any) -> None:
+        if self._conn is None:
+            return
+        pool = await self._config.provide_pool()
+        await asyncio.to_thread(pool.release, self._conn)
+        self._conn = None
+
+
+class MssqlPythonConfig(SyncDatabaseConfig[MssqlPythonConnection, MssqlPythonConnectionPool, MssqlPythonDriver]):
+    """Configuration for mssql-python synchronous database connections."""
+
+    __slots__ = ("_user_connection_hook",)
+
+    driver_type: "ClassVar[type[MssqlPythonDriver]]" = MssqlPythonDriver
+    connection_type: "ClassVar[type[MssqlPythonConnection]]" = MssqlPythonConnection
+    migration_tracker_type: "ClassVar[type[MssqlPythonSyncMigrationTracker]]" = MssqlPythonSyncMigrationTracker
+    supports_transactional_ddl: "ClassVar[bool]" = True
+    supports_native_arrow_export: "ClassVar[bool]" = True
+    supports_native_arrow_import: "ClassVar[bool]" = False
+    supports_native_parquet_export: "ClassVar[bool]" = False
+    supports_native_parquet_import: "ClassVar[bool]" = False
+    _connection_context_class: "ClassVar[type[MssqlPythonConnectionContext]]" = MssqlPythonConnectionContext
+    _session_factory_class: "ClassVar[type[_MssqlPythonSyncSessionConnectionHandler]]" = (
+        _MssqlPythonSyncSessionConnectionHandler
+    )
+    _session_context_class: "ClassVar[type[MssqlPythonSessionContext]]" = MssqlPythonSessionContext
+    _default_statement_config = default_statement_config
+
+    def __init__(
+        self,
+        *,
+        connection_config: "MssqlPythonPoolParams | dict[str, Any] | None" = None,
+        connection_instance: "MssqlPythonConnectionPool | None" = None,
+        migration_config: "dict[str, Any] | None" = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "MssqlPythonDriverFeatures | dict[str, Any] | None" = None,
+        bind_key: "str | None" = None,
+        extension_config: "ExtensionConfigs | None" = None,
+        observability_config: "ObservabilityConfig | None" = None,
+        **kwargs: Any,
+    ) -> None:
+        normalized = normalize_connection_config(connection_config)
+        features_dict = apply_driver_features(dict(driver_features or {}))
+        self._user_connection_hook: Callable[[MssqlPythonConnection], None] | None = features_dict.pop(
+            "on_connection_create", None
+        )
+        super().__init__(
+            bind_key=bind_key,
+            connection_config=normalized,
+            connection_instance=connection_instance,
+            migration_config=migration_config,
+            statement_config=statement_config or default_statement_config,
+            driver_features=features_dict,
+            extension_config=extension_config,
+            observability_config=observability_config,
+            **kwargs,
+        )
+
+    def create_connection(self) -> "MssqlPythonConnection":
+        pool = self.provide_pool()
+        return pool.acquire()
+
+    def get_signature_namespace(self) -> "dict[str, Any]":
+        namespace = super().get_signature_namespace()
+        namespace.update({
+            "MssqlPythonConfig": MssqlPythonConfig,
+            "MssqlPythonConnection": MssqlPythonConnection,
+            "MssqlPythonConnectionContext": MssqlPythonConnectionContext,
+            "MssqlPythonConnectionParams": MssqlPythonConnectionParams,
+            "MssqlPythonConnectionPool": MssqlPythonConnectionPool,
+            "MssqlPythonDriver": MssqlPythonDriver,
+            "MssqlPythonDriverFeatures": MssqlPythonDriverFeatures,
+            "MssqlPythonPoolParams": MssqlPythonPoolParams,
+            "MssqlPythonSessionContext": MssqlPythonSessionContext,
+        })
+        return namespace
+
+    def _create_pool(self) -> "MssqlPythonConnectionPool":
+        return _create_mssql_python_pool(dict(self.connection_config), self.driver_features, self._user_connection_hook)
+
+    def _close_pool(self) -> None:
+        if self.connection_instance is not None:
+            self.connection_instance.close()
+
+
+class MssqlPythonAsyncConfig(
+    AsyncDatabaseConfig[MssqlPythonConnection, MssqlPythonConnectionPool, MssqlPythonAsyncDriver]
+):
+    """Configuration for mssql-python async database connections."""
+
+    __slots__ = ("_user_connection_hook",)
+
+    driver_type: "ClassVar[type[MssqlPythonAsyncDriver]]" = MssqlPythonAsyncDriver
+    connection_type: "ClassVar[type[MssqlPythonConnection]]" = MssqlPythonConnection
+    migration_tracker_type: "ClassVar[type[MssqlPythonAsyncMigrationTracker]]" = MssqlPythonAsyncMigrationTracker
+    supports_transactional_ddl: "ClassVar[bool]" = True
+    supports_native_arrow_export: "ClassVar[bool]" = True
+    supports_native_arrow_import: "ClassVar[bool]" = False
+    supports_native_parquet_export: "ClassVar[bool]" = False
+    supports_native_parquet_import: "ClassVar[bool]" = False
+    _connection_context_class: "ClassVar[type[MssqlPythonAsyncConnectionContext]]" = MssqlPythonAsyncConnectionContext
+    _session_factory_class: "ClassVar[type[_MssqlPythonAsyncSessionConnectionHandler]]" = (
+        _MssqlPythonAsyncSessionConnectionHandler
+    )
+    _session_context_class: "ClassVar[type[MssqlPythonAsyncSessionContext]]" = MssqlPythonAsyncSessionContext
+    _default_statement_config = default_statement_config
+
+    def __init__(
+        self,
+        *,
+        connection_config: "MssqlPythonPoolParams | dict[str, Any] | None" = None,
+        connection_instance: "MssqlPythonConnectionPool | None" = None,
+        migration_config: "dict[str, Any] | None" = None,
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "MssqlPythonDriverFeatures | dict[str, Any] | None" = None,
+        bind_key: "str | None" = None,
+        extension_config: "ExtensionConfigs | None" = None,
+        observability_config: "ObservabilityConfig | None" = None,
+        **kwargs: Any,
+    ) -> None:
+        normalized = normalize_connection_config(connection_config)
+        features_dict = apply_driver_features(dict(driver_features or {}))
+        self._user_connection_hook: Callable[[MssqlPythonConnection], None] | None = features_dict.pop(
+            "on_connection_create", None
+        )
+        super().__init__(
+            bind_key=bind_key,
+            connection_config=normalized,
+            connection_instance=connection_instance,
+            migration_config=migration_config,
+            statement_config=statement_config or default_statement_config,
+            driver_features=features_dict,
+            extension_config=extension_config,
+            observability_config=observability_config,
+            **kwargs,
+        )
+
+    async def create_connection(self) -> "MssqlPythonConnection":
+        pool = await self.provide_pool()
+        return await asyncio.to_thread(pool.acquire)
+
+    def get_signature_namespace(self) -> "dict[str, Any]":
+        namespace = super().get_signature_namespace()
+        namespace.update({
+            "MssqlPythonAsyncConfig": MssqlPythonAsyncConfig,
+            "MssqlPythonAsyncConnectionContext": MssqlPythonAsyncConnectionContext,
+            "MssqlPythonAsyncDriver": MssqlPythonAsyncDriver,
+            "MssqlPythonAsyncSessionContext": MssqlPythonAsyncSessionContext,
+            "MssqlPythonConfig": MssqlPythonConfig,
+            "MssqlPythonConnection": MssqlPythonConnection,
+            "MssqlPythonConnectionParams": MssqlPythonConnectionParams,
+            "MssqlPythonConnectionPool": MssqlPythonConnectionPool,
+            "MssqlPythonDriver": MssqlPythonDriver,
+            "MssqlPythonDriverFeatures": MssqlPythonDriverFeatures,
+            "MssqlPythonPoolParams": MssqlPythonPoolParams,
+            "MssqlPythonSessionContext": MssqlPythonSessionContext,
+        })
+        return namespace
+
+    async def _create_pool(self) -> "MssqlPythonConnectionPool":
+        return await asyncio.to_thread(
+            _create_mssql_python_pool, dict(self.connection_config), self.driver_features, self._user_connection_hook
+        )
+
+    async def _close_pool(self) -> None:
+        if self.connection_instance is not None:
+            await asyncio.to_thread(self.connection_instance.close)
+
+
+def _create_mssql_python_pool(
+    connection_config: "dict[str, Any]",
+    driver_features: "dict[str, Any]",
+    on_connection_create: "Callable[[MssqlPythonConnection], None] | None" = None,
+) -> "MssqlPythonConnectionPool":
+    pool_size = int(connection_config.get("pool_size", 100))
+    pool_idle_timeout = int(connection_config.get("pool_idle_timeout", 600))
+    pool_enabled = bool(connection_config.get("pool_enabled", driver_features.get("use_pool", True)))
+    connection_string, connect_kwargs = build_connection_config(connection_config)
+    return MssqlPythonConnectionPool(
+        connection_string=connection_string,
+        connect_kwargs=connect_kwargs,
+        max_size=pool_size,
+        idle_timeout=pool_idle_timeout,
+        enabled=pool_enabled,
+        on_connection_create=on_connection_create,
+    )

--- a/sqlspec/adapters/mssql_python/core.py
+++ b/sqlspec/adapters/mssql_python/core.py
@@ -1,0 +1,219 @@
+"""mssql-python adapter core helpers."""
+
+import re
+from importlib.metadata import PackageNotFoundError, version
+from typing import TYPE_CHECKING, Any, Final
+
+from sqlspec.core.parameters import ParameterStyle
+from sqlspec.core.parameters._registry import build_statement_config_from_profile
+from sqlspec.core.parameters._types import DriverParameterProfile
+from sqlspec.exceptions import (
+    DatabaseConnectionError,
+    DataError,
+    DeadlockError,
+    ForeignKeyViolationError,
+    IntegrityError,
+    NotNullViolationError,
+    OperationalError,
+    PermissionDeniedError,
+    QueryTimeoutError,
+    SQLSpecError,
+    UniqueViolationError,
+)
+from sqlspec.utils.serializers import from_json, to_json
+from sqlspec.utils.type_converters import build_uuid_coercions
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from logging import Logger
+
+    from sqlspec.core import StatementConfig
+
+__all__ = (
+    "MSSQL_PYTHON_VERSION",
+    "apply_driver_features",
+    "build_connection_config",
+    "build_profile",
+    "build_statement_config",
+    "create_mapped_exception",
+    "default_statement_config",
+    "driver_profile",
+)
+
+_ERROR_NUMBER_PATTERN: Final[re.Pattern[str]] = re.compile(r"\(([-]?\d+)\)")
+_VERSION_PATTERN: Final[re.Pattern[str]] = re.compile(r"(\d+)")
+_VERSION_PART_COUNT: Final[int] = 3
+_CONNECTION_STRING_KEYS: Final[tuple[tuple[str, str], ...]] = (
+    ("server", "Server"),
+    ("database", "Database"),
+    ("uid", "UID"),
+    ("user", "UID"),
+    ("pwd", "PWD"),
+    ("password", "PWD"),
+    ("authentication", "Authentication"),
+    ("encrypt", "Encrypt"),
+    ("trust_server_certificate", "TrustServerCertificate"),
+    ("connection_timeout", "Connection Timeout"),
+    ("command_timeout", "Command Timeout"),
+    ("application_name", "Application Name"),
+    ("workstation_id", "Workstation ID"),
+    ("multiple_active_result_sets", "MultipleActiveResultSets"),
+    ("application_intent", "ApplicationIntent"),
+)
+_CONNECT_KWARG_KEYS: Final[set[str]] = {"autocommit", "attrs_before", "timeout", "native_uuid"}
+_POOL_CONFIG_KEYS: Final[set[str]] = {"pool_size", "pool_idle_timeout", "pool_enabled"}
+_ERROR_CODE_MAPPING: Final[dict[int, tuple[type[SQLSpecError], str]]] = {
+    2601: (UniqueViolationError, "unique constraint violation"),
+    2627: (UniqueViolationError, "unique constraint violation"),
+    547: (ForeignKeyViolationError, "foreign key or check constraint violation"),
+    515: (NotNullViolationError, "not-null constraint violation"),
+    18456: (PermissionDeniedError, "permission denied"),
+    4060: (DatabaseConnectionError, "database connection error"),
+    53: (DatabaseConnectionError, "database connection error"),
+    1205: (DeadlockError, "deadlock detected"),
+    -2: (QueryTimeoutError, "query timeout"),
+    8114: (DataError, "data conversion error"),
+    1105: (OperationalError, "operational error"),
+}
+
+
+def create_mapped_exception(exc: Exception, logger: "Logger | None" = None) -> Exception:
+    """Map a mssql-python exception to SQLSpec's exception hierarchy."""
+    error_number = _extract_error_number(exc)
+    if error_number is not None:
+        mapping = _ERROR_CODE_MAPPING.get(error_number)
+        if mapping is not None:
+            error_class, description = mapping
+            return error_class(f"SQL Server error {error_number}: {description}. Original error: {exc}")
+        if logger is not None:
+            logger.debug("Unmapped SQL Server error number: %s", error_number)
+
+    exc_name = type(exc).__name__
+    if exc_name == "IntegrityError":
+        return IntegrityError(f"SQL Server integrity error. Original error: {exc}")
+    if exc_name == "OperationalError":
+        return OperationalError(f"SQL Server operational error. Original error: {exc}")
+    if exc_name == "DataError":
+        return DataError(f"SQL Server data error. Original error: {exc}")
+    return SQLSpecError(f"SQL Server database error. Original error: {exc}")
+
+
+def apply_driver_features(features: "dict[str, Any] | None") -> dict[str, Any]:
+    """Merge mssql-python driver-feature defaults with caller overrides."""
+    defaults: dict[str, Any] = {"use_pool": True, "json_serializer": to_json, "json_deserializer": from_json}
+    defaults.update(features or {})
+    return defaults
+
+
+def build_connection_config(params: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+    """Build an ODBC connection string and mssql-python connect kwargs."""
+    config = dict(params)
+    connect_kwargs = {key: config.pop(key) for key in tuple(config) if key in _CONNECT_KWARG_KEYS}
+    for key in _POOL_CONFIG_KEYS:
+        config.pop(key, None)
+
+    connection_string = config.pop("connection_string", None)
+    if connection_string is not None:
+        return str(connection_string), connect_kwargs
+
+    server = config.get("server")
+    if not server:
+        msg = "mssql-python connection_config requires 'server' or 'connection_string'."
+        raise ValueError(msg)
+    config["server"] = _append_port(str(server), config.pop("port", None))
+
+    parts: list[str] = []
+    consumed: set[str] = set()
+    for key, option_name in _CONNECTION_STRING_KEYS:
+        if key not in config:
+            continue
+        value = config[key]
+        if value is None:
+            continue
+        parts.append(f"{option_name}={_format_connection_value(value)}")
+        consumed.add(key)
+
+    extra = config.get("extra")
+    if isinstance(extra, dict):
+        parts.extend(f"{key}={_format_connection_value(value)}" for key, value in extra.items() if value is not None)
+        consumed.add("extra")
+
+    for key, value in config.items():
+        if key in consumed or value is None:
+            continue
+        parts.append(f"{key}={_format_connection_value(value)}")
+
+    return ";".join(parts) + ";", connect_kwargs
+
+
+def _build_mssql_python_custom_type_coercions() -> "dict[type, Callable[[Any], Any]]":
+    """Return custom type coercions for mssql-python."""
+    return {bool: _identity, int: _identity, float: _identity, bytes: _identity, **build_uuid_coercions(native=True)}
+
+
+def build_profile() -> "DriverParameterProfile":
+    """Create the mssql-python driver parameter profile."""
+    return DriverParameterProfile(
+        name="mssql_python",
+        default_style=ParameterStyle.QMARK,
+        supported_styles={ParameterStyle.QMARK, ParameterStyle.NAMED_PYFORMAT},
+        default_execution_style=ParameterStyle.QMARK,
+        supported_execution_styles={ParameterStyle.QMARK},
+        has_native_list_expansion=False,
+        preserve_parameter_format=True,
+        needs_static_script_compilation=False,
+        allow_mixed_parameter_styles=False,
+        preserve_original_params_for_many=False,
+        json_serializer_strategy="helper",
+        custom_type_coercions=_build_mssql_python_custom_type_coercions(),
+        default_dialect="tsql",
+    )
+
+
+def build_statement_config(*, json_serializer: "Callable[[Any], str] | None" = None) -> "StatementConfig":
+    """Construct the mssql-python statement configuration."""
+    return build_statement_config_from_profile(
+        driver_profile, statement_overrides={"dialect": "tsql"}, json_serializer=json_serializer or to_json
+    )
+
+
+def _parse_version() -> tuple[int, int, int]:
+    try:
+        raw_version = version("mssql-python")
+    except PackageNotFoundError:
+        return 0, 0, 0
+    parts = [int(value) for value in _VERSION_PATTERN.findall(raw_version)]
+    while len(parts) < _VERSION_PART_COUNT:
+        parts.append(0)
+    return parts[0], parts[1], parts[2]
+
+
+def _identity(value: Any) -> Any:
+    return value
+
+
+def _format_connection_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    return str(value)
+
+
+def _append_port(server: str, port: Any) -> str:
+    if not port or "," in server or ":" in server:
+        return server
+    return f"{server},{port}"
+
+
+def _extract_error_number(exc: Exception) -> "int | None":
+    matches = _ERROR_NUMBER_PATTERN.findall(str(exc))
+    if not matches:
+        return None
+    try:
+        return int(matches[-1])
+    except ValueError:
+        return None
+
+
+MSSQL_PYTHON_VERSION: Final[tuple[int, int, int]] = _parse_version()
+driver_profile = build_profile()
+default_statement_config = build_statement_config()

--- a/sqlspec/adapters/mssql_python/data_dictionary.py
+++ b/sqlspec/adapters/mssql_python/data_dictionary.py
@@ -1,0 +1,377 @@
+"""mssql-python data dictionary."""
+
+from typing import TYPE_CHECKING, Any, ClassVar, cast
+
+from mypy_extensions import mypyc_attr
+
+from sqlspec.data_dictionary import get_dialect_config
+from sqlspec.data_dictionary.dialects.mssql import (
+    extract_mssql_version_value,
+    is_mssql_azure_sql,
+    list_mssql_available_features,
+    merge_mssql_table_lists,
+    mssql_supports_native_json,
+    parse_mssql_engine_edition,
+    parse_mssql_version_components,
+    resolve_mssql_feature_flag,
+)
+from sqlspec.driver import AsyncDataDictionaryBase, SyncDataDictionaryBase
+from sqlspec.typing import ColumnMetadata, ForeignKeyMetadata, IndexMetadata, TableMetadata, VersionInfo
+from sqlspec.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from sqlspec.data_dictionary._types import DialectConfig
+
+logger = get_logger("sqlspec.adapters.mssql_python.data_dictionary")
+
+__all__ = ("MssqlPythonAsyncDataDictionary", "MssqlPythonSyncDataDictionary", "MssqlVersionInfo")
+
+
+class MssqlVersionInfo(VersionInfo):
+    """MSSQL database version info with build, revision, and Azure SQL detection."""
+
+    def __init__(
+        self,
+        major: int,
+        minor: int = 0,
+        build: int = 0,
+        revision: int = 0,
+        edition: str | None = None,
+        engine_edition: int | None = None,
+    ) -> None:
+        super().__init__(major, minor, build)
+        self.build = build
+        self.revision = revision
+        self.edition = edition
+        self.engine_edition = engine_edition
+        self.is_azure_sql = is_mssql_azure_sql(engine_edition)
+
+    def supports_native_json(self) -> bool:
+        """Return whether this server supports the native JSON type."""
+        return mssql_supports_native_json(self.major, is_azure_sql=self.is_azure_sql)
+
+    def __str__(self) -> str:
+        """String representation of version info."""
+        version_str = f"{self.major}.{self.minor}.{self.build}.{self.revision}"
+        if self.edition:
+            version_str += f" ({self.edition})"
+        if self.is_azure_sql:
+            version_str += " [Azure]"
+        return version_str
+
+
+class _MssqlDataDictionaryMixin:
+    """Shared helpers for MSSQL data dictionaries."""
+
+    dialect: ClassVar[str] = "mssql"
+
+    def get_dialect_config(self) -> "DialectConfig":
+        """Return the dialect configuration for this data dictionary."""
+        return get_dialect_config(type(self).dialect)
+
+    def resolve_schema(self, schema: str | None) -> str | None:
+        """Return a schema name using dialect defaults when missing."""
+        if schema is not None:
+            return schema
+        return self.get_dialect_config().default_schema
+
+    def list_available_features(self) -> list[str]:
+        """List available feature flags for this dialect."""
+        return list_mssql_available_features(self.get_dialect_config())
+
+    def _build_version_info(
+        self, version_value: str | None, edition: str | None, engine_edition_value: Any
+    ) -> MssqlVersionInfo | None:
+        if not version_value:
+            return None
+        major, minor, build, revision = parse_mssql_version_components(version_value)
+        return MssqlVersionInfo(
+            major,
+            minor,
+            build,
+            revision,
+            edition=edition,
+            engine_edition=parse_mssql_engine_edition(engine_edition_value),
+        )
+
+    def _get_optimal_type_from_version(self, version_info: MssqlVersionInfo | None, type_category: str) -> str:
+        if type_category in {"json", "jsonb"} and version_info is not None and version_info.supports_native_json():
+            return "JSON"
+        return self.get_dialect_config().get_optimal_type(type_category)
+
+
+@mypyc_attr(allow_interpreted_subclasses=True, native_class=False)
+class MssqlPythonSyncDataDictionary(_MssqlDataDictionaryMixin, SyncDataDictionaryBase):
+    """MSSQL sync data dictionary."""
+
+    dialect: ClassVar[str] = "mssql"
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def get_version(self, driver: Any) -> MssqlVersionInfo | None:
+        """Get SQL Server version information."""
+        driver_id = id(driver)
+        if driver_id in self._version_fetch_attempted:
+            return cast("MssqlVersionInfo | None", self._version_cache.get(driver_id))
+
+        row = driver.select_one_or_none(self.get_query_text("version"))
+        if not row:
+            self._log_version_unavailable(type(self).dialect, "missing")
+            self.cache_version(driver_id, None)
+            return None
+
+        version_value = extract_mssql_version_value(
+            _row_value(row, "product_version") or _row_value(row, "version_string", "version")
+        )
+        edition_value = _row_value(row, "edition")
+        edition = str(edition_value) if edition_value is not None else None
+        version_info = self._build_version_info(version_value, edition, _row_value(row, "engine_edition"))
+        if version_info is None:
+            self._log_version_unavailable(type(self).dialect, "parse_failed")
+            self.cache_version(driver_id, None)
+            return None
+
+        self._log_version_detected(type(self).dialect, version_info)
+        self.cache_version(driver_id, version_info)
+        return version_info
+
+    def get_feature_flag(self, driver: Any, feature: str) -> bool:
+        """Check whether SQL Server supports a feature."""
+        version_info = self.get_version(driver)
+        return resolve_mssql_feature_flag(
+            feature,
+            major=version_info.major if version_info is not None else 0,
+            is_azure_sql=bool(version_info and version_info.is_azure_sql),
+            config=self.get_dialect_config(),
+            version_info=version_info,
+        )
+
+    def get_optimal_type(self, driver: Any, type_category: str) -> str:
+        """Get optimal SQL Server type for a category."""
+        return self._get_optimal_type_from_version(self.get_version(driver), type_category)
+
+    def get_tables(self, driver: Any, schema: str | None = None) -> list[TableMetadata]:
+        """Get tables sorted by dependency order with catalog fallback."""
+        schema_name = self.resolve_schema(schema)
+        self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="tables")
+        ordered = cast(
+            "list[TableMetadata]",
+            driver.select(self.get_query("tables_by_schema"), schema_name=schema_name, schema_type=TableMetadata),
+        )
+        all_rows = cast(
+            "list[TableMetadata]",
+            driver.select(self.get_query("all_tables_by_schema"), schema_name=schema_name, schema_type=TableMetadata),
+        )
+        return merge_mssql_table_lists(ordered, all_rows)
+
+    def get_columns(self, driver: Any, table: str | None = None, schema: str | None = None) -> list[ColumnMetadata]:
+        """Get column information for a table or schema."""
+        schema_name = self.resolve_schema(schema)
+        if table is None:
+            self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="columns")
+            return cast(
+                "list[ColumnMetadata]",
+                driver.select(self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata),
+            )
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="columns")
+        return cast(
+            "list[ColumnMetadata]",
+            driver.select(
+                self.get_query("columns_by_table"),
+                schema_name=schema_name,
+                table_name=table,
+                schema_type=ColumnMetadata,
+            ),
+        )
+
+    def get_indexes(self, driver: Any, table: str | None = None, schema: str | None = None) -> list[IndexMetadata]:
+        """Get index metadata for a table or schema."""
+        schema_name = self.resolve_schema(schema)
+        if table is None:
+            self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="indexes")
+            return cast(
+                "list[IndexMetadata]",
+                driver.select(self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata),
+            )
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="indexes")
+        return cast(
+            "list[IndexMetadata]",
+            driver.select(
+                self.get_query("indexes_by_table"), schema_name=schema_name, table_name=table, schema_type=IndexMetadata
+            ),
+        )
+
+    def get_foreign_keys(
+        self, driver: Any, table: str | None = None, schema: str | None = None
+    ) -> list[ForeignKeyMetadata]:
+        """Get foreign key metadata."""
+        schema_name = self.resolve_schema(schema)
+        if table is None:
+            self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="foreign_keys")
+            return cast(
+                "list[ForeignKeyMetadata]",
+                driver.select(
+                    self.get_query("foreign_keys_by_schema"), schema_name=schema_name, schema_type=ForeignKeyMetadata
+                ),
+            )
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="foreign_keys")
+        return cast(
+            "list[ForeignKeyMetadata]",
+            driver.select(
+                self.get_query("foreign_keys_by_table"),
+                schema_name=schema_name,
+                table_name=table,
+                schema_type=ForeignKeyMetadata,
+            ),
+        )
+
+
+@mypyc_attr(allow_interpreted_subclasses=True, native_class=False)
+class MssqlPythonAsyncDataDictionary(_MssqlDataDictionaryMixin, AsyncDataDictionaryBase):
+    """MSSQL async data dictionary."""
+
+    dialect: ClassVar[str] = "mssql"
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    async def get_version(self, driver: Any) -> MssqlVersionInfo | None:
+        """Get SQL Server version information."""
+        driver_id = id(driver)
+        if driver_id in self._version_fetch_attempted:
+            return cast("MssqlVersionInfo | None", self._version_cache.get(driver_id))
+
+        row = await driver.select_one_or_none(self.get_query_text("version"))
+        if not row:
+            self._log_version_unavailable(type(self).dialect, "missing")
+            self.cache_version(driver_id, None)
+            return None
+
+        version_value = extract_mssql_version_value(
+            _row_value(row, "product_version") or _row_value(row, "version_string", "version")
+        )
+        edition_value = _row_value(row, "edition")
+        edition = str(edition_value) if edition_value is not None else None
+        version_info = self._build_version_info(version_value, edition, _row_value(row, "engine_edition"))
+        if version_info is None:
+            self._log_version_unavailable(type(self).dialect, "parse_failed")
+            self.cache_version(driver_id, None)
+            return None
+
+        self._log_version_detected(type(self).dialect, version_info)
+        self.cache_version(driver_id, version_info)
+        return version_info
+
+    async def get_feature_flag(self, driver: Any, feature: str) -> bool:
+        """Check whether SQL Server supports a feature."""
+        version_info = await self.get_version(driver)
+        return resolve_mssql_feature_flag(
+            feature,
+            major=version_info.major if version_info is not None else 0,
+            is_azure_sql=bool(version_info and version_info.is_azure_sql),
+            config=self.get_dialect_config(),
+            version_info=version_info,
+        )
+
+    async def get_optimal_type(self, driver: Any, type_category: str) -> str:
+        """Get optimal SQL Server type for a category."""
+        return self._get_optimal_type_from_version(await self.get_version(driver), type_category)
+
+    async def get_tables(self, driver: Any, schema: str | None = None) -> list[TableMetadata]:
+        """Get tables sorted by dependency order with catalog fallback."""
+        schema_name = self.resolve_schema(schema)
+        self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="tables")
+        ordered = cast(
+            "list[TableMetadata]",
+            await driver.select(self.get_query("tables_by_schema"), schema_name=schema_name, schema_type=TableMetadata),
+        )
+        all_rows = cast(
+            "list[TableMetadata]",
+            await driver.select(
+                self.get_query("all_tables_by_schema"), schema_name=schema_name, schema_type=TableMetadata
+            ),
+        )
+        return merge_mssql_table_lists(ordered, all_rows)
+
+    async def get_columns(
+        self, driver: Any, table: str | None = None, schema: str | None = None
+    ) -> list[ColumnMetadata]:
+        """Get column information for a table or schema."""
+        schema_name = self.resolve_schema(schema)
+        if table is None:
+            self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="columns")
+            return cast(
+                "list[ColumnMetadata]",
+                await driver.select(
+                    self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
+                ),
+            )
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="columns")
+        return cast(
+            "list[ColumnMetadata]",
+            await driver.select(
+                self.get_query("columns_by_table"),
+                schema_name=schema_name,
+                table_name=table,
+                schema_type=ColumnMetadata,
+            ),
+        )
+
+    async def get_indexes(
+        self, driver: Any, table: str | None = None, schema: str | None = None
+    ) -> list[IndexMetadata]:
+        """Get index metadata for a table or schema."""
+        schema_name = self.resolve_schema(schema)
+        if table is None:
+            self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="indexes")
+            return cast(
+                "list[IndexMetadata]",
+                await driver.select(
+                    self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
+                ),
+            )
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="indexes")
+        return cast(
+            "list[IndexMetadata]",
+            await driver.select(
+                self.get_query("indexes_by_table"), schema_name=schema_name, table_name=table, schema_type=IndexMetadata
+            ),
+        )
+
+    async def get_foreign_keys(
+        self, driver: Any, table: str | None = None, schema: str | None = None
+    ) -> list[ForeignKeyMetadata]:
+        """Get foreign key metadata."""
+        schema_name = self.resolve_schema(schema)
+        if table is None:
+            self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="foreign_keys")
+            return cast(
+                "list[ForeignKeyMetadata]",
+                await driver.select(
+                    self.get_query("foreign_keys_by_schema"), schema_name=schema_name, schema_type=ForeignKeyMetadata
+                ),
+            )
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="foreign_keys")
+        return cast(
+            "list[ForeignKeyMetadata]",
+            await driver.select(
+                self.get_query("foreign_keys_by_table"),
+                schema_name=schema_name,
+                table_name=table,
+                schema_type=ForeignKeyMetadata,
+            ),
+        )
+
+
+def _row_value(row: object, *names: str) -> Any:
+    """Return the first named value from a row-like object."""
+    if isinstance(row, dict):
+        for name in names:
+            if name in row:
+                return row[name]
+            upper_name = name.upper()
+            if upper_name in row:
+                return row[upper_name]
+        return None
+    return getattr(row, names[0], None) if names else None

--- a/sqlspec/adapters/mssql_python/driver.py
+++ b/sqlspec/adapters/mssql_python/driver.py
@@ -1,0 +1,427 @@
+"""mssql-python sync and async drivers."""
+
+import asyncio
+from typing import TYPE_CHECKING, Any, cast
+
+from sqlspec.adapters.mssql_python._typing import (
+    MSSQL_PYTHON_MODULE,
+    MssqlPythonAsyncCursor,
+    MssqlPythonAsyncSessionContext,
+    MssqlPythonConnection,
+    MssqlPythonCursor,
+    MssqlPythonRawCursor,
+    MssqlPythonSessionContext,
+)
+from sqlspec.adapters.mssql_python.core import create_mapped_exception, default_statement_config, driver_profile
+from sqlspec.adapters.mssql_python.data_dictionary import MssqlPythonAsyncDataDictionary, MssqlPythonSyncDataDictionary
+from sqlspec.core import build_arrow_result_from_table, get_cache_config, register_driver_profile
+from sqlspec.driver import (
+    AsyncDriverAdapterBase,
+    BaseAsyncExceptionHandler,
+    BaseSyncExceptionHandler,
+    SyncDriverAdapterBase,
+)
+from sqlspec.exceptions import SQLSpecError
+from sqlspec.utils.logging import get_logger
+from sqlspec.utils.module_loader import ensure_pyarrow
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from sqlspec.builder import QueryBuilder
+    from sqlspec.core import SQL, ArrowResult, Statement, StatementConfig, StatementFilter
+    from sqlspec.driver import ExecutionResult
+    from sqlspec.typing import ArrowReturnFormat, StatementParameters
+
+__all__ = (
+    "MssqlPythonAsyncCursor",
+    "MssqlPythonAsyncDriver",
+    "MssqlPythonAsyncExceptionHandler",
+    "MssqlPythonAsyncSessionContext",
+    "MssqlPythonCursor",
+    "MssqlPythonDriver",
+    "MssqlPythonExceptionHandler",
+    "MssqlPythonSessionContext",
+)
+
+logger = get_logger("sqlspec.adapters.mssql_python")
+_MSSQL_ERROR = cast("type[BaseException]", getattr(MSSQL_PYTHON_MODULE, "Error", Exception))
+
+
+class MssqlPythonExceptionHandler(BaseSyncExceptionHandler):
+    """Sync context manager handling mssql-python exceptions."""
+
+    __slots__ = ()
+
+    def _handle_exception(self, exc_type: "type[BaseException] | None", exc_val: "BaseException") -> bool:
+        if exc_type is None:
+            return False
+        if isinstance(exc_val, _MSSQL_ERROR):
+            self.pending_exception = create_mapped_exception(cast("Exception", exc_val), logger=logger)
+            return True
+        return False
+
+
+class MssqlPythonAsyncExceptionHandler(BaseAsyncExceptionHandler):
+    """Async context manager handling mssql-python exceptions."""
+
+    __slots__ = ()
+
+    def _handle_exception(self, exc_type: "type[BaseException] | None", exc_val: "BaseException") -> bool:
+        if exc_type is None:
+            return False
+        if isinstance(exc_val, _MSSQL_ERROR):
+            self.pending_exception = create_mapped_exception(cast("Exception", exc_val), logger=logger)
+            return True
+        return False
+
+
+class MssqlPythonDriver(SyncDriverAdapterBase):
+    """mssql-python sync driver."""
+
+    __slots__ = ("_data_dictionary",)
+    dialect = "tsql"
+
+    def __init__(
+        self,
+        connection: "MssqlPythonConnection",
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "dict[str, Any] | None" = None,
+    ) -> None:
+        if statement_config is None:
+            statement_config = default_statement_config.replace(
+                enable_caching=get_cache_config().compiled_cache_enabled
+            )
+        super().__init__(connection=connection, statement_config=statement_config, driver_features=driver_features)
+        self._data_dictionary: MssqlPythonSyncDataDictionary | None = None
+
+    @property
+    def data_dictionary(self) -> "MssqlPythonSyncDataDictionary":
+        if self._data_dictionary is None:
+            self._data_dictionary = MssqlPythonSyncDataDictionary()
+        return self._data_dictionary
+
+    def dispatch_execute(self, cursor: "MssqlPythonRawCursor", statement: "SQL") -> "ExecutionResult":
+        sql, prepared_parameters = self._get_compiled_sql(statement, self.statement_config)
+        _execute_cursor(cursor, sql, prepared_parameters)
+
+        if statement.returns_rows():
+            fetched = cursor.fetchall()
+            column_names = [desc[0] for desc in (cursor.description or [])]
+            return self.create_execution_result(
+                cursor,
+                selected_data=fetched,
+                column_names=column_names,
+                data_row_count=len(fetched),
+                is_select_result=True,
+                row_format="tuple",
+            )
+
+        return self.create_execution_result(cursor, rowcount_override=_cursor_rowcount(cursor))
+
+    def dispatch_execute_many(self, cursor: "MssqlPythonRawCursor", statement: "SQL") -> "ExecutionResult":
+        sql, prepared_parameters = self._get_compiled_sql(statement, self.statement_config)
+        cursor.executemany(sql, cast("Any", prepared_parameters))
+        return self.create_execution_result(cursor, rowcount_override=_cursor_rowcount(cursor), is_many_result=True)
+
+    def dispatch_execute_script(self, cursor: "MssqlPythonRawCursor", statement: "SQL") -> "ExecutionResult":
+        sql, prepared_parameters = self._get_compiled_sql(statement, self.statement_config)
+        statements = self.split_script_statements(sql, statement.statement_config, strip_trailing_semicolon=True)
+        successful_count = 0
+        for stmt in statements:
+            _execute_cursor(cursor, stmt, prepared_parameters)
+            successful_count += 1
+        return self.create_execution_result(
+            cursor, statement_count=len(statements), successful_statements=successful_count, is_script_result=True
+        )
+
+    def collect_rows(self, cursor: "MssqlPythonRawCursor", fetched: "list[Any]") -> "tuple[list[Any], list[str], int]":
+        column_names = [desc[0] for desc in (cursor.description or [])]
+        return fetched, column_names, len(fetched)
+
+    def resolve_rowcount(self, cursor: "MssqlPythonRawCursor") -> int:
+        return _cursor_rowcount(cursor)
+
+    def begin(self) -> None:
+        return None
+
+    def commit(self) -> None:
+        try:
+            self.connection.commit()
+        except _MSSQL_ERROR as exc:
+            msg = f"Failed to commit transaction: {exc}"
+            raise SQLSpecError(msg) from exc
+
+    def rollback(self) -> None:
+        try:
+            self.connection.rollback()
+        except _MSSQL_ERROR as exc:
+            msg = f"Failed to rollback transaction: {exc}"
+            raise SQLSpecError(msg) from exc
+
+    def with_cursor(self, connection: "MssqlPythonConnection") -> "MssqlPythonCursor":
+        return MssqlPythonCursor(connection)
+
+    def handle_database_exceptions(self) -> "MssqlPythonExceptionHandler":
+        return MssqlPythonExceptionHandler()
+
+    def create_savepoint(self, name: str) -> None:
+        self.execute_script(f"SAVE TRANSACTION {name}")
+
+    def release_savepoint(self, name: str) -> None:
+        return None
+
+    def rollback_to_savepoint(self, name: str) -> None:
+        self.execute_script(f"ROLLBACK TRANSACTION {name}")
+
+    def select_to_arrow(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        statement_config: "StatementConfig | None" = None,
+        return_format: "ArrowReturnFormat" = "table",
+        native_only: bool = False,
+        batch_size: int | None = None,
+        arrow_schema: Any = None,
+        **kwargs: Any,
+    ) -> "ArrowResult":
+        """Execute a query and return native mssql-python Arrow results."""
+        ensure_pyarrow()
+        config = statement_config or self.statement_config
+        prepared_statement = self.prepare_statement(statement, parameters, statement_config=config, kwargs=kwargs)
+        sql, prepared_parameters = self._get_compiled_sql(prepared_statement, config)
+        arrow_kwargs = {"batch_size": batch_size} if batch_size is not None else {}
+        table: Any | None = None
+
+        exc_handler = self.handle_database_exceptions()
+        with exc_handler, self.with_cursor(self.connection) as cursor:
+            _execute_cursor(cursor, sql, prepared_parameters)
+            table = cursor.arrow(**arrow_kwargs)
+        self._check_pending_exception(exc_handler)
+
+        if table is None:
+            msg = "mssql-python did not return an Arrow table."
+            raise SQLSpecError(msg)
+        return build_arrow_result_from_table(
+            prepared_statement, table, return_format=return_format, batch_size=batch_size, arrow_schema=arrow_schema
+        )
+
+    def bulk_copy(
+        self,
+        target_table: str,
+        rows: "Iterable[tuple[Any, ...]]",
+        *,
+        batch_size: int = 64_000,
+        timeout: int = 3600,
+        column_mappings: list[str] | list[tuple[int, str]] | None = None,
+        keep_identity: bool = False,
+        check_constraints: bool = True,
+        table_lock: bool = False,
+        keep_nulls: bool = False,
+        fire_triggers: bool = False,
+        use_internal_transaction: bool = False,
+    ) -> int:
+        """Bulk insert rows via mssql-python cursor.bulkcopy()."""
+        rowcount = 0
+        exc_handler = self.handle_database_exceptions()
+        with exc_handler, self.with_cursor(self.connection) as cursor:
+            cursor.bulkcopy(
+                target_table,
+                rows,
+                batch_size=batch_size,
+                timeout=timeout,
+                column_mappings=column_mappings,
+                keep_identity=keep_identity,
+                check_constraints=check_constraints,
+                table_lock=table_lock,
+                keep_nulls=keep_nulls,
+                fire_triggers=fire_triggers,
+                use_internal_transaction=use_internal_transaction,
+            )
+            rowcount = _cursor_rowcount(cursor)
+        self._check_pending_exception(exc_handler)
+        return int(rowcount)
+
+
+class MssqlPythonAsyncDriver(AsyncDriverAdapterBase):
+    """Async wrapper around mssql-python's sync DB-API via asyncio.to_thread."""
+
+    __slots__ = ("_data_dictionary",)
+    dialect = "tsql"
+
+    def __init__(
+        self,
+        connection: "MssqlPythonConnection",
+        statement_config: "StatementConfig | None" = None,
+        driver_features: "dict[str, Any] | None" = None,
+    ) -> None:
+        if statement_config is None:
+            statement_config = default_statement_config.replace(
+                enable_caching=get_cache_config().compiled_cache_enabled
+            )
+        super().__init__(connection=connection, statement_config=statement_config, driver_features=driver_features)
+        self._data_dictionary: MssqlPythonAsyncDataDictionary | None = None
+
+    @property
+    def data_dictionary(self) -> "MssqlPythonAsyncDataDictionary":
+        if self._data_dictionary is None:
+            self._data_dictionary = MssqlPythonAsyncDataDictionary()
+        return self._data_dictionary
+
+    async def dispatch_execute(self, cursor: "MssqlPythonRawCursor", statement: "SQL") -> "ExecutionResult":
+        sql, prepared_parameters = self._get_compiled_sql(statement, self.statement_config)
+        await asyncio.to_thread(_execute_cursor, cursor, sql, prepared_parameters)
+
+        if statement.returns_rows():
+            fetched = await asyncio.to_thread(cursor.fetchall)
+            column_names = [desc[0] for desc in (cursor.description or [])]
+            return self.create_execution_result(
+                cursor,
+                selected_data=fetched,
+                column_names=column_names,
+                data_row_count=len(fetched),
+                is_select_result=True,
+                row_format="tuple",
+            )
+
+        return self.create_execution_result(cursor, rowcount_override=_cursor_rowcount(cursor))
+
+    async def dispatch_execute_many(self, cursor: "MssqlPythonRawCursor", statement: "SQL") -> "ExecutionResult":
+        sql, prepared_parameters = self._get_compiled_sql(statement, self.statement_config)
+        await asyncio.to_thread(cursor.executemany, sql, cast("Any", prepared_parameters))
+        return self.create_execution_result(cursor, rowcount_override=_cursor_rowcount(cursor), is_many_result=True)
+
+    async def dispatch_execute_script(self, cursor: "MssqlPythonRawCursor", statement: "SQL") -> "ExecutionResult":
+        sql, prepared_parameters = self._get_compiled_sql(statement, self.statement_config)
+        statements = self.split_script_statements(sql, statement.statement_config, strip_trailing_semicolon=True)
+        successful_count = 0
+        for stmt in statements:
+            await asyncio.to_thread(_execute_cursor, cursor, stmt, prepared_parameters)
+            successful_count += 1
+        return self.create_execution_result(
+            cursor, statement_count=len(statements), successful_statements=successful_count, is_script_result=True
+        )
+
+    def collect_rows(self, cursor: "MssqlPythonRawCursor", fetched: "list[Any]") -> "tuple[list[Any], list[str], int]":
+        column_names = [desc[0] for desc in (cursor.description or [])]
+        return fetched, column_names, len(fetched)
+
+    def resolve_rowcount(self, cursor: "MssqlPythonRawCursor") -> int:
+        return _cursor_rowcount(cursor)
+
+    async def begin(self) -> None:
+        return None
+
+    async def commit(self) -> None:
+        try:
+            await asyncio.to_thread(self.connection.commit)
+        except _MSSQL_ERROR as exc:
+            msg = f"Failed to commit transaction: {exc}"
+            raise SQLSpecError(msg) from exc
+
+    async def rollback(self) -> None:
+        try:
+            await asyncio.to_thread(self.connection.rollback)
+        except _MSSQL_ERROR as exc:
+            msg = f"Failed to rollback transaction: {exc}"
+            raise SQLSpecError(msg) from exc
+
+    def with_cursor(self, connection: "MssqlPythonConnection") -> "MssqlPythonAsyncCursor":
+        return MssqlPythonAsyncCursor(connection)
+
+    def handle_database_exceptions(self) -> "MssqlPythonAsyncExceptionHandler":
+        return MssqlPythonAsyncExceptionHandler()
+
+    async def create_savepoint(self, name: str) -> None:
+        await self.execute_script(f"SAVE TRANSACTION {name}")
+
+    async def release_savepoint(self, name: str) -> None:
+        return None
+
+    async def rollback_to_savepoint(self, name: str) -> None:
+        await self.execute_script(f"ROLLBACK TRANSACTION {name}")
+
+    async def select_to_arrow(
+        self,
+        statement: "Statement | QueryBuilder",
+        /,
+        *parameters: "StatementParameters | StatementFilter",
+        statement_config: "StatementConfig | None" = None,
+        return_format: "ArrowReturnFormat" = "table",
+        native_only: bool = False,
+        batch_size: int | None = None,
+        arrow_schema: Any = None,
+        **kwargs: Any,
+    ) -> "ArrowResult":
+        """Execute a query and return native mssql-python Arrow results."""
+        ensure_pyarrow()
+        config = statement_config or self.statement_config
+        prepared_statement = self.prepare_statement(statement, parameters, statement_config=config, kwargs=kwargs)
+        sql, prepared_parameters = self._get_compiled_sql(prepared_statement, config)
+        arrow_kwargs = {"batch_size": batch_size} if batch_size is not None else {}
+        table: Any | None = None
+        exc_handler = self.handle_database_exceptions()
+        async with exc_handler, self.with_cursor(self.connection) as cursor:
+            await asyncio.to_thread(_execute_cursor, cursor, sql, prepared_parameters)
+            table = await asyncio.to_thread(cursor.arrow, **arrow_kwargs)
+        self._check_pending_exception(exc_handler)
+
+        if table is None:
+            msg = "mssql-python did not return an Arrow table."
+            raise SQLSpecError(msg)
+        return build_arrow_result_from_table(
+            prepared_statement, table, return_format=return_format, batch_size=batch_size, arrow_schema=arrow_schema
+        )
+
+    async def bulk_copy(
+        self,
+        target_table: str,
+        rows: "Iterable[tuple[Any, ...]]",
+        *,
+        batch_size: int = 64_000,
+        timeout: int = 3600,
+        column_mappings: list[str] | list[tuple[int, str]] | None = None,
+        keep_identity: bool = False,
+        check_constraints: bool = True,
+        table_lock: bool = False,
+        keep_nulls: bool = False,
+        fire_triggers: bool = False,
+        use_internal_transaction: bool = False,
+    ) -> int:
+        """Bulk insert rows via mssql-python cursor.bulkcopy()."""
+        exc_handler = self.handle_database_exceptions()
+        rowcount = 0
+        async with exc_handler, self.with_cursor(self.connection) as cursor:
+            await asyncio.to_thread(
+                cursor.bulkcopy,
+                target_table,
+                rows,
+                batch_size=batch_size,
+                timeout=timeout,
+                column_mappings=column_mappings,
+                keep_identity=keep_identity,
+                check_constraints=check_constraints,
+                table_lock=table_lock,
+                keep_nulls=keep_nulls,
+                fire_triggers=fire_triggers,
+                use_internal_transaction=use_internal_transaction,
+            )
+            rowcount = _cursor_rowcount(cursor)
+        self._check_pending_exception(exc_handler)
+        return rowcount
+
+
+def _execute_cursor(cursor: "MssqlPythonRawCursor", sql: str, parameters: Any) -> None:
+    if parameters is None:
+        cursor.execute(sql)
+    else:
+        cursor.execute(sql, parameters)
+
+
+def _cursor_rowcount(cursor: "MssqlPythonRawCursor") -> int:
+    rowcount = getattr(cursor, "rowcount", 0)
+    return rowcount if isinstance(rowcount, int) and rowcount > 0 else 0
+
+
+register_driver_profile("mssql_python", driver_profile, allow_override=True)

--- a/sqlspec/adapters/mssql_python/events/__init__.py
+++ b/sqlspec/adapters/mssql_python/events/__init__.py
@@ -1,0 +1,9 @@
+"""Event queue store for the mssql-python adapter."""
+
+from sqlspec.adapters.mssql_python.events.store import (
+    MssqlPythonAsyncEventQueueStore,
+    MssqlPythonEventQueueStore,
+    MssqlPythonSyncEventQueueStore,
+)
+
+__all__ = ("MssqlPythonAsyncEventQueueStore", "MssqlPythonEventQueueStore", "MssqlPythonSyncEventQueueStore")

--- a/sqlspec/adapters/mssql_python/events/store.py
+++ b/sqlspec/adapters/mssql_python/events/store.py
@@ -1,0 +1,82 @@
+"""mssql-python event queue store with T-SQL-specific DDL."""
+
+import re
+
+from sqlspec.adapters.mssql_python.config import MssqlPythonAsyncConfig, MssqlPythonConfig
+from sqlspec.extensions.events import BaseEventQueueStore
+
+__all__ = ("MssqlPythonAsyncEventQueueStore", "MssqlPythonEventQueueStore", "MssqlPythonSyncEventQueueStore")
+
+_NVARCHAR_MAX_THRESHOLD = 4000
+
+
+class _MssqlPythonEventStoreMixin:
+    """Shared T-SQL DDL hooks for sync and async event queue stores."""
+
+    __slots__ = ()
+
+    def _column_types(self) -> tuple[str, str, str]:
+        return "NVARCHAR(MAX)", "NVARCHAR(MAX)", "DATETIME2(6)"
+
+    def _string_type(self, length: int) -> str:
+        if length >= _NVARCHAR_MAX_THRESHOLD:
+            return "NVARCHAR(MAX)"
+        return f"NVARCHAR({length})"
+
+    def _integer_type(self) -> str:
+        return "INT"
+
+    def _timestamp_default(self) -> str:
+        return "SYSUTCDATETIME()"
+
+    def _wrap_create_statement(self, statement: str, object_type: str) -> str:
+        if object_type == "table":
+            match = re.search(r"CREATE TABLE\s+(\S+)", statement, re.IGNORECASE)
+            if match:
+                table_name = match.group(1).strip("[]")
+                return f"IF OBJECT_ID(N'{_object_name(table_name)}', N'U') IS NULL BEGIN {statement}; END"
+        if object_type == "index":
+            match = re.search(r"CREATE INDEX\s+(\S+)\s+ON\s+(\S+)", statement, re.IGNORECASE)
+            if match:
+                index_name = match.group(1).strip("[]")
+                table_name = match.group(2).strip("[]")
+                return (
+                    "IF NOT EXISTS (SELECT 1 FROM sys.indexes "
+                    f"WHERE name = N'{index_name}' AND object_id = OBJECT_ID(N'{_object_name(table_name)}')) "
+                    f"BEGIN {statement}; END"
+                )
+        return statement
+
+    def _wrap_drop_statement(self, statement: str) -> str:
+        match = re.search(r"DROP TABLE\s+(\S+)", statement, re.IGNORECASE)
+        if match:
+            table_name = match.group(1).strip("[]")
+            return f"IF OBJECT_ID(N'{_object_name(table_name)}', N'U') IS NOT NULL DROP TABLE {table_name};"
+        return statement
+
+
+class MssqlPythonEventQueueStore(_MssqlPythonEventStoreMixin, BaseEventQueueStore[MssqlPythonConfig]):
+    """Event queue DDL for mssql-python sync configs."""
+
+    __slots__ = ()
+
+
+class MssqlPythonAsyncEventQueueStore(_MssqlPythonEventStoreMixin, BaseEventQueueStore[MssqlPythonAsyncConfig]):
+    """Event queue DDL for mssql-python async configs."""
+
+    __slots__ = ()
+
+
+MssqlPythonSyncEventQueueStore = MssqlPythonEventQueueStore
+
+
+def _split_table_name(table_name: str) -> tuple[str, str]:
+    if "." not in table_name:
+        return "dbo", table_name
+    schema_name, bare_table_name = table_name.rsplit(".", 1)
+    return schema_name.strip("[]"), bare_table_name.strip("[]")
+
+
+def _object_name(table_name: str) -> str:
+    schema_name, bare_table_name = _split_table_name(table_name)
+    return f"{schema_name}.{bare_table_name}"

--- a/sqlspec/adapters/mssql_python/litestar/__init__.py
+++ b/sqlspec/adapters/mssql_python/litestar/__init__.py
@@ -1,0 +1,5 @@
+"""Litestar Store integration for mssql_python."""
+
+from sqlspec.adapters.mssql_python.litestar.store import MssqlPythonStore
+
+__all__ = ("MssqlPythonStore",)

--- a/sqlspec/adapters/mssql_python/litestar/store.py
+++ b/sqlspec/adapters/mssql_python/litestar/store.py
@@ -1,0 +1,202 @@
+"""mssql-python Litestar Store implementation."""
+
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any
+
+from sqlspec.extensions.litestar.store import BaseSQLSpecStore
+
+if TYPE_CHECKING:
+    from sqlspec.adapters.mssql_python.config import MssqlPythonAsyncConfig
+
+__all__ = ("MssqlPythonStore",)
+
+
+class MssqlPythonStore(BaseSQLSpecStore["MssqlPythonAsyncConfig"]):
+    """SQL Server-backed session store using mssql-python async sessions."""
+
+    __slots__ = ()
+
+    def __init__(self, config: "MssqlPythonAsyncConfig") -> None:
+        super().__init__(config)
+
+    async def create_table(self) -> None:
+        """Create the session table if it doesn't exist."""
+        async with self._config.provide_session() as session:
+            await session.execute_script(self._get_create_table_sql())
+        self._log_table_created()
+
+    async def get(self, key: str, renew_for: "int | timedelta | None" = None) -> "bytes | None":
+        """Get a session value by key."""
+        async with self._config.provide_session() as session:
+            row = await session.select_one_or_none(
+                f"SELECT data, expires_at FROM {self._table_name} WHERE session_id = ?", (key,)
+            )
+            if row is None:
+                return None
+
+            expires_at = _normalize_utc(_row_value(row, "expires_at", 1))
+            if expires_at is not None and expires_at < datetime.now(timezone.utc):
+                await self.delete(key)
+                return None
+
+            if renew_for is not None and expires_at is not None:
+                new_expires_at = self._calculate_expires_at(renew_for)
+                if new_expires_at is not None:
+                    await session.execute(
+                        f"""
+                        UPDATE {self._table_name}
+                        SET expires_at = ?, updated_at = SYSUTCDATETIME()
+                        WHERE session_id = ?
+                        """,
+                        (new_expires_at, key),
+                    )
+                    await session.commit()
+
+            return _coerce_bytes(_row_value(row, "data", 0))
+
+    async def set(self, key: str, value: "str | bytes", expires_in: "int | timedelta | None" = None) -> None:
+        """Store a session value."""
+        data = self._value_to_bytes(value)
+        expires_at = self._calculate_expires_at(expires_in)
+        async with self._config.provide_session() as session:
+            await session.execute(
+                f"""
+                MERGE INTO {self._table_name} AS target
+                USING (SELECT ? AS session_id, ? AS data, ? AS expires_at) AS src
+                   ON target.session_id = src.session_id
+                WHEN MATCHED THEN
+                    UPDATE SET
+                        data = src.data,
+                        expires_at = src.expires_at,
+                        updated_at = SYSUTCDATETIME()
+                WHEN NOT MATCHED THEN
+                    INSERT (session_id, data, expires_at)
+                    VALUES (src.session_id, src.data, src.expires_at);
+                """,
+                (key, data, expires_at),
+            )
+            await session.commit()
+
+    async def delete(self, key: str) -> None:
+        """Delete a session by key."""
+        async with self._config.provide_session() as session:
+            await session.execute(f"DELETE FROM {self._table_name} WHERE session_id = ?", (key,))
+            await session.commit()
+
+    async def delete_all(self) -> None:
+        """Delete all sessions from the store."""
+        async with self._config.provide_session() as session:
+            await session.execute_script(f"TRUNCATE TABLE {self._table_name}")
+            await session.commit()
+        self._log_delete_all()
+
+    async def exists(self, key: str) -> bool:
+        """Check if a session key exists and is not expired."""
+        async with self._config.provide_session() as session:
+            row = await session.select_one_or_none(
+                f"""
+                SELECT 1 AS exists_flag
+                FROM {self._table_name}
+                WHERE session_id = ?
+                  AND (expires_at IS NULL OR expires_at > SYSUTCDATETIME())
+                """,
+                (key,),
+            )
+            return row is not None
+
+    async def expires_in(self, key: str) -> "int | None":
+        """Get the time in seconds until the session expires."""
+        async with self._config.provide_session() as session:
+            row = await session.select_one_or_none(
+                f"SELECT expires_at FROM {self._table_name} WHERE session_id = ?", (key,)
+            )
+            if row is None:
+                return None
+            expires_at = _normalize_utc(_row_value(row, "expires_at", 0))
+            if expires_at is None:
+                return None
+            remaining = expires_at - datetime.now(timezone.utc)
+            return max(0, int(remaining.total_seconds()))
+
+    async def delete_expired(self) -> int:
+        """Delete all expired sessions."""
+        async with self._config.provide_session() as session:
+            result = await session.execute(
+                f"""
+                DELETE FROM {self._table_name}
+                WHERE expires_at IS NOT NULL
+                  AND expires_at < SYSUTCDATETIME()
+                """
+            )
+            await session.commit()
+
+        count = int(getattr(result, "rows_affected", 0) or 0)
+        if count > 0:
+            self._log_delete_expired(count)
+        return count
+
+    def _get_create_table_sql(self) -> str:
+        """Get SQL Server CREATE TABLE SQL with idempotent guards."""
+        return f"""
+        IF NOT EXISTS (
+            SELECT 1
+            FROM sys.tables
+            WHERE name = N'{self._table_name}'
+              AND schema_id = SCHEMA_ID(N'dbo')
+        )
+        BEGIN
+            CREATE TABLE {self._table_name} (
+                session_id NVARCHAR(255) PRIMARY KEY,
+                data VARBINARY(MAX) NOT NULL,
+                expires_at DATETIME2(6) NULL,
+                created_at DATETIME2(6) NOT NULL DEFAULT SYSUTCDATETIME(),
+                updated_at DATETIME2(6) NOT NULL DEFAULT SYSUTCDATETIME()
+            );
+
+            CREATE INDEX IX_{self._table_name}_expires_at
+                ON {self._table_name}(expires_at)
+                WHERE expires_at IS NOT NULL;
+        END;
+        """
+
+    def _get_drop_table_sql(self) -> "list[str]":
+        """Get SQL Server DROP TABLE statements."""
+        return [f"IF OBJECT_ID(N'dbo.{self._table_name}', N'U') IS NOT NULL DROP TABLE dbo.{self._table_name};"]
+
+
+def _row_value(row: object, key: str, index: int) -> Any:
+    """Return a value from dict-like or sequence-like driver rows."""
+    if isinstance(row, dict):
+        if key in row:
+            return row[key]
+        upper_key = key.upper()
+        if upper_key in row:
+            return row[upper_key]
+        return None
+    if isinstance(row, (list, tuple)) and len(row) > index:
+        return row[index]
+    return getattr(row, key, None)
+
+
+def _normalize_utc(value: Any) -> "datetime | None":
+    if value is None:
+        return None
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _coerce_bytes(value: Any) -> bytes:
+    if value is None:
+        return b""
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, bytearray):
+        return bytes(value)
+    if isinstance(value, memoryview):
+        return value.tobytes()
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    return bytes(value)

--- a/sqlspec/adapters/mssql_python/migrations.py
+++ b/sqlspec/adapters/mssql_python/migrations.py
@@ -1,0 +1,226 @@
+"""mssql-python-specific migration tracker."""
+
+import logging
+import os
+from contextlib import suppress
+from typing import TYPE_CHECKING
+
+from sqlspec.builder import CreateTable, sql
+from sqlspec.migrations.tracker import AsyncMigrationTracker, SyncMigrationTracker
+from sqlspec.migrations.version import parse_version
+from sqlspec.observability import resolve_db_system
+from sqlspec.utils.logging import get_logger, log_with_context
+
+if TYPE_CHECKING:
+    from sqlspec.driver import AsyncDriverAdapterBase, SyncDriverAdapterBase
+
+__all__ = ("MssqlPythonAsyncMigrationTracker", "MssqlPythonSyncMigrationTracker")
+
+logger = get_logger("sqlspec.migrations.mssql_python")
+
+
+class MssqlPythonMigrationTrackerMixin:
+    """T-SQL-specific migration table DDL and schema maintenance."""
+
+    __slots__ = ()
+
+    version_table: str
+
+    def _get_create_table_sql(self) -> CreateTable:
+        """Return T-SQL-compatible migration tracking table DDL."""
+        return (
+            sql
+            .create_table(self.version_table)
+            .column("version_num", "NVARCHAR(32)", primary_key=True)
+            .column("version_type", "NVARCHAR(16)")
+            .column("execution_sequence", "INT")
+            .column("description", "NVARCHAR(MAX)")
+            .column("applied_at", "DATETIME2(6)", default="SYSUTCDATETIME()", not_null=True)
+            .column("execution_time_ms", "INT")
+            .column("checksum", "NVARCHAR(64)")
+            .column("applied_by", "NVARCHAR(255)")
+            .column("replaces", "NVARCHAR(MAX)")
+        )
+
+    def _get_idempotent_create_table_sql_text(self) -> str:
+        """Wrap CREATE TABLE in a T-SQL sys.tables existence probe."""
+        schema_name, table_name = _split_schema_table(self.version_table)
+        create_sql = self._get_create_table_sql_text().rstrip().rstrip(";")
+        return (
+            "IF NOT EXISTS (SELECT 1 FROM sys.tables "
+            f"WHERE name = '{_escape_sql_literal(table_name)}' "
+            f"AND schema_id = SCHEMA_ID('{_escape_sql_literal(schema_name)}')) "
+            f"BEGIN {create_sql}; END;"
+        )
+
+    def _get_create_table_sql_text(self) -> str:
+        """Render CREATE TABLE text without routing SQL Server types through sqlglot."""
+        column_lines: list[str] = []
+        for column_def in self._get_create_table_sql().columns:
+            default_clause = f" DEFAULT {column_def.default}" if column_def.default else ""
+            not_null_clause = " NOT NULL" if column_def.not_null else ""
+            primary_key_clause = " PRIMARY KEY" if column_def.primary_key else ""
+            column_lines.append(
+                f"    {column_def.name} {column_def.dtype}{primary_key_clause}{default_clause}{not_null_clause}"
+            )
+        return f"CREATE TABLE {self.version_table} (\n" + ",\n".join(column_lines) + "\n)"
+
+    def _get_existing_columns_sql(self) -> str:
+        """Return T-SQL query text for migration tracking table columns."""
+        schema_name, table_name = _split_schema_table(self.version_table)
+        return f"""
+            SELECT c.name AS column_name
+            FROM sys.columns c
+            INNER JOIN sys.tables t ON c.object_id = t.object_id
+            WHERE t.name = '{_escape_sql_literal(table_name)}'
+              AND t.schema_id = SCHEMA_ID('{_escape_sql_literal(schema_name)}')
+        """
+
+    def _get_add_column_sql_text(self, column_name: str) -> str | None:
+        """Return T-SQL ALTER TABLE text for a missing migration column."""
+        target_create = self._get_create_table_sql()
+        column_def = next((col for col in target_create.columns if col.name.lower() == column_name), None)
+        if column_def is None:
+            return None
+        default_clause = f" DEFAULT {column_def.default}" if column_def.default else ""
+        nullable_clause = " NOT NULL" if column_def.not_null else " NULL"
+        return f"ALTER TABLE {self.version_table} ADD {column_def.name} {column_def.dtype}{default_clause}{nullable_clause};"
+
+
+class MssqlPythonSyncMigrationTracker(MssqlPythonMigrationTrackerMixin, SyncMigrationTracker):
+    """T-SQL sync migration tracker."""
+
+    def ensure_tracking_table(self, driver: "SyncDriverAdapterBase") -> None:
+        """Create the migration tracking table if it does not exist."""
+        driver.execute_script(self._get_idempotent_create_table_sql_text())
+        driver.commit()
+        self._migrate_schema_if_needed(driver)
+
+    def record_migration(
+        self, driver: "SyncDriverAdapterBase", version: str, description: str, execution_time_ms: int, checksum: str
+    ) -> None:
+        """Record a successfully applied migration with T-SQL-compatible metadata."""
+        parsed_version = parse_version(version)
+        version_type = parsed_version.type.value
+        result = driver.execute(self._get_next_execution_sequence_sql())
+        next_sequence = result.get_data()[0]["next_seq"] if result.data else 1
+        driver.execute(
+            self._get_record_migration_sql(
+                version,
+                version_type,
+                next_sequence,
+                description,
+                execution_time_ms,
+                checksum,
+                os.environ.get("USER", "unknown"),
+            )
+        )
+        driver.commit()
+
+    def _migrate_schema_if_needed(self, driver: "SyncDriverAdapterBase") -> None:
+        """Check and add missing tracking table columns through SQL Server catalog views."""
+        try:
+            rows = driver.select(self._get_existing_columns_sql())
+            existing_columns = {str(row["column_name"]).lower() for row in rows if row.get("column_name") is not None}
+            missing_columns = self._detect_missing_columns(existing_columns)
+            if not missing_columns:
+                return
+            for column_name in sorted(missing_columns):
+                self._add_column(driver, column_name)
+            driver.commit()
+        except Exception as exc:
+            with suppress(Exception):
+                driver.rollback()
+            log_with_context(
+                logger,
+                logging.ERROR,
+                "migration.track",
+                db_system=resolve_db_system(type(driver).__name__),
+                table=self.version_table,
+                operation="schema_check",
+                status="failed",
+                error_type=type(exc).__name__,
+            )
+
+    def _add_column(self, driver: "SyncDriverAdapterBase", column_name: str) -> None:
+        """Add a single missing migration tracking column."""
+        add_column_sql = self._get_add_column_sql_text(column_name)
+        if add_column_sql is None:
+            return
+        driver.execute_script(add_column_sql)
+
+
+class MssqlPythonAsyncMigrationTracker(MssqlPythonMigrationTrackerMixin, AsyncMigrationTracker):
+    """T-SQL async migration tracker."""
+
+    async def ensure_tracking_table(self, driver: "AsyncDriverAdapterBase") -> None:
+        """Create the migration tracking table if it does not exist."""
+        await driver.execute_script(self._get_idempotent_create_table_sql_text())
+        await driver.commit()
+        await self._migrate_schema_if_needed(driver)
+
+    async def record_migration(
+        self, driver: "AsyncDriverAdapterBase", version: str, description: str, execution_time_ms: int, checksum: str
+    ) -> None:
+        """Record a successfully applied migration with T-SQL-compatible metadata."""
+        parsed_version = parse_version(version)
+        version_type = parsed_version.type.value
+        result = await driver.execute(self._get_next_execution_sequence_sql())
+        next_sequence = result.get_data()[0]["next_seq"] if result.data else 1
+        await driver.execute(
+            self._get_record_migration_sql(
+                version,
+                version_type,
+                next_sequence,
+                description,
+                execution_time_ms,
+                checksum,
+                os.environ.get("USER", "unknown"),
+            )
+        )
+        await driver.commit()
+
+    async def _migrate_schema_if_needed(self, driver: "AsyncDriverAdapterBase") -> None:
+        """Check and add missing tracking table columns through SQL Server catalog views."""
+        try:
+            rows = await driver.select(self._get_existing_columns_sql())
+            existing_columns = {str(row["column_name"]).lower() for row in rows if row.get("column_name") is not None}
+            missing_columns = self._detect_missing_columns(existing_columns)
+            if not missing_columns:
+                return
+            for column_name in sorted(missing_columns):
+                await self._add_column(driver, column_name)
+            await driver.commit()
+        except Exception as exc:
+            with suppress(Exception):
+                await driver.rollback()
+            log_with_context(
+                logger,
+                logging.ERROR,
+                "migration.track",
+                db_system=resolve_db_system(type(driver).__name__),
+                table=self.version_table,
+                operation="schema_check",
+                status="failed",
+                error_type=type(exc).__name__,
+            )
+
+    async def _add_column(self, driver: "AsyncDriverAdapterBase", column_name: str) -> None:
+        """Add a single missing migration tracking column."""
+        add_column_sql = self._get_add_column_sql_text(column_name)
+        if add_column_sql is None:
+            return
+        await driver.execute_script(add_column_sql)
+
+
+def _escape_sql_literal(value: str) -> str:
+    """Escape a string for inclusion in a T-SQL string literal."""
+    return value.replace("'", "''")
+
+
+def _split_schema_table(table_name: str) -> tuple[str, str]:
+    """Split a schema-qualified table name into schema and table parts."""
+    if "." not in table_name:
+        return "dbo", table_name
+    schema_name, bare_table_name = table_name.rsplit(".", 1)
+    return schema_name.strip("[]") or "dbo", bare_table_name.strip("[]")

--- a/sqlspec/adapters/mssql_python/type_converter.py
+++ b/sqlspec/adapters/mssql_python/type_converter.py
@@ -1,0 +1,83 @@
+"""Type converters for mssql-python parameter binding."""
+
+from typing import TYPE_CHECKING, Any, Final, cast
+from uuid import UUID
+
+from sqlspec.utils.module_loader import ensure_pyarrow
+from sqlspec.utils.serializers import from_json, to_json
+
+if TYPE_CHECKING:
+    import pyarrow as pa
+
+__all__ = ("MssqlPythonTypeConverter", "mssql_type_to_arrow")
+
+_MSSQL_ARROW_TYPE_SPECS: Final[dict[str, tuple[str, tuple[Any, ...], dict[str, Any]]]] = {
+    "bit": ("bool_", (), {}),
+    "tinyint": ("uint8", (), {}),
+    "smallint": ("int16", (), {}),
+    "int": ("int32", (), {}),
+    "bigint": ("int64", (), {}),
+    "float": ("float64", (), {}),
+    "real": ("float32", (), {}),
+    "smallmoney": ("decimal128", (10, 4), {}),
+    "money": ("decimal128", (19, 4), {}),
+    "date": ("date32", (), {}),
+    "datetime": ("timestamp", ("ms",), {}),
+    "datetime2": ("timestamp", ("us",), {}),
+    "smalldatetime": ("timestamp", ("s",), {}),
+    "datetimeoffset": ("timestamp", ("us",), {"tz": "UTC"}),
+    "uniqueidentifier": ("string", (), {}),
+    "xml": ("string", (), {}),
+    "image": ("binary", (), {}),
+    "binary": ("binary", (), {}),
+    "varbinary": ("binary", (), {}),
+    "timestamp": ("binary", (), {}),
+    "rowversion": ("binary", (), {}),
+    "char": ("string", (), {}),
+    "varchar": ("string", (), {}),
+    "nchar": ("string", (), {}),
+    "nvarchar": ("string", (), {}),
+    "text": ("string", (), {}),
+    "ntext": ("string", (), {}),
+}
+
+
+class MssqlPythonTypeConverter:
+    """Bind-side and read-side coercion for mssql-python."""
+
+    __slots__ = ("_json_deserializer", "_json_serializer")
+
+    def __init__(self, json_serializer: "Any" = to_json, json_deserializer: "Any" = from_json) -> None:
+        self._json_serializer = json_serializer
+        self._json_deserializer = json_deserializer
+
+    def coerce_bind_value(self, value: "Any") -> "Any":
+        """Coerce Python values before mssql-python parameter binding."""
+        if isinstance(value, (dict, list)):
+            return self._json_serializer(value)
+        if isinstance(value, UUID):
+            return value
+        return value
+
+    def coerce_read_value(self, value: "Any") -> "Any":
+        """Coerce mssql-python result values after fetching."""
+        return value
+
+
+def mssql_type_to_arrow(sql_type: str, *, precision: int | None = None, scale: int | None = None) -> "pa.DataType":
+    """Resolve a T-SQL type name to an Arrow data type."""
+    normalized_type = sql_type.lower().split("(", 1)[0].strip()
+    if normalized_type in {"decimal", "numeric"} and precision is not None and scale is not None:
+        return _arrow_type("decimal128", (precision, scale))
+    spec = _MSSQL_ARROW_TYPE_SPECS.get(normalized_type)
+    if spec is None:
+        return _arrow_type("string")
+    name, args, kwargs = spec
+    return _arrow_type(name, args, kwargs)
+
+
+def _arrow_type(name: str, args: tuple[Any, ...] = (), kwargs: dict[str, Any] | None = None) -> "pa.DataType":
+    ensure_pyarrow()
+    import pyarrow as pa
+
+    return cast("pa.DataType", getattr(pa, name)(*args, **(kwargs or {})))

--- a/sqlspec/core/result/_base.py
+++ b/sqlspec/core/result/_base.py
@@ -803,16 +803,23 @@ class ArrowResult(StatementResult):
         """
         return self.data is not None
 
-    def get_data(self) -> "ArrowTable":
-        """Get the Apache Arrow Table from the result.
+    def get_data(self) -> "Any":
+        """Get the Arrow payload from the result.
 
-        Returns:
-            The Arrow table containing the result data.
+        Returns the value shaped by ``arrow_table_to_return_format``: a
+        ``pa.Table`` for ``return_format='table'``, a ``pa.RecordBatchReader``
+        for ``'reader'``, a single ``pa.RecordBatch`` for ``'batch'``, or a
+        ``list[pa.RecordBatch]`` for ``'batches'``.
 
         Raises:
-            ValueError: If no Arrow table is available.
-            TypeError: If data is not an Arrow Table.
+            ValueError: If no Arrow data is available.
         """
+        if self.data is None:
+            msg = "No Arrow data available for this result"
+            raise ValueError(msg)
+        return self.data
+
+    def _as_table(self) -> "ArrowTable":
         if self.data is None:
             msg = "No Arrow table available for this result"
             raise ValueError(msg)
@@ -829,7 +836,7 @@ class ArrowResult(StatementResult):
             ValueError: If no Arrow table is available.
             TypeError: If data is not an Arrow Table.
         """
-        return arrow_table_column_names(self.get_data())
+        return arrow_table_column_names(self._as_table())
 
     @property
     def num_rows(self) -> int:
@@ -842,7 +849,7 @@ class ArrowResult(StatementResult):
             ValueError: If no Arrow table is available.
             TypeError: If data is not an Arrow Table.
         """
-        return arrow_table_num_rows(self.get_data())
+        return arrow_table_num_rows(self._as_table())
 
     @property
     def num_columns(self) -> int:
@@ -855,7 +862,7 @@ class ArrowResult(StatementResult):
             ValueError: If no Arrow table is available.
             TypeError: If data is not an Arrow Table.
         """
-        return arrow_table_num_columns(self.get_data())
+        return arrow_table_num_columns(self._as_table())
 
     def to_pandas(self) -> "PandasDataFrame":
         """Convert Arrow data to pandas DataFrame.
@@ -871,7 +878,7 @@ class ArrowResult(StatementResult):
             >>> df = result.to_pandas()
             >>> print(df.head())
         """
-        return arrow_table_to_pandas(self.get_data())
+        return arrow_table_to_pandas(self._as_table())
 
     def to_polars(self) -> "PolarsDataFrame":
         """Convert Arrow data to Polars DataFrame.
@@ -887,7 +894,7 @@ class ArrowResult(StatementResult):
             >>> df = result.to_polars()
             >>> print(df.head())
         """
-        return arrow_table_to_polars(self.get_data())
+        return arrow_table_to_polars(self._as_table())
 
     def to_dict(self) -> "list[dict[str, Any]]":
         """Convert Arrow data to list of dictionaries.
@@ -907,7 +914,7 @@ class ArrowResult(StatementResult):
             >>> print(rows[0])
             {'id': 1, 'name': 'Alice'}
         """
-        return arrow_table_to_pylist(self.get_data())
+        return arrow_table_to_pylist(self._as_table())
 
     def write_to_storage_sync(
         self,
@@ -918,7 +925,7 @@ class ArrowResult(StatementResult):
         compression: str | None = None,
         pipeline: "SyncStoragePipeline | None" = None,
     ) -> "StorageTelemetry":
-        table = self.get_data()
+        table = self._as_table()
         active_pipeline = pipeline or SyncStoragePipeline()
         return active_pipeline.write_arrow(
             table, destination, format_hint=format_hint, storage_options=storage_options, compression=compression
@@ -933,7 +940,7 @@ class ArrowResult(StatementResult):
         compression: str | None = None,
         pipeline: "AsyncStoragePipeline | None" = None,
     ) -> "StorageTelemetry":
-        table = self.get_data()
+        table = self._as_table()
         active_pipeline = pipeline or AsyncStoragePipeline()
         return await active_pipeline.write_arrow(
             table, destination, format_hint=format_hint, storage_options=storage_options, compression=compression
@@ -954,7 +961,7 @@ class ArrowResult(StatementResult):
             >>> print(len(result))
             100
         """
-        return arrow_table_num_rows(self.get_data())
+        return arrow_table_num_rows(self._as_table())
 
     def __iter__(self) -> "Iterator[dict[str, Any]]":
         """Iterate over rows as dictionaries.
@@ -972,7 +979,7 @@ class ArrowResult(StatementResult):
             >>> for row in result:
             ...     print(row["name"])
         """
-        yield from arrow_table_to_pylist(self.get_data())
+        yield from arrow_table_to_pylist(self._as_table())
 
 
 class EmptyResult(StatementResult):

--- a/sqlspec/core/splitter.py
+++ b/sqlspec/core/splitter.py
@@ -875,9 +875,6 @@ class StatementSplitter:
                     if token.value in self._dialect.statement_terminators:
                         should_delay = self._dialect.should_delay_semicolon_termination(all_tokens, token_idx)
 
-                        if not should_delay and token.value == ";" and self._dialect.batch_separators:
-                            should_delay = True
-
                         if not should_delay:
                             is_terminator = True
                     elif token.value in self._dialect.special_terminators:
@@ -889,7 +886,9 @@ class StatementSplitter:
                     is_terminator = True
 
             if is_terminator:
-                if current_statement_writer is None:
+                if token.type == TokenType.KEYWORD and token_upper in self._dialect.batch_separators:
+                    statement = _join_string_fragments([item.value for item in current_statement_tokens[:-1]]).strip()
+                elif current_statement_writer is None:
                     statement = _join_string_fragments(current_statement_chars).strip()
                 else:
                     statement = cast("str", current_statement_writer.getvalue()).strip()

--- a/sqlspec/data_dictionary/_registry.py
+++ b/sqlspec/data_dictionary/_registry.py
@@ -10,7 +10,13 @@ __all__ = ("get_dialect_config", "list_registered_dialects", "normalize_dialect_
 _DIALECT_CONFIGS: dict[str, "DialectConfig"] = {}
 _DIALECTS_LOADED = False
 
-DIALECT_ALIASES: dict[str, str] = {"postgresql": "postgres", "mariadb": "mysql", "cockroach": "cockroachdb"}
+DIALECT_ALIASES: dict[str, str] = {
+    "postgresql": "postgres",
+    "mariadb": "mysql",
+    "cockroach": "cockroachdb",
+    "tsql": "mssql",
+    "sqlserver": "mssql",
+}
 
 
 def normalize_dialect_name(dialect: str) -> str:

--- a/sqlspec/data_dictionary/dialects/__init__.py
+++ b/sqlspec/data_dictionary/dialects/__init__.py
@@ -3,6 +3,7 @@
 from sqlspec.data_dictionary.dialects.bigquery import BIGQUERY_CONFIG
 from sqlspec.data_dictionary.dialects.cockroachdb import COCKROACHDB_CONFIG
 from sqlspec.data_dictionary.dialects.duckdb import DUCKDB_CONFIG
+from sqlspec.data_dictionary.dialects.mssql import MSSQL_CONFIG
 from sqlspec.data_dictionary.dialects.mysql import MYSQL_CONFIG
 from sqlspec.data_dictionary.dialects.oracle import ORACLE_CONFIG
 from sqlspec.data_dictionary.dialects.postgres import POSTGRES_CONFIG
@@ -13,6 +14,7 @@ __all__ = (
     "BIGQUERY_CONFIG",
     "COCKROACHDB_CONFIG",
     "DUCKDB_CONFIG",
+    "MSSQL_CONFIG",
     "MYSQL_CONFIG",
     "ORACLE_CONFIG",
     "POSTGRES_CONFIG",

--- a/sqlspec/data_dictionary/dialects/mssql.py
+++ b/sqlspec/data_dictionary/dialects/mssql.py
@@ -1,0 +1,207 @@
+import re
+from typing import TYPE_CHECKING, Any, Final
+
+from sqlspec.data_dictionary import DialectConfig, FeatureFlags, FeatureVersions, register_dialect
+
+if TYPE_CHECKING:
+    from sqlspec.typing import TableMetadata, VersionInfo
+
+__all__ = (
+    "extract_mssql_version_value",
+    "is_mssql_azure_sql",
+    "list_mssql_available_features",
+    "merge_mssql_table_lists",
+    "mssql_supports_greatest_least",
+    "mssql_supports_json_functions",
+    "mssql_supports_native_json",
+    "mssql_supports_string_agg",
+    "parse_mssql_engine_edition",
+    "parse_mssql_version_components",
+    "resolve_mssql_default_schema",
+    "resolve_mssql_feature_flag",
+)
+
+MSSQL_VERSION_PATTERN = re.compile(r"(\d+)")
+MSSQL_PRODUCT_VERSION_PATTERN = re.compile(r"\b(\d+)\.(\d+)\.(\d+)\.(\d+)\b")
+MSSQL_VERSION_PARTS_COUNT: Final[int] = 4
+MSSQL_MIN_JSON_FUNCTIONS_VERSION: Final[int] = 13
+MSSQL_MIN_STRING_AGG_VERSION: Final[int] = 14
+MSSQL_MIN_GREATEST_LEAST_VERSION: Final[int] = 16
+MSSQL_MIN_NATIVE_JSON_VERSION: Final[int] = 17
+MSSQL_ENGINE_EDITION_AZURE_SET: Final[frozenset[int]] = frozenset({5, 8, 11})
+
+MSSQL_DYNAMIC_FEATURES: Final[tuple[str, ...]] = (
+    "is_azure_sql",
+    "supports_json_functions",
+    "supports_string_agg",
+    "supports_greatest_least",
+    "supports_native_json",
+)
+
+MSSQL_FEATURE_VERSIONS: "FeatureVersions" = {}
+
+MSSQL_FEATURE_FLAGS: "FeatureFlags" = {
+    "supports_transactions": True,
+    "supports_prepared_statements": True,
+    "supports_schemas": True,
+    "supports_in_memory": True,
+}
+
+MSSQL_TYPE_MAPPINGS: dict[str, str] = {
+    "uuid": "UNIQUEIDENTIFIER",
+    "boolean": "BIT",
+    "text": "NVARCHAR(MAX)",
+    "json": "NVARCHAR(MAX)",
+    "jsonb": "NVARCHAR(MAX)",
+    "timestamp": "DATETIME2(6)",
+    "timestamptz": "DATETIMEOFFSET(6)",
+    "bytea": "VARBINARY(MAX)",
+    "blob": "VARBINARY(MAX)",
+}
+
+MSSQL_CONFIG = DialectConfig(
+    name="mssql",
+    feature_versions=MSSQL_FEATURE_VERSIONS,
+    feature_flags=MSSQL_FEATURE_FLAGS,
+    type_mappings=MSSQL_TYPE_MAPPINGS,
+    version_pattern=MSSQL_VERSION_PATTERN,
+    default_schema="dbo",
+    parameter_style="qmark",
+)
+
+register_dialect(MSSQL_CONFIG)
+
+
+def extract_mssql_version_value(row: object) -> "str | None":
+    """Extract a SQL Server version string from a row-like object."""
+    if isinstance(row, dict):
+        for key in ("version", "VERSION", "Version", "product_version", "ProductVersion"):
+            value = row.get(key)
+            if value:
+                return str(value)
+    if isinstance(row, (list, tuple)) and row:
+        return str(row[0])
+    if row is not None:
+        return str(row)
+    return None
+
+
+def parse_mssql_version_components(version_string: str) -> tuple[int, int, int, int]:
+    """Parse MSSQL version text into major, minor, build, revision components."""
+    product_version = MSSQL_PRODUCT_VERSION_PATTERN.search(version_string)
+    if product_version is not None:
+        groups = product_version.groups()
+        return int(groups[0]), int(groups[1]), int(groups[2]), int(groups[3])
+
+    parts = [int(value) for value in MSSQL_VERSION_PATTERN.findall(version_string)]
+    if not parts:
+        return 0, 0, 0, 0
+    while len(parts) < MSSQL_VERSION_PARTS_COUNT:
+        parts.append(0)
+    return parts[0], parts[1], parts[2], parts[3]
+
+
+def parse_mssql_engine_edition(value: Any) -> int | None:
+    """Parse a SQL Server EngineEdition value into an integer."""
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        value = value.decode(errors="ignore")
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def is_mssql_azure_sql(engine_edition: int | None) -> bool:
+    """Return whether an EngineEdition value represents Azure SQL."""
+    return engine_edition in MSSQL_ENGINE_EDITION_AZURE_SET
+
+
+def resolve_mssql_default_schema() -> str:
+    """Return the default MSSQL schema used for introspection."""
+    return "dbo"
+
+
+def mssql_supports_json_functions(major: int) -> bool:
+    """Return whether the SQL Server version supports JSON functions."""
+    return major >= MSSQL_MIN_JSON_FUNCTIONS_VERSION
+
+
+def mssql_supports_string_agg(major: int) -> bool:
+    """Return whether the SQL Server version supports STRING_AGG."""
+    return major >= MSSQL_MIN_STRING_AGG_VERSION
+
+
+def mssql_supports_greatest_least(major: int) -> bool:
+    """Return whether the SQL Server version supports GREATEST and LEAST."""
+    return major >= MSSQL_MIN_GREATEST_LEAST_VERSION
+
+
+def mssql_supports_native_json(major: int, is_azure_sql: bool = False) -> bool:
+    """Return whether the SQL Server version supports the native JSON type."""
+    return is_azure_sql or major >= MSSQL_MIN_NATIVE_JSON_VERSION
+
+
+def resolve_mssql_feature_flag(
+    feature: str,
+    *,
+    major: int,
+    is_azure_sql: bool = False,
+    config: "DialectConfig | None" = None,
+    version_info: "VersionInfo | None" = None,
+) -> bool:
+    """Resolve an MSSQL feature flag from static config and version details."""
+    if version_info is not None:
+        major = version_info.major
+    if feature == "is_azure_sql":
+        return is_azure_sql
+    if feature == "supports_json_functions":
+        return mssql_supports_json_functions(major)
+    if feature == "supports_string_agg":
+        return mssql_supports_string_agg(major)
+    if feature == "supports_greatest_least":
+        return mssql_supports_greatest_least(major)
+    if feature == "supports_native_json":
+        return mssql_supports_native_json(major, is_azure_sql=is_azure_sql)
+
+    dialect_config = config or MSSQL_CONFIG
+    flag = dialect_config.get_feature_flag(feature)
+    if flag is not None:
+        return flag
+    required_version = dialect_config.get_feature_version(feature)
+    if required_version is None or version_info is None:
+        return False
+    return bool(version_info >= required_version)
+
+
+def list_mssql_available_features(config: "DialectConfig | None" = None) -> list[str]:
+    """List static and dynamic MSSQL data-dictionary feature flags."""
+    dialect_config = config or MSSQL_CONFIG
+    features: set[str] = set()
+    features.update(dialect_config.feature_flags.keys())
+    features.update(dialect_config.feature_versions.keys())
+    features.update(MSSQL_DYNAMIC_FEATURES)
+    return sorted(features)
+
+
+def merge_mssql_table_lists(ordered: "list[TableMetadata]", all_rows: "list[TableMetadata]") -> "list[TableMetadata]":
+    """Merge dependency-ordered table rows with catalog rows not in the dependency tree."""
+    merged: list[TableMetadata] = []
+    seen: set[tuple[str | None, str | None]] = set()
+
+    for row in ordered:
+        key = (row.get("schema_name") or row.get("table_schema"), row.get("table_name"))
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(row)
+
+    for row in all_rows:
+        key = (row.get("schema_name") or row.get("table_schema"), row.get("table_name"))
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(row)
+
+    return merged

--- a/sqlspec/data_dictionary/sql/mssql/columns.sql
+++ b/sqlspec/data_dictionary/sql/mssql/columns.sql
@@ -1,0 +1,76 @@
+-- name: columns_by_table
+-- dialect: mssql
+SELECT
+    s.name AS schema_name,
+    tab.name AS table_name,
+    c.column_id AS ordinal_position,
+    c.name AS column_name,
+    typ.name AS data_type,
+    CASE WHEN c.is_nullable = 1 THEN 'YES' ELSE 'NO' END AS is_nullable,
+    OBJECT_DEFINITION(c.default_object_id) AS column_default,
+    c.max_length,
+    c.precision AS numeric_precision,
+    c.scale AS numeric_scale,
+    CAST(CASE WHEN pk_cols.column_id IS NULL THEN 0 ELSE 1 END AS BIT) AS is_primary,
+    CAST(CASE WHEN unique_cols.column_id IS NULL THEN 0 ELSE 1 END AS BIT) AS is_unique
+FROM sys.columns c
+INNER JOIN sys.types typ ON c.user_type_id = typ.user_type_id
+INNER JOIN sys.tables tab ON c.object_id = tab.object_id
+INNER JOIN sys.schemas s ON tab.schema_id = s.schema_id
+OUTER APPLY (
+    SELECT TOP 1 ic.column_id
+    FROM sys.indexes i
+    INNER JOIN sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id
+    WHERE i.object_id = tab.object_id
+      AND i.is_primary_key = 1
+      AND ic.column_id = c.column_id
+) pk_cols
+OUTER APPLY (
+    SELECT TOP 1 ic.column_id
+    FROM sys.indexes i
+    INNER JOIN sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id
+    WHERE i.object_id = tab.object_id
+      AND i.is_unique = 1
+      AND ic.column_id = c.column_id
+) unique_cols
+WHERE s.name = :schema_name
+  AND tab.name = :table_name
+ORDER BY c.column_id;
+
+-- name: columns_by_schema
+-- dialect: mssql
+SELECT
+    s.name AS schema_name,
+    tab.name AS table_name,
+    c.column_id AS ordinal_position,
+    c.name AS column_name,
+    typ.name AS data_type,
+    CASE WHEN c.is_nullable = 1 THEN 'YES' ELSE 'NO' END AS is_nullable,
+    OBJECT_DEFINITION(c.default_object_id) AS column_default,
+    c.max_length,
+    c.precision AS numeric_precision,
+    c.scale AS numeric_scale,
+    CAST(CASE WHEN pk_cols.column_id IS NULL THEN 0 ELSE 1 END AS BIT) AS is_primary,
+    CAST(CASE WHEN unique_cols.column_id IS NULL THEN 0 ELSE 1 END AS BIT) AS is_unique
+FROM sys.columns c
+INNER JOIN sys.types typ ON c.user_type_id = typ.user_type_id
+INNER JOIN sys.tables tab ON c.object_id = tab.object_id
+INNER JOIN sys.schemas s ON tab.schema_id = s.schema_id
+OUTER APPLY (
+    SELECT TOP 1 ic.column_id
+    FROM sys.indexes i
+    INNER JOIN sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id
+    WHERE i.object_id = tab.object_id
+      AND i.is_primary_key = 1
+      AND ic.column_id = c.column_id
+) pk_cols
+OUTER APPLY (
+    SELECT TOP 1 ic.column_id
+    FROM sys.indexes i
+    INNER JOIN sys.index_columns ic ON i.object_id = ic.object_id AND i.index_id = ic.index_id
+    WHERE i.object_id = tab.object_id
+      AND i.is_unique = 1
+      AND ic.column_id = c.column_id
+) unique_cols
+WHERE (:schema_name IS NULL OR s.name = :schema_name)
+ORDER BY s.name, tab.name, c.column_id;

--- a/sqlspec/data_dictionary/sql/mssql/foreign_keys.sql
+++ b/sqlspec/data_dictionary/sql/mssql/foreign_keys.sql
@@ -1,0 +1,38 @@
+-- name: foreign_keys_by_table
+-- dialect: mssql
+SELECT
+    OBJECT_SCHEMA_NAME(fk.parent_object_id) AS schema_name,
+    fk.name AS constraint_name,
+    OBJECT_NAME(fk.parent_object_id) AS table_name,
+    cpa.name AS column_name,
+    OBJECT_SCHEMA_NAME(fk.referenced_object_id) AS referenced_schema,
+    OBJECT_NAME(fk.referenced_object_id) AS referenced_table,
+    cref.name AS referenced_column
+FROM sys.foreign_keys fk
+INNER JOIN sys.foreign_key_columns fkc ON fk.object_id = fkc.constraint_object_id
+INNER JOIN sys.columns cpa
+    ON fkc.parent_object_id = cpa.object_id AND fkc.parent_column_id = cpa.column_id
+INNER JOIN sys.columns cref
+    ON fkc.referenced_object_id = cref.object_id AND fkc.referenced_column_id = cref.column_id
+WHERE OBJECT_SCHEMA_NAME(fk.parent_object_id) = :schema_name
+  AND OBJECT_NAME(fk.parent_object_id) = :table_name
+ORDER BY fk.name, fkc.constraint_column_id;
+
+-- name: foreign_keys_by_schema
+-- dialect: mssql
+SELECT
+    OBJECT_SCHEMA_NAME(fk.parent_object_id) AS schema_name,
+    fk.name AS constraint_name,
+    OBJECT_NAME(fk.parent_object_id) AS table_name,
+    cpa.name AS column_name,
+    OBJECT_SCHEMA_NAME(fk.referenced_object_id) AS referenced_schema,
+    OBJECT_NAME(fk.referenced_object_id) AS referenced_table,
+    cref.name AS referenced_column
+FROM sys.foreign_keys fk
+INNER JOIN sys.foreign_key_columns fkc ON fk.object_id = fkc.constraint_object_id
+INNER JOIN sys.columns cpa
+    ON fkc.parent_object_id = cpa.object_id AND fkc.parent_column_id = cpa.column_id
+INNER JOIN sys.columns cref
+    ON fkc.referenced_object_id = cref.object_id AND fkc.referenced_column_id = cref.column_id
+WHERE (:schema_name IS NULL OR OBJECT_SCHEMA_NAME(fk.parent_object_id) = :schema_name)
+ORDER BY OBJECT_SCHEMA_NAME(fk.parent_object_id), OBJECT_NAME(fk.parent_object_id), fk.name, fkc.constraint_column_id;

--- a/sqlspec/data_dictionary/sql/mssql/indexes.sql
+++ b/sqlspec/data_dictionary/sql/mssql/indexes.sql
@@ -1,0 +1,50 @@
+-- name: indexes_by_table
+-- dialect: mssql
+SELECT
+    s.name AS schema_name,
+    t.name AS table_name,
+    i.name AS index_name,
+    CAST(i.is_unique AS BIT) AS is_unique,
+    CAST(i.is_primary_key AS BIT) AS is_primary,
+    STUFF((
+        SELECT ',' + c2.name
+        FROM sys.index_columns ic2
+        INNER JOIN sys.columns c2 ON ic2.object_id = c2.object_id AND ic2.column_id = c2.column_id
+        WHERE ic2.object_id = i.object_id
+          AND ic2.index_id = i.index_id
+          AND ic2.is_included_column = 0
+        ORDER BY ic2.key_ordinal
+        FOR XML PATH(''), TYPE
+    ).value('.', 'NVARCHAR(MAX)'), 1, 1, '') AS columns
+FROM sys.indexes i
+INNER JOIN sys.tables t ON i.object_id = t.object_id
+INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
+WHERE s.name = :schema_name
+  AND t.name = :table_name
+  AND i.name IS NOT NULL
+ORDER BY i.name;
+
+-- name: indexes_by_schema
+-- dialect: mssql
+SELECT
+    s.name AS schema_name,
+    t.name AS table_name,
+    i.name AS index_name,
+    CAST(i.is_unique AS BIT) AS is_unique,
+    CAST(i.is_primary_key AS BIT) AS is_primary,
+    STUFF((
+        SELECT ',' + c2.name
+        FROM sys.index_columns ic2
+        INNER JOIN sys.columns c2 ON ic2.object_id = c2.object_id AND ic2.column_id = c2.column_id
+        WHERE ic2.object_id = i.object_id
+          AND ic2.index_id = i.index_id
+          AND ic2.is_included_column = 0
+        ORDER BY ic2.key_ordinal
+        FOR XML PATH(''), TYPE
+    ).value('.', 'NVARCHAR(MAX)'), 1, 1, '') AS columns
+FROM sys.indexes i
+INNER JOIN sys.tables t ON i.object_id = t.object_id
+INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
+WHERE (:schema_name IS NULL OR s.name = :schema_name)
+  AND i.name IS NOT NULL
+ORDER BY s.name, t.name, i.name;

--- a/sqlspec/data_dictionary/sql/mssql/tables.sql
+++ b/sqlspec/data_dictionary/sql/mssql/tables.sql
@@ -1,0 +1,52 @@
+-- name: tables_by_schema
+-- dialect: mssql
+WITH dependency_tree AS (
+    SELECT
+        s.name AS schema_name,
+        t.name AS table_name,
+        t.object_id,
+        0 AS level,
+        CAST(CONCAT('|', t.object_id, '|') AS NVARCHAR(MAX)) AS path
+    FROM sys.tables t
+    INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE (:schema_name IS NULL OR s.name = :schema_name)
+      AND NOT EXISTS (
+          SELECT 1
+          FROM sys.foreign_keys fk
+          WHERE fk.parent_object_id = t.object_id
+      )
+
+    UNION ALL
+
+    SELECT
+        child_schema.name AS schema_name,
+        child_table.name AS table_name,
+        child_table.object_id,
+        dependency_tree.level + 1 AS level,
+        CAST(CONCAT(dependency_tree.path, child_table.object_id, '|') AS NVARCHAR(MAX)) AS path
+    FROM sys.foreign_keys fk
+    INNER JOIN sys.tables child_table ON fk.parent_object_id = child_table.object_id
+    INNER JOIN sys.schemas child_schema ON child_table.schema_id = child_schema.schema_id
+    INNER JOIN dependency_tree ON fk.referenced_object_id = dependency_tree.object_id
+    WHERE (:schema_name IS NULL OR child_schema.name = :schema_name)
+      AND CHARINDEX(CONCAT('|', child_table.object_id, '|'), dependency_tree.path) = 0
+)
+SELECT
+    schema_name,
+    table_name,
+    MAX(level) AS level
+FROM dependency_tree
+GROUP BY schema_name, table_name
+ORDER BY level, schema_name, table_name;
+
+-- name: all_tables_by_schema
+-- dialect: mssql
+SELECT
+    s.name AS schema_name,
+    t.name AS table_name,
+    t.create_date,
+    t.modify_date
+FROM sys.tables t
+INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
+WHERE (:schema_name IS NULL OR s.name = :schema_name)
+ORDER BY s.name, t.name;

--- a/sqlspec/data_dictionary/sql/mssql/version.sql
+++ b/sqlspec/data_dictionary/sql/mssql/version.sql
@@ -1,0 +1,7 @@
+-- name: version
+-- dialect: mssql
+SELECT
+    @@VERSION AS version_string,
+    CONVERT(NVARCHAR(128), SERVERPROPERTY('ProductVersion')) AS product_version,
+    CONVERT(NVARCHAR(256), SERVERPROPERTY('Edition')) AS edition,
+    CONVERT(INT, SERVERPROPERTY('EngineEdition')) AS engine_edition;

--- a/tests/unit/adapters/test_arrow_odbc.py
+++ b/tests/unit/adapters/test_arrow_odbc.py
@@ -1,0 +1,209 @@
+"""Unit tests for the arrow_odbc adapter."""
+
+from typing import Any, cast
+
+import pyarrow as pa
+import pytest
+
+pytest.importorskip("arrow_odbc")
+
+from sqlspec.adapters.arrow_odbc import ArrowOdbcConfig, ArrowOdbcDriver, resolve_dialect_from_dbms_name
+from sqlspec.adapters.arrow_odbc import driver as driver_module
+from sqlspec.exceptions import SQLSpecError
+
+
+class FakeReader:
+    """Minimal Arrow batch reader."""
+
+    def __init__(self, table: pa.Table) -> None:
+        self._batches = table.to_batches(max_chunksize=2)
+        self.schema = table.schema
+
+    def __iter__(self) -> Any:
+        return iter(self._batches)
+
+
+class FakeConnection:
+    """Connection stub for arrow_odbc driver tests."""
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.read_calls: list[dict[str, Any]] = []
+        self.insert_calls: list[tuple[str, int, pa.Table]] = []
+        self.executed: list[tuple[str, Any]] = []
+
+    def read_arrow_batches(self, **kwargs: Any) -> FakeReader:
+        self.read_calls.append(kwargs)
+        return FakeReader(pa.table({"x": [1, 2, 3]}))
+
+    def from_table_to_db(self, source: pa.Table, target: str, chunk_size: int = 1000) -> None:
+        self.insert_calls.append((target, chunk_size, source))
+
+    def execute(self, query: str, parameters: Any = None) -> None:
+        self.executed.append((query, parameters))
+
+    def commit(self) -> None:
+        return None
+
+    def rollback(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class NoCloseConnection:
+    """Connection stub matching arrow-odbc 10.4's no-close public surface."""
+
+    dbms_name = "Microsoft SQL Server"
+
+
+class FakeOdbcError(Exception):
+    """Constructible stand-in for arrow_odbc.Error."""
+
+
+class ErrorConnection(FakeConnection):
+    """Connection stub that raises an ODBC driver error."""
+
+    def read_arrow_batches(self, **kwargs: Any) -> FakeReader:
+        raise FakeOdbcError("read failed")
+
+    def from_table_to_db(self, source: pa.Table, target: str, chunk_size: int = 1000) -> None:
+        raise FakeOdbcError("insert failed")
+
+
+def test_resolve_dialect_from_dbms_name() -> None:
+    """ODBC DBMS names and driver strings should map to SQLSpec dialects."""
+    assert resolve_dialect_from_dbms_name("Microsoft SQL Server") == "mssql"
+    assert resolve_dialect_from_dbms_name("ODBC Driver 18 for SQL Server") == "mssql"
+    assert resolve_dialect_from_dbms_name("Oracle in instantclient_19_24") == "oracle"
+    assert resolve_dialect_from_dbms_name("MySQL ODBC 8.0 Unicode Driver") == "mysql"
+
+
+def test_arrow_odbc_select_to_arrow_uses_native_reader() -> None:
+    """select_to_arrow should materialize batches returned by arrow-odbc."""
+    connection = FakeConnection()
+    driver = ArrowOdbcDriver(
+        cast("Any", connection),
+        driver_features={"connection_string": "Driver={ODBC Driver 18 for SQL Server};", "chunk_size": 2},
+    )
+
+    result = driver.select_to_arrow("SELECT 1 AS x")
+
+    assert driver.dialect == "tsql"
+    assert driver.data_dictionary.get_dialect_config().name == "mssql"
+    assert result.get_data().num_rows == 3
+    assert connection.read_calls[0]["query"] == "SELECT 1 AS x"
+    assert connection.read_calls[0]["batch_size"] == 2
+
+
+def test_arrow_odbc_select_to_arrow_batches_returns_batches() -> None:
+    """select_to_arrow should use SQLSpec's canonical batches return format."""
+    connection = FakeConnection()
+    driver = ArrowOdbcDriver(cast("Any", connection), driver_features={"chunk_size": 2})
+
+    result = driver.select_to_arrow("SELECT 1 AS x", return_format="batches", batch_size=2)
+    batches = result.get_data()
+
+    assert [batch.num_rows for batch in batches] == [2, 1]
+
+
+def test_arrow_odbc_select_to_arrow_raises_mapped_driver_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Native read failures should use SQLSpec's deferred exception mapping."""
+    monkeypatch.setattr(driver_module.ARROW_ODBC_MODULE, "Error", FakeOdbcError)
+    connection = ErrorConnection()
+    driver = ArrowOdbcDriver(cast("Any", connection), driver_features={"chunk_size": 2})
+
+    with pytest.raises(SQLSpecError, match="ODBC database error"):
+        driver.select_to_arrow("SELECT 1 AS x")
+
+
+def test_arrow_odbc_bulk_insert_arrow_uses_from_table_to_db() -> None:
+    """bulk_insert_arrow should use the table-specific write API when given a Table."""
+    connection = FakeConnection()
+    driver = ArrowOdbcDriver(cast("Any", connection), driver_features={"chunk_size": 10})
+    table = pa.table({"x": [1, 2, 3]})
+
+    driver.bulk_insert_arrow("dbo.target", table)
+
+    assert connection.insert_calls == [("dbo.target", 10, table)]
+
+
+def test_arrow_odbc_bulk_insert_arrow_raises_mapped_driver_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Native write failures should not be swallowed by the deferred exception handler."""
+    monkeypatch.setattr(driver_module.ARROW_ODBC_MODULE, "Error", FakeOdbcError)
+    connection = ErrorConnection()
+    driver = ArrowOdbcDriver(cast("Any", connection), driver_features={"chunk_size": 10})
+
+    with pytest.raises(SQLSpecError, match="ODBC database error"):
+        driver.bulk_insert_arrow("dbo.target", pa.table({"x": [1]}))
+
+
+def test_arrow_odbc_config_connects_with_verified_keyword_names(monkeypatch: Any) -> None:
+    """Config should call arrow_odbc.connect with 10.4 keyword names."""
+    calls: list[tuple[str, dict[str, Any]]] = []
+    connection = FakeConnection()
+
+    def fake_connect(connection_string: str, **kwargs: Any) -> FakeConnection:
+        calls.append((connection_string, kwargs))
+        return connection
+
+    monkeypatch.setattr("sqlspec.adapters.arrow_odbc.config.ARROW_ODBC_MODULE.connect", fake_connect)
+
+    config = ArrowOdbcConfig(
+        connection_config={
+            "connection_string": "Driver={ODBC Driver 18 for SQL Server};",
+            "login_timeout": 3,
+            "autocommit": False,
+        }
+    )
+
+    with config.provide_session() as session:
+        assert isinstance(session, ArrowOdbcDriver)
+
+    assert calls == [("Driver={ODBC Driver 18 for SQL Server};", {"login_timeout_sec": 3, "autocommit": False})]
+    assert connection.closed is True
+
+
+def test_arrow_odbc_session_release_allows_connections_without_close(monkeypatch: Any) -> None:
+    """arrow-odbc 10.4 Connection has no close() method, so release should be a no-op."""
+    connection = NoCloseConnection()
+
+    monkeypatch.setattr(
+        "sqlspec.adapters.arrow_odbc.config.ARROW_ODBC_MODULE.connect", lambda *_args, **_kwargs: connection
+    )
+
+    config = ArrowOdbcConfig(connection_config={"connection_string": "Driver={ODBC Driver 18 for SQL Server};"})
+
+    with config.provide_session() as session:
+        assert isinstance(session, ArrowOdbcDriver)
+
+
+def test_arrow_odbc_field_config_uses_driver_name_for_dialect(monkeypatch: Any) -> None:
+    """Field-based configs should still infer dialect from the ODBC driver name."""
+    connection = NoCloseConnection()
+
+    monkeypatch.setattr(
+        "sqlspec.adapters.arrow_odbc.config.ARROW_ODBC_MODULE.connect", lambda *_args, **_kwargs: connection
+    )
+
+    config = ArrowOdbcConfig(
+        connection_config={"driver": "ODBC Driver 18 for SQL Server", "server": "localhost", "database": "app"}
+    )
+
+    with config.provide_session() as session:
+        assert session.dialect == "tsql"
+
+
+def test_arrow_odbc_mssql_driver_uses_tsql_statement_dialect() -> None:
+    """SQL Server ODBC connections should compile with sqlglot's tsql dialect."""
+    connection = FakeConnection()
+    driver = ArrowOdbcDriver(cast("Any", connection), driver_features={"dbms_name": "Microsoft SQL Server"})
+
+    prepared = driver.prepare_statement("SELECT :value", (), kwargs={"value": 1})
+    sql, parameters = driver._get_compiled_sql(prepared, driver.statement_config)
+
+    assert driver.dialect == "tsql"
+    assert driver.statement_config.dialect == "tsql"
+    assert sql == "SELECT ?"
+    assert parameters == (1,)

--- a/tests/unit/adapters/test_arrow_odbc.py
+++ b/tests/unit/adapters/test_arrow_odbc.py
@@ -168,9 +168,7 @@ def test_arrow_odbc_session_release_allows_connections_without_close(monkeypatch
     """arrow-odbc 10.4 Connection has no close() method, so release should be a no-op."""
     connection = NoCloseConnection()
 
-    monkeypatch.setattr(
-        "sqlspec.adapters.arrow_odbc.config.arrow_odbc_connect", lambda *_args, **_kwargs: connection
-    )
+    monkeypatch.setattr("sqlspec.adapters.arrow_odbc.config.arrow_odbc_connect", lambda *_args, **_kwargs: connection)
 
     config = ArrowOdbcConfig(connection_config={"connection_string": "Driver={ODBC Driver 18 for SQL Server};"})
 
@@ -182,9 +180,7 @@ def test_arrow_odbc_field_config_uses_driver_name_for_dialect(monkeypatch: Any) 
     """Field-based configs should still infer dialect from the ODBC driver name."""
     connection = NoCloseConnection()
 
-    monkeypatch.setattr(
-        "sqlspec.adapters.arrow_odbc.config.arrow_odbc_connect", lambda *_args, **_kwargs: connection
-    )
+    monkeypatch.setattr("sqlspec.adapters.arrow_odbc.config.arrow_odbc_connect", lambda *_args, **_kwargs: connection)
 
     config = ArrowOdbcConfig(
         connection_config={"driver": "ODBC Driver 18 for SQL Server", "server": "localhost", "database": "app"}

--- a/tests/unit/adapters/test_arrow_odbc.py
+++ b/tests/unit/adapters/test_arrow_odbc.py
@@ -8,7 +8,6 @@ import pytest
 pytest.importorskip("arrow_odbc")
 
 from sqlspec.adapters.arrow_odbc import ArrowOdbcConfig, ArrowOdbcDriver, resolve_dialect_from_dbms_name
-from sqlspec.adapters.arrow_odbc import driver as driver_module
 from sqlspec.exceptions import SQLSpecError
 
 
@@ -110,7 +109,7 @@ def test_arrow_odbc_select_to_arrow_batches_returns_batches() -> None:
 
 def test_arrow_odbc_select_to_arrow_raises_mapped_driver_exception(monkeypatch: pytest.MonkeyPatch) -> None:
     """Native read failures should use SQLSpec's deferred exception mapping."""
-    monkeypatch.setattr(driver_module.ARROW_ODBC_MODULE, "Error", FakeOdbcError)
+    monkeypatch.setattr("sqlspec.adapters.arrow_odbc.driver.ArrowOdbcError", FakeOdbcError)
     connection = ErrorConnection()
     driver = ArrowOdbcDriver(cast("Any", connection), driver_features={"chunk_size": 2})
 
@@ -131,7 +130,7 @@ def test_arrow_odbc_bulk_insert_arrow_uses_from_table_to_db() -> None:
 
 def test_arrow_odbc_bulk_insert_arrow_raises_mapped_driver_exception(monkeypatch: pytest.MonkeyPatch) -> None:
     """Native write failures should not be swallowed by the deferred exception handler."""
-    monkeypatch.setattr(driver_module.ARROW_ODBC_MODULE, "Error", FakeOdbcError)
+    monkeypatch.setattr("sqlspec.adapters.arrow_odbc.driver.ArrowOdbcError", FakeOdbcError)
     connection = ErrorConnection()
     driver = ArrowOdbcDriver(cast("Any", connection), driver_features={"chunk_size": 10})
 
@@ -148,7 +147,7 @@ def test_arrow_odbc_config_connects_with_verified_keyword_names(monkeypatch: Any
         calls.append((connection_string, kwargs))
         return connection
 
-    monkeypatch.setattr("sqlspec.adapters.arrow_odbc.config.ARROW_ODBC_MODULE.connect", fake_connect)
+    monkeypatch.setattr("sqlspec.adapters.arrow_odbc.config.arrow_odbc_connect", fake_connect)
 
     config = ArrowOdbcConfig(
         connection_config={
@@ -170,7 +169,7 @@ def test_arrow_odbc_session_release_allows_connections_without_close(monkeypatch
     connection = NoCloseConnection()
 
     monkeypatch.setattr(
-        "sqlspec.adapters.arrow_odbc.config.ARROW_ODBC_MODULE.connect", lambda *_args, **_kwargs: connection
+        "sqlspec.adapters.arrow_odbc.config.arrow_odbc_connect", lambda *_args, **_kwargs: connection
     )
 
     config = ArrowOdbcConfig(connection_config={"connection_string": "Driver={ODBC Driver 18 for SQL Server};"})
@@ -184,7 +183,7 @@ def test_arrow_odbc_field_config_uses_driver_name_for_dialect(monkeypatch: Any) 
     connection = NoCloseConnection()
 
     monkeypatch.setattr(
-        "sqlspec.adapters.arrow_odbc.config.ARROW_ODBC_MODULE.connect", lambda *_args, **_kwargs: connection
+        "sqlspec.adapters.arrow_odbc.config.arrow_odbc_connect", lambda *_args, **_kwargs: connection
     )
 
     config = ArrowOdbcConfig(

--- a/tests/unit/adapters/test_mssql_python/__init__.py
+++ b/tests/unit/adapters/test_mssql_python/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for mssql_python adapter."""

--- a/tests/unit/adapters/test_mssql_python/conftest.py
+++ b/tests/unit/adapters/test_mssql_python/conftest.py
@@ -1,0 +1,5 @@
+"""Shared test guards for optional mssql-python adapter tests."""
+
+import pytest
+
+pytest.importorskip("mssql_python")

--- a/tests/unit/adapters/test_mssql_python/test_arrow.py
+++ b/tests/unit/adapters/test_mssql_python/test_arrow.py
@@ -1,0 +1,224 @@
+"""Unit tests for mssql_python Arrow and BulkCopy driver methods."""
+
+from typing import Any, cast
+
+import pytest
+
+from sqlspec.adapters.mssql_python import driver as driver_module
+from sqlspec.adapters.mssql_python.driver import MssqlPythonAsyncDriver, MssqlPythonDriver
+from sqlspec.exceptions import UniqueViolationError
+
+mssql_python = pytest.importorskip("mssql_python")
+
+
+class ArrowCursor:
+    """Cursor stub for Arrow and BulkCopy tests."""
+
+    description = (("x",),)
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.executed: list[tuple[str, Any]] = []
+        self.bulkcopy_calls: list[tuple[str, Any, dict[str, Any]]] = []
+        self.rowcount = 0
+
+    def execute(self, sql: str, parameters: Any = None) -> None:
+        self.executed.append((sql, parameters))
+
+    def arrow(self, batch_size: int = 8192) -> Any:
+        import pyarrow as pa
+
+        return pa.table({"x": [1, 2, 3]})
+
+    def arrow_reader(self, batch_size: int = 8192) -> Any:
+        import pyarrow as pa
+
+        table = pa.table({"x": [1, 2, 3]})
+        return iter(table.to_batches(max_chunksize=batch_size))
+
+    def bulkcopy(self, target_table: str, rows: Any, **kwargs: Any) -> None:
+        rows = list(rows)
+        self.bulkcopy_calls.append((target_table, rows, kwargs))
+        self.rowcount = len(rows)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class ArrowConnection:
+    """Connection stub returning the same cursor instance."""
+
+    def __init__(self) -> None:
+        self.cursor_obj = ArrowCursor()
+
+    def cursor(self) -> ArrowCursor:
+        return self.cursor_obj
+
+    def commit(self) -> None:
+        return None
+
+    def rollback(self) -> None:
+        return None
+
+
+class ErrorArrowCursor(ArrowCursor):
+    """Cursor stub that raises a mssql-python error from native methods."""
+
+    def arrow(self, batch_size: int = 8192) -> Any:
+        raise mssql_python.Error("driver", "(2627)")
+
+    def bulkcopy(self, target_table: str, rows: Any, **kwargs: Any) -> None:
+        raise mssql_python.Error("driver", "(2627)")
+
+
+class ErrorArrowConnection(ArrowConnection):
+    """Connection stub returning an erroring cursor."""
+
+    def __init__(self) -> None:
+        self.cursor_obj = ErrorArrowCursor()
+
+
+def test_select_to_arrow_returns_arrow_result_from_native_cursor() -> None:
+    """The sync driver should wrap cursor.arrow() in an ArrowResult."""
+    connection = ArrowConnection()
+    driver = MssqlPythonDriver(cast("Any", connection))
+
+    result = driver.select_to_arrow("SELECT 1 AS x")
+
+    table = result.get_data()
+    assert table.column_names == ["x"]
+    assert table.num_rows == 3
+    assert connection.cursor_obj.executed[0][0] == "SELECT 1 AS x"
+    assert connection.cursor_obj.closed is True
+
+
+def test_select_to_arrow_raises_mapped_driver_exception() -> None:
+    """Native Arrow failures should use SQLSpec's deferred exception mapping."""
+    connection = ErrorArrowConnection()
+    driver = MssqlPythonDriver(cast("Any", connection))
+
+    with pytest.raises(UniqueViolationError):
+        driver.select_to_arrow("SELECT 1 AS x")
+
+    assert connection.cursor_obj.closed is True
+
+
+def test_select_to_arrow_batches_returns_batches() -> None:
+    """The sync driver should support SQLSpec's canonical batches return format."""
+    connection = ArrowConnection()
+    driver = MssqlPythonDriver(cast("Any", connection))
+
+    result = driver.select_to_arrow("SELECT 1 AS x", return_format="batches", batch_size=2)
+    batches = result.get_data()
+
+    assert [batch.num_rows for batch in batches] == [2, 1]
+    assert connection.cursor_obj.closed is True
+
+
+def test_bulk_copy_forwards_options_to_cursor_bulkcopy() -> None:
+    """BulkCopy options should be forwarded without SQLSpec-side rewriting."""
+    connection = ArrowConnection()
+    driver = MssqlPythonDriver(cast("Any", connection))
+
+    inserted = driver.bulk_copy(
+        "dbo.target", [(1, "a"), (2, "b")], batch_size=1000, timeout=30, table_lock=True, keep_nulls=True
+    )
+
+    target_table, rows, options = connection.cursor_obj.bulkcopy_calls[0]
+    assert inserted == 2
+    assert target_table == "dbo.target"
+    assert rows == [(1, "a"), (2, "b")]
+    assert options["batch_size"] == 1000
+    assert options["timeout"] == 30
+    assert options["table_lock"] is True
+    assert options["keep_nulls"] is True
+    assert connection.cursor_obj.closed is True
+
+
+def test_bulk_copy_raises_mapped_driver_exception() -> None:
+    """BulkCopy failures should not be swallowed by the deferred exception handler."""
+    connection = ErrorArrowConnection()
+    driver = MssqlPythonDriver(cast("Any", connection))
+
+    with pytest.raises(UniqueViolationError):
+        driver.bulk_copy("dbo.target", [(1,)])
+
+    assert connection.cursor_obj.closed is True
+
+
+@pytest.mark.anyio
+async def test_async_select_to_arrow_offloads_cursor_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The async driver should offload blocking Arrow cursor work."""
+    calls: list[str] = []
+
+    async def fake_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        calls.append(getattr(func, "__name__", repr(func)))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(driver_module.asyncio, "to_thread", fake_to_thread)
+
+    connection = ArrowConnection()
+    driver = MssqlPythonAsyncDriver(cast("Any", connection))
+
+    result = await driver.select_to_arrow("SELECT 1 AS x")
+
+    assert result.get_data().num_rows == 3
+    assert "_execute_cursor" in calls
+    assert "arrow" in calls
+    assert "close" in calls
+
+
+@pytest.mark.anyio
+async def test_async_select_to_arrow_raises_mapped_driver_exception() -> None:
+    """Async native Arrow failures should use SQLSpec's deferred exception mapping."""
+    connection = ErrorArrowConnection()
+    driver = MssqlPythonAsyncDriver(cast("Any", connection))
+
+    with pytest.raises(UniqueViolationError):
+        await driver.select_to_arrow("SELECT 1 AS x")
+
+    assert connection.cursor_obj.closed is True
+
+
+@pytest.mark.anyio
+async def test_async_select_to_arrow_batches_offloads_table_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The async driver should offload native Arrow reads for SQLSpec's batches format."""
+    calls: list[str] = []
+
+    async def fake_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        calls.append(getattr(func, "__name__", repr(func)))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(driver_module.asyncio, "to_thread", fake_to_thread)
+
+    connection = ArrowConnection()
+    driver = MssqlPythonAsyncDriver(cast("Any", connection))
+
+    result = await driver.select_to_arrow("SELECT 1 AS x", return_format="batches", batch_size=2)
+    batches = result.get_data()
+
+    assert [batch.num_rows for batch in batches] == [2, 1]
+    assert "_execute_cursor" in calls
+    assert "arrow" in calls
+    assert "close" in calls
+
+
+@pytest.mark.anyio
+async def test_async_bulk_copy_offloads_bulkcopy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The async driver should offload cursor.bulkcopy()."""
+    calls: list[str] = []
+
+    async def fake_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        calls.append(getattr(func, "__name__", repr(func)))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(driver_module.asyncio, "to_thread", fake_to_thread)
+
+    connection = ArrowConnection()
+    driver = MssqlPythonAsyncDriver(cast("Any", connection))
+
+    inserted = await driver.bulk_copy("dbo.target", [(1,), (2,)], batch_size=500)
+
+    assert inserted == 2
+    assert "bulkcopy" in calls
+    assert "close" in calls

--- a/tests/unit/adapters/test_mssql_python/test_async.py
+++ b/tests/unit/adapters/test_mssql_python/test_async.py
@@ -1,0 +1,109 @@
+"""Unit tests for the mssql_python async wrapper."""
+
+from typing import Any, cast
+
+import pytest
+
+from sqlspec.adapters.mssql_python import MssqlPythonAsyncConfig, MssqlPythonAsyncDriver
+
+
+class DummyCursor:
+    """Minimal cursor for async driver dispatch tests."""
+
+    description = (("value",),)
+    rowcount = 1
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.executed: list[tuple[str, Any]] = []
+
+    def execute(self, sql: str, parameters: Any = None) -> None:
+        self.executed.append((sql, parameters))
+
+    def fetchall(self) -> list[tuple[int]]:
+        return [(1,)]
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class DummyConnection:
+    """Minimal connection for async config and driver tests."""
+
+    def __init__(self) -> None:
+        self.cursor_obj = DummyCursor()
+        self.closed = False
+
+    def cursor(self) -> DummyCursor:
+        return self.cursor_obj
+
+    def close(self) -> None:
+        self.closed = True
+
+    def commit(self) -> None:
+        return None
+
+    def rollback(self) -> None:
+        return None
+
+
+@pytest.mark.anyio
+async def test_async_config_provide_session_yields_async_driver(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MssqlPythonAsyncConfig should provide an async driver and release connections."""
+    connection = DummyConnection()
+
+    monkeypatch.setattr("sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.pooling", lambda **_: None)
+    monkeypatch.setattr(
+        "sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.connect", lambda *_args, **_kwargs: connection
+    )
+
+    config = MssqlPythonAsyncConfig(connection_config={"server": "localhost"})
+
+    async with config.provide_session() as session:
+        assert isinstance(session, MssqlPythonAsyncDriver)
+
+    assert connection.closed is True
+
+
+@pytest.mark.anyio
+async def test_async_config_connection_hook_runs_for_session_connections(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Async session acquisition should preserve the on_connection_create hook."""
+    connection = DummyConnection()
+    seen: list[DummyConnection] = []
+
+    monkeypatch.setattr("sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.pooling", lambda **_: None)
+    monkeypatch.setattr(
+        "sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.connect", lambda *_args, **_kwargs: connection
+    )
+
+    config = MssqlPythonAsyncConfig(
+        connection_config={"server": "localhost"}, driver_features={"on_connection_create": seen.append}
+    )
+
+    async with config.provide_session():
+        pass
+
+    assert seen == [connection]
+
+
+@pytest.mark.anyio
+async def test_async_driver_uses_to_thread_for_cursor_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Async driver dispatch should offload blocking cursor work through asyncio.to_thread."""
+    from sqlspec.adapters.mssql_python import driver as driver_module
+
+    calls: list[str] = []
+
+    async def fake_to_thread(func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        calls.append(getattr(func, "__name__", repr(func)))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(driver_module.asyncio, "to_thread", fake_to_thread)
+
+    connection = DummyConnection()
+    driver = MssqlPythonAsyncDriver(cast("Any", connection))
+
+    result = await driver.select_value("SELECT 1")
+
+    assert result == 1
+    assert "_execute_cursor" in calls
+    assert "fetchall" in calls

--- a/tests/unit/adapters/test_mssql_python/test_config.py
+++ b/tests/unit/adapters/test_mssql_python/test_config.py
@@ -1,0 +1,91 @@
+"""Unit tests for mssql_python adapter configuration."""
+
+from typing import Any
+
+import pytest
+
+from sqlspec.adapters.mssql_python.config import MssqlPythonConfig, MssqlPythonConnectionPool
+
+
+class DummyConnection:
+    """Minimal connection object for pool lifecycle assertions."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_connection_pool_configures_mssql_python_pooling(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The SQLSpec pool wrapper should configure driver-level pooling before connect."""
+    calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+    connection = DummyConnection()
+
+    def fake_pooling(*args: Any, **kwargs: Any) -> None:
+        calls.append(("pooling", args, kwargs))
+
+    def fake_connect(connection_string: str, **kwargs: Any) -> DummyConnection:
+        calls.append(("connect", (connection_string,), kwargs))
+        return connection
+
+    monkeypatch.setattr("sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.pooling", fake_pooling)
+    monkeypatch.setattr("sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.connect", fake_connect)
+
+    pool = MssqlPythonConnectionPool(
+        connection_string="Server=localhost;", connect_kwargs={"timeout": 5}, max_size=7, idle_timeout=30, enabled=True
+    )
+    acquired = pool.acquire()
+    pool.release(acquired)
+
+    assert calls == [
+        ("pooling", (), {"max_size": 7, "idle_timeout": 30, "enabled": True}),
+        ("connect", ("Server=localhost;",), {"timeout": 5}),
+    ]
+    assert connection.closed is True
+
+
+def test_config_create_pool_splits_connection_and_pool_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MssqlPythonConfig should pass connection options and pool options to the right APIs."""
+    pooling_calls: list[dict[str, Any]] = []
+
+    def fake_pooling(**kwargs: Any) -> None:
+        pooling_calls.append(kwargs)
+
+    monkeypatch.setattr("sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.pooling", fake_pooling)
+
+    config = MssqlPythonConfig(
+        connection_config={
+            "server": "localhost",
+            "database": "tempdb",
+            "pool_size": 3,
+            "pool_idle_timeout": 10,
+            "timeout": 20,
+        }
+    )
+
+    pool = config.create_pool()
+
+    assert pool.connection_string == "Server=localhost;Database=tempdb;"
+    assert pool.connect_kwargs == {"timeout": 20}
+    assert pooling_calls == [{"max_size": 3, "idle_timeout": 10, "enabled": True}]
+
+
+def test_config_connection_hook_runs_for_session_connections(monkeypatch: pytest.MonkeyPatch) -> None:
+    """on_connection_create should run for connections acquired by provide_session()."""
+    connection = DummyConnection()
+    seen: list[DummyConnection] = []
+
+    monkeypatch.setattr("sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.pooling", lambda **_: None)
+    monkeypatch.setattr(
+        "sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.connect", lambda *_args, **_kwargs: connection
+    )
+
+    config = MssqlPythonConfig(
+        connection_config={"server": "localhost"}, driver_features={"on_connection_create": seen.append}
+    )
+
+    with config.provide_session():
+        pass
+
+    assert seen == [connection]

--- a/tests/unit/adapters/test_mssql_python/test_core.py
+++ b/tests/unit/adapters/test_mssql_python/test_core.py
@@ -1,0 +1,70 @@
+"""Unit tests for mssql_python adapter core helpers."""
+
+import pytest
+
+from sqlspec.adapters.mssql_python._typing import MSSQL_PYTHON_MODULE
+from sqlspec.adapters.mssql_python.core import build_connection_config, create_mapped_exception
+from sqlspec.exceptions import DatabaseConnectionError, UniqueViolationError
+
+
+def test_build_connection_config_uses_supplied_connection_string() -> None:
+    """A pre-built ODBC connection string should pass through unchanged."""
+    connection_string, kwargs = build_connection_config({
+        "connection_string": "Server=localhost;Database=tempdb;",
+        "timeout": 15,
+        "native_uuid": True,
+    })
+
+    assert connection_string == "Server=localhost;Database=tempdb;"
+    assert kwargs == {"timeout": 15, "native_uuid": True}
+
+
+def test_build_connection_config_from_parts_formats_odbc_options() -> None:
+    """Connection parts should be formatted into a semicolon-delimited ODBC string."""
+    connection_string, kwargs = build_connection_config({
+        "server": "localhost",
+        "port": 1433,
+        "database": "app",
+        "uid": "sa",
+        "pwd": "secret",
+        "encrypt": False,
+        "trust_server_certificate": True,
+        "autocommit": True,
+    })
+
+    assert connection_string == (
+        "Server=localhost,1433;Database=app;UID=sa;PWD=secret;Encrypt=no;TrustServerCertificate=yes;"
+    )
+    assert kwargs == {"autocommit": True}
+
+
+def test_create_mapped_exception_extracts_sql_server_error_number() -> None:
+    """SQL Server native error numbers should map to specific SQLSpec exceptions."""
+    exc = MSSQL_PYTHON_MODULE.IntegrityError(
+        "23000",
+        "[23000] [Microsoft][ODBC Driver 18 for SQL Server][SQL Server]Violation of UNIQUE KEY constraint. (2627)",
+    )
+
+    mapped = create_mapped_exception(exc)
+
+    assert isinstance(mapped, UniqueViolationError)
+    assert "2627" in str(mapped)
+
+
+def test_create_mapped_exception_falls_back_for_connection_errors() -> None:
+    """Known connection error numbers should map to DatabaseConnectionError."""
+    exc = MSSQL_PYTHON_MODULE.OperationalError(
+        "08001",
+        "[08001] [Microsoft][ODBC Driver 18 for SQL Server]Named Pipes Provider: "
+        "Could not open a connection to SQL Server (53)",
+    )
+
+    mapped = create_mapped_exception(exc)
+
+    assert isinstance(mapped, DatabaseConnectionError)
+
+
+def test_build_connection_config_requires_server_when_missing_connection_string() -> None:
+    """Part-based configuration should fail fast without a server."""
+    with pytest.raises(ValueError, match="server"):
+        build_connection_config({"database": "app"})

--- a/tests/unit/adapters/test_mssql_python/test_data_dictionary.py
+++ b/tests/unit/adapters/test_mssql_python/test_data_dictionary.py
@@ -1,0 +1,132 @@
+"""Unit tests for the mssql_python data dictionary."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from sqlspec.adapters.mssql_python.data_dictionary import (
+    MssqlPythonAsyncDataDictionary,
+    MssqlPythonSyncDataDictionary,
+    MssqlVersionInfo,
+)
+
+MSSQL_QUERY_DIR = Path("sqlspec/data_dictionary/sql/mssql")
+EXPECTED_MSSQL_QUERY_FILES = {"columns.sql", "foreign_keys.sql", "indexes.sql", "tables.sql", "version.sql"}
+
+
+class FakeSyncDriver:
+    """Minimal sync driver for data dictionary tests."""
+
+    def __init__(self) -> None:
+        self.select_calls: list[tuple[Any, dict[str, Any]]] = []
+
+    def select_one_or_none(self, _statement: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "version_string": "Microsoft SQL Server 2022 - 16.0.4131.2 (X64)",
+            "product_version": "16.0.4131.2",
+            "edition": "Developer Edition",
+            "engine_edition": 3,
+        }
+
+    def select(self, statement: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        self.select_calls.append((statement, kwargs))
+        if kwargs.get("table_name") == "app":
+            return [{"column_name": "id"}]
+        if len(self.select_calls) == 1:
+            return [{"schema_name": "dbo", "table_name": "parent"}]
+        if len(self.select_calls) == 2:
+            return [{"schema_name": "dbo", "table_name": "parent"}, {"schema_name": "dbo", "table_name": "orphan"}]
+        return []
+
+
+class FakeAsyncDriver:
+    """Minimal async driver for data dictionary tests."""
+
+    def __init__(self) -> None:
+        self.select_calls: list[tuple[Any, dict[str, Any]]] = []
+
+    async def select_one_or_none(self, _statement: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "version_string": "Microsoft SQL Azure - 12.0.2000.8",
+            "product_version": "12.0.2000.8",
+            "edition": "Azure SQL Database",
+            "engine_edition": "5",
+        }
+
+    async def select(self, statement: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        self.select_calls.append((statement, kwargs))
+        return [{"index_name": "ix_app_id", "table_name": "app", "columns": "id"}]
+
+
+def test_mssql_query_files_follow_dialect_category_layout() -> None:
+    """MSSQL data-dictionary SQL should use the existing per-category file layout."""
+    assert {path.name for path in MSSQL_QUERY_DIR.glob("*.sql")} == EXPECTED_MSSQL_QUERY_FILES
+
+
+def test_sync_data_dictionary_builds_version_info() -> None:
+    """The sync dictionary should parse product version and edition metadata."""
+    driver = FakeSyncDriver()
+    data_dictionary = MssqlPythonSyncDataDictionary()
+
+    version = data_dictionary.get_version(driver)
+
+    assert isinstance(version, MssqlVersionInfo)
+    assert version.major == 16
+    assert version.build == 4131
+    assert version.revision == 2
+    assert version.edition == "Developer Edition"
+    assert version.is_azure_sql is False
+    assert data_dictionary.get_feature_flag(driver, "supports_greatest_least") is True
+    assert data_dictionary.get_feature_flag(driver, "supports_native_json") is False
+
+
+def test_sync_data_dictionary_merges_table_lists_with_default_schema() -> None:
+    """The sync dictionary should query dbo by default and append unordered tables."""
+    driver = FakeSyncDriver()
+    data_dictionary = MssqlPythonSyncDataDictionary()
+
+    tables = data_dictionary.get_tables(driver)
+
+    assert tables == [{"schema_name": "dbo", "table_name": "parent"}, {"schema_name": "dbo", "table_name": "orphan"}]
+    assert driver.select_calls[0][1]["schema_name"] == "dbo"
+    assert driver.select_calls[1][1]["schema_name"] == "dbo"
+
+
+def test_sync_data_dictionary_selects_columns_by_table() -> None:
+    """Table-scoped metadata calls should bind schema and table parameters."""
+    driver = FakeSyncDriver()
+    data_dictionary = MssqlPythonSyncDataDictionary()
+
+    columns = data_dictionary.get_columns(driver, table="app", schema="custom")
+
+    assert columns == [{"column_name": "id"}]
+    assert driver.select_calls[0][1]["schema_name"] == "custom"
+    assert driver.select_calls[0][1]["table_name"] == "app"
+
+
+@pytest.mark.anyio
+async def test_async_data_dictionary_builds_azure_version_info() -> None:
+    """The async dictionary should parse Azure SQL engine editions."""
+    driver = FakeAsyncDriver()
+    data_dictionary = MssqlPythonAsyncDataDictionary()
+
+    version = await data_dictionary.get_version(driver)
+
+    assert isinstance(version, MssqlVersionInfo)
+    assert version.major == 12
+    assert version.is_azure_sql is True
+    assert await data_dictionary.get_feature_flag(driver, "supports_native_json") is True
+
+
+@pytest.mark.anyio
+async def test_async_data_dictionary_selects_indexes_by_table() -> None:
+    """The async dictionary should use table-scoped index queries when a table is supplied."""
+    driver = FakeAsyncDriver()
+    data_dictionary = MssqlPythonAsyncDataDictionary()
+
+    indexes = await data_dictionary.get_indexes(driver, table="app")
+
+    assert indexes == [{"index_name": "ix_app_id", "table_name": "app", "columns": "id"}]
+    assert driver.select_calls[0][1]["schema_name"] == "dbo"
+    assert driver.select_calls[0][1]["table_name"] == "app"

--- a/tests/unit/adapters/test_mssql_python/test_driver.py
+++ b/tests/unit/adapters/test_mssql_python/test_driver.py
@@ -1,0 +1,32 @@
+"""Unit tests for mssql_python driver wiring."""
+
+from typing import Any, cast
+
+from sqlspec.adapters.mssql_python.data_dictionary import MssqlPythonAsyncDataDictionary, MssqlPythonSyncDataDictionary
+from sqlspec.adapters.mssql_python.driver import MssqlPythonAsyncDriver, MssqlPythonDriver
+
+
+class DummyConnection:
+    """Minimal connection for driver construction."""
+
+    def commit(self) -> None:
+        return None
+
+    def rollback(self) -> None:
+        return None
+
+
+def test_sync_driver_lazily_initializes_data_dictionary() -> None:
+    """The sync driver should expose the MSSQL data dictionary."""
+    driver = MssqlPythonDriver(cast("Any", DummyConnection()))
+
+    assert isinstance(driver.data_dictionary, MssqlPythonSyncDataDictionary)
+    assert driver.data_dictionary is driver.data_dictionary
+
+
+def test_async_driver_lazily_initializes_data_dictionary() -> None:
+    """The async driver should expose the MSSQL async data dictionary."""
+    driver = MssqlPythonAsyncDriver(cast("Any", DummyConnection()))
+
+    assert isinstance(driver.data_dictionary, MssqlPythonAsyncDataDictionary)
+    assert driver.data_dictionary is driver.data_dictionary

--- a/tests/unit/adapters/test_mssql_python/test_events_store.py
+++ b/tests/unit/adapters/test_mssql_python/test_events_store.py
@@ -1,0 +1,33 @@
+"""Unit tests for mssql_python event queue store DDL."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from sqlspec.adapters.mssql_python import MssqlPythonConfig
+from sqlspec.adapters.mssql_python.events.store import MssqlPythonEventQueueStore
+
+
+def _config(extension_config: dict[str, Any] | None = None) -> Any:
+    return SimpleNamespace(extension_config=extension_config or {"events": {}})
+
+
+def test_event_queue_store_uses_tsql_column_types_and_idempotency() -> None:
+    """Event queue DDL should use T-SQL types and sys catalog guards."""
+    store = MssqlPythonEventQueueStore(cast(MssqlPythonConfig, _config()))
+
+    statements = store.create_statements()
+    ddl = "\n".join(statements)
+
+    assert "IF OBJECT_ID(N'dbo.sqlspec_event_queue', N'U') IS NULL" in ddl
+    assert "payload_json NVARCHAR(MAX) NOT NULL" in ddl
+    assert "available_at DATETIME2(6) NOT NULL DEFAULT SYSUTCDATETIME()" in ddl
+    assert "IF NOT EXISTS (SELECT 1 FROM sys.indexes" in ddl
+
+
+def test_event_queue_store_drop_uses_object_id_guard() -> None:
+    """Event queue drop DDL should be idempotent for SQL Server."""
+    store = MssqlPythonEventQueueStore(cast(MssqlPythonConfig, _config()))
+
+    assert store.drop_statements() == [
+        "IF OBJECT_ID(N'dbo.sqlspec_event_queue', N'U') IS NOT NULL DROP TABLE sqlspec_event_queue;"
+    ]

--- a/tests/unit/adapters/test_mssql_python/test_litestar_store.py
+++ b/tests/unit/adapters/test_mssql_python/test_litestar_store.py
@@ -1,0 +1,134 @@
+"""Unit tests for the mssql-python Litestar store."""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, cast
+
+from sqlspec.adapters.mssql_python.litestar import MssqlPythonStore
+
+
+class FakeResult:
+    """Small SQL result stub exposing rows_affected."""
+
+    def __init__(self, rows_affected: int) -> None:
+        self.rows_affected = rows_affected
+
+
+class FakeSession:
+    """Async driver stub that records store SQL calls."""
+
+    def __init__(self, rows: list[Any] | None = None, rows_affected: int = 0) -> None:
+        self.rows = list(rows or [])
+        self.rows_affected = rows_affected
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+        self.scripts: list[str] = []
+        self.commits = 0
+
+    async def execute(self, sql: str, *parameters: Any, **kwargs: Any) -> FakeResult:
+        self.executed.append((sql, parameters))
+        return FakeResult(self.rows_affected)
+
+    async def execute_script(self, sql: str, *parameters: Any, **kwargs: Any) -> FakeResult:
+        self.scripts.append(sql)
+        return FakeResult(self.rows_affected)
+
+    async def select_one_or_none(self, sql: str, *parameters: Any, **kwargs: Any) -> Any:
+        self.executed.append((sql, parameters))
+        if self.rows:
+            return self.rows.pop(0)
+        return None
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+
+class FakeSessionContext:
+    """Async context manager returning a fake session."""
+
+    def __init__(self, session: FakeSession) -> None:
+        self.session = session
+
+    async def __aenter__(self) -> FakeSession:
+        return self.session
+
+    async def __aexit__(self, *_: object) -> None:
+        return None
+
+
+class FakeConfig:
+    """Config stub implementing provide_session."""
+
+    def __init__(self, session: FakeSession, table_name: str = "mssql_sessions") -> None:
+        self.extension_config = {"litestar": {"session_table": table_name}}
+        self.session = session
+
+    def provide_session(self) -> FakeSessionContext:
+        return FakeSessionContext(self.session)
+
+
+def test_mssql_python_store_imports() -> None:
+    """The mssql_python Litestar namespace should export the store."""
+    assert MssqlPythonStore.__name__ == "MssqlPythonStore"
+
+
+def test_mssql_python_store_create_table_uses_tsql_guards() -> None:
+    """The store DDL should use SQL Server idempotent guards and binary payload storage."""
+    store = MssqlPythonStore(cast("Any", FakeConfig(FakeSession())))
+
+    ddl = store._get_create_table_sql()
+
+    assert "IF NOT EXISTS" in ddl
+    assert "sys.tables" in ddl
+    assert "VARBINARY(MAX)" in ddl
+    assert "DATETIME2(6)" in ddl
+    assert "WHERE expires_at IS NOT NULL" in ddl
+
+
+async def test_mssql_python_store_set_uses_merge_with_positional_parameters() -> None:
+    """set should upsert with MERGE and pass the key/data/expiry as positional parameters."""
+    session = FakeSession()
+    store = MssqlPythonStore(cast("Any", FakeConfig(session)))
+
+    await store.set("session-1", "payload", expires_in=60)
+
+    sql, parameters = session.executed[0]
+    assert "MERGE INTO mssql_sessions" in sql
+    assert parameters[0] == ("session-1", b"payload", parameters[0][2])
+    assert isinstance(parameters[0][2], datetime)
+    assert session.commits == 1
+
+
+async def test_mssql_python_store_get_renews_unexpired_session() -> None:
+    """get should return bytes and renew expiry only when the existing row had an expiry."""
+    future = datetime.now(timezone.utc) + timedelta(minutes=5)
+    session = FakeSession(rows=[{"data": b"payload", "expires_at": future}])
+    store = MssqlPythonStore(cast("Any", FakeConfig(session)))
+
+    data = await store.get("session-1", renew_for=60)
+
+    assert data == b"payload"
+    assert any("UPDATE mssql_sessions" in sql for sql, _ in session.executed)
+    assert session.commits == 1
+
+
+async def test_mssql_python_store_get_deletes_expired_session() -> None:
+    """get should lazily delete expired rows before returning None."""
+    past = datetime.now(timezone.utc) - timedelta(seconds=1)
+    session = FakeSession(rows=[{"data": b"payload", "expires_at": past}])
+    store = MssqlPythonStore(cast("Any", FakeConfig(session)))
+
+    data = await store.get("session-1")
+
+    assert data is None
+    assert any("DELETE FROM mssql_sessions" in sql for sql, _ in session.executed)
+    assert session.commits == 1
+
+
+async def test_mssql_python_store_delete_expired_returns_rows_affected() -> None:
+    """delete_expired should return the SQLSpec result rowcount."""
+    session = FakeSession(rows_affected=3)
+    store = MssqlPythonStore(cast("Any", FakeConfig(session)))
+
+    count = await store.delete_expired()
+
+    assert count == 3
+    assert session.commits == 1

--- a/tests/unit/adapters/test_mssql_python/test_migrations.py
+++ b/tests/unit/adapters/test_mssql_python/test_migrations.py
@@ -1,0 +1,79 @@
+"""Unit tests for the mssql_python migration tracker."""
+
+from typing import Any, cast
+
+import pytest
+
+from sqlspec.adapters.mssql_python.config import MssqlPythonAsyncConfig, MssqlPythonConfig
+from sqlspec.adapters.mssql_python.migrations import MssqlPythonAsyncMigrationTracker, MssqlPythonSyncMigrationTracker
+
+
+class FakeSyncMigrationDriver:
+    """Minimal sync driver for migration tracker tests."""
+
+    def __init__(self) -> None:
+        self.scripts: list[str] = []
+        self.commits = 0
+
+    def execute_script(self, statement: str) -> None:
+        self.scripts.append(statement)
+
+    def select(self, _statement: Any, **_kwargs: Any) -> list[dict[str, str]]:
+        return [{"column_name": "version_num"}, {"column_name": "version_type"}]
+
+    def commit(self) -> None:
+        self.commits += 1
+
+
+class FakeAsyncMigrationDriver:
+    """Minimal async driver for migration tracker tests."""
+
+    def __init__(self) -> None:
+        self.scripts: list[str] = []
+        self.commits = 0
+
+    async def execute_script(self, statement: str) -> None:
+        self.scripts.append(statement)
+
+    async def select(self, _statement: Any, **_kwargs: Any) -> list[dict[str, str]]:
+        return [{"column_name": "version_num"}, {"column_name": "version_type"}]
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+
+def test_sync_tracker_uses_tsql_idempotent_create_table() -> None:
+    """The sync tracker should create the version table with T-SQL-safe DDL."""
+    driver = FakeSyncMigrationDriver()
+    tracker = MssqlPythonSyncMigrationTracker(version_table_name="__migrations_test")
+
+    tracker.ensure_tracking_table(cast("Any", driver))
+
+    ddl = "\n".join(driver.scripts)
+    assert "IF NOT EXISTS (SELECT 1 FROM sys.tables" in ddl
+    assert "SCHEMA_ID('dbo')" in ddl
+    assert "NVARCHAR(32)" in ddl
+    assert "DATETIME2(6)" in ddl
+    assert "TIMESTAMP" not in ddl
+    assert driver.commits >= 1
+
+
+@pytest.mark.anyio
+async def test_async_tracker_uses_tsql_idempotent_create_table() -> None:
+    """The async tracker should use the same T-SQL-safe DDL."""
+    driver = FakeAsyncMigrationDriver()
+    tracker = MssqlPythonAsyncMigrationTracker(version_table_name="__migrations_test")
+
+    await tracker.ensure_tracking_table(cast("Any", driver))
+
+    ddl = "\n".join(driver.scripts)
+    assert "IF NOT EXISTS (SELECT 1 FROM sys.tables" in ddl
+    assert "NVARCHAR(MAX)" in ddl
+    assert "DATETIME2(6)" in ddl
+    assert driver.commits >= 1
+
+
+def test_mssql_python_configs_use_tsql_migration_trackers() -> None:
+    """Sync and async configs should use the MSSQL migration tracker types."""
+    assert MssqlPythonConfig.migration_tracker_type is MssqlPythonSyncMigrationTracker
+    assert MssqlPythonAsyncConfig.migration_tracker_type is MssqlPythonAsyncMigrationTracker

--- a/tests/unit/adapters/test_mssql_python/test_type_converter.py
+++ b/tests/unit/adapters/test_mssql_python/test_type_converter.py
@@ -1,0 +1,39 @@
+"""Unit tests for mssql_python type conversion helpers."""
+
+from uuid import UUID
+
+from sqlspec.adapters.mssql_python.type_converter import MssqlPythonTypeConverter, mssql_type_to_arrow
+
+
+def test_type_converter_serializes_json_containers() -> None:
+    """dict and list parameters should bind as JSON text."""
+    converter = MssqlPythonTypeConverter(json_serializer=lambda value: f"json:{value!r}")
+
+    assert converter.coerce_bind_value({"a": 1}) == "json:{'a': 1}"
+    assert converter.coerce_bind_value([1, 2]) == "json:[1, 2]"
+
+
+def test_type_converter_preserves_uuid_values() -> None:
+    """mssql-python 1.5+ binds UUID values natively."""
+    value = UUID("00000000-0000-0000-0000-000000000001")
+    converter = MssqlPythonTypeConverter()
+
+    assert converter.coerce_bind_value(value) is value
+
+
+def test_mssql_type_to_arrow_maps_core_sql_server_types() -> None:
+    """SQL Server type names should resolve to stable Arrow data types."""
+    import pyarrow as pa
+
+    assert mssql_type_to_arrow("bit") == pa.bool_()
+    assert mssql_type_to_arrow("int") == pa.int32()
+    assert mssql_type_to_arrow("datetimeoffset") == pa.timestamp("us", tz="UTC")
+    assert mssql_type_to_arrow("uniqueidentifier") == pa.string()
+
+
+def test_mssql_type_to_arrow_uses_decimal_precision_and_scale() -> None:
+    """DECIMAL and NUMERIC should preserve declared precision and scale."""
+    import pyarrow as pa
+
+    assert mssql_type_to_arrow("decimal", precision=18, scale=4) == pa.decimal128(18, 4)
+    assert mssql_type_to_arrow("numeric", precision=10, scale=2) == pa.decimal128(10, 2)

--- a/tests/unit/core/test_parameters.py
+++ b/tests/unit/core/test_parameters.py
@@ -442,6 +442,22 @@ def test_get_driver_profile_missing_raises() -> None:
         get_driver_profile("does-not-exist")
 
 
+def test_mssql_python_parameter_profile_registered() -> None:
+    """mssql_python should register a qmark default profile with pyformat support."""
+    pytest.importorskip("mssql_python")
+    from sqlspec.adapters.mssql_python.core import driver_profile  # noqa: F401
+
+    profile = get_driver_profile("mssql_python")
+
+    assert profile.default_dialect == "tsql"
+    assert profile.default_style is ParameterStyle.QMARK
+    assert ParameterStyle.QMARK in profile.supported_styles
+    assert ParameterStyle.NAMED_PYFORMAT in profile.supported_styles
+    assert profile.default_execution_style is ParameterStyle.QMARK
+    assert profile.supported_execution_styles == frozenset({ParameterStyle.QMARK})
+    assert profile.allow_mixed_parameter_styles is False
+
+
 def test_register_driver_profile_duplicate_guard() -> None:
     """Registering the same adapter twice without override should fail."""
 

--- a/tests/unit/core/test_splitter.py
+++ b/tests/unit/core/test_splitter.py
@@ -11,3 +11,64 @@ def test_join_string_fragments_returns_joined_text() -> None:
 def test_split_sql_script_preserves_statement_output() -> None:
     """Statement splitting should preserve existing semicolon handling."""
     assert split_sql_script("SELECT 1; SELECT 2;", strip_trailing_terminator=True) == ["SELECT 1", "SELECT 2"]
+
+
+def test_tsql_go_separates_batches() -> None:
+    """T-SQL GO batch separators should split scripts into executable batches."""
+    script = "CREATE TABLE t1 (id INT);\nGO\nINSERT INTO t1 VALUES (1);\nGO\nSELECT * FROM t1;"
+
+    statements = split_sql_script(script, dialect="tsql", strip_trailing_terminator=True)
+
+    assert len(statements) == 3
+    assert statements[0].startswith("CREATE TABLE")
+    assert statements[1].startswith("INSERT")
+    assert statements[2].startswith("SELECT")
+
+
+def test_tsql_go_is_case_insensitive() -> None:
+    """T-SQL GO batch matching should not depend on casing."""
+    script = "SELECT 1;\ngo\nSELECT 2;\nGO\nSELECT 3;"
+
+    statements = split_sql_script(script, dialect="tsql", strip_trailing_terminator=True)
+
+    assert statements == ["SELECT 1", "SELECT 2", "SELECT 3"]
+
+
+def test_tsql_begin_try_block_not_split_on_inner_semicolons() -> None:
+    """T-SQL TRY/CATCH blocks should remain one statement despite inner semicolons."""
+    script = (
+        "BEGIN TRY\n"
+        "  INSERT INTO t1 VALUES (1);\n"
+        "  INSERT INTO t1 VALUES (2);\n"
+        "END TRY\n"
+        "BEGIN CATCH\n"
+        "  THROW;\n"
+        "END CATCH;"
+    )
+
+    statements = split_sql_script(script, dialect="tsql", strip_trailing_terminator=True)
+
+    assert len(statements) == 1
+
+
+def test_tsql_semicolon_terminator_within_batch() -> None:
+    """T-SQL semicolons should split statements inside the current batch."""
+    script = "SELECT 1;\nSELECT 2;\nGO\nSELECT 3;"
+
+    statements = split_sql_script(script, dialect="tsql", strip_trailing_terminator=True)
+
+    assert statements == ["SELECT 1", "SELECT 2", "SELECT 3"]
+
+
+def test_mssql_alias_dispatches_to_tsql_splitter() -> None:
+    """The mssql alias should use the same splitter behavior as tsql."""
+    script = "SELECT 1;\nGO\nSELECT 2;"
+
+    assert split_sql_script(script, dialect="mssql") == split_sql_script(script, dialect="tsql")
+
+
+def test_sqlserver_alias_dispatches_to_tsql_splitter() -> None:
+    """The sqlserver alias should use the same splitter behavior as tsql."""
+    script = "SELECT 1;\nGO\nSELECT 2;"
+
+    assert split_sql_script(script, dialect="sqlserver") == split_sql_script(script, dialect="tsql")

--- a/tests/unit/data_dictionary/test_dialects.py
+++ b/tests/unit/data_dictionary/test_dialects.py
@@ -1,0 +1,20 @@
+"""Unit tests for built-in data dictionary dialect registration."""
+
+from sqlspec.data_dictionary import get_dialect_config
+
+
+def test_mssql_dialect_registered() -> None:
+    """The MSSQL data-dictionary dialect should be available by canonical name."""
+    cfg = get_dialect_config("mssql")
+
+    assert cfg.name == "mssql"
+
+
+def test_tsql_alias_resolves_to_mssql() -> None:
+    """The tsql alias should resolve to the MSSQL dialect config."""
+    assert get_dialect_config("tsql") is get_dialect_config("mssql")
+
+
+def test_sqlserver_alias_resolves_to_mssql() -> None:
+    """The sqlserver alias should resolve to the MSSQL dialect config."""
+    assert get_dialect_config("sqlserver") is get_dialect_config("mssql")

--- a/tests/unit/data_dictionary/test_mssql_dialect.py
+++ b/tests/unit/data_dictionary/test_mssql_dialect.py
@@ -1,0 +1,109 @@
+"""Unit tests for MSSQL data dictionary dialect helpers."""
+
+import pytest
+
+from sqlspec.data_dictionary.dialects.mssql import (
+    is_mssql_azure_sql,
+    list_mssql_available_features,
+    merge_mssql_table_lists,
+    mssql_supports_greatest_least,
+    mssql_supports_json_functions,
+    mssql_supports_native_json,
+    mssql_supports_string_agg,
+    parse_mssql_engine_edition,
+    parse_mssql_version_components,
+    resolve_mssql_default_schema,
+    resolve_mssql_feature_flag,
+)
+from sqlspec.typing import TableMetadata
+
+
+@pytest.mark.parametrize(
+    ("version_string", "expected"),
+    [
+        ("Microsoft SQL Server 2022 (RTM-CU13) (KB5036432) - 16.0.4131.2 (X64)", (16, 0, 4131, 2)),
+        ("Microsoft SQL Server 2019 (RTM-CU25) (KB5033688) - 15.0.4360.2 (X64)", (15, 0, 4360, 2)),
+        ("Microsoft SQL Server 2017 (RTM-CU31) (KB5016884) - 14.0.3456.2 (X64)", (14, 0, 3456, 2)),
+        ("Microsoft SQL Azure (RTM) - 12.0.2000.8", (12, 0, 2000, 8)),
+    ],
+)
+def test_parse_mssql_version_components(version_string: str, expected: tuple[int, int, int, int]) -> None:
+    """MSSQL version strings should parse into four integer components."""
+    assert parse_mssql_version_components(version_string) == expected
+
+
+def test_feature_predicates_sql_server_2016() -> None:
+    """SQL Server 2016 should expose JSON functions but not later features."""
+    assert mssql_supports_json_functions(13) is True
+    assert mssql_supports_string_agg(13) is False
+    assert mssql_supports_greatest_least(13) is False
+    assert mssql_supports_native_json(13) is False
+
+
+def test_feature_predicates_sql_server_2022() -> None:
+    """SQL Server 2022 should expose STRING_AGG and GREATEST/LEAST."""
+    assert mssql_supports_json_functions(16) is True
+    assert mssql_supports_string_agg(16) is True
+    assert mssql_supports_greatest_least(16) is True
+    assert mssql_supports_native_json(16) is False
+
+
+def test_feature_predicates_sql_server_2025() -> None:
+    """SQL Server 2025 should expose the native JSON type."""
+    assert mssql_supports_native_json(17) is True
+
+
+def test_azure_sql_native_json_via_feature_probe() -> None:
+    """Azure SQL can opt into native JSON even with evergreen major versions."""
+    assert mssql_supports_native_json(12, is_azure_sql=True) is True
+
+
+def test_list_mssql_available_features_includes_dynamic_flags() -> None:
+    """The feature list should include static and MSSQL-specific dynamic flags."""
+    features = list_mssql_available_features()
+
+    assert "supports_json_functions" in features
+    assert "supports_string_agg" in features
+    assert "supports_transactions" in features
+
+
+def test_resolve_mssql_feature_flag_uses_version_predicates() -> None:
+    """Dynamic flags should resolve from SQL Server major version information."""
+    assert resolve_mssql_feature_flag("supports_greatest_least", major=16) is True
+    assert resolve_mssql_feature_flag("supports_greatest_least", major=15) is False
+
+
+@pytest.mark.parametrize(("value", "expected"), [(5, 5), ("8", 8), (b"11", 11), (None, None), ("not-an-edition", None)])
+def test_parse_mssql_engine_edition(value: object, expected: int | None) -> None:
+    """EngineEdition values should parse defensively from driver-returned scalars."""
+    assert parse_mssql_engine_edition(value) == expected
+
+
+@pytest.mark.parametrize("edition", [5, 8, 11])
+def test_is_mssql_azure_sql(edition: int) -> None:
+    """Azure SQL engine editions should be recognized."""
+    assert is_mssql_azure_sql(edition) is True
+
+
+def test_mssql_default_schema_is_dbo() -> None:
+    """MSSQL should default introspection to dbo."""
+    assert resolve_mssql_default_schema() == "dbo"
+
+
+def test_merge_mssql_table_lists_preserves_dependency_order_and_appends_orphans() -> None:
+    """Dependency-ordered rows should win and catalog-only rows should be appended."""
+    ordered: list[TableMetadata] = [
+        {"schema_name": "dbo", "table_name": "parent"},
+        {"schema_name": "dbo", "table_name": "child"},
+    ]
+    all_rows: list[TableMetadata] = [
+        {"schema_name": "dbo", "table_name": "child"},
+        {"schema_name": "dbo", "table_name": "orphan"},
+        {"schema_name": "dbo", "table_name": "parent"},
+    ]
+
+    assert merge_mssql_table_lists(ordered, all_rows) == [
+        {"schema_name": "dbo", "table_name": "parent"},
+        {"schema_name": "dbo", "table_name": "child"},
+        {"schema_name": "dbo", "table_name": "orphan"},
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -402,6 +402,23 @@ wheels = [
 ]
 
 [[package]]
+name = "arrow-odbc"
+version = "10.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "pyarrow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/d9/733054d1f6c3239abd36734eccb13a407114c420e7cc994a266c22f1f790/arrow_odbc-10.4.0.tar.gz", hash = "sha256:7453cbf9cb9318696c7df7ea10eb2dad182c9bd4bbd010ec1b785fa45dbfb470", size = 106032, upload-time = "2026-04-30T09:30:18.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ea/1b900e387a2420ec6c81acb2772018943235ef153150b1c3fc4bc6d6c626/arrow_odbc-10.4.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e7ecf8ebb2c4db3c5ac79cbcbfc191dff896f379041d87e90daa46cfb07db151", size = 808016, upload-time = "2026-04-30T09:33:11.86Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e1/265408e9a79faebee0e4957cb0895e09943c758f2a68694ae9486cd44b74/arrow_odbc-10.4.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d2a8371cfe06ad4fd82de6d7920d35c3ebe3727e18d79cc179864b9522b70a", size = 782554, upload-time = "2026-04-30T09:30:17.018Z" },
+    { url = "https://files.pythonhosted.org/packages/15/07/6daf87290bd539bf229c65cafc1990a25c935be8c3f1a8ce3c867f0540d5/arrow_odbc-10.4.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:e73517ba27036f486e21a406d6c0b960540c188df71e8d88603563f8d791c312", size = 891516, upload-time = "2026-04-30T09:31:49.399Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f1/39a940a857179a675710afe68a0624f34c9b14a0ba54a48a9606f8e62901/arrow_odbc-10.4.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:a44de146e3db7aac1f054f803c4bbd00319dfdb4c2143c76425b62a969725264", size = 921999, upload-time = "2026-04-30T09:31:44.559Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/47/cc26007858cd8b36ce3a2d3da1232a29cebfb4b27455d6d92f0ff2e7ab5e/arrow_odbc-10.4.0-py3-none-win_amd64.whl", hash = "sha256:019bda957449463f0ce36ba0cfb14ddeeed7ba462468838aed912ddf81e1ad98", size = 691034, upload-time = "2026-04-30T09:31:47.267Z" },
+]
+
+[[package]]
 name = "ast-serialize"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6400,6 +6417,10 @@ aiosqlite = [
 alloydb = [
     { name = "google-cloud-alloydb-connector" },
 ]
+arrow-odbc = [
+    { name = "arrow-odbc" },
+    { name = "pyarrow" },
+]
 asyncmy = [
     { name = "asyncmy" },
 ]
@@ -6677,6 +6698,7 @@ requires-dist = [
     { name = "aiomysql", marker = "extra == 'aiomysql'" },
     { name = "aioodbc", marker = "extra == 'aioodbc'" },
     { name = "aiosqlite", marker = "extra == 'aiosqlite'" },
+    { name = "arrow-odbc", marker = "extra == 'arrow-odbc'", specifier = ">=10.4" },
     { name = "asyncmy", marker = "extra == 'asyncmy'" },
     { name = "asyncpg", marker = "extra == 'asyncpg'" },
     { name = "asyncpg", marker = "extra == 'cockroachdb'" },
@@ -6711,6 +6733,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'cockroachdb'" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'psycopg'" },
     { name = "pyarrow", marker = "extra == 'adbc'" },
+    { name = "pyarrow", marker = "extra == 'arrow-odbc'" },
     { name = "pyarrow", marker = "extra == 'pandas'" },
     { name = "pyarrow", marker = "extra == 'polars'" },
     { name = "pydantic", marker = "extra == 'pydantic'" },
@@ -6727,7 +6750,7 @@ requires-dist = [
     { name = "typing-extensions" },
     { name = "uuid-utils", marker = "extra == 'uuid'" },
 ]
-provides-extras = ["adbc", "adk", "aiomysql", "aioodbc", "aiosqlite", "alloydb", "asyncmy", "asyncpg", "attrs", "bigquery", "cloud-sql", "cockroachdb", "duckdb", "fastapi", "flask", "fsspec", "litestar", "msgspec", "mypyc", "mysql-connector", "nanoid", "obstore", "opentelemetry", "oracledb", "orjson", "pandas", "performance", "polars", "prometheus", "psqlpy", "psycopg", "pydantic", "pymssql", "pymysql", "sanic", "spanner", "starlette", "uuid"]
+provides-extras = ["adbc", "adk", "aiomysql", "aioodbc", "aiosqlite", "alloydb", "arrow-odbc", "asyncmy", "asyncpg", "attrs", "bigquery", "cloud-sql", "cockroachdb", "duckdb", "fastapi", "flask", "fsspec", "litestar", "msgspec", "mypyc", "mysql-connector", "nanoid", "obstore", "opentelemetry", "oracledb", "orjson", "pandas", "performance", "polars", "prometheus", "psqlpy", "psycopg", "pydantic", "pymssql", "pymysql", "sanic", "spanner", "starlette", "uuid"]
 
 [package.metadata.requires-dev]
 benchmarks = [

--- a/uv.lock
+++ b/uv.lock
@@ -630,6 +630,35 @@ sphinx = [
 ]
 
 [[package]]
+name = "azure-core"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f3/b416179e408990df5db0d516283022dde0f5d0111d98c1a848e41853e81c/azure_core-1.41.0.tar.gz", hash = "sha256:f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a", size = 381042, upload-time = "2026-05-07T23:30:54.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/db/325c6d7312d2200251c52323878281045aaffcb5586612296484e4280eaa/azure_core-1.41.0-py3-none-any.whl", hash = "sha256:522b4011e8180b1a3dcd2024396a4e7fe9ac37fb8597db47163d230b5efe892d", size = 220920, upload-time = "2026-05-07T23:30:56.357Z" },
+]
+
+[[package]]
+name = "azure-identity"
+version = "1.25.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "msal" },
+    { name = "msal-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/0e/3a63efb48aa4a5ae2cfca61ee152fbcb668092134d3eb8bfda472dd5c617/azure_identity-1.25.3.tar.gz", hash = "sha256:ab23c0d63015f50b630ef6c6cf395e7262f439ce06e5d07a64e874c724f8d9e6", size = 286304, upload-time = "2026-03-13T01:12:20.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/9a/417b3a533e01953a7c618884df2cb05a71e7b68bdbce4fbdb62349d2a2e8/azure_identity-1.25.3-py3-none-any.whl", hash = "sha256:f4d0b956a8146f30333e071374171f3cfa7bdb8073adb8c3814b65567aa7447c", size = 192138, upload-time = "2026-03-13T01:12:22.951Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3094,6 +3123,32 @@ wheels = [
 ]
 
 [[package]]
+name = "msal"
+version = "1.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/cb/b02b0f748ac668922364ccb3c3bff5b71628a05f5adfec2ba2a5c3031483/msal-1.36.0.tar.gz", hash = "sha256:3f6a4af2b036b476a4215111c4297b4e6e236ed186cd804faefba23e4990978b", size = 174217, upload-time = "2026-04-09T10:20:33.525Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/d3/414d1f0a5f6f4fe5313c2b002c54e78a3332970feb3f5fed14237aa17064/msal-1.36.0-py3-none-any.whl", hash = "sha256:36ecac30e2ff4322d956029aabce3c82301c29f0acb1ad89b94edcabb0e58ec4", size = 121547, upload-time = "2026-04-09T10:20:32.336Z" },
+]
+
+[[package]]
+name = "msal-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/99/5d239b6156eddf761a636bded1118414d161bd6b7b37a9335549ed159396/msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4", size = 23315, upload-time = "2025-03-14T23:51:03.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/75/bd9b7bb966668920f06b200e84454c8f3566b102183bc55c5473d96cb2b9/msal_extensions-1.3.1-py3-none-any.whl", hash = "sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca", size = 20583, upload-time = "2025-03-14T23:51:03.016Z" },
+]
+
+[[package]]
 name = "msgspec"
 version = "0.21.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3147,6 +3202,50 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/42/b4/c0f54632103846b658a10930025f4de41c8724b5e4805a5f3b395586cb7e/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0d03867786e5d7ba25d666df4b11320c27170f4aeafcb8e3a8b0a50a4fb742ca", size = 231822, upload-time = "2026-04-12T21:44:46.343Z" },
     { url = "https://files.pythonhosted.org/packages/ea/1d/0d85cc79d0ccf5508e9c846cc66552a6a16bf92abd1dbd8362617f7b35cd/msgspec-0.21.1-cp314-cp314t-win_amd64.whl", hash = "sha256:740fbf1c9d59992ca3537d6fbe9ebbf9eaf726a65fbf31448e0ecbc710697a63", size = 206650, upload-time = "2026-04-12T21:44:47.601Z" },
     { url = "https://files.pythonhosted.org/packages/90/91/56c5d560f20e6c20e9e4f55bd0e458f7f162aa689ee350346c04c48eac0b/msgspec-0.21.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0d2cc73df6058d811a126ac3a8ad63a4dfa210c82f9cf5a004802eaf4712de90", size = 183149, upload-time = "2026-04-12T21:44:48.833Z" },
+]
+
+[[package]]
+name = "mssql-python"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-identity" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/46/10560fd47990859ee3e02970fc8a03c76f88136b81f9dea9b38b3f89749b/mssql_python-1.7.1-cp310-cp310-macosx_15_0_universal2.whl", hash = "sha256:3208a49455bb99ea0dbd15dc18855feb755c4c74257d39a49722eb294220a1be", size = 28109464, upload-time = "2026-05-20T10:46:25.352Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/de/9237817b6192f4ffa5cf7f0e6673d22cba38eabc210b444a9ad8cd51adf1/mssql_python-1.7.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:ae667e8a716ce5ed21bdb5b1377bc5889addfc4e93b3c19c2924fb35f942f4aa", size = 25039662, upload-time = "2026-05-20T10:46:29.872Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/61/d3f15c2adbc6f2efe093981f703ca5b3d826c22a59fb8742d2a647968a67/mssql_python-1.7.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:1807269903ebb7c61a16a773ccf2f6faae6dd65e181802b28b9b11ea4b04c541", size = 25286139, upload-time = "2026-05-20T10:46:33.668Z" },
+    { url = "https://files.pythonhosted.org/packages/28/25/b22db4241c084bf42c601b87dd94cb23c5da1da1c72ef5c0166dfee68003/mssql_python-1.7.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:92bb73fe9dc0ce24a130ea357f2eec393118ebfa469ecfc8b829e7efccbc7794", size = 24970539, upload-time = "2026-05-20T10:46:37.741Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e8/6dd2b34273c7d4fc05007a2a8fdc2da4d79870bfd1f7d6b6df3022c34853/mssql_python-1.7.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0b6699a23cb02134c9b74b1d739bbfed311467587eb36a851d7ef83d9542af71", size = 25211307, upload-time = "2026-05-20T10:46:41.52Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/9c/d6e5a91e80db6daa875372a553c33bf6a39b036a5e7e277c747caafe4170/mssql_python-1.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:1b7c6f0d87289aaa848ac4ffed58a912f20b3e5ac797625b2b3ad6b29da420e7", size = 15466082, upload-time = "2026-05-20T10:46:44.986Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d1/435b395c33c85a207357684546a47e29b8d2a47561a3e50bfbcfa4705e80/mssql_python-1.7.1-cp311-cp311-macosx_15_0_universal2.whl", hash = "sha256:9d2f70c39cf3ba449c4288f459a97ed981cbbb690741ff2c923c4692c8927336", size = 28110812, upload-time = "2026-05-20T10:46:48.799Z" },
+    { url = "https://files.pythonhosted.org/packages/af/ea/899798a996456988cbe5c00d432e1a10a33873f5db0e6575a1447e6e1472/mssql_python-1.7.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:521cde6b60b5cf7cb21df78550d9c39a5625f0f9daf083ebd4e49ff40c25a620", size = 25540223, upload-time = "2026-05-20T10:46:52.886Z" },
+    { url = "https://files.pythonhosted.org/packages/94/eb/f37ba9771626be8727f39f02c1f313e223a0f8458a82b7daf5ca8c9403df/mssql_python-1.7.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:43d6953be8439331ae7e5ced93b969a36e9daa34ec54fae94e0efab8b5f797a6", size = 25951778, upload-time = "2026-05-20T10:46:56.477Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cf/b278405e118cd3377ca7406934e02a5bf07a82413813fa2430a198cbe1bb/mssql_python-1.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:12415b09920397f0c34e070ffddac5cee263409fa3e995e532f7667ba837c78f", size = 25405073, upload-time = "2026-05-20T10:47:00.299Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/0e/979aa615a653b1e80eed1b6a90f4c14fb0e12b163df41bbbc7318d9b4417/mssql_python-1.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bcf2e249806c4880c0be0eb341d71ea0908fc4ba9b2892bca39fc73d7b80c6d9", size = 25803920, upload-time = "2026-05-20T10:47:03.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/53/601fecc8ebfa946ad1eee1bcb96b6850ad9ff8b4ffb24bcc7a055311c579/mssql_python-1.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:c544700c17d0f475499f685fb1774f00891110606158b9276eb79438d60d92a4", size = 15464300, upload-time = "2026-05-20T10:47:06.954Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/77/7382591d5d3324425b32377f5b4a5ebef57fae0d6d3f750cac0fa5dfbd70/mssql_python-1.7.1-cp311-cp311-win_arm64.whl", hash = "sha256:95fe46716f50092014dba582d783759491f298245a572b42374ee5dacfea3e37", size = 18528454, upload-time = "2026-05-20T10:47:09.967Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/4c/8a4d582f16faa63fd73676048c0dac381a8c629ae049d47ff6e5f821c0af/mssql_python-1.7.1-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:3d4281657a3cac35b8fae031fa8d4b94d19d2e39749158a58af7de6891ae81da", size = 28118715, upload-time = "2026-05-20T10:47:13.791Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/56/b9c327625fa6ab524da866683eab80957bc7c57ed0200e5aaad2b0add0b2/mssql_python-1.7.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:32af320f29d32dc34489650e94d16fad5f0e7affb9ecdc229ef2612a45a48645", size = 26036075, upload-time = "2026-05-20T10:47:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/f4/137e7711db057bd5ab6c9d70c1e2b10385427a7450d4754526bf11926667/mssql_python-1.7.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:dc1dcde69bac5b90193e37cd7b3a193dfb41cdfeb4460643dd8adc2d312ffefd", size = 26612898, upload-time = "2026-05-20T10:47:21.565Z" },
+    { url = "https://files.pythonhosted.org/packages/55/35/3c8d799a24392ccdb903582f1788968f8b19998e514f666d4891af452044/mssql_python-1.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:12a0da62dc7972980586b4636febac6281040b0a7c8ec07bd2983448bfcf586e", size = 25834286, upload-time = "2026-05-20T10:47:25.569Z" },
+    { url = "https://files.pythonhosted.org/packages/33/85/ce43969245bc0cf794bdaa5d5425927f4531b17bfe35cf04f9fb7c44a8ea/mssql_python-1.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fa551d6a907614936c25c50e964580cad492b970b1f4ea55802a2420f3e50fb3", size = 26393056, upload-time = "2026-05-20T10:47:29.363Z" },
+    { url = "https://files.pythonhosted.org/packages/05/77/30812559f61dc404090793c38aaec07d508598d0f1ceb594d914fecf89aa/mssql_python-1.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:26fe105bdb73561e2b19011d75fe0832243d440ab200519c1658924a7485379a", size = 15464577, upload-time = "2026-05-20T10:47:32.722Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ad/8a2d579bb4e6613ea5fe391a16d3fff3c1de169c27949df623de7b314327/mssql_python-1.7.1-cp312-cp312-win_arm64.whl", hash = "sha256:45b02a8247062f5bc84b2233df81b3f56a12e711c65159053dc426102d2b459e", size = 18528548, upload-time = "2026-05-20T10:47:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cb/3fccc5d85fb50bb9691c041dd47a16125003f4131872f6ab4ff918c4e039/mssql_python-1.7.1-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:b823a42226977b26d599f37b265d3fde9a3c26338c1f6849fdd5160428a48886", size = 28118712, upload-time = "2026-05-20T10:47:40.419Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1a/a7a67b21290bc9abc4e44dd1fd3010a9017f0c9076084642772b6ccca2cc/mssql_python-1.7.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:e27aa83b16564dd2bd93d78531cffa07558b5c721c144b5ce30bd39670a77d3c", size = 26536189, upload-time = "2026-05-20T10:47:44.453Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/43/bb574707a4510787a98d1fc4b0b0a959c30677136dfbb9c04bd9235a9e3d/mssql_python-1.7.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:2199e61c410cc14a1d17738b1d0f4187120abad8c9c7d5c93f71c3b0d54f1379", size = 27277981, upload-time = "2026-05-20T10:47:48.626Z" },
+    { url = "https://files.pythonhosted.org/packages/14/9e/c7a32a874d0bb06f41bdbe9aa929c7e922c1af0a642d70114b9b28f196a1/mssql_python-1.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:77d4c1bc4de3b5b95a16ce581de8e1629cb5709078e622821b8cccafaed0bca4", size = 26266809, upload-time = "2026-05-20T10:47:52.438Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/21/732aadf20f2ec168af8a04c44b93d8a0dd208926458da1edca5a62f207a4/mssql_python-1.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5d4a2794e692ff598666203e93759182e941f7d7751be370924f94fd97b96bfd", size = 26985887, upload-time = "2026-05-20T10:47:56.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/a9/cbac3dc17300c17dc2f1c4251fadfed8f337f5dcc8afb270ee847d58a80a/mssql_python-1.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:31a404e73bd49dd6566ef6fb7deb7a90e5fa2eb60cdb89232c388af9ea83d8fb", size = 15463865, upload-time = "2026-05-20T10:48:00.1Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/57/d9f43b228c863df962fe1375ecb9b1a26782214fff77cd78692203aaf473/mssql_python-1.7.1-cp313-cp313-win_arm64.whl", hash = "sha256:89580a585d4309111968c76c5af7bd226c881c786c92f22eaed5586ddacf4aaa", size = 18527852, upload-time = "2026-05-20T10:48:03.29Z" },
+    { url = "https://files.pythonhosted.org/packages/89/d9/2c94c1bee748b71cd84d6a2e520890dbd40fb8a25cd0c74f4290dad300cd/mssql_python-1.7.1-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:d31a6c815c8a3709fc1f5b59906376b63844c085b5cd0f93ca451be1db82438d", size = 28111978, upload-time = "2026-05-20T10:48:06.789Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/df/83be720f21a8e7e3a449012cfbc1b4cc3e306c0c062ad6bb2ce5526e8704/mssql_python-1.7.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a47f76f9927d65e0978ce7683049a2f481fdbbddd6d314ce9253fdc8236ebbae", size = 27038204, upload-time = "2026-05-20T10:48:10.757Z" },
+    { url = "https://files.pythonhosted.org/packages/da/24/54a301d1451e61af98f25d60f7f89345b93d7debd8dcfd112998312b844e/mssql_python-1.7.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:2d372e9d4bbad8b89d4b0154dbb9a3e6a4b8e473b88449842d75bf426199f008", size = 27945219, upload-time = "2026-05-20T10:48:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/7d/7c02637f3c85536f1694b102a2733277b81e9db9cf96739d62be79ebd7bd/mssql_python-1.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b6013180e2b5f252f5f7dc3008c6964482c14e50d263dd55d883f9c93f8cbc22", size = 26703582, upload-time = "2026-05-20T10:48:18.98Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/13/f50469590ac8b7ffbbbd9ef062ec75d6926c93df949b05f2dd1d398f778c/mssql_python-1.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:77f50558171f01b5d26e83ca55fd6253a241a63f053ea36b76614328be3bafb1", size = 27579144, upload-time = "2026-05-20T10:48:23.133Z" },
+    { url = "https://files.pythonhosted.org/packages/56/bf/b582b9f8b6b39b414491a91835e475af839a99933b16e612d25b94364090/mssql_python-1.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:a4fc35cc1c3de6f7741334f76fb81a682daeaefffa33e7cf6a3b69766254d910", size = 15985357, upload-time = "2026-05-20T10:48:26.345Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/76/ee2787ffd725e2c58370b73b55c8c8840f688f6cb534e39e14c2e7798511/mssql_python-1.7.1-cp314-cp314-win_arm64.whl", hash = "sha256:6a9d2aed556a4a4c01c0ba02f19671020bbf5b268bd9eb3546bcbe2b9ef07201", size = 19146020, upload-time = "2026-05-20T10:48:30.38Z" },
 ]
 
 [[package]]
@@ -5005,6 +5104,23 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pymssql"
 version = "2.3.13"
 source = { registry = "https://pypi.org/simple" }
@@ -6461,6 +6577,9 @@ litestar = [
 msgspec = [
     { name = "msgspec" },
 ]
+mssql-python = [
+    { name = "mssql-python" },
+]
 mypyc = [
     { name = "sqlglot", extra = ["c"] },
 ]
@@ -6719,6 +6838,7 @@ requires-dist = [
     { name = "litestar", marker = "extra == 'litestar'", specifier = ">=2.22.0" },
     { name = "msgspec", marker = "extra == 'msgspec'" },
     { name = "msgspec", marker = "extra == 'performance'" },
+    { name = "mssql-python", marker = "extra == 'mssql-python'", specifier = ">=1.7" },
     { name = "mypy-extensions" },
     { name = "mysql-connector-python", marker = "python_full_version >= '3.12' and extra == 'mysql-connector'", specifier = "<9.7.0" },
     { name = "mysql-connector-python", marker = "python_full_version < '3.12' and extra == 'mysql-connector'" },
@@ -6750,7 +6870,7 @@ requires-dist = [
     { name = "typing-extensions" },
     { name = "uuid-utils", marker = "extra == 'uuid'" },
 ]
-provides-extras = ["adbc", "adk", "aiomysql", "aioodbc", "aiosqlite", "alloydb", "arrow-odbc", "asyncmy", "asyncpg", "attrs", "bigquery", "cloud-sql", "cockroachdb", "duckdb", "fastapi", "flask", "fsspec", "litestar", "msgspec", "mypyc", "mysql-connector", "nanoid", "obstore", "opentelemetry", "oracledb", "orjson", "pandas", "performance", "polars", "prometheus", "psqlpy", "psycopg", "pydantic", "pymssql", "pymysql", "sanic", "spanner", "starlette", "uuid"]
+provides-extras = ["adbc", "adk", "aiomysql", "aioodbc", "aiosqlite", "alloydb", "arrow-odbc", "asyncmy", "asyncpg", "attrs", "bigquery", "cloud-sql", "cockroachdb", "duckdb", "fastapi", "flask", "fsspec", "litestar", "msgspec", "mssql-python", "mypyc", "mysql-connector", "nanoid", "obstore", "opentelemetry", "oracledb", "orjson", "pandas", "performance", "polars", "prometheus", "psqlpy", "psycopg", "pydantic", "pymssql", "pymysql", "sanic", "spanner", "starlette", "uuid"]
 
 [package.metadata.requires-dev]
 benchmarks = [


### PR DESCRIPTION
## Summary

Adds two new SQL Server-capable adapters and the shared MSSQL data-dictionary dialect that backs them.

### `sqlspec.adapters.arrow_odbc`
- Sync Arrow-over-ODBC adapter built on the [`arrow-odbc`](https://pypi.org/project/arrow-odbc/) bindings. Streams `pyarrow.RecordBatchReader` results from any ODBC-compliant driver, purpose-built for analytic data transfer.
- Auto-detects SQL Server from the ODBC DBMS name and dispatches to the shared MSSQL data dictionary, so it ships with first-class SQL Server schema introspection out of the box.
- New optional extra: `arrow-odbc` (depends on `arrow-odbc>=10.4` and `pyarrow`).
- No ADK or Litestar store; ODBC adapters are read-heavy Arrow-transfer surfaces and the fit is deferred.

### `sqlspec.adapters.mssql_python`
- Sync + async adapter on top of Microsoft's official [`mssql-python`](https://pypi.org/project/mssql-python/) driver.
- Ships data dictionary, parameter profile (qmark + pyformat), Litestar `Store`, events queue store, type converter, and migrations tracker.
- Registers the `mssql_python` driver profile and `mssql_python` pytest marker. New optional extra: `mssql-python` (depends on `mssql-python>=1.7`).
- ADK store is deferred until the ADK 2.0 contract lands.

### Shared MSSQL data-dictionary dialect
- New `sqlspec/data_dictionary/dialects/mssql.py` plus introspection SQL files under `sqlspec/data_dictionary/sql/mssql/` (`tables`, `columns`, `indexes`, `foreign_keys`, `version`).
- Registered with `tsql` / `sqlserver` aliases. Both adapters above consume it.

### Core changes
- T-SQL `GO` batch-separator handling in `sqlspec/core/splitter.py` so multi-batch T-SQL scripts split correctly.
- `ArrowResult.get_data()` now honors whatever `return_format` produced (`table` / `reader` / `batch` / `batches`) instead of always coercing to `pa.Table`. Table-only accessors (`column_names`, `num_rows`, `to_pandas`, `to_polars`, `to_dict`, `__len__`, `__iter__`, storage writers) route through a private `_as_table()` helper.

### Docs
- Reference pages at `docs/reference/adapters/arrow_odbc.rst` and `docs/reference/adapters/mssql_python.rst`, plus index entries and feature-comparison rows.