### PR TITLE
fix(tests): add __init__.py to sqlite unit-test package

### DIFF
--- a/tests/unit/adapters/sqlite/__init__.py
+++ b/tests/unit/adapters/sqlite/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for sqlite adapter."""


### PR DESCRIPTION
## Summary

`tests/unit/adapters/sqlite/` is the only adapter unit-test directory still missing an `__init__.py`. Without the marker file, pytest's default rootdir-prepend import mode loads `tests/unit/adapters/sqlite/test_rowcount_optimization.py` as the top-level module `test_rowcount_optimization`, populating `sys.modules` on the worker.

The filename doesn't collide with anything in the current tree, so this isn't breaking CI today — but the same anti-pattern recently caused a hard-to-diagnose `Module 'test_config' has no attribute 'config'` failure on the `feat/mssql-python-adapter` branch (fixed by adding `__init__.py` to `tests/unit/adapters/test_mssql_python/`).

This brings sqlite in line with every other adapter test package.
