### PR TITLE
fix(core): use Oracle-safe generated parameter names

### DIFF
--- a/sqlspec/core/statement.py
+++ b/sqlspec/core/statement.py
@@ -996,9 +996,9 @@ class SQL:
     # ==========================================================================
 
     def _generate_sql_param_name(self, base_name: str) -> str:
-        """Generate unique parameter name with _sqlspec_ prefix.
+        """Generate unique parameter name with parameter_ prefix.
 
-        Uses _sqlspec_ prefix to avoid collision with user-provided parameters.
+        Uses parameter_ prefix to avoid collision with user-provided parameters.
         Auto-generated parameters are namespaced to prevent conflicts.
 
         Args:
@@ -1007,7 +1007,7 @@ class SQL:
         Returns:
             A unique parameter name that doesn't exist in current parameters
         """
-        prefixed_base = f"_sqlspec_{base_name}"
+        prefixed_base = f"parameter_{base_name}"
         current_index = self._sql_param_counters.get(prefixed_base, 0)
 
         if prefixed_base not in self._named_parameters:

--- a/tests/unit/core/test_sql_modifiers.py
+++ b/tests/unit/core/test_sql_modifiers.py
@@ -6,8 +6,20 @@ and select_only functionality added to the SQL class.
 
 import pytest
 
-from sqlspec.core import SQL
+from sqlspec.core import SQL, ParameterStyle, ParameterStyleConfig, StatementConfig
 from sqlspec.exceptions import SQLSpecError
+
+
+def _named_colon_config() -> StatementConfig:
+    """Create a statement config that preserves named-colon placeholders."""
+    return StatementConfig(
+        parameter_config=ParameterStyleConfig(
+            default_parameter_style=ParameterStyle.NAMED_COLON,
+            supported_parameter_styles={ParameterStyle.NAMED_COLON},
+            default_execution_parameter_style=ParameterStyle.NAMED_COLON,
+            supported_execution_parameter_styles={ParameterStyle.NAMED_COLON},
+        )
+    )
 
 
 def test_sql_where_eq_where_eq_creates_equality_condition() -> None:
@@ -16,8 +28,8 @@ def test_sql_where_eq_where_eq_creates_equality_condition() -> None:
     modified = stmt.where_eq("status", "active")
     assert "WHERE" in modified.raw_sql
     assert "status" in modified.raw_sql
-    assert "_sqlspec_status" in modified.named_parameters
-    assert modified.named_parameters["_sqlspec_status"] == "active"
+    assert "parameter_status" in modified.named_parameters
+    assert modified.named_parameters["parameter_status"] == "active"
 
 
 def test_sql_where_eq_where_eq_preserves_original() -> None:
@@ -34,8 +46,8 @@ def test_sql_where_eq_where_eq_chains_with_and() -> None:
     stmt = SQL("SELECT * FROM users")
     modified = stmt.where_eq("status", "active").where_eq("role", "admin")
     assert "AND" in modified.raw_sql
-    assert "_sqlspec_status" in modified.named_parameters
-    assert "_sqlspec_role" in modified.named_parameters
+    assert "parameter_status" in modified.named_parameters
+    assert "parameter_role" in modified.named_parameters
 
 
 def test_sql_where_neq_where_neq_creates_not_equal_condition() -> None:
@@ -44,8 +56,8 @@ def test_sql_where_neq_where_neq_creates_not_equal_condition() -> None:
     modified = stmt.where_neq("status", "deleted")
     assert "WHERE" in modified.raw_sql
     assert "<>" in modified.raw_sql or "!=" in modified.raw_sql
-    assert "_sqlspec_status" in modified.named_parameters
-    assert modified.named_parameters["_sqlspec_status"] == "deleted"
+    assert "parameter_status" in modified.named_parameters
+    assert modified.named_parameters["parameter_status"] == "deleted"
 
 
 def test_sql_where_comparisons_where_lt() -> None:
@@ -54,7 +66,7 @@ def test_sql_where_comparisons_where_lt() -> None:
     modified = stmt.where_lt("price", 100)
     assert "WHERE" in modified.raw_sql
     assert "<" in modified.raw_sql
-    assert modified.named_parameters["_sqlspec_price"] == 100
+    assert modified.named_parameters["parameter_price"] == 100
 
 
 def test_sql_where_comparisons_where_lte() -> None:
@@ -63,7 +75,7 @@ def test_sql_where_comparisons_where_lte() -> None:
     modified = stmt.where_lte("price", 100)
     assert "WHERE" in modified.raw_sql
     assert "<=" in modified.raw_sql
-    assert modified.named_parameters["_sqlspec_price"] == 100
+    assert modified.named_parameters["parameter_price"] == 100
 
 
 def test_sql_where_comparisons_where_gt() -> None:
@@ -72,7 +84,7 @@ def test_sql_where_comparisons_where_gt() -> None:
     modified = stmt.where_gt("price", 50)
     assert "WHERE" in modified.raw_sql
     assert ">" in modified.raw_sql
-    assert modified.named_parameters["_sqlspec_price"] == 50
+    assert modified.named_parameters["parameter_price"] == 50
 
 
 def test_sql_where_comparisons_where_gte() -> None:
@@ -81,7 +93,7 @@ def test_sql_where_comparisons_where_gte() -> None:
     modified = stmt.where_gte("price", 50)
     assert "WHERE" in modified.raw_sql
     assert ">=" in modified.raw_sql
-    assert modified.named_parameters["_sqlspec_price"] == 50
+    assert modified.named_parameters["parameter_price"] == 50
 
 
 def test_sql_where_like_where_like() -> None:
@@ -90,7 +102,7 @@ def test_sql_where_like_where_like() -> None:
     modified = stmt.where_like("name", "%john%")
     assert "WHERE" in modified.raw_sql
     assert "LIKE" in modified.raw_sql
-    assert modified.named_parameters["_sqlspec_name"] == "%john%"
+    assert modified.named_parameters["parameter_name"] == "%john%"
 
 
 def test_sql_where_like_where_ilike() -> None:
@@ -99,7 +111,7 @@ def test_sql_where_like_where_ilike() -> None:
     modified = stmt.where_ilike("name", "%john%")
     assert "WHERE" in modified.raw_sql
     assert "ILIKE" in modified.raw_sql
-    assert modified.named_parameters["_sqlspec_name"] == "%john%"
+    assert modified.named_parameters["parameter_name"] == "%john%"
 
 
 def test_sql_where_null_where_is_null() -> None:
@@ -167,10 +179,10 @@ def test_sql_where_between_where_between_creates_between_condition() -> None:
     assert "WHERE" in modified.raw_sql
     assert "BETWEEN" in modified.raw_sql
     assert "AND" in modified.raw_sql
-    assert "_sqlspec_total_low" in modified.named_parameters
-    assert "_sqlspec_total_high" in modified.named_parameters
-    assert modified.named_parameters["_sqlspec_total_low"] == 100
-    assert modified.named_parameters["_sqlspec_total_high"] == 500
+    assert "parameter_total_low" in modified.named_parameters
+    assert "parameter_total_high" in modified.named_parameters
+    assert modified.named_parameters["parameter_total_low"] == 100
+    assert modified.named_parameters["parameter_total_high"] == 500
 
 
 def test_sql_limit_limit_adds_limit_clause() -> None:
@@ -272,7 +284,34 @@ def test_parameter_generation_params_dont_collide_with_user_params() -> None:
     modified = stmt.where_eq("status", "active")
     assert "status" in modified.named_parameters
     assert modified.named_parameters["status"] == 1
-    assert "_sqlspec_status" in modified.named_parameters
+    assert "parameter_status" in modified.named_parameters
+
+
+def test_parameter_generation_avoids_generated_prefix_collision() -> None:
+    """Test generated params append suffixes when the namespace already exists."""
+    stmt = SQL("SELECT * FROM users WHERE id = :parameter_status", {"parameter_status": 1})
+    modified = stmt.where_eq("status", "active")
+    assert modified.named_parameters["parameter_status"] == 1
+    assert modified.named_parameters["parameter_status_1"] == "active"
+
+
+def test_sql_where_in_uses_oracle_safe_generated_names() -> None:
+    """Test where_in creates letter-leading generated parameters."""
+    stmt = SQL("SELECT * FROM users")
+    modified = stmt.where_in("status", ["active", "pending"])
+    assert "parameter_status_in_0" in modified.named_parameters
+    assert "parameter_status_in_1" in modified.named_parameters
+    assert "_sqlspec_status_in_0" not in modified.named_parameters
+
+
+def test_generated_parameter_names_are_safe_for_named_colon_placeholders() -> None:
+    """Test named-colon compilation does not expose underscore-leading binds."""
+    stmt = SQL("SELECT * FROM users", statement_config=_named_colon_config())
+    modified = stmt.where_eq("status", "active")
+    compiled_sql, parameters = modified.compile()
+    assert ":parameter_status" in compiled_sql
+    assert ":_sqlspec" not in compiled_sql
+    assert parameters == {"parameter_status": "active"}
 
 
 def test_cte_preservation_where_eq_preserves_cte() -> None:


### PR DESCRIPTION
## Summary

- change generated SQL modifier bind names from `_sqlspec_*` to `parameter_*` so named-colon placeholders begin with a letter for Oracle
- preserve existing generated-name collision behavior by appending numeric suffixes when `parameter_<name>` is already present
- add focused coverage for basic generated names, collision fallback, `where_in`, `where_between`, and named-colon compilation

Closes #487.