### PR TITLE
fix(core): normalize dialect identifier bindings

### DIFF
--- a/docs/usage/migrations.rst
+++ b/docs/usage/migrations.rst
@@ -144,9 +144,9 @@ opt in raises ``MigrationError`` before any DDL is issued.
    * - ``oracledb`` (sync and async)
      - Supported
      - ``ALTER SESSION SET CURRENT_SCHEMA``; validates ``ALL_USERS``. The
-       schema is matched verbatim, so callers must pass the literal stored
-       identifier — typically uppercase for users created unquoted, the
-       exact case for users created with quoted identifiers.
+       schema is normalized to Oracle's stored identifier rules: lowercase
+       unquoted names are uppercased, while mixed-case and explicitly quoted
+       names are preserved.
    * - ``duckdb``
      - Supported
      - ``SET search_path``; validates ``information_schema.schemata``.

--- a/sqlspec/adapters/adbc/data_dictionary.py
+++ b/sqlspec/adapters/adbc/data_dictionary.py
@@ -26,6 +26,7 @@ from sqlspec.data_dictionary.dialects.postgres import resolve_postgres_json_type
 from sqlspec.data_dictionary.dialects.sqlite import resolve_sqlite_json_type
 from sqlspec.driver import SyncDataDictionaryBase
 from sqlspec.exceptions import SQLFileNotFoundError
+from sqlspec.utils.text import normalize_identifier
 
 if TYPE_CHECKING:
     from sqlspec.adapters.adbc.driver import AdbcDriver
@@ -62,13 +63,22 @@ class AdbcDataDictionary(SyncDataDictionaryBase):
             return None
 
     def _resolve_schema(self, dialect: str, schema: "str | None") -> "str | None":
-        if schema is not None:
-            return schema
         try:
             config = get_dialect_config(dialect)
         except ValueError:
+            return schema
+        if schema is not None:
+            return normalize_identifier(schema, config.name)
+        if config.default_schema is None:
             return None
-        return config.default_schema
+        return normalize_identifier(config.default_schema, config.name)
+
+    def _resolve_identifier(self, dialect: str, identifier: str) -> str:
+        try:
+            config = get_dialect_config(dialect)
+        except ValueError:
+            return identifier
+        return normalize_identifier(identifier, config.name)
 
     def _resolve_feature_flag(self, dialect: str, feature: str, version_info: "VersionInfo | None") -> bool:
         try:
@@ -205,7 +215,8 @@ class AdbcDataDictionary(SyncDataDictionaryBase):
                 query_text = self._get_query_text(dialect, "columns_by_schema").format(schema_prefix=schema_prefix)
                 return driver.select(query_text, schema_name=schema_name, schema_type=ColumnMetadata)
             query_text = self._get_query_text(dialect, "columns_by_table").format(schema_prefix=schema_prefix)
-            return driver.select(query_text, table_name=table, schema_name=schema_name, schema_type=ColumnMetadata)
+            table_name = self._resolve_identifier(dialect, table)
+            return driver.select(query_text, table_name=table_name, schema_name=schema_name, schema_type=ColumnMetadata)
 
         if dialect == "sqlite":
             schema_prefix = f"{format_identifier(schema_name)}." if schema_name else ""
@@ -222,10 +233,11 @@ class AdbcDataDictionary(SyncDataDictionaryBase):
             return driver.select(
                 self._get_query(dialect, "columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
             )
+        table_name = self._resolve_identifier(dialect, table)
         return driver.select(
             self._get_query(dialect, "columns_by_table"),
             schema_name=schema_name,
-            table_name=table,
+            table_name=table_name,
             schema_type=ColumnMetadata,
         )
 
@@ -287,10 +299,11 @@ class AdbcDataDictionary(SyncDataDictionaryBase):
                 self._get_query(dialect, "indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
             )
 
+        table_name = self._resolve_identifier(dialect, table)
         return driver.select(
             self._get_query(dialect, "indexes_by_table"),
             schema_name=schema_name,
-            table_name=table,
+            table_name=table_name,
             schema_type=IndexMetadata,
         )
 
@@ -315,7 +328,10 @@ class AdbcDataDictionary(SyncDataDictionaryBase):
             query_text = self._get_query_text(dialect, "foreign_keys_by_table").format(
                 kcu_table=kcu_table, rc_table=rc_table
             )
-            return driver.select(query_text, table_name=table, schema_name=schema_name, schema_type=ForeignKeyMetadata)
+            table_name = self._resolve_identifier(dialect, table)
+            return driver.select(
+                query_text, table_name=table_name, schema_name=schema_name, schema_type=ForeignKeyMetadata
+            )
 
         if dialect == "sqlite":
             if table is None:
@@ -334,9 +350,10 @@ class AdbcDataDictionary(SyncDataDictionaryBase):
             if query_text_optional is not None:
                 return driver.select(query_text_optional, schema_name=schema_name, schema_type=ForeignKeyMetadata)
 
+        resolved_table_name = self._resolve_identifier(dialect, table) if table is not None else None
         return driver.select(
             self._get_query(dialect, "foreign_keys_by_table"),
             schema_name=schema_name,
-            table_name=table,
+            table_name=resolved_table_name,
             schema_type=ForeignKeyMetadata,
         )

--- a/sqlspec/adapters/adbc/driver.py
+++ b/sqlspec/adapters/adbc/driver.py
@@ -34,7 +34,7 @@ from sqlspec.exceptions import DatabaseConnectionError, SQLSpecError
 from sqlspec.utils.logging import get_logger
 from sqlspec.utils.module_loader import ensure_pyarrow
 from sqlspec.utils.serializers import to_json
-from sqlspec.utils.text import quote_identifier
+from sqlspec.utils.text import normalize_identifier, quote_identifier
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -272,7 +272,8 @@ class AdbcDriver(SyncDriverAdapterBase):
         if not self._is_postgres:
             super().set_migration_session_schema(schema)
             return
-        quoted_schema = quote_identifier(schema)
+        normalized_schema = normalize_identifier(schema, "postgres")
+        quoted_schema = quote_identifier(normalized_schema)
         with self.with_cursor(self.connection) as cursor:
             cursor.execute(f'SET search_path TO {quoted_schema}, "$user", public')
 
@@ -292,8 +293,11 @@ class AdbcDriver(SyncDriverAdapterBase):
         """Return whether a PostgreSQL schema exists when using ADBC PostgreSQL."""
         if not self._is_postgres:
             return super().has_schema(schema)
+        normalized_schema = normalize_identifier(schema, "postgres")
         with self.with_cursor(self.connection) as cursor:
-            cursor.execute("SELECT 1 FROM information_schema.schemata WHERE schema_name = $1", parameters=[schema])
+            cursor.execute(
+                "SELECT 1 FROM information_schema.schemata WHERE schema_name = $1", parameters=[normalized_schema]
+            )
             return cursor.fetchone() is not None
 
     def with_cursor(self, connection: "AdbcConnection") -> "AdbcCursor":

--- a/sqlspec/adapters/arrow_odbc/data_dictionary.py
+++ b/sqlspec/adapters/arrow_odbc/data_dictionary.py
@@ -15,6 +15,7 @@ from sqlspec.data_dictionary import (
 )
 from sqlspec.driver import SyncDataDictionaryBase
 from sqlspec.exceptions import SQLFileNotFoundError
+from sqlspec.utils.text import normalize_identifier
 
 if TYPE_CHECKING:
     from sqlspec.adapters.arrow_odbc.driver import ArrowOdbcDriver
@@ -50,9 +51,16 @@ class ArrowOdbcDataDictionary(SyncDataDictionaryBase):
 
     def resolve_schema(self, schema: str | None) -> str | None:
         """Return a schema name using runtime dialect defaults when missing."""
+        config = self.get_dialect_config()
         if schema is not None:
-            return schema
-        return self.get_dialect_config().default_schema
+            return normalize_identifier(schema, config.name)
+        if config.default_schema is None:
+            return None
+        return normalize_identifier(config.default_schema, config.name)
+
+    def resolve_identifier(self, identifier: str) -> str:
+        """Return a runtime-dialect-normalized identifier."""
+        return normalize_identifier(identifier, self.get_dialect_config().name)
 
     def get_version(self, driver: "ArrowOdbcDriver") -> VersionInfo | None:
         """Get database version information when the runtime dialect provides a query."""
@@ -110,7 +118,7 @@ class ArrowOdbcDataDictionary(SyncDataDictionaryBase):
         query_name = "columns_by_table" if table is not None else "columns_by_schema"
         parameters: dict[str, Any] = {"schema_name": self.resolve_schema(schema)}
         if table is not None:
-            parameters["table_name"] = table
+            parameters["table_name"] = self.resolve_identifier(table)
         try:
             return driver.select(self.get_query(query_name), schema_type=ColumnMetadata, **parameters)
         except SQLFileNotFoundError:
@@ -123,7 +131,7 @@ class ArrowOdbcDataDictionary(SyncDataDictionaryBase):
         query_name = "indexes_by_table" if table is not None else "indexes_by_schema"
         parameters: dict[str, Any] = {"schema_name": self.resolve_schema(schema)}
         if table is not None:
-            parameters["table_name"] = table
+            parameters["table_name"] = self.resolve_identifier(table)
         try:
             return driver.select(self.get_query(query_name), schema_type=IndexMetadata, **parameters)
         except SQLFileNotFoundError:
@@ -136,7 +144,7 @@ class ArrowOdbcDataDictionary(SyncDataDictionaryBase):
         query_name = "foreign_keys_by_table" if table is not None else "foreign_keys_by_schema"
         parameters: dict[str, Any] = {"schema_name": self.resolve_schema(schema)}
         if table is not None:
-            parameters["table_name"] = table
+            parameters["table_name"] = self.resolve_identifier(table)
         try:
             return driver.select(self.get_query(query_name), schema_type=ForeignKeyMetadata, **parameters)
         except SQLFileNotFoundError:

--- a/sqlspec/adapters/asyncpg/data_dictionary.py
+++ b/sqlspec/adapters/asyncpg/data_dictionary.py
@@ -99,9 +99,13 @@ class AsyncpgDataDictionary(AsyncDataDictionaryBase):
                 self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
             )
 
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="columns")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="columns")
         return await driver.select(
-            self.get_query("columns_by_table"), schema_name=schema_name, table_name=table, schema_type=ColumnMetadata
+            self.get_query("columns_by_table"),
+            schema_name=schema_name,
+            table_name=table_name,
+            schema_type=ColumnMetadata,
         )
 
     async def get_indexes(
@@ -115,9 +119,13 @@ class AsyncpgDataDictionary(AsyncDataDictionaryBase):
                 self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
             )
 
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="indexes")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="indexes")
         return await driver.select(
-            self.get_query("indexes_by_table"), schema_name=schema_name, table_name=table, schema_type=IndexMetadata
+            self.get_query("indexes_by_table"),
+            schema_name=schema_name,
+            table_name=table_name,
+            schema_type=IndexMetadata,
         )
 
     async def get_foreign_keys(
@@ -130,10 +138,11 @@ class AsyncpgDataDictionary(AsyncDataDictionaryBase):
             return await driver.select(
                 self.get_query("foreign_keys_by_schema"), schema_name=schema_name, schema_type=ForeignKeyMetadata
             )
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="foreign_keys")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="foreign_keys")
         return await driver.select(
             self.get_query("foreign_keys_by_table"),
             schema_name=schema_name,
-            table_name=table,
+            table_name=table_name,
             schema_type=ForeignKeyMetadata,
         )

--- a/sqlspec/adapters/asyncpg/driver.py
+++ b/sqlspec/adapters/asyncpg/driver.py
@@ -38,7 +38,7 @@ from sqlspec.driver import (
 )
 from sqlspec.exceptions import SQLSpecError, StackExecutionError
 from sqlspec.utils.logging import get_logger
-from sqlspec.utils.text import quote_identifier
+from sqlspec.utils.text import normalize_identifier, quote_identifier
 from sqlspec.utils.type_guards import has_sqlstate
 
 if TYPE_CHECKING:
@@ -237,12 +237,14 @@ class AsyncpgDriver(AsyncDriverAdapterBase):
 
     async def set_migration_session_schema(self, schema: str) -> None:
         """Set the PostgreSQL search path for migration SQL."""
-        quoted_schema = quote_identifier(schema)
+        normalized_schema = normalize_identifier(schema, "postgres")
+        quoted_schema = quote_identifier(normalized_schema)
         await self.connection.execute(f'SET LOCAL search_path TO {quoted_schema}, "$user", public')
 
     async def set_migration_non_transactional_schema(self, schema: str) -> None:
         """Set the PostgreSQL search path for non-transactional migration SQL."""
-        quoted_schema = quote_identifier(schema)
+        normalized_schema = normalize_identifier(schema, "postgres")
+        quoted_schema = quote_identifier(normalized_schema)
         await self.connection.execute(f'SET search_path TO {quoted_schema}, "$user", public')
 
     async def reset_migration_session_schema(self) -> None:
@@ -251,8 +253,11 @@ class AsyncpgDriver(AsyncDriverAdapterBase):
 
     async def has_schema(self, schema: str) -> bool:
         """Return whether a PostgreSQL schema exists."""
+        normalized_schema = normalize_identifier(schema, "postgres")
         return bool(
-            await self.connection.fetchval("SELECT 1 FROM information_schema.schemata WHERE schema_name = $1", schema)
+            await self.connection.fetchval(
+                "SELECT 1 FROM information_schema.schemata WHERE schema_name = $1", normalized_schema
+            )
         )
 
     def with_cursor(self, connection: "AsyncpgConnection") -> "AsyncpgCursor":

--- a/sqlspec/adapters/cockroach_asyncpg/data_dictionary.py
+++ b/sqlspec/adapters/cockroach_asyncpg/data_dictionary.py
@@ -65,9 +65,13 @@ class CockroachAsyncpgDataDictionary(AsyncDataDictionaryBase):
                 self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
             )
 
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="columns")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="columns")
         return await driver.select(
-            self.get_query("columns_by_table"), schema_name=schema_name, table_name=table, schema_type=ColumnMetadata
+            self.get_query("columns_by_table"),
+            schema_name=schema_name,
+            table_name=table_name,
+            schema_type=ColumnMetadata,
         )
 
     async def get_indexes(
@@ -80,9 +84,13 @@ class CockroachAsyncpgDataDictionary(AsyncDataDictionaryBase):
                 self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
             )
 
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="indexes")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="indexes")
         return await driver.select(
-            self.get_query("indexes_by_table"), schema_name=schema_name, table_name=table, schema_type=IndexMetadata
+            self.get_query("indexes_by_table"),
+            schema_name=schema_name,
+            table_name=table_name,
+            schema_type=IndexMetadata,
         )
 
     async def get_foreign_keys(
@@ -95,10 +103,11 @@ class CockroachAsyncpgDataDictionary(AsyncDataDictionaryBase):
                 self.get_query("foreign_keys_by_schema"), schema_name=schema_name, schema_type=ForeignKeyMetadata
             )
 
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="foreign_keys")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="foreign_keys")
         return await driver.select(
             self.get_query("foreign_keys_by_table"),
-            table_name=table,
+            table_name=table_name,
             schema_name=schema_name,
             schema_type=ForeignKeyMetadata,
         )

--- a/sqlspec/adapters/cockroach_psycopg/data_dictionary.py
+++ b/sqlspec/adapters/cockroach_psycopg/data_dictionary.py
@@ -74,9 +74,13 @@ class CockroachPsycopgSyncDataDictionary(SyncDataDictionaryBase):
                 self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
             )
 
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="columns")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="columns")
         return driver.select(
-            self.get_query("columns_by_table"), schema_name=schema_name, table_name=table, schema_type=ColumnMetadata
+            self.get_query("columns_by_table"),
+            schema_name=schema_name,
+            table_name=table_name,
+            schema_type=ColumnMetadata,
         )
 
     def get_indexes(
@@ -90,9 +94,13 @@ class CockroachPsycopgSyncDataDictionary(SyncDataDictionaryBase):
                 self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
             )
 
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="indexes")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="indexes")
         return driver.select(
-            self.get_query("indexes_by_table"), schema_name=schema_name, table_name=table, schema_type=IndexMetadata
+            self.get_query("indexes_by_table"),
+            schema_name=schema_name,
+            table_name=table_name,
+            schema_type=IndexMetadata,
         )
 
     def get_foreign_keys(
@@ -106,10 +114,11 @@ class CockroachPsycopgSyncDataDictionary(SyncDataDictionaryBase):
                 self.get_query("foreign_keys_by_schema"), schema_name=schema_name, schema_type=ForeignKeyMetadata
             )
 
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="foreign_keys")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="foreign_keys")
         return driver.select(
             self.get_query("foreign_keys_by_table"),
-            table_name=table,
+            table_name=table_name,
             schema_name=schema_name,
             schema_type=ForeignKeyMetadata,
         )
@@ -179,9 +188,13 @@ class CockroachPsycopgAsyncDataDictionary(AsyncDataDictionaryBase):
                 self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
             )
 
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="columns")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="columns")
         return await driver.select(
-            self.get_query("columns_by_table"), schema_name=schema_name, table_name=table, schema_type=ColumnMetadata
+            self.get_query("columns_by_table"),
+            schema_name=schema_name,
+            table_name=table_name,
+            schema_type=ColumnMetadata,
         )
 
     async def get_indexes(
@@ -195,9 +208,13 @@ class CockroachPsycopgAsyncDataDictionary(AsyncDataDictionaryBase):
                 self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
             )
 
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="indexes")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="indexes")
         return await driver.select(
-            self.get_query("indexes_by_table"), schema_name=schema_name, table_name=table, schema_type=IndexMetadata
+            self.get_query("indexes_by_table"),
+            schema_name=schema_name,
+            table_name=table_name,
+            schema_type=IndexMetadata,
         )
 
     async def get_foreign_keys(
@@ -211,10 +228,11 @@ class CockroachPsycopgAsyncDataDictionary(AsyncDataDictionaryBase):
                 self.get_query("foreign_keys_by_schema"), schema_name=schema_name, schema_type=ForeignKeyMetadata
             )
 
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="foreign_keys")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="foreign_keys")
         return await driver.select(
             self.get_query("foreign_keys_by_table"),
-            table_name=table,
+            table_name=table_name,
             schema_name=schema_name,
             schema_type=ForeignKeyMetadata,
         )

--- a/sqlspec/adapters/oracledb/data_dictionary.py
+++ b/sqlspec/adapters/oracledb/data_dictionary.py
@@ -26,6 +26,7 @@ from sqlspec.data_dictionary.dialects.oracle import (
 )
 from sqlspec.driver import AsyncDataDictionaryBase, SyncDataDictionaryBase
 from sqlspec.utils.logging import get_logger
+from sqlspec.utils.text import normalize_identifier
 
 if TYPE_CHECKING:
     from sqlspec.adapters.oracledb.driver import OracleAsyncDriver, OracleSyncDriver
@@ -97,9 +98,12 @@ class OracledbSyncDataDictionary(SyncDataDictionaryBase):
 
     def resolve_schema(self, schema: "str | None") -> "str | None":
         """Return a schema name using dialect defaults when missing."""
+        config = self.get_dialect_config()
         if schema is not None:
-            return schema
-        return self.get_dialect_config().default_schema
+            return normalize_identifier(schema, config.name)
+        if config.default_schema is None:
+            return None
+        return normalize_identifier(config.default_schema, config.name)
 
     def _build_version_info(
         self, version_value: "str | None", compatible: "str | None", is_autonomous: bool
@@ -207,9 +211,13 @@ class OracledbSyncDataDictionary(SyncDataDictionaryBase):
             return driver.select(
                 self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
             )
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="columns")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="columns")
         return driver.select(
-            self.get_query("columns_by_table"), schema_name=schema_name, table_name=table, schema_type=ColumnMetadata
+            self.get_query("columns_by_table"),
+            schema_name=schema_name,
+            table_name=table_name,
+            schema_type=ColumnMetadata,
         )
 
     def get_indexes(
@@ -222,9 +230,13 @@ class OracledbSyncDataDictionary(SyncDataDictionaryBase):
             return driver.select(
                 self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
             )
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="indexes")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="indexes")
         return driver.select(
-            self.get_query("indexes_by_table"), schema_name=schema_name, table_name=table, schema_type=IndexMetadata
+            self.get_query("indexes_by_table"),
+            schema_name=schema_name,
+            table_name=table_name,
+            schema_type=IndexMetadata,
         )
 
     def get_foreign_keys(
@@ -237,11 +249,12 @@ class OracledbSyncDataDictionary(SyncDataDictionaryBase):
             return driver.select(
                 self.get_query("foreign_keys_by_schema"), schema_name=schema_name, schema_type=ForeignKeyMetadata
             )
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="foreign_keys")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="foreign_keys")
         return driver.select(
             self.get_query("foreign_keys_by_table"),
             schema_name=schema_name,
-            table_name=table,
+            table_name=table_name,
             schema_type=ForeignKeyMetadata,
         )
 
@@ -261,9 +274,12 @@ class OracledbAsyncDataDictionary(AsyncDataDictionaryBase):
 
     def resolve_schema(self, schema: "str | None") -> "str | None":
         """Return a schema name using dialect defaults when missing."""
+        config = self.get_dialect_config()
         if schema is not None:
-            return schema
-        return self.get_dialect_config().default_schema
+            return normalize_identifier(schema, config.name)
+        if config.default_schema is None:
+            return None
+        return normalize_identifier(config.default_schema, config.name)
 
     def _build_version_info(
         self, version_value: "str | None", compatible: "str | None", is_autonomous: bool
@@ -371,9 +387,13 @@ class OracledbAsyncDataDictionary(AsyncDataDictionaryBase):
             return await driver.select(
                 self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
             )
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="columns")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="columns")
         return await driver.select(
-            self.get_query("columns_by_table"), schema_name=schema_name, table_name=table, schema_type=ColumnMetadata
+            self.get_query("columns_by_table"),
+            schema_name=schema_name,
+            table_name=table_name,
+            schema_type=ColumnMetadata,
         )
 
     async def get_indexes(
@@ -386,9 +406,13 @@ class OracledbAsyncDataDictionary(AsyncDataDictionaryBase):
             return await driver.select(
                 self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
             )
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="indexes")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="indexes")
         return await driver.select(
-            self.get_query("indexes_by_table"), schema_name=schema_name, table_name=table, schema_type=IndexMetadata
+            self.get_query("indexes_by_table"),
+            schema_name=schema_name,
+            table_name=table_name,
+            schema_type=IndexMetadata,
         )
 
     async def get_foreign_keys(
@@ -401,10 +425,11 @@ class OracledbAsyncDataDictionary(AsyncDataDictionaryBase):
             return await driver.select(
                 self.get_query("foreign_keys_by_schema"), schema_name=schema_name, schema_type=ForeignKeyMetadata
             )
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="foreign_keys")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="foreign_keys")
         return await driver.select(
             self.get_query("foreign_keys_by_table"),
             schema_name=schema_name,
-            table_name=table,
+            table_name=table_name,
             schema_type=ForeignKeyMetadata,
         )

--- a/sqlspec/adapters/oracledb/driver.py
+++ b/sqlspec/adapters/oracledb/driver.py
@@ -53,7 +53,7 @@ from sqlspec.driver import (
 from sqlspec.exceptions import ImproperConfigurationError, SQLSpecError, StackExecutionError
 from sqlspec.utils.logging import get_logger, log_with_context
 from sqlspec.utils.module_loader import ensure_pyarrow
-from sqlspec.utils.text import quote_identifier
+from sqlspec.utils.text import normalize_identifier, quote_identifier
 from sqlspec.utils.type_guards import has_pipeline_capability
 
 if TYPE_CHECKING:
@@ -444,20 +444,17 @@ class OracleSyncDriver(OraclePipelineMixin, SyncDriverAdapterBase):
             raise SQLSpecError(msg) from e
 
     def set_migration_session_schema(self, schema: str) -> None:
-        """Set Oracle CURRENT_SCHEMA for migration SQL.
-
-        The schema is quoted verbatim; callers must pass the literal stored
-        identifier (typically uppercase for unquoted-created users; the exact
-        case for users created with quoted identifiers).
-        """
-        quoted_schema = quote_identifier(schema.strip())
+        """Set Oracle CURRENT_SCHEMA for migration SQL."""
+        normalized_schema = normalize_identifier(schema, "oracle")
+        quoted_schema = quote_identifier(normalized_schema)
         with self.with_cursor(self.connection) as cursor:
             cursor.execute(f"ALTER SESSION SET CURRENT_SCHEMA = {quoted_schema}")
 
     def has_schema(self, schema: str) -> bool:
-        """Return whether an Oracle schema/user exists (literal-case match)."""
+        """Return whether an Oracle schema/user exists."""
+        normalized_schema = normalize_identifier(schema, "oracle")
         with self.with_cursor(self.connection) as cursor:
-            cursor.execute("SELECT 1 FROM ALL_USERS WHERE USERNAME = :schema_name", {"schema_name": schema.strip()})
+            cursor.execute("SELECT 1 FROM ALL_USERS WHERE USERNAME = :schema_name", {"schema_name": normalized_schema})
             return cursor.fetchone() is not None
 
     def with_cursor(self, connection: OracleSyncConnection) -> OracleSyncCursor:
@@ -939,21 +936,18 @@ class OracleAsyncDriver(OraclePipelineMixin, AsyncDriverAdapterBase):
             raise SQLSpecError(msg) from e
 
     async def set_migration_session_schema(self, schema: str) -> None:
-        """Set Oracle CURRENT_SCHEMA for migration SQL.
-
-        The schema is quoted verbatim; callers must pass the literal stored
-        identifier (typically uppercase for unquoted-created users; the exact
-        case for users created with quoted identifiers).
-        """
-        quoted_schema = quote_identifier(schema.strip())
+        """Set Oracle CURRENT_SCHEMA for migration SQL."""
+        normalized_schema = normalize_identifier(schema, "oracle")
+        quoted_schema = quote_identifier(normalized_schema)
         async with self.with_cursor(self.connection) as cursor:
             await cursor.execute(f"ALTER SESSION SET CURRENT_SCHEMA = {quoted_schema}")
 
     async def has_schema(self, schema: str) -> bool:
-        """Return whether an Oracle schema/user exists (literal-case match)."""
+        """Return whether an Oracle schema/user exists."""
+        normalized_schema = normalize_identifier(schema, "oracle")
         async with self.with_cursor(self.connection) as cursor:
             await cursor.execute(
-                "SELECT 1 FROM ALL_USERS WHERE USERNAME = :schema_name", {"schema_name": schema.strip()}
+                "SELECT 1 FROM ALL_USERS WHERE USERNAME = :schema_name", {"schema_name": normalized_schema}
             )
             row = await cursor.fetchone()
             return row is not None

--- a/sqlspec/adapters/oracledb/migrations.py
+++ b/sqlspec/adapters/oracledb/migrations.py
@@ -13,6 +13,7 @@ from sqlspec.builder import CreateTable, Select, sql
 from sqlspec.migrations.base import BaseMigrationTracker
 from sqlspec.migrations.version import parse_version
 from sqlspec.utils.logging import get_logger
+from sqlspec.utils.text import normalize_identifier, quote_identifier
 
 if TYPE_CHECKING:
     from sqlspec.driver import AsyncDriverAdapterBase, SyncDriverAdapterBase
@@ -41,18 +42,29 @@ class OracleMigrationTrackerMixin:
     version_table_name: str
     version_table_schema: str | None
 
+    @staticmethod
+    def _normalize_oracle_identifier(identifier: str) -> str:
+        """Return an Oracle metadata identifier without SQL quoting."""
+        return normalize_identifier(identifier, "oracle")
+
+    @classmethod
+    def _quote_oracle_identifier(cls, identifier: str) -> str:
+        """Return a quoted Oracle identifier after dialect normalization."""
+        return quote_identifier(cls._normalize_oracle_identifier(identifier))
+
     def _qualify_version_table(self, version_table_name: str, version_table_schema: str | None) -> str:
-        """Return Oracle tracker table name, uppercasing qualified identifiers."""
+        """Return a safely quoted Oracle tracker table name."""
+        quoted_table_name = self._quote_oracle_identifier(version_table_name)
         if version_table_schema:
-            return f"{version_table_schema.upper()}.{version_table_name.upper()}"
-        return version_table_name
+            return f"{self._quote_oracle_identifier(version_table_schema)}.{quoted_table_name}"
+        return quoted_table_name
 
     def _get_create_table_builder(self) -> CreateTable:
         """Return an Oracle CREATE TABLE builder for the tracker table."""
-        table_name = self.version_table_name.upper() if self.version_table_schema else self.version_table_name
+        table_name = self._normalize_oracle_identifier(self.version_table_name)
         builder = sql.create_table(table_name)
         if self.version_table_schema:
-            builder.in_schema(self.version_table_schema.upper())
+            builder.in_schema(self._normalize_oracle_identifier(self.version_table_schema))
         return builder
 
     def _get_create_table_sql(self) -> CreateTable:
@@ -167,7 +179,7 @@ class OracleSyncMigrationTracker(OracleMigrationTrackerMixin, BaseMigrationTrack
         try:
             if self.version_table_schema:
                 columns_data = driver.data_dictionary.get_columns(
-                    driver, self.version_table_name.upper(), schema=self.version_table_schema.upper()
+                    driver, self.version_table_name, schema=self.version_table_schema
                 )
             else:
                 columns_data = driver.data_dictionary.get_columns(driver, self.version_table_name)
@@ -368,7 +380,7 @@ class OracleAsyncMigrationTracker(OracleMigrationTrackerMixin, BaseMigrationTrac
         try:
             if self.version_table_schema:
                 columns_data = await driver.data_dictionary.get_columns(
-                    driver, self.version_table_name.upper(), schema=self.version_table_schema.upper()
+                    driver, self.version_table_name, schema=self.version_table_schema
                 )
             else:
                 columns_data = await driver.data_dictionary.get_columns(driver, self.version_table_name)

--- a/sqlspec/adapters/psqlpy/data_dictionary.py
+++ b/sqlspec/adapters/psqlpy/data_dictionary.py
@@ -81,9 +81,13 @@ class PsqlpyDataDictionary(AsyncDataDictionaryBase):
                 self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
             )
 
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="columns")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="columns")
         return await driver.select(
-            self.get_query("columns_by_table"), schema_name=schema_name, table_name=table, schema_type=ColumnMetadata
+            self.get_query("columns_by_table"),
+            schema_name=schema_name,
+            table_name=table_name,
+            schema_type=ColumnMetadata,
         )
 
     async def get_indexes(
@@ -97,9 +101,13 @@ class PsqlpyDataDictionary(AsyncDataDictionaryBase):
                 self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
             )
 
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="indexes")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="indexes")
         return await driver.select(
-            self.get_query("indexes_by_table"), schema_name=schema_name, table_name=table, schema_type=IndexMetadata
+            self.get_query("indexes_by_table"),
+            schema_name=schema_name,
+            table_name=table_name,
+            schema_type=IndexMetadata,
         )
 
     async def get_foreign_keys(
@@ -112,10 +120,11 @@ class PsqlpyDataDictionary(AsyncDataDictionaryBase):
             return await driver.select(
                 self.get_query("foreign_keys_by_schema"), schema_name=schema_name, schema_type=ForeignKeyMetadata
             )
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="foreign_keys")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="foreign_keys")
         return await driver.select(
             self.get_query("foreign_keys_by_table"),
             schema_name=schema_name,
-            table_name=table,
+            table_name=table_name,
             schema_type=ForeignKeyMetadata,
         )

--- a/sqlspec/adapters/psqlpy/driver.py
+++ b/sqlspec/adapters/psqlpy/driver.py
@@ -32,7 +32,7 @@ from sqlspec.core import SQL, StatementConfig, get_cache_config, register_driver
 from sqlspec.driver import AsyncDriverAdapterBase, BaseAsyncExceptionHandler
 from sqlspec.exceptions import SQLSpecError
 from sqlspec.utils.logging import get_logger
-from sqlspec.utils.text import quote_identifier
+from sqlspec.utils.text import normalize_identifier, quote_identifier
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -222,12 +222,14 @@ class PsqlpyDriver(AsyncDriverAdapterBase):
 
     async def set_migration_session_schema(self, schema: str) -> None:
         """Set the PostgreSQL search path for migration SQL."""
-        quoted_schema = quote_identifier(schema)
+        normalized_schema = normalize_identifier(schema, "postgres")
+        quoted_schema = quote_identifier(normalized_schema)
         await self.connection.execute(f'SET LOCAL search_path TO {quoted_schema}, "$user", public')
 
     async def set_migration_non_transactional_schema(self, schema: str) -> None:
         """Set the PostgreSQL search path for non-transactional migration SQL."""
-        quoted_schema = quote_identifier(schema)
+        normalized_schema = normalize_identifier(schema, "postgres")
+        quoted_schema = quote_identifier(normalized_schema)
         await self.connection.execute(f'SET search_path TO {quoted_schema}, "$user", public')
 
     async def reset_migration_session_schema(self) -> None:
@@ -236,7 +238,10 @@ class PsqlpyDriver(AsyncDriverAdapterBase):
 
     async def has_schema(self, schema: str) -> bool:
         """Return whether a PostgreSQL schema exists."""
-        rows = await self.connection.fetch("SELECT 1 FROM information_schema.schemata WHERE schema_name = $1", [schema])
+        normalized_schema = normalize_identifier(schema, "postgres")
+        rows = await self.connection.fetch(
+            "SELECT 1 FROM information_schema.schemata WHERE schema_name = $1", [normalized_schema]
+        )
         data, _ = collect_rows(rows)
         return bool(data)
 

--- a/sqlspec/adapters/psycopg/data_dictionary.py
+++ b/sqlspec/adapters/psycopg/data_dictionary.py
@@ -102,9 +102,13 @@ class PsycopgSyncDataDictionary(SyncDataDictionaryBase):
                 self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
             )
 
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="columns")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="columns")
         return driver.select(
-            self.get_query("columns_by_table"), schema_name=schema_name, table_name=table, schema_type=ColumnMetadata
+            self.get_query("columns_by_table"),
+            schema_name=schema_name,
+            table_name=table_name,
+            schema_type=ColumnMetadata,
         )
 
     def get_indexes(
@@ -118,9 +122,13 @@ class PsycopgSyncDataDictionary(SyncDataDictionaryBase):
                 self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
             )
 
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="indexes")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="indexes")
         return driver.select(
-            self.get_query("indexes_by_table"), schema_name=schema_name, table_name=table, schema_type=IndexMetadata
+            self.get_query("indexes_by_table"),
+            schema_name=schema_name,
+            table_name=table_name,
+            schema_type=IndexMetadata,
         )
 
     def get_foreign_keys(
@@ -133,11 +141,12 @@ class PsycopgSyncDataDictionary(SyncDataDictionaryBase):
             return driver.select(
                 self.get_query("foreign_keys_by_schema"), schema_name=schema_name, schema_type=ForeignKeyMetadata
             )
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="foreign_keys")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="foreign_keys")
         return driver.select(
             self.get_query("foreign_keys_by_table"),
             schema_name=schema_name,
-            table_name=table,
+            table_name=table_name,
             schema_type=ForeignKeyMetadata,
         )
 
@@ -232,9 +241,13 @@ class PsycopgAsyncDataDictionary(AsyncDataDictionaryBase):
                 self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
             )
 
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="columns")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="columns")
         return await driver.select(
-            self.get_query("columns_by_table"), schema_name=schema_name, table_name=table, schema_type=ColumnMetadata
+            self.get_query("columns_by_table"),
+            schema_name=schema_name,
+            table_name=table_name,
+            schema_type=ColumnMetadata,
         )
 
     async def get_indexes(
@@ -248,9 +261,13 @@ class PsycopgAsyncDataDictionary(AsyncDataDictionaryBase):
                 self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
             )
 
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="indexes")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="indexes")
         return await driver.select(
-            self.get_query("indexes_by_table"), schema_name=schema_name, table_name=table, schema_type=IndexMetadata
+            self.get_query("indexes_by_table"),
+            schema_name=schema_name,
+            table_name=table_name,
+            schema_type=IndexMetadata,
         )
 
     async def get_foreign_keys(
@@ -263,10 +280,11 @@ class PsycopgAsyncDataDictionary(AsyncDataDictionaryBase):
             return await driver.select(
                 self.get_query("foreign_keys_by_schema"), schema_name=schema_name, schema_type=ForeignKeyMetadata
             )
-        self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="foreign_keys")
+        table_name = self.resolve_identifier(table)
+        self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="foreign_keys")
         return await driver.select(
             self.get_query("foreign_keys_by_table"),
             schema_name=schema_name,
-            table_name=table,
+            table_name=table_name,
             schema_type=ForeignKeyMetadata,
         )

--- a/sqlspec/adapters/psycopg/driver.py
+++ b/sqlspec/adapters/psycopg/driver.py
@@ -57,7 +57,7 @@ from sqlspec.driver import (
 )
 from sqlspec.exceptions import SQLSpecError, StackExecutionError
 from sqlspec.utils.logging import get_logger
-from sqlspec.utils.text import quote_identifier
+from sqlspec.utils.text import normalize_identifier, quote_identifier
 from sqlspec.utils.type_guards import is_readable
 
 if TYPE_CHECKING:
@@ -347,14 +347,16 @@ class PsycopgSyncDriver(PsycopgPipelineMixin, SyncDriverAdapterBase):
 
     def set_migration_session_schema(self, schema: str) -> None:
         """Set the PostgreSQL search path for migration SQL."""
-        quoted_schema = quote_identifier(schema)
+        normalized_schema = normalize_identifier(schema, "postgres")
+        quoted_schema = quote_identifier(normalized_schema)
         sql = cast("LiteralString", f'SET LOCAL search_path TO {quoted_schema}, "$user", public')  # type: ignore[redundant-cast]
         with self.with_cursor(self.connection) as cursor:
             cursor.execute(sql)
 
     def set_migration_non_transactional_schema(self, schema: str) -> None:
         """Set the PostgreSQL search path for non-transactional migration SQL."""
-        quoted_schema = quote_identifier(schema)
+        normalized_schema = normalize_identifier(schema, "postgres")
+        quoted_schema = quote_identifier(normalized_schema)
         sql = cast("LiteralString", f'SET search_path TO {quoted_schema}, "$user", public')  # type: ignore[redundant-cast]
         with self.with_cursor(self.connection) as cursor:
             cursor.execute(sql)
@@ -367,8 +369,9 @@ class PsycopgSyncDriver(PsycopgPipelineMixin, SyncDriverAdapterBase):
 
     def has_schema(self, schema: str) -> bool:
         """Return whether a PostgreSQL schema exists."""
+        normalized_schema = normalize_identifier(schema, "postgres")
         with self.with_cursor(self.connection) as cursor:
-            cursor.execute("SELECT 1 FROM information_schema.schemata WHERE schema_name = %s", (schema,))
+            cursor.execute("SELECT 1 FROM information_schema.schemata WHERE schema_name = %s", (normalized_schema,))
             return cursor.fetchone() is not None
 
     def with_cursor(self, connection: PsycopgSyncConnection) -> PsycopgSyncCursor:
@@ -834,14 +837,16 @@ class PsycopgAsyncDriver(PsycopgPipelineMixin, AsyncDriverAdapterBase):
 
     async def set_migration_session_schema(self, schema: str) -> None:
         """Set the PostgreSQL search path for migration SQL."""
-        quoted_schema = quote_identifier(schema)
+        normalized_schema = normalize_identifier(schema, "postgres")
+        quoted_schema = quote_identifier(normalized_schema)
         sql = cast("LiteralString", f'SET LOCAL search_path TO {quoted_schema}, "$user", public')  # type: ignore[redundant-cast]
         async with self.with_cursor(self.connection) as cursor:
             await cursor.execute(sql)
 
     async def set_migration_non_transactional_schema(self, schema: str) -> None:
         """Set the PostgreSQL search path for non-transactional migration SQL."""
-        quoted_schema = quote_identifier(schema)
+        normalized_schema = normalize_identifier(schema, "postgres")
+        quoted_schema = quote_identifier(normalized_schema)
         sql = cast("LiteralString", f'SET search_path TO {quoted_schema}, "$user", public')  # type: ignore[redundant-cast]
         async with self.with_cursor(self.connection) as cursor:
             await cursor.execute(sql)
@@ -854,8 +859,11 @@ class PsycopgAsyncDriver(PsycopgPipelineMixin, AsyncDriverAdapterBase):
 
     async def has_schema(self, schema: str) -> bool:
         """Return whether a PostgreSQL schema exists."""
+        normalized_schema = normalize_identifier(schema, "postgres")
         async with self.with_cursor(self.connection) as cursor:
-            await cursor.execute("SELECT 1 FROM information_schema.schemata WHERE schema_name = %s", (schema,))
+            await cursor.execute(
+                "SELECT 1 FROM information_schema.schemata WHERE schema_name = %s", (normalized_schema,)
+            )
             row = await cursor.fetchone()
             return row is not None
 

--- a/sqlspec/data_dictionary/sql/oracle/columns.sql
+++ b/sqlspec/data_dictionary/sql/oracle/columns.sql
@@ -7,7 +7,7 @@ SELECT
     data_default AS column_default
 FROM all_tab_columns
 WHERE owner = COALESCE(:schema_name, USER)
-  AND table_name = UPPER(:table_name)
+  AND table_name = :table_name
 ORDER BY column_id;
 
 -- name: columns_by_schema

--- a/sqlspec/data_dictionary/sql/oracle/foreign_keys.sql
+++ b/sqlspec/data_dictionary/sql/oracle/foreign_keys.sql
@@ -21,7 +21,7 @@ JOIN all_cons_columns rcc
   AND cc.position = rcc.position
 WHERE c.constraint_type = 'R'
   AND c.owner = COALESCE(:schema_name, USER)
-  AND (:table_name IS NULL OR c.table_name = UPPER(:table_name));
+  AND (:table_name IS NULL OR c.table_name = :table_name);
 
 -- name: foreign_keys_by_schema
 -- dialect: oracle

--- a/sqlspec/data_dictionary/sql/oracle/indexes.sql
+++ b/sqlspec/data_dictionary/sql/oracle/indexes.sql
@@ -17,7 +17,7 @@ LEFT JOIN all_constraints c
   ON c.owner = i.owner
   AND c.index_name = i.index_name
   AND c.constraint_type = 'P'
-WHERE i.table_name = UPPER(:table_name)
+WHERE i.table_name = :table_name
   AND i.owner = COALESCE(:schema_name, USER)
 GROUP BY i.index_name, i.table_name, i.uniqueness;
 

--- a/sqlspec/driver/_common.py
+++ b/sqlspec/driver/_common.py
@@ -49,6 +49,7 @@ from sqlspec.protocols import HasDataProtocol, HasExecuteProtocol, StatementProt
 from sqlspec.utils.dispatch import TypeDispatcher
 from sqlspec.utils.logging import get_logger, log_with_context
 from sqlspec.utils.schema import to_schema as _to_schema_impl
+from sqlspec.utils.text import normalize_identifier
 from sqlspec.utils.type_guards import (
     has_array_interface,
     has_asdict_method,
@@ -457,10 +458,16 @@ class DataDictionaryDialectMixin:
 
     def resolve_schema(self, schema: "str | None") -> "str | None":
         """Return a schema name using dialect defaults when missing."""
-        if schema is not None:
-            return schema
         config = self.get_dialect_config()
-        return config.default_schema
+        if schema is not None:
+            return normalize_identifier(schema, config.name)
+        if config.default_schema is None:
+            return None
+        return normalize_identifier(config.default_schema, config.name)
+
+    def resolve_identifier(self, identifier: str) -> str:
+        """Return a dialect-normalized identifier value."""
+        return normalize_identifier(identifier, self.get_dialect_config().name)
 
     def resolve_feature_flag(self, feature: str, version: "VersionInfo | None") -> bool:
         """Resolve a feature flag using dialect config and version info."""

--- a/sqlspec/utils/text.py
+++ b/sqlspec/utils/text.py
@@ -12,6 +12,7 @@ from functools import lru_cache
 __all__ = (
     "camelize",
     "kebabize",
+    "normalize_identifier",
     "pascalize",
     "quote_backtick_identifier",
     "quote_identifier",
@@ -28,6 +29,7 @@ _SNAKE_CASE_UPPER_TO_UPPER_LOWER = re.compile(r"(?<=[A-Z])(?=[A-Z][a-z])", re.UN
 _SNAKE_CASE_HYPHEN_SPACE = re.compile(r"[.\s@-]+", re.UNICODE)
 _SNAKE_CASE_REMOVE_NON_WORD = re.compile(r"[^\w]+", re.UNICODE)
 _SNAKE_CASE_MULTIPLE_UNDERSCORES = re.compile(r"__+", re.UNICODE)
+_MIN_QUOTED_IDENTIFIER_LENGTH = 2
 
 
 def slugify(value: str, allow_unicode: bool = False, separator: str | None = None) -> str:
@@ -125,9 +127,7 @@ def quote_identifier(identifier: str) -> str:
     identifier-shaped values (schemas, tables, columns) into SQL where
     bind parameters are not allowed (DDL identifiers, ``SET`` commands).
 
-    Dialect-aware case-folding (Oracle uppercases unquoted identifiers,
-    PostgreSQL lowercases them) is a separate concern; callers must
-    pre-normalize when binding identifier values into metadata queries.
+    Dialect-aware case-folding is handled by ``normalize_identifier``.
 
     Args:
         identifier: SQL identifier (schema, table, column, ...).
@@ -136,6 +136,30 @@ def quote_identifier(identifier: str) -> str:
         Double-quoted, escape-safe identifier.
     """
     return '"' + identifier.replace('"', '""') + '"'
+
+
+def normalize_identifier(identifier: str, dialect: str) -> str:
+    """Normalize an identifier-shaped value for dialect metadata lookups.
+
+    Args:
+        identifier: SQL identifier supplied by the caller.
+        dialect: SQL dialect name.
+
+    Returns:
+        Identifier in the form expected by the dialect's metadata tables.
+    """
+    value = identifier.strip()
+    if len(value) >= _MIN_QUOTED_IDENTIFIER_LENGTH and value[0] == value[-1] == '"':
+        return value[1:-1].replace('""', '"')
+    if len(value) >= _MIN_QUOTED_IDENTIFIER_LENGTH and value[0] == value[-1] == "`":
+        return value[1:-1].replace("``", "`")
+
+    normalized_dialect = dialect.lower().replace("-", "_")
+    if normalized_dialect in {"postgres", "postgresql", "cockroach", "cockroachdb"}:
+        return value.lower()
+    if normalized_dialect == "oracle" and value.islower():
+        return value.upper()
+    return value
 
 
 def quote_backtick_identifier(identifier: str) -> str:

--- a/tests/unit/adapters/test_oracledb/test_migration_schema.py
+++ b/tests/unit/adapters/test_oracledb/test_migration_schema.py
@@ -81,6 +81,19 @@ def test_oracle_sync_preserves_mixed_case_identifier() -> None:
     ]
 
 
+def test_oracle_sync_normalizes_lowercase_identifier() -> None:
+    cursor = FakeSyncCursor()
+    driver = OracleSyncDriver(FakeSyncConnection(cursor))  # type: ignore[arg-type]
+
+    driver.set_migration_session_schema("tenant")
+    assert driver.has_schema("tenant") is True
+
+    assert cursor.executed == [
+        ('ALTER SESSION SET CURRENT_SCHEMA = "TENANT"', None),
+        ("SELECT 1 FROM ALL_USERS WHERE USERNAME = :schema_name", {"schema_name": "TENANT"}),
+    ]
+
+
 @pytest.mark.anyio
 async def test_oracle_async_migration_schema_hooks() -> None:
     cursor = FakeAsyncCursor()

--- a/tests/unit/adapters/test_postgres_migration_schema.py
+++ b/tests/unit/adapters/test_postgres_migration_schema.py
@@ -119,6 +119,34 @@ async def test_asyncpg_migration_schema_hooks() -> None:
 
 
 @pytest.mark.anyio
+async def test_asyncpg_migration_schema_hooks_normalize_unquoted_identifier() -> None:
+    connection = FakeAsyncpgConnection()
+    driver = AsyncpgDriver(connection)  # type: ignore[arg-type]
+
+    await driver.set_migration_session_schema("Tenant")
+    assert await driver.has_schema("Tenant") is True
+
+    assert connection.executed == [
+        ('SET LOCAL search_path TO "tenant", "$user", public', ()),
+        ("SELECT 1 FROM information_schema.schemata WHERE schema_name = $1", ("tenant",)),
+    ]
+
+
+@pytest.mark.anyio
+async def test_asyncpg_migration_schema_hooks_preserve_explicitly_quoted_identifier() -> None:
+    connection = FakeAsyncpgConnection()
+    driver = AsyncpgDriver(connection)  # type: ignore[arg-type]
+
+    await driver.set_migration_session_schema('"Tenant"')
+    assert await driver.has_schema('"Tenant"') is True
+
+    assert connection.executed == [
+        ('SET LOCAL search_path TO "Tenant", "$user", public', ()),
+        ("SELECT 1 FROM information_schema.schemata WHERE schema_name = $1", ("Tenant",)),
+    ]
+
+
+@pytest.mark.anyio
 async def test_asyncpg_non_transactional_migration_schema_hooks() -> None:
     connection = FakeAsyncpgConnection()
     driver = AsyncpgDriver(connection)  # type: ignore[arg-type]

--- a/tests/unit/driver/test_data_dictionary.py
+++ b/tests/unit/driver/test_data_dictionary.py
@@ -102,6 +102,32 @@ def test_public_data_dictionary_classes_remain_constructible() -> None:
         assert dictionary_type().__class__ is dictionary_type
 
 
+def test_postgres_data_dictionary_normalizes_identifier_binds() -> None:
+    """PostgreSQL metadata lookups should bind normalized schema and table identifiers."""
+    mock_driver = Mock(spec=SyncDriverAdapterBase)
+    mock_driver.select.return_value = []
+
+    data_dict = PsycopgSyncDataDictionary()
+    data_dict.get_columns(mock_driver, table="Widgets", schema="Tenant")
+
+    _, kwargs = mock_driver.select.call_args
+    assert kwargs["schema_name"] == "tenant"
+    assert kwargs["table_name"] == "widgets"
+
+
+def test_oracle_data_dictionary_normalizes_lowercase_schema_and_preserves_mixed_case_table() -> None:
+    """Oracle metadata lookups should normalize lowercase users without flattening mixed-case names."""
+    mock_driver = Mock(spec=SyncDriverAdapterBase)
+    mock_driver.select.return_value = []
+
+    data_dict = OracledbSyncDataDictionary()
+    data_dict.get_columns(mock_driver, table="MixedCase", schema="myapp")
+
+    _, kwargs = mock_driver.select.call_args
+    assert kwargs["schema_name"] == "MYAPP"
+    assert kwargs["table_name"] == "MixedCase"
+
+
 def test_sqlite_get_version_success() -> None:
     """Test successful version detection for SQLite."""
     mock_driver = Mock(spec=SyncDriverAdapterBase)

--- a/tests/unit/migrations/test_tracker_idempotency.py
+++ b/tests/unit/migrations/test_tracker_idempotency.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 
-from sqlspec.adapters.oracledb.migrations import OracleSyncMigrationTracker
+from sqlspec.adapters.oracledb.migrations import OracleAsyncMigrationTracker, OracleSyncMigrationTracker
 from sqlspec.driver._async import AsyncDriverAdapterBase
 from sqlspec.driver._sync import SyncDriverAdapterBase
 from sqlspec.migrations.tracker import AsyncMigrationTracker, SyncMigrationTracker
@@ -92,13 +92,56 @@ async def test_async_tracker_introspects_bare_table_name_with_schema() -> None:
     driver.execute.assert_not_awaited()
 
 
-def test_oracle_tracker_uppercases_qualified_tracking_table() -> None:
-    """Oracle tracker should qualify migration table names using Oracle's uppercase convention."""
+def test_oracle_tracker_quotes_lowercase_qualified_tracking_table() -> None:
+    """Oracle tracker should normalize lowercase names before quoting them."""
     tracker = OracleSyncMigrationTracker(version_table_name="ddl_migrations", version_table_schema="app_owner")
 
-    assert tracker.version_table == "APP_OWNER.DDL_MIGRATIONS"
+    assert tracker.version_table == '"APP_OWNER"."DDL_MIGRATIONS"'
     assert tracker.version_table_schema == "app_owner"
     assert tracker.version_table_name == "ddl_migrations"
+
+
+def test_oracle_tracker_preserves_mixed_case_qualified_tracking_table() -> None:
+    """Oracle tracker should preserve mixed-case schema/table names as quoted identifiers."""
+    tracker = OracleSyncMigrationTracker(version_table_name="DdlMigrations", version_table_schema="AppOwner")
+
+    assert tracker.version_table == '"AppOwner"."DdlMigrations"'
+    assert tracker.version_table_schema == "AppOwner"
+    assert tracker.version_table_name == "DdlMigrations"
+
+
+def test_oracle_sync_tracker_introspects_unmodified_table_name_with_schema() -> None:
+    """Oracle data-dictionary calls should preserve mixed-case configured identifiers."""
+    tracker = OracleSyncMigrationTracker(version_table_name="DdlMigrations", version_table_schema="AppOwner")
+    driver = Mock()
+    driver.data_dictionary.get_columns.return_value = [
+        {"column_name": column.name}
+        for column in tracker._get_create_table_sql().columns  # pyright: ignore[reportPrivateUsage]
+    ]
+
+    tracker._migrate_schema_if_needed(driver)  # pyright: ignore[reportPrivateUsage]
+
+    driver.data_dictionary.get_columns.assert_called_once_with(driver, "DdlMigrations", schema="AppOwner")
+    driver.execute.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_oracle_async_tracker_introspects_unmodified_table_name_with_schema() -> None:
+    """Oracle async data-dictionary calls should preserve mixed-case configured identifiers."""
+    tracker = OracleAsyncMigrationTracker(version_table_name="DdlMigrations", version_table_schema="AppOwner")
+    driver = MagicMock()
+    driver.data_dictionary.get_columns = AsyncMock(
+        return_value=[
+            {"column_name": column.name}
+            for column in tracker._get_create_table_sql().columns  # pyright: ignore[reportPrivateUsage]
+        ]
+    )
+    driver.execute = AsyncMock()
+
+    await tracker._migrate_schema_if_needed(driver)  # pyright: ignore[reportPrivateUsage]
+
+    driver.data_dictionary.get_columns.assert_awaited_once_with(driver, "DdlMigrations", schema="AppOwner")
+    driver.execute.assert_not_awaited()
 
 
 def test_sync_driver_migration_schema_hook_logs_noop(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/unit/utils/test_text.py
+++ b/tests/unit/utils/test_text.py
@@ -6,7 +6,7 @@ camelCase conversion, and snake_case conversion.
 
 import pytest
 
-from sqlspec.utils.text import camelize, slugify, snake_case
+from sqlspec.utils.text import camelize, normalize_identifier, slugify, snake_case
 
 
 def test_slugify_basic() -> None:
@@ -184,6 +184,36 @@ def test_text_utilities_integration() -> None:
 
     slugified = slugify(original)
     assert slugified == "hello-world-test"
+
+
+@pytest.mark.parametrize(
+    ("dialect", "identifier", "expected"),
+    [
+        ("postgres", "MyApp", "myapp"),
+        ("postgresql", "MyApp", "myapp"),
+        ("cockroachdb", "MyApp", "myapp"),
+        ("oracle", "myapp", "MYAPP"),
+        ("oracle", "MYAPP", "MYAPP"),
+        ("oracle", "MixedCase", "MixedCase"),
+        ("sqlite", "MixedCase", "MixedCase"),
+    ],
+)
+def test_normalize_identifier_applies_dialect_case_rules(dialect: str, identifier: str, expected: str) -> None:
+    assert normalize_identifier(identifier, dialect) == expected
+
+
+@pytest.mark.parametrize(
+    ("dialect", "identifier", "expected"),
+    [
+        ("postgres", '"MixedCase"', "MixedCase"),
+        ("oracle", '"MixedCase"', "MixedCase"),
+        ("mysql", "`MixedCase`", "MixedCase"),
+    ],
+)
+def test_normalize_identifier_preserves_explicitly_quoted_identifiers(
+    dialect: str, identifier: str, expected: str
+) -> None:
+    assert normalize_identifier(identifier, dialect) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add a shared `normalize_identifier()` helper for dialect-aware metadata lookup values
- normalize schema/table identifier binds across data dictionaries and migration schema hooks for PostgreSQL-family, Oracle, ADBC, and Arrow ODBC paths
- preserve Oracle mixed-case identifiers while uppercasing lowercase unquoted convenience names, and quote Oracle migration tracker table identifiers safely
- update Oracle metadata SQL and migration docs to remove the old literal-stored-identifier contract

Closes #477.
Closes #478.
Closes #479.