### PR TITLE
ci: free runner disk before docker image load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,14 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev
 
+      - name: Free runner disk before docker work
+        run: |
+          set -eu
+          df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL /usr/local/lib/android /usr/local/share/boost
+          sudo apt-get clean
+          df -h /
+
       - name: Cache docker images
         id: docker-image-cache
         uses: actions/cache@v5
@@ -136,7 +144,9 @@ jobs:
 
       - name: Load cached docker images
         if: steps.docker-image-cache.outputs.cache-hit == 'true'
-        run: docker load -i /tmp/docker-images/sqlspec-test-images.tar
+        run: |
+          docker load -i /tmp/docker-images/sqlspec-test-images.tar
+          rm -f /tmp/docker-images/sqlspec-test-images.tar
 
       - name: Pre-pull docker images
         if: steps.docker-image-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

`test-linux` matrix jobs intermittently fail with `no space left on device` while `docker load`s the cached image tarball:

```
Run docker load -i /tmp/docker-images/sqlspec-test-images.tar
write /usr/lib/x86_64-linux-gnu/libLLVM.so.19.1: no space left on device
Error: Process completed with exit code 1.
```

GitHub-hosted ubuntu runners ship with ~14 GB free disk. After:

| Stage | Disk consumed |
| --- | --- |
| `uv sync --all-extras --dev` | ~3–4 GB venv |
| `actions/cache` restoring `docker-images-v1-*` | ~2.4 GB tar + ~5–6 GB uncompressed |
| `docker load` extracting image layers | ~5–6 GB into `/var/lib/docker/` |

…the runner runs out of space partway through extracting a Mesa/LLVM layer (the symptom file varies; `libLLVM.so.19.1` was the unlucky write last run).

## Fix

Two minimal subtractive changes to `test-linux` in `.github/workflows/ci.yml`:

1. New `Free runner disk before docker work` step. Removes pre-installed runner content we never touch (`dotnet`, `GHC`, `CodeQL`, Android SDK, Boost) plus `apt` cache — frees ~25 GB. Logs `df -h /` before and after for visibility on future regressions.
2. After `docker load` consumes the tarball, delete it from `/tmp/docker-images/` so the ~5 GB doesn't sit on disk through the test run.