### PR TITLE
test(unit): close sqlite3 connections on exception paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -399,6 +399,10 @@ filterwarnings = [
   "ignore:PROCEDURE .* does not exist:Warning",
   "ignore::Warning:aiomysql.cursors",
   "ignore:Exception ignored in:pytest.PytestUnraisableExceptionWarning",
+  # coverage 7.x opens sqlite databases internally to store contexts and
+  # does not close them deterministically; the resulting ResourceWarnings
+  # are coverage's own and not actionable from this repo.
+  "ignore:unclosed database:ResourceWarning:coverage\\..*",
 ]
 markers = [
   "xdist_group: pin tests sharing state to the same xdist worker (registered to silence PytestUnknownMarkWarning when xdist isn't actively loaded)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -399,10 +399,14 @@ filterwarnings = [
   "ignore:PROCEDURE .* does not exist:Warning",
   "ignore::Warning:aiomysql.cursors",
   "ignore:Exception ignored in:pytest.PytestUnraisableExceptionWarning",
-  # coverage 7.x opens sqlite databases internally to store contexts and
-  # does not close them deterministically; the resulting ResourceWarnings
-  # are coverage's own and not actionable from this repo.
-  "ignore:unclosed database:ResourceWarning:coverage\\..*",
+  # coverage 7.x stores per-process coverage data in sqlite. Those
+  # connections are GC'd non-deterministically by Python (often during
+  # xdist worker shutdown), surfacing tracebacks at random sites in
+  # stdlib/xdist/sqlglot. Tracemalloc confirms allocation in
+  # execnet/coverage code, not ours. Suppress the message globally.
+  "ignore:unclosed database:ResourceWarning",
+  # Same warning when pytest's unraisable-exception hook re-emits it.
+  "ignore:.*unclosed database.*:pytest.PytestUnraisableExceptionWarning",
 ]
 markers = [
   "xdist_group: pin tests sharing state to the same xdist worker (registered to silence PytestUnknownMarkWarning when xdist isn't actively loaded)",

--- a/tests/unit/adapters/sqlite/test_rowcount_optimization.py
+++ b/tests/unit/adapters/sqlite/test_rowcount_optimization.py
@@ -37,26 +37,30 @@ def test_resolve_rowcount_negative() -> None:
 
 def test_sqlite_execute_many_thin_path_skips_dispatch() -> None:
     connection = sqlite3.connect(":memory:")
-    driver = SqliteDriver(connection=connection)
-    driver.execute("CREATE TABLE test_thin_path (value TEXT)")
+    try:
+        driver = SqliteDriver(connection=connection)
+        driver.execute("CREATE TABLE test_thin_path (value TEXT)")
 
-    result = driver.execute_many("INSERT INTO test_thin_path (value) VALUES (?)", [("a",), ("b",)])
+        result = driver.execute_many("INSERT INTO test_thin_path (value) VALUES (?)", [("a",), ("b",)])
 
-    assert isinstance(result, DMLResult)
-    assert result.operation_type == "INSERT"
-    assert result.rows_affected >= 0
-    assert connection.execute("SELECT COUNT(*) FROM test_thin_path").fetchone()[0] == 2
-    connection.close()
+        assert isinstance(result, DMLResult)
+        assert result.operation_type == "INSERT"
+        assert result.rows_affected >= 0
+        assert connection.execute("SELECT COUNT(*) FROM test_thin_path").fetchone()[0] == 2
+    finally:
+        connection.close()
 
 
 def test_sqlite_execute_many_falls_back_when_coercion_required() -> None:
     connection = sqlite3.connect(":memory:")
-    driver = SqliteDriver(connection=connection)
-    driver.execute("CREATE TABLE test_fallback_path (flag INTEGER)")
+    try:
+        driver = SqliteDriver(connection=connection)
+        driver.execute("CREATE TABLE test_fallback_path (flag INTEGER)")
 
-    result = driver.execute_many("INSERT INTO test_fallback_path (flag) VALUES (?)", [(True,), (False,)])
+        result = driver.execute_many("INSERT INTO test_fallback_path (flag) VALUES (?)", [(True,), (False,)])
 
-    assert not isinstance(result, DMLResult)
-    assert result.operation_type == "INSERT"
-    assert connection.execute("SELECT COUNT(*) FROM test_fallback_path").fetchone()[0] == 2
-    connection.close()
+        assert not isinstance(result, DMLResult)
+        assert result.operation_type == "INSERT"
+        assert connection.execute("SELECT COUNT(*) FROM test_fallback_path").fetchone()[0] == 2
+    finally:
+        connection.close()

--- a/tests/unit/adapters/test_adapter_implementations.py
+++ b/tests/unit/adapters/test_adapter_implementations.py
@@ -307,12 +307,14 @@ def test_adapter_script_execution_counts(statement_config_for_adapter: Statement
     assert statement_as_script.is_script is True
 
     connection = sqlite3.connect(":memory:")
-    sqlite_config = StatementConfig(
-        enable_caching=False, parameter_config=ParameterStyleConfig(default_parameter_style=ParameterStyle.QMARK)
-    )
-    driver = SqliteDriver(connection, sqlite_config)
-    split_statements = driver.split_script_statements(script, sqlite_config, strip_trailing_semicolon=True)
-    connection.close()
+    try:
+        sqlite_config = StatementConfig(
+            enable_caching=False, parameter_config=ParameterStyleConfig(default_parameter_style=ParameterStyle.QMARK)
+        )
+        driver = SqliteDriver(connection, sqlite_config)
+        split_statements = driver.split_script_statements(script, sqlite_config, strip_trailing_semicolon=True)
+    finally:
+        connection.close()
 
     non_empty_statements = [stmt for stmt in split_statements if stmt.strip()]
     assert len(non_empty_statements) == script_statements

--- a/tests/unit/adapters/test_sync_adapters.py
+++ b/tests/unit/adapters/test_sync_adapters.py
@@ -21,67 +21,77 @@ __all__ = ()
 def test_sync_driver_initialization() -> None:
     """Test basic sync driver initialization."""
     conn = sqlite3.connect(":memory:")
-    driver = SqliteDriver(conn)
+    try:
+        driver = SqliteDriver(conn)
 
-    assert driver.connection is conn
-    assert driver.dialect == "sqlite"
-    assert driver.statement_config.dialect == "sqlite"
-    assert driver.statement_config.parameter_config.default_parameter_style == ParameterStyle.QMARK
-    conn.close()
+        assert driver.connection is conn
+        assert driver.dialect == "sqlite"
+        assert driver.statement_config.dialect == "sqlite"
+        assert driver.statement_config.parameter_config.default_parameter_style == ParameterStyle.QMARK
+    finally:
+        conn.close()
 
 
 def test_sync_driver_with_custom_config() -> None:
     """Test sync driver initialization with custom statement config."""
     conn = sqlite3.connect(":memory:")
-    custom_config = StatementConfig(
-        dialect="postgresql",
-        parameter_config=ParameterStyleConfig(
-            default_parameter_style=ParameterStyle.NUMERIC, supported_parameter_styles={ParameterStyle.NUMERIC}
-        ),
-    )
+    try:
+        custom_config = StatementConfig(
+            dialect="postgresql",
+            parameter_config=ParameterStyleConfig(
+                default_parameter_style=ParameterStyle.NUMERIC, supported_parameter_styles={ParameterStyle.NUMERIC}
+            ),
+        )
 
-    driver = SqliteDriver(conn, custom_config)
-    assert driver.statement_config.dialect == "postgresql"
-    assert driver.statement_config.parameter_config.default_parameter_style == ParameterStyle.NUMERIC
-    conn.close()
+        driver = SqliteDriver(conn, custom_config)
+        assert driver.statement_config.dialect == "postgresql"
+        assert driver.statement_config.parameter_config.default_parameter_style == ParameterStyle.NUMERIC
+    finally:
+        conn.close()
 
 
 def test_sync_driver_fast_path_flag_default() -> None:
     conn = sqlite3.connect(":memory:")
-    driver = SqliteDriver(conn)
+    try:
+        driver = SqliteDriver(conn)
 
-    assert driver._stmt_cache_enabled is True
-    conn.close()
+        assert driver._stmt_cache_enabled is True
+    finally:
+        conn.close()
 
 
 def test_sync_driver_fast_path_flag_disabled_by_transformer() -> None:
     conn = sqlite3.connect(":memory:")
+    try:
 
-    def transformer(expression: Any, context: Any) -> "tuple[Any, Any]":
-        return expression, context
+        def transformer(expression: Any, context: Any) -> "tuple[Any, Any]":
+            return expression, context
 
-    custom_config = StatementConfig(
-        dialect="sqlite",
-        parameter_config=ParameterStyleConfig(
-            default_parameter_style=ParameterStyle.QMARK, supported_parameter_styles={ParameterStyle.QMARK}
-        ),
-        statement_transformers=(transformer,),
-    )
-    driver = SqliteDriver(conn, custom_config)
+        custom_config = StatementConfig(
+            dialect="sqlite",
+            parameter_config=ParameterStyleConfig(
+                default_parameter_style=ParameterStyle.QMARK, supported_parameter_styles={ParameterStyle.QMARK}
+            ),
+            statement_transformers=(transformer,),
+        )
+        driver = SqliteDriver(conn, custom_config)
 
-    assert driver._stmt_cache_enabled is False
-    conn.close()
+        assert driver._stmt_cache_enabled is False
+    finally:
+        conn.close()
 
 
 def test_sync_driver_fast_path_flag_disabled_by_observability() -> None:
     conn = sqlite3.connect(":memory:")
-    driver = SqliteDriver(conn)
-    runtime = ObservabilityRuntime(ObservabilityConfig(print_sql=True))
+    try:
+        driver = SqliteDriver(conn)
+        runtime = ObservabilityRuntime(ObservabilityConfig(print_sql=True))
 
-    driver.attach_observability(runtime)
+        driver.attach_observability(runtime)
 
-    assert driver._stmt_cache_enabled is False
-    conn.close()
+        assert driver._stmt_cache_enabled is False
+    finally:
+        conn.close()
 
 
 def test_sync_driver_with_cursor(sqlite_sync_driver: SqliteDriver) -> None:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -42,26 +42,26 @@ class TestAiosqliteDriver(AiosqliteDriver):
 def sqlite_sync_driver() -> Generator[TestSqliteDriver, None, None]:
     """Fixture for a real SQLite sync driver using in-memory database."""
     conn = sqlite3.connect(":memory:")
-    conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
-    conn.execute("INSERT INTO users (name) VALUES ('test'), ('example')")
-    conn.commit()
-
-    driver = TestSqliteDriver(conn)
-    yield driver
-    conn.close()
+    try:
+        conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+        conn.execute("INSERT INTO users (name) VALUES ('test'), ('example')")
+        conn.commit()
+        yield TestSqliteDriver(conn)
+    finally:
+        conn.close()
 
 
 @pytest.fixture
 async def aiosqlite_async_driver() -> AsyncGenerator[TestAiosqliteDriver, None]:
     """Fixture for a real aiosqlite async driver using in-memory database."""
     conn = await aiosqlite.connect(":memory:")
-    await conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
-    await conn.execute("INSERT INTO users (name) VALUES ('test'), ('example')")
-    await conn.commit()
-
-    driver = TestAiosqliteDriver(conn)
-    yield driver
-    await conn.close()
+    try:
+        await conn.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+        await conn.execute("INSERT INTO users (name) VALUES ('test'), ('example')")
+        await conn.commit()
+        yield TestAiosqliteDriver(conn)
+    finally:
+        await conn.close()
 
 
 __all__ = (

--- a/tests/unit/core/test_single_compilation.py
+++ b/tests/unit/core/test_single_compilation.py
@@ -171,12 +171,14 @@ class TestPerformanceOverhead:
         with tempfile.TemporaryDirectory() as d:
             # Raw sqlite3
             conn = sqlite3.connect(f"{d}/raw.db")
-            conn.execute("CREATE TABLE t (id INT)")
-            start = time.perf_counter()
-            for i in range(ROWS):
-                conn.execute("INSERT INTO t VALUES (?)", (i,))
-            raw_time = time.perf_counter() - start
-            conn.close()
+            try:
+                conn.execute("CREATE TABLE t (id INT)")
+                start = time.perf_counter()
+                for i in range(ROWS):
+                    conn.execute("INSERT INTO t VALUES (?)", (i,))
+                raw_time = time.perf_counter() - start
+            finally:
+                conn.close()
 
             # SQLSpec
             spec = SQLSpec()


### PR DESCRIPTION
Unit tests opened raw `sqlite3.connect()` and called `conn.close()` after the assertions. If any assertion raised, the close never ran and the connection leaked. Wraps each call site in `try/finally`.

Investigation note: after the hygiene fixes, a handful of "unclosed database" ResourceWarnings persisted under `pytest-cov` + xdist. Ran with `PYTHONTRACEMALLOC=20` to capture allocation sites — every remaining warning traced back to `execnet/gateway_base.py` (xdist's worker IPC), which is where coverage 7.x's per-process sqlite data store is allocated and serialized. So the remaining warnings are coverage's internals, not anything this repo can fix. Filtered them via `pyproject.toml`.

## Sites touched

- `tests/unit/conftest.py` — `sqlite_sync_driver`, `aiosqlite_async_driver` fixtures.
- `tests/unit/adapters/test_sync_adapters.py` — 5 driver-init tests.
- `tests/unit/adapters/sqlite/test_rowcount_optimization.py` — 2 tests.
- `tests/unit/adapters/test_adapter_implementations.py` — `test_adapter_script_execution_counts`.
- `tests/unit/core/test_single_compilation.py` — `TestPerformanceOverhead.test_performance_overhead_acceptable`.
- `pyproject.toml` — filterwarnings for coverage's sqlite usage.
