### PR TITLE
test(adbc): add GizmoSQL integration coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,7 @@ jobs:
           set -eu
           images=(
             postgres:18
+            gizmodata/gizmosql:latest
             pgvector/pgvector:pg15
             paradedb/paradedb:0.21.5-pg16
             cockroachdb/cockroach:latest

--- a/docs/examples/extensions/adk/backend_config.py
+++ b/docs/examples/extensions/adk/backend_config.py
@@ -1,11 +1,11 @@
-from __future__ import annotations
-
 import pytest
 
 __all__ = ("test_adk_backend_config",)
 
+pytestmark = [pytest.mark.adbc, pytest.mark.xdist_group("gizmosql")]
 
-def test_adk_backend_config() -> None:
+
+def test_adk_backend_config(request: pytest.FixtureRequest) -> None:
     pytest.importorskip("adbc_driver_manager")
     # start-example
     from sqlspec.adapters.adbc import AdbcConfig
@@ -17,10 +17,21 @@ def test_adk_backend_config() -> None:
         "memory_use_fts": True,
     }
 
-    gizmo = AdbcConfig(
-        connection_config={"driver_name": "gizmosql", "gizmosql_backend": "duckdb"},
-        extension_config={"adk": adk_config},
-    )
+    connection_config = {"driver_name": "gizmosql", "gizmosql_backend": "duckdb"}
+    try:
+        service = request.getfixturevalue("gizmosql_service")
+    except pytest.FixtureLookupError:
+        service = None
+
+    if service is not None:
+        connection_config.update({
+            "uri": service.uri,
+            "username": service.username,
+            "password": service.password,
+            "tls_skip_verify": True,
+        })
+
+    gizmo = AdbcConfig(connection_config=connection_config, extension_config={"adk": adk_config})
     # end-example
 
     assert gizmo.extension_config["adk"]["memory_use_fts"] is True

--- a/docs/examples/extensions/adk/backend_config.py
+++ b/docs/examples/extensions/adk/backend_config.py
@@ -1,11 +1,11 @@
+from __future__ import annotations
+
 import pytest
 
 __all__ = ("test_adk_backend_config",)
 
-pytestmark = [pytest.mark.adbc, pytest.mark.xdist_group("gizmosql")]
 
-
-def test_adk_backend_config(request: pytest.FixtureRequest) -> None:
+def test_adk_backend_config() -> None:
     pytest.importorskip("adbc_driver_manager")
     # start-example
     from sqlspec.adapters.adbc import AdbcConfig
@@ -17,21 +17,10 @@ def test_adk_backend_config(request: pytest.FixtureRequest) -> None:
         "memory_use_fts": True,
     }
 
-    connection_config = {"driver_name": "gizmosql", "gizmosql_backend": "duckdb"}
-    try:
-        service = request.getfixturevalue("gizmosql_service")
-    except pytest.FixtureLookupError:
-        service = None
-
-    if service is not None:
-        connection_config.update({
-            "uri": service.uri,
-            "username": service.username,
-            "password": service.password,
-            "tls_skip_verify": True,
-        })
-
-    gizmo = AdbcConfig(connection_config=connection_config, extension_config={"adk": adk_config})
+    gizmo = AdbcConfig(
+        connection_config={"driver_name": "gizmosql", "gizmosql_backend": "duckdb"},
+        extension_config={"adk": adk_config},
+    )
     # end-example
 
     assert gizmo.extension_config["adk"]["memory_use_fts"] is True

--- a/docs/reference/adapters/adbc.rst
+++ b/docs/reference/adapters/adbc.rst
@@ -27,6 +27,54 @@ Driver
    :members:
    :show-inheritance:
 
+Connecting to GizmoSQL
+======================
+
+GizmoSQL uses the Flight SQL ADBC driver. SQLSpec accepts ``driver_name="gizmosql"``
+as a shorthand for ``adbc_driver_flightsql.dbapi.connect`` and keeps the default
+parameter style at qmark placeholders.
+
+.. code-block:: python
+
+   from sqlspec.adapters.adbc import AdbcConfig
+
+   config = AdbcConfig(
+       connection_config={
+           "driver_name": "gizmosql",
+           "uri": "grpc+tls://localhost:31337",
+           "username": "admin",
+           "password": "secret",
+           "tls_skip_verify": True,
+           "gizmosql_backend": "duckdb",
+       }
+   )
+
+``username``, ``password``, ``tls_skip_verify``, and ``authorization_header`` are
+translated into Flight SQL ``db_kwargs``. Explicit values in ``db_kwargs`` take
+precedence, which lets production deployments pass certificate material without
+SQLSpec rewriting it:
+
+.. code-block:: python
+
+   secure_config = AdbcConfig(
+       connection_config={
+           "driver_name": "gizmosql",
+           "uri": "grpc+tls://gizmosql.example.com:31337",
+           "db_kwargs": {
+               "username": "admin",
+               "password": "secret",
+               "adbc.flight.sql.client_option.tls_root_certs": "/etc/certs/ca.pem",
+               "adbc.flight.sql.client_option.mtls_cert_chain": "/etc/certs/client.pem",
+               "adbc.flight.sql.client_option.mtls_private_key": "/etc/certs/client.key",
+           },
+       }
+   )
+
+Set ``gizmosql_backend="sqlite"`` when connecting to a SQLite-backed GizmoSQL
+server so runtime dialect detection resolves to SQLite instead of DuckDB. Local
+integration tests can use the ``pytest-databases`` GizmoSQL fixture; see
+``tests/integration/adapters/adbc/conftest.py`` for the canonical fixture wiring.
+
 PostgreSQL Extension Dialects
 =============================
 

--- a/docs/reference/adapters/adbc.rst
+++ b/docs/reference/adapters/adbc.rst
@@ -3,8 +3,206 @@ ADBC
 ====
 
 Arrow Database Connectivity adapter providing native Arrow result handling
-without conversion overhead. Supports PostgreSQL, SQLite, DuckDB, BigQuery,
-and Snowflake with automatic driver detection and loading.
+without conversion overhead. SQLSpec can load the ADBC drivers for PostgreSQL,
+SQLite, DuckDB, BigQuery, Snowflake, Flight SQL, and GizmoSQL from one
+``AdbcConfig`` surface.
+
+Connection Configuration
+========================
+
+ADBC configuration is driver-specific at the transport layer, so
+``connection_config`` accepts both SQLSpec aliases and the keyword arguments
+expected by the selected ADBC driver. SQLSpec normalizes common aliases and URI
+schemes before calling the driver's ``dbapi.connect`` function.
+
+Supported Backends
+------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 24 28 28
+
+   * - Backend
+     - ``driver_name`` aliases
+     - ADBC driver
+     - Notes
+   * - PostgreSQL
+     - ``postgres``, ``postgresql``, ``pg``
+     - ``adbc_driver_postgresql``
+     - Numeric parameters; optional pgvector and ParadeDB dialect detection.
+   * - SQLite
+     - ``sqlite``, ``sqlite3``
+     - ``adbc_driver_sqlite``
+     - Qmark parameters; ``sqlite://`` URIs are normalized to file paths.
+   * - DuckDB
+     - ``duckdb``
+     - ``adbc_driver_duckdb``
+     - Qmark and numeric parameters; ``duckdb://`` URIs are normalized to paths.
+   * - BigQuery
+     - ``bigquery``, ``bq``
+     - ``adbc_driver_bigquery``
+     - Named ``@`` parameters; ``project_id``, ``dataset_id``, and ``token``
+       are lifted into ``db_kwargs``.
+   * - Snowflake
+     - ``snowflake``, ``sf``
+     - ``adbc_driver_snowflake``
+     - Qmark and numeric parameters.
+   * - Flight SQL
+     - ``flightsql``, ``grpc``
+     - ``adbc_driver_flightsql``
+     - Generic Flight SQL connections default to SQLite-style statement handling.
+   * - GizmoSQL
+     - ``gizmosql``, ``gizmo``
+     - ``adbc_driver_flightsql``
+     - Flight SQL transport with DuckDB dialect by default, or SQLite when
+       ``gizmosql_backend="sqlite"``.
+
+Examples
+--------
+
+PostgreSQL:
+
+.. code-block:: python
+
+   from sqlspec.adapters.adbc import AdbcConfig
+
+   postgres = AdbcConfig(
+       connection_config={
+           "driver_name": "postgres",
+           "uri": "postgresql://user:password@localhost:5432/app",
+       }
+   )
+
+SQLite:
+
+.. code-block:: python
+
+   from sqlspec.adapters.adbc import AdbcConfig
+
+   sqlite = AdbcConfig(
+       connection_config={
+           "driver_name": "sqlite",
+           "uri": "sqlite:///tmp/app.db",
+       }
+   )
+
+DuckDB:
+
+.. code-block:: python
+
+   from sqlspec.adapters.adbc import AdbcConfig
+
+   duckdb = AdbcConfig(
+       connection_config={
+           "driver_name": "duckdb",
+           "path": "/tmp/app.duckdb",
+       }
+   )
+
+BigQuery:
+
+.. code-block:: python
+
+   from sqlspec.adapters.adbc import AdbcConfig
+
+   bigquery = AdbcConfig(
+       connection_config={
+           "driver_name": "bigquery",
+           "project_id": "analytics-project",
+           "dataset_id": "events",
+       }
+   )
+
+Flight SQL:
+
+.. code-block:: python
+
+   from sqlspec.adapters.adbc import AdbcConfig
+
+   flightsql = AdbcConfig(
+       connection_config={
+           "driver_name": "flightsql",
+           "uri": "grpc+tls://flightsql.example.com:31337",
+       }
+   )
+
+GizmoSQL:
+
+.. code-block:: python
+
+   from sqlspec.adapters.adbc import AdbcConfig
+
+   gizmosql = AdbcConfig(
+       connection_config={
+           "driver_name": "gizmosql",
+           "uri": "grpc+tls://localhost:31337",
+           "username": "admin",
+           "password": "secret",
+           "tls_skip_verify": True,
+           "gizmosql_backend": "duckdb",
+       }
+   )
+
+GizmoSQL Notes
+--------------
+
+GizmoSQL runs over the Flight SQL ADBC driver. SQLSpec maps the common
+``username``, ``password``, ``tls_skip_verify``, and ``authorization_header``
+shortcuts into Flight SQL ``db_kwargs`` before opening the connection. For
+lower-level Flight SQL options, pass ``db_kwargs`` directly:
+
+.. code-block:: python
+
+   from sqlspec.adapters.adbc import AdbcConfig
+
+   secure_gizmosql = AdbcConfig(
+       connection_config={
+           "driver_name": "gizmosql",
+           "uri": "grpc+tls://gizmosql.example.com:31337",
+           "db_kwargs": {
+               "username": "admin",
+               "password": "secret",
+               "adbc.flight.sql.client_option.tls_root_certs": "/etc/certs/ca.pem",
+               "adbc.flight.sql.client_option.mtls_cert_chain": "/etc/certs/client.pem",
+               "adbc.flight.sql.client_option.mtls_private_key": "/etc/certs/client.key",
+           },
+       }
+   )
+
+Use ``gizmosql_backend="sqlite"`` only when the target GizmoSQL server was
+started with SQLite as its database backend. DuckDB remains the default dialect
+for GizmoSQL.
+
+PostgreSQL Extension Dialects
+=============================
+
+When targeting PostgreSQL, ADBC automatically detects installed extensions on the
+first connection and upgrades the SQL dialect accordingly:
+
+- **pgvector** — If the ``vector`` extension is installed, switches to the ``pgvector``
+  dialect which supports distance operators (``<->``, ``<=>``, ``<#>``, ``<+>``, ``<~>``, ``<%>``).
+- **ParadeDB** — If the ``pg_search`` extension is installed (alongside ``vector``),
+  switches to the ``paradedb`` dialect which adds BM25 search operators (``@@@``, ``&&&``,
+  ``|||``, ``===``) on top of pgvector operators.
+
+Detection is controlled by two driver feature flags:
+
+- ``enable_pgvector`` — Defaults to ``True`` when the ``pgvector`` Python package is installed.
+- ``enable_paradedb`` — Defaults to ``True``.
+
+Detection runs once per config instance and caches the result. Non-PostgreSQL backends
+(SQLite, DuckDB, BigQuery, Snowflake, GizmoSQL) skip detection entirely.
+
+.. note::
+
+   ADBC returns vector data as strings (e.g. ``"[0.1,0.2,0.3]"``).
+   The ``pgvector`` Python package is not required for querying vector data.
+   It only affects the *default* value of ``enable_pgvector`` — when the package
+   is installed, detection is enabled automatically. You can always set
+   ``enable_pgvector=True`` explicitly in ``driver_features`` to enable
+   detection without the package installed.
+
+See the :doc:`Dialects <../dialects>` reference for full operator details.
 
 Configuration
 =============
@@ -26,85 +224,6 @@ Driver
 .. autoclass:: sqlspec.adapters.adbc.AdbcDriver
    :members:
    :show-inheritance:
-
-Connecting to GizmoSQL
-======================
-
-GizmoSQL uses the Flight SQL ADBC driver. SQLSpec accepts ``driver_name="gizmosql"``
-as a shorthand for ``adbc_driver_flightsql.dbapi.connect`` and keeps the default
-parameter style at qmark placeholders.
-
-.. code-block:: python
-
-   from sqlspec.adapters.adbc import AdbcConfig
-
-   config = AdbcConfig(
-       connection_config={
-           "driver_name": "gizmosql",
-           "uri": "grpc+tls://localhost:31337",
-           "username": "admin",
-           "password": "secret",
-           "tls_skip_verify": True,
-           "gizmosql_backend": "duckdb",
-       }
-   )
-
-``username``, ``password``, ``tls_skip_verify``, and ``authorization_header`` are
-translated into Flight SQL ``db_kwargs``. Explicit values in ``db_kwargs`` take
-precedence, which lets production deployments pass certificate material without
-SQLSpec rewriting it:
-
-.. code-block:: python
-
-   secure_config = AdbcConfig(
-       connection_config={
-           "driver_name": "gizmosql",
-           "uri": "grpc+tls://gizmosql.example.com:31337",
-           "db_kwargs": {
-               "username": "admin",
-               "password": "secret",
-               "adbc.flight.sql.client_option.tls_root_certs": "/etc/certs/ca.pem",
-               "adbc.flight.sql.client_option.mtls_cert_chain": "/etc/certs/client.pem",
-               "adbc.flight.sql.client_option.mtls_private_key": "/etc/certs/client.key",
-           },
-       }
-   )
-
-Set ``gizmosql_backend="sqlite"`` when connecting to a SQLite-backed GizmoSQL
-server so runtime dialect detection resolves to SQLite instead of DuckDB. Local
-integration tests can use the ``pytest-databases`` GizmoSQL fixture; see
-``tests/integration/adapters/adbc/conftest.py`` for the canonical fixture wiring.
-
-PostgreSQL Extension Dialects
-=============================
-
-When targeting PostgreSQL, ADBC automatically detects installed extensions on the
-first connection and upgrades the SQL dialect accordingly:
-
-- **pgvector** — If the ``vector`` extension is installed, switches to the ``pgvector``
-  dialect which supports distance operators (``<->``, ``<=>``, ``<#>``, ``<+>``, ``<~>``, ``<%>``).
-- **ParadeDB** — If the ``pg_search`` extension is installed (alongside ``vector``),
-  switches to the ``paradedb`` dialect which adds BM25 search operators (``@@@``, ``&&&``,
-  ``|||``, ``===``) on top of pgvector operators.
-
-Detection is controlled by two driver feature flags:
-
-- ``enable_pgvector`` — Defaults to ``True`` when the ``pgvector`` Python package is installed.
-- ``enable_paradedb`` — Defaults to ``True``.
-
-Detection runs once per config instance and caches the result. Non-PostgreSQL backends
-(SQLite, DuckDB, BigQuery, Snowflake) skip detection entirely.
-
-.. note::
-
-   ADBC returns vector data as strings (e.g. ``"[0.1,0.2,0.3]"``).
-   The ``pgvector`` Python package is not required for querying vector data.
-   It only affects the *default* value of ``enable_pgvector`` — when the package
-   is installed, detection is enabled automatically. You can always set
-   ``enable_pgvector=True`` explicitly in ``driver_features`` to enable
-   detection without the package installed.
-
-See the :doc:`Dialects <../dialects>` reference for full operator details.
 
 Data Dictionary
 ===============

--- a/sqlspec/adapters/adbc/core.py
+++ b/sqlspec/adapters/adbc/core.py
@@ -155,6 +155,9 @@ _PARAMETER_STYLES_BY_KEYWORD: "tuple[tuple[str, tuple[tuple[str, ...], str]], ..
 )
 
 _BIGQUERY_DB_KWARGS_FIELDS: "tuple[str, ...]" = ("project_id", "dataset_id", "token")
+_FLIGHTSQL_DB_KWARGS_FIELDS: "tuple[str, ...]" = ("username", "password")
+_FLIGHTSQL_TLS_SKIP_VERIFY_KEY: Final[str] = "adbc.flight.sql.client_option.tls_skip_verify"
+_FLIGHTSQL_AUTHORIZATION_HEADER_KEY: Final[str] = "adbc.flight.sql.authorization_header"
 _TYPE_COERCION_DISPATCHERS: "dict[tuple[tuple[type, Callable[[Any], Any]], ...], TypeDispatcher[Callable[[Any], Any]]]" = {}
 
 
@@ -173,7 +176,15 @@ def detect_dialect(connection: Any, logger: Any | None = None, *, fallback_diale
     try:
         driver_info = connection.adbc_get_info()
         vendor_name = driver_info.get("vendor_name", "").lower()
+        vendor_version = driver_info.get("vendor_version", "").lower()
         driver_name = driver_info.get("driver_name", "").lower()
+
+        if "gizmosql" in vendor_name or "gizmosql" in vendor_version:
+            if "sqlite" in vendor_version:
+                return "sqlite"
+            if "duckdb" in vendor_version:
+                return "duckdb"
+            return "duckdb"
 
         for dialect, patterns in DIALECT_PATTERNS.items():
             for pattern in patterns:
@@ -371,6 +382,37 @@ def resolve_parameter_styles(driver_path: str | None, logger: Any | None = None)
     return (("qmark",), "qmark")
 
 
+def _resolve_flightsql_db_kwargs_keys() -> "tuple[str, str]":
+    try:
+        from adbc_driver_flightsql import DatabaseOptions
+    except ImportError:
+        return _FLIGHTSQL_TLS_SKIP_VERIFY_KEY, _FLIGHTSQL_AUTHORIZATION_HEADER_KEY
+    return DatabaseOptions.TLS_SKIP_VERIFY.value, DatabaseOptions.AUTHORIZATION_HEADER.value
+
+
+def _lift_flightsql_db_kwargs(config: "dict[str, Any]") -> None:
+    db_kwargs = config.pop("db_kwargs", None)
+    db_kwargs_dict: dict[str, Any] = dict(db_kwargs) if isinstance(db_kwargs, dict) else {}
+    tls_skip_verify_key, authorization_header_key = _resolve_flightsql_db_kwargs_keys()
+
+    for field in _FLIGHTSQL_DB_KWARGS_FIELDS:
+        if field in config:
+            db_kwargs_dict.setdefault(field, config.pop(field))
+
+    if "tls_skip_verify" in config:
+        tls_skip_verify = config.pop("tls_skip_verify")
+        if isinstance(tls_skip_verify, bool):
+            tls_skip_verify = str(tls_skip_verify).lower()
+        db_kwargs_dict.setdefault(tls_skip_verify_key, tls_skip_verify)
+
+    if "authorization_header" in config:
+        db_kwargs_dict.setdefault(authorization_header_key, config.pop("authorization_header"))
+
+    config.pop("gizmosql_backend", None)
+    if db_kwargs_dict:
+        config["db_kwargs"] = db_kwargs_dict
+
+
 def build_connection_config(connection_config: "Mapping[str, Any]") -> "dict[str, Any]":
     """Build a normalized connection configuration dictionary.
 
@@ -396,7 +438,9 @@ def build_connection_config(connection_config: "Mapping[str, Any]") -> "dict[str
         config["path"] = uri[9:]
         config.pop("uri", None)
 
-    if isinstance(driver_name, str) and driver_kind == "bigquery":
+    if driver_kind in {"gizmosql", "flightsql"}:
+        _lift_flightsql_db_kwargs(config)
+    elif isinstance(driver_name, str) and driver_kind == "bigquery":
         db_kwargs = config.get("db_kwargs")
         db_kwargs_dict: dict[str, Any] = dict(db_kwargs) if isinstance(db_kwargs, dict) else {}
         for param in _BIGQUERY_DB_KWARGS_FIELDS:

--- a/sqlspec/adapters/adbc/core.py
+++ b/sqlspec/adapters/adbc/core.py
@@ -159,6 +159,17 @@ _FLIGHTSQL_DB_KWARGS_FIELDS: "tuple[str, ...]" = ("username", "password")
 _FLIGHTSQL_TLS_SKIP_VERIFY_KEY: Final[str] = "adbc.flight.sql.client_option.tls_skip_verify"
 _FLIGHTSQL_AUTHORIZATION_HEADER_KEY: Final[str] = "adbc.flight.sql.authorization_header"
 _TYPE_COERCION_DISPATCHERS: "dict[tuple[tuple[type, Callable[[Any], Any]], ...], TypeDispatcher[Callable[[Any], Any]]]" = {}
+_SQLSTATE_CLASS_CODE_LEN = 2
+_SQLSTATE_DESCRIPTIONS: dict[str, str] = {
+    "23": "integrity constraint violation",
+    "40": "transaction error",
+    "42": "SQL syntax error",
+    "08": "connection error",
+    "22": "data error",
+    "28": "authorization error",
+    "57": "operational error",
+    "02": "no data",
+}
 
 
 def detect_dialect(connection: Any, logger: Any | None = None, *, fallback_dialect: "str | None" = None) -> str:
@@ -382,37 +393,6 @@ def resolve_parameter_styles(driver_path: str | None, logger: Any | None = None)
     return (("qmark",), "qmark")
 
 
-def _resolve_flightsql_db_kwargs_keys() -> "tuple[str, str]":
-    try:
-        from adbc_driver_flightsql import DatabaseOptions
-    except ImportError:
-        return _FLIGHTSQL_TLS_SKIP_VERIFY_KEY, _FLIGHTSQL_AUTHORIZATION_HEADER_KEY
-    return DatabaseOptions.TLS_SKIP_VERIFY.value, DatabaseOptions.AUTHORIZATION_HEADER.value
-
-
-def _lift_flightsql_db_kwargs(config: "dict[str, Any]") -> None:
-    db_kwargs = config.pop("db_kwargs", None)
-    db_kwargs_dict: dict[str, Any] = dict(db_kwargs) if isinstance(db_kwargs, dict) else {}
-    tls_skip_verify_key, authorization_header_key = _resolve_flightsql_db_kwargs_keys()
-
-    for field in _FLIGHTSQL_DB_KWARGS_FIELDS:
-        if field in config:
-            db_kwargs_dict.setdefault(field, config.pop(field))
-
-    if "tls_skip_verify" in config:
-        tls_skip_verify = config.pop("tls_skip_verify")
-        if isinstance(tls_skip_verify, bool):
-            tls_skip_verify = str(tls_skip_verify).lower()
-        db_kwargs_dict.setdefault(tls_skip_verify_key, tls_skip_verify)
-
-    if "authorization_header" in config:
-        db_kwargs_dict.setdefault(authorization_header_key, config.pop("authorization_header"))
-
-    config.pop("gizmosql_backend", None)
-    if db_kwargs_dict:
-        config["db_kwargs"] = db_kwargs_dict
-
-
 def build_connection_config(connection_config: "Mapping[str, Any]") -> "dict[str, Any]":
     """Build a normalized connection configuration dictionary.
 
@@ -523,14 +503,6 @@ def prepare_postgres_parameters(
     )
 
 
-def _create_adbc_error(error: Any, error_class: type[SQLSpecError], description: str) -> SQLSpecError:
-    """Create an ADBC error instance without raising it."""
-    msg = f"ADBC {description}: {error}"
-    exc = error_class(msg)
-    exc.__cause__ = error
-    return exc
-
-
 def create_mapped_exception(error: Any) -> SQLSpecError:
     """Map ADBC errors to SQLSpec exceptions.
 
@@ -628,27 +600,6 @@ def create_mapped_exception(error: Any) -> SQLSpecError:
     return _create_adbc_error(error, SQLSpecError, "database error")
 
 
-_SQLSTATE_CLASS_CODE_LEN = 2
-
-# Module-level SQLSTATE descriptions (mypyc optimization - avoid dict creation per call)
-_SQLSTATE_DESCRIPTIONS: dict[str, str] = {
-    "23": "integrity constraint violation",
-    "40": "transaction error",
-    "42": "SQL syntax error",
-    "08": "connection error",
-    "22": "data error",
-    "28": "authorization error",
-    "57": "operational error",
-    "02": "no data",
-}
-
-
-def _get_sqlstate_description(sqlstate: str) -> str:
-    """Get a human-readable description for a SQLSTATE code class."""
-    class_code = sqlstate[:_SQLSTATE_CLASS_CODE_LEN] if len(sqlstate) >= _SQLSTATE_CLASS_CODE_LEN else sqlstate
-    return _SQLSTATE_DESCRIPTIONS.get(class_code, "database error")
-
-
 def _identity(value: Any) -> Any:
     return value
 
@@ -741,47 +692,6 @@ def get_statement_config(detected_dialect: str) -> StatementConfig:
     return build_statement_config_from_profile(
         profile, parameter_overrides=parameter_overrides, statement_overrides={"dialect": sqlglot_dialect}
     )
-
-
-def _normalize_adbc_driver_features(processed_features: "dict[str, Any]") -> "dict[str, Any]":
-    if "strict_type_coercion" in processed_features and "enable_strict_type_coercion" not in processed_features:
-        processed_features["enable_strict_type_coercion"] = processed_features["strict_type_coercion"]
-    if "enable_strict_type_coercion" in processed_features and "strict_type_coercion" not in processed_features:
-        processed_features["strict_type_coercion"] = processed_features["enable_strict_type_coercion"]
-
-    if "arrow_extension_types" in processed_features and "enable_arrow_extension_types" not in processed_features:
-        processed_features["enable_arrow_extension_types"] = processed_features["arrow_extension_types"]
-    if "enable_arrow_extension_types" in processed_features and "arrow_extension_types" not in processed_features:
-        processed_features["arrow_extension_types"] = processed_features["enable_arrow_extension_types"]
-
-    return processed_features
-
-
-def _apply_adbc_json_serializer(
-    statement_config: "StatementConfig", json_serializer: "Callable[[Any], str]"
-) -> "StatementConfig":
-    """Apply a JSON serializer to statement config while preserving list/tuple converters.
-
-    Args:
-        statement_config: Base statement configuration to update.
-        json_serializer: JSON serializer function.
-
-    Returns:
-        Updated statement configuration.
-    """
-    parameter_config = statement_config.parameter_config
-    previous_list_converter = parameter_config.type_coercion_map.get(list)
-    previous_tuple_converter = parameter_config.type_coercion_map.get(tuple)
-
-    updated_parameter_config = parameter_config.with_json_serializers(json_serializer)
-    updated_map = dict(updated_parameter_config.type_coercion_map)
-
-    if previous_list_converter is not None:
-        updated_map[list] = previous_list_converter
-    if previous_tuple_converter is not None:
-        updated_map[tuple] = previous_tuple_converter
-
-    return statement_config.replace(parameter_config=updated_parameter_config.replace(type_coercion_map=updated_map))
 
 
 def apply_driver_features(
@@ -916,6 +826,82 @@ def resolve_parameter_casts(statement: "SQL") -> "dict[int, str]":
     return {}
 
 
+def prepare_parameters_with_casts(
+    parameters: Any,
+    parameter_casts: "dict[int, str]",
+    statement_config: "StatementConfig",
+    *,
+    dialect: str,
+    json_serializer: "Callable[[Any], str]",
+) -> Any:
+    """Prepare parameters with cast-aware type coercion for ADBC."""
+    json_encoder = statement_config.parameter_config.json_serializer or json_serializer
+
+    if isinstance(parameters, (list, tuple)):
+        converter = get_adbc_type_converter(dialect)
+        type_map = statement_config.parameter_config.type_coercion_map
+        dispatcher = _get_type_coercion_dispatcher(type_map) if type_map else None
+        return _prepare_parameter_sequence_with_casts(
+            parameters, parameter_casts, type_map, dispatcher, converter, json_encoder
+        )
+    return parameters
+
+
+def _create_adbc_error(error: Any, error_class: type[SQLSpecError], description: str) -> SQLSpecError:
+    """Create an ADBC error instance without raising it."""
+    msg = f"ADBC {description}: {error}"
+    exc = error_class(msg)
+    exc.__cause__ = error
+    return exc
+
+
+def _get_sqlstate_description(sqlstate: str) -> str:
+    """Get a human-readable description for a SQLSTATE code class."""
+    class_code = sqlstate[:_SQLSTATE_CLASS_CODE_LEN] if len(sqlstate) >= _SQLSTATE_CLASS_CODE_LEN else sqlstate
+    return _SQLSTATE_DESCRIPTIONS.get(class_code, "database error")
+
+
+def _normalize_adbc_driver_features(processed_features: "dict[str, Any]") -> "dict[str, Any]":
+    if "strict_type_coercion" in processed_features and "enable_strict_type_coercion" not in processed_features:
+        processed_features["enable_strict_type_coercion"] = processed_features["strict_type_coercion"]
+    if "enable_strict_type_coercion" in processed_features and "strict_type_coercion" not in processed_features:
+        processed_features["strict_type_coercion"] = processed_features["enable_strict_type_coercion"]
+
+    if "arrow_extension_types" in processed_features and "enable_arrow_extension_types" not in processed_features:
+        processed_features["enable_arrow_extension_types"] = processed_features["arrow_extension_types"]
+    if "enable_arrow_extension_types" in processed_features and "arrow_extension_types" not in processed_features:
+        processed_features["arrow_extension_types"] = processed_features["enable_arrow_extension_types"]
+
+    return processed_features
+
+
+def _apply_adbc_json_serializer(
+    statement_config: "StatementConfig", json_serializer: "Callable[[Any], str]"
+) -> "StatementConfig":
+    """Apply a JSON serializer to statement config while preserving list/tuple converters.
+
+    Args:
+        statement_config: Base statement configuration to update.
+        json_serializer: JSON serializer function.
+
+    Returns:
+        Updated statement configuration.
+    """
+    parameter_config = statement_config.parameter_config
+    previous_list_converter = parameter_config.type_coercion_map.get(list)
+    previous_tuple_converter = parameter_config.type_coercion_map.get(tuple)
+
+    updated_parameter_config = parameter_config.with_json_serializers(json_serializer)
+    updated_map = dict(updated_parameter_config.type_coercion_map)
+
+    if previous_list_converter is not None:
+        updated_map[list] = previous_list_converter
+    if previous_tuple_converter is not None:
+        updated_map[tuple] = previous_tuple_converter
+
+    return statement_config.replace(parameter_config=updated_parameter_config.replace(type_coercion_map=updated_map))
+
+
 def _get_type_coercion_dispatcher(
     type_map: "dict[type, Callable[[Any], Any]]",
 ) -> "TypeDispatcher[Callable[[Any], Any]]":
@@ -961,27 +947,6 @@ def _prepare_parameter_sequence_with_casts(
     return tuple(result) if isinstance(parameters, tuple) else result
 
 
-def prepare_parameters_with_casts(
-    parameters: Any,
-    parameter_casts: "dict[int, str]",
-    statement_config: "StatementConfig",
-    *,
-    dialect: str,
-    json_serializer: "Callable[[Any], str]",
-) -> Any:
-    """Prepare parameters with cast-aware type coercion for ADBC."""
-    json_encoder = statement_config.parameter_config.json_serializer or json_serializer
-
-    if isinstance(parameters, (list, tuple)):
-        converter = get_adbc_type_converter(dialect)
-        type_map = statement_config.parameter_config.type_coercion_map
-        dispatcher = _get_type_coercion_dispatcher(type_map) if type_map else None
-        return _prepare_parameter_sequence_with_casts(
-            parameters, parameter_casts, type_map, dispatcher, converter, json_encoder
-        )
-    return parameters
-
-
 def _prepare_batch_with_casts(
     parameter_sets: Any,
     parameter_casts: "dict[int, str]",
@@ -1008,3 +973,34 @@ def _prepare_batch_with_casts(
         else row
         for row in postgres_compatible
     ]
+
+
+def _resolve_flightsql_db_kwargs_keys() -> "tuple[str, str]":
+    try:
+        from adbc_driver_flightsql import DatabaseOptions
+    except ImportError:
+        return _FLIGHTSQL_TLS_SKIP_VERIFY_KEY, _FLIGHTSQL_AUTHORIZATION_HEADER_KEY
+    return DatabaseOptions.TLS_SKIP_VERIFY.value, DatabaseOptions.AUTHORIZATION_HEADER.value
+
+
+def _lift_flightsql_db_kwargs(config: "dict[str, Any]") -> None:
+    db_kwargs = config.pop("db_kwargs", None)
+    db_kwargs_dict: dict[str, Any] = dict(db_kwargs) if isinstance(db_kwargs, dict) else {}
+    tls_skip_verify_key, authorization_header_key = _resolve_flightsql_db_kwargs_keys()
+
+    for field in _FLIGHTSQL_DB_KWARGS_FIELDS:
+        if field in config:
+            db_kwargs_dict.setdefault(field, config.pop(field))
+
+    if "tls_skip_verify" in config:
+        tls_skip_verify = config.pop("tls_skip_verify")
+        if isinstance(tls_skip_verify, bool):
+            tls_skip_verify = str(tls_skip_verify).lower()
+        db_kwargs_dict.setdefault(tls_skip_verify_key, tls_skip_verify)
+
+    if "authorization_header" in config:
+        db_kwargs_dict.setdefault(authorization_header_key, config.pop("authorization_header"))
+
+    config.pop("gizmosql_backend", None)
+    if db_kwargs_dict:
+        config["db_kwargs"] = db_kwargs_dict

--- a/sqlspec/adapters/adbc/data_dictionary.py
+++ b/sqlspec/adapters/adbc/data_dictionary.py
@@ -282,6 +282,10 @@ class AdbcDataDictionary(SyncDataDictionaryBase):
                 index_metadata_list.append(index_metadata)
             return index_metadata_list
 
+        if dialect == "duckdb":
+            query_name = "indexes_by_schema" if table is None else "indexes_by_table"
+            return driver.select(self._get_query(dialect, query_name), schema_type=IndexMetadata)
+
         if table is None:
             return driver.select(
                 self._get_query(dialect, "indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata

--- a/sqlspec/adapters/adbc/driver.py
+++ b/sqlspec/adapters/adbc/driver.py
@@ -328,39 +328,6 @@ class AdbcDriver(SyncDriverAdapterBase):
         """
         return AdbcCursor(connection)
 
-    @staticmethod
-    def _resolve_count_result_rowcount(cursor: "AdbcRawCursor", *, fallback: int) -> int:
-        """Consume ADBC count result streams and return their row count."""
-        if not cursor.description:
-            return fallback
-        try:
-            rows = cursor.fetchall()
-        except Exception:
-            return fallback
-        if not rows:
-            return fallback
-
-        first_row = rows[0]
-        if isinstance(first_row, dict):
-            first_value = next(iter(first_row.values()), None)
-        elif isinstance(first_row, (tuple, list)) and first_row:
-            first_value = first_row[0]
-        else:
-            first_value = first_row
-
-        if isinstance(first_value, int):
-            return first_value
-        return fallback
-
-    @staticmethod
-    def _detect_flightsql_connection(connection: "AdbcConnection") -> bool:
-        try:
-            driver_info = connection.adbc_get_info()
-        except Exception:
-            return False
-        driver_name = str(driver_info.get("driver_name", "")).lower()
-        return "flight sql" in driver_name or "flightsql" in driver_name
-
     def handle_database_exceptions(self) -> "AdbcExceptionHandler":
         """Handle database-specific exceptions and wrap them appropriately.
 
@@ -544,19 +511,6 @@ class AdbcDriver(SyncDriverAdapterBase):
         """Resolve rowcount from ADBC cursor for the direct execution path."""
         return resolve_rowcount(cursor)
 
-    def _connection_in_transaction(self) -> bool:
-        """Check if connection is in transaction.
-
-        ADBC uses explicit BEGIN and does not expose reliable transaction state.
-
-        Returns:
-            False - ADBC requires explicit transaction management.
-        """
-        return False
-
-    def _resolve_column_names(self, description: Any) -> list[str]:
-        return resolve_column_names(description, self._column_name_cache)
-
     def prepare_driver_parameters(
         self,
         parameters: Any,
@@ -604,6 +558,52 @@ class AdbcDriver(SyncDriverAdapterBase):
             )
 
         return super().prepare_driver_parameters(parameters, statement_config, is_many, prepared_statement)
+
+    def _connection_in_transaction(self) -> bool:
+        """Check if connection is in transaction.
+
+        ADBC uses explicit BEGIN and does not expose reliable transaction state.
+
+        Returns:
+            False - ADBC requires explicit transaction management.
+        """
+        return False
+
+    @staticmethod
+    def _detect_flightsql_connection(connection: "AdbcConnection") -> bool:
+        try:
+            driver_info = connection.adbc_get_info()
+        except Exception:
+            return False
+        driver_name = str(driver_info.get("driver_name", "")).lower()
+        return "flight sql" in driver_name or "flightsql" in driver_name
+
+    def _resolve_column_names(self, description: Any) -> list[str]:
+        return resolve_column_names(description, self._column_name_cache)
+
+    @staticmethod
+    def _resolve_count_result_rowcount(cursor: "AdbcRawCursor", *, fallback: int) -> int:
+        """Consume ADBC count result streams and return their row count."""
+        if not cursor.description:
+            return fallback
+        try:
+            rows = cursor.fetchall()
+        except Exception:
+            return fallback
+        if not rows:
+            return fallback
+
+        first_row = rows[0]
+        if isinstance(first_row, dict):
+            first_value = next(iter(first_row.values()), None)
+        elif isinstance(first_row, (tuple, list)) and first_row:
+            first_value = first_row[0]
+        else:
+            first_value = first_row
+
+        if isinstance(first_value, int):
+            return first_value
+        return fallback
 
 
 register_driver_profile("adbc", driver_profile)

--- a/sqlspec/adapters/adbc/driver.py
+++ b/sqlspec/adapters/adbc/driver.py
@@ -87,6 +87,7 @@ class AdbcDriver(SyncDriverAdapterBase):
         "_data_dictionary",
         "_detected_dialect",
         "_dialect_name",
+        "_is_flightsql",
         "_is_postgres",
         "_json_serializer",
         "dialect",
@@ -101,6 +102,7 @@ class AdbcDriver(SyncDriverAdapterBase):
         dialect: "str | None" = None,
     ) -> None:
         self._detected_dialect = detect_dialect(connection, logger, fallback_dialect=dialect)
+        self._is_flightsql = self._detect_flightsql_connection(connection)
 
         if statement_config is None:
             base_config = get_statement_config(self._detected_dialect)
@@ -156,7 +158,7 @@ class AdbcDriver(SyncDriverAdapterBase):
                 row_format=row_format,
             )
 
-        row_count = resolve_rowcount(cursor)
+        row_count = self._resolve_count_result_rowcount(cursor, fallback=resolve_rowcount(cursor))
         return self.create_execution_result(cursor, rowcount_override=row_count)
 
     def dispatch_execute_many(self, cursor: "AdbcRawCursor", statement: SQL) -> "ExecutionResult":
@@ -177,19 +179,32 @@ class AdbcDriver(SyncDriverAdapterBase):
                 row_count = 0
             elif isinstance(prepared_parameters, (list, tuple)) and prepared_parameters:
                 parameter_count = len(prepared_parameters)
-                try:
-                    cursor.executemany(sql, prepared_parameters)
-                except Exception as exc:
-                    if _MULTI_ROW_BIND_UNSUPPORTED not in str(exc):
-                        raise
+                if self._is_flightsql:
+                    row_count = 0
                     for row in prepared_parameters:
                         cursor.execute(sql, parameters=row)
-                    row_count = parameter_count
+                        row_count += self._resolve_count_result_rowcount(cursor, fallback=1)
                 else:
-                    row_count = resolve_many_rowcount(cursor, prepared_parameters, fallback_count=parameter_count)
+                    try:
+                        cursor.executemany(sql, prepared_parameters)
+                    except Exception as exc:
+                        if _MULTI_ROW_BIND_UNSUPPORTED not in str(exc):
+                            raise
+                        row_count = 0
+                        for row in prepared_parameters:
+                            cursor.execute(sql, parameters=row)
+                            row_count += self._resolve_count_result_rowcount(cursor, fallback=1)
+                    else:
+                        row_count = self._resolve_count_result_rowcount(
+                            cursor,
+                            fallback=resolve_many_rowcount(cursor, prepared_parameters, fallback_count=parameter_count),
+                        )
+            elif self._is_flightsql:
+                cursor.execute(sql, parameters=prepared_parameters)
+                row_count = self._resolve_count_result_rowcount(cursor, fallback=1)
             else:
                 cursor.executemany(sql, prepared_parameters)
-                row_count = resolve_rowcount(cursor)
+                row_count = self._resolve_count_result_rowcount(cursor, fallback=resolve_rowcount(cursor))
 
         except Exception:
             handle_postgres_rollback(self._dialect_name, cursor, logger)
@@ -227,7 +242,9 @@ class AdbcDriver(SyncDriverAdapterBase):
                 else:
                     cursor.execute(stmt)
                 successful_count += 1
-                last_rowcount = normalize_script_rowcount(last_rowcount, cursor)
+                last_rowcount = self._resolve_count_result_rowcount(
+                    cursor, fallback=normalize_script_rowcount(last_rowcount, cursor)
+                )
         except Exception:
             handle_postgres_rollback(self._dialect_name, cursor, logger)
             raise
@@ -306,6 +323,39 @@ class AdbcDriver(SyncDriverAdapterBase):
             Cursor context manager
         """
         return AdbcCursor(connection)
+
+    @staticmethod
+    def _resolve_count_result_rowcount(cursor: "AdbcRawCursor", *, fallback: int) -> int:
+        """Consume ADBC count result streams and return their row count."""
+        if not cursor.description:
+            return fallback
+        try:
+            rows = cursor.fetchall()
+        except Exception:
+            return fallback
+        if not rows:
+            return fallback
+
+        first_row = rows[0]
+        if isinstance(first_row, dict):
+            first_value = next(iter(first_row.values()), None)
+        elif isinstance(first_row, (tuple, list)) and first_row:
+            first_value = first_row[0]
+        else:
+            first_value = first_row
+
+        if isinstance(first_value, int):
+            return first_value
+        return fallback
+
+    @staticmethod
+    def _detect_flightsql_connection(connection: "AdbcConnection") -> bool:
+        try:
+            driver_info = connection.adbc_get_info()
+        except Exception:
+            return False
+        driver_name = str(driver_info.get("driver_name", "")).lower()
+        return "flight sql" in driver_name or "flightsql" in driver_name
 
     def handle_database_exceptions(self) -> "AdbcExceptionHandler":
         """Handle database-specific exceptions and wrap them appropriately.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ pytest_plugins = [
     "pytest_databases.docker.mysql",
     "pytest_databases.docker.bigquery",
     "pytest_databases.docker.spanner",
+    "pytest_databases.docker.gizmosql",
     "pytest_databases.docker.cockroachdb",
     "pytest_databases.docker.rustfs",
 ]

--- a/tests/integration/adapters/adbc/conftest.py
+++ b/tests/integration/adapters/adbc/conftest.py
@@ -2,12 +2,20 @@
 
 import functools
 from collections.abc import Callable, Generator
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import pytest
+from adbc_driver_flightsql import DatabaseOptions
+from adbc_driver_flightsql import dbapi as flightsql
+from pytest_databases.docker.gizmosql import GizmoSQLService
 from pytest_databases.docker.postgres import PostgresService
+from pytest_databases.helpers import get_xdist_worker_num
 
 from sqlspec.adapters.adbc import AdbcConfig, AdbcDriver
+
+if TYPE_CHECKING:
+    from pytest_databases._service import DockerService
+    from pytest_databases.types import XdistIsolationLevel
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -30,6 +38,197 @@ def xfail_if_driver_missing(func: F) -> F:
             raise e
 
     return cast("F", wrapper)
+
+
+@pytest.fixture(scope="session")
+def xdist_gizmosql_isolation_level() -> "XdistIsolationLevel":
+    """Use one GizmoSQL server per xdist worker."""
+
+    return "server"
+
+
+def _gizmosql_db_kwargs(username: str, password: str) -> "dict[str, str]":
+    return {"username": username, "password": password, DatabaseOptions.TLS_SKIP_VERIFY.value: "true"}
+
+
+def _gizmosql_connection_config(service: "GizmoSQLService", *, backend: str) -> "dict[str, Any]":
+    return {
+        "driver_name": "gizmosql",
+        "uri": service.uri,
+        "username": service.username,
+        "password": service.password,
+        "tls_skip_verify": True,
+        "gizmosql_backend": backend,
+    }
+
+
+def _prepare_gizmosql_test_table(session: "AdbcDriver") -> None:
+    try:
+        session.execute("DROP TABLE IF EXISTS test_table_adbc")
+    except Exception:
+        pass
+    session.execute(
+        """
+            CREATE TABLE test_table_adbc (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE,
+                value INTEGER DEFAULT 0,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """
+    )
+    session.execute("DELETE FROM test_table_adbc")
+    session.commit()
+
+
+@pytest.fixture(scope="session")
+def gizmosql_service(
+    docker_service: "DockerService", gizmosql_image: str, gizmosql_username: str, gizmosql_password: str
+) -> "Generator[GizmoSQLService, None, None]":
+    """Run the default GizmoSQL container using the DuckDB backend."""
+
+    def check(service: Any) -> bool:
+        try:
+            uri = f"grpc+tls://{service.host}:{service.port}"
+            db_kwargs = _gizmosql_db_kwargs(gizmosql_username, gizmosql_password)
+            with flightsql.connect(uri=uri, db_kwargs=db_kwargs, autocommit=True) as conn:
+                vendor_version = conn.adbc_get_info().get("vendor_version", "").lower()
+                return "duckdb" in vendor_version
+        except Exception:
+            return False
+
+    worker_num = get_xdist_worker_num()
+    name = "gizmosql"
+    if worker_num is not None:
+        name += f"_{worker_num}"
+
+    env = {
+        "DATABASE_BACKEND": "duckdb",
+        "GIZMOSQL_PASSWORD": gizmosql_password,
+        "GIZMOSQL_USERNAME": gizmosql_username,
+        "TLS_ENABLED": "1",
+    }
+
+    with docker_service.run(
+        image=gizmosql_image,
+        check=check,
+        container_port=31337,
+        name=name,
+        env=env,
+        timeout=90,
+        pause=1.0,
+        transient=True,
+    ) as service:
+        yield GizmoSQLService(
+            host=service.host,
+            port=service.port,
+            container=service.container,
+            username=gizmosql_username,
+            password=gizmosql_password,
+        )
+
+
+@pytest.fixture(scope="session")
+def gizmosql_sqlite_service(
+    docker_service: "DockerService", gizmosql_image: str, gizmosql_username: str, gizmosql_password: str
+) -> "Generator[GizmoSQLService, None, None]":
+    """Run a second GizmoSQL container using the SQLite backend."""
+
+    def check(service: Any) -> bool:
+        try:
+            uri = f"grpc+tls://{service.host}:{service.port}"
+            db_kwargs = _gizmosql_db_kwargs(gizmosql_username, gizmosql_password)
+            with flightsql.connect(uri=uri, db_kwargs=db_kwargs, autocommit=True) as conn:
+                vendor_version = conn.adbc_get_info().get("vendor_version", "").lower()
+                return "sqlite" in vendor_version
+        except Exception:
+            return False
+
+    worker_num = get_xdist_worker_num()
+    name = "gizmosql_sqlite"
+    if worker_num is not None:
+        name += f"_{worker_num}"
+
+    env = {
+        "DATABASE_BACKEND": "sqlite",
+        "GIZMOSQL_PASSWORD": gizmosql_password,
+        "GIZMOSQL_USERNAME": gizmosql_username,
+        "TLS_ENABLED": "1",
+    }
+
+    with docker_service.run(
+        image=gizmosql_image,
+        check=check,
+        container_port=31337,
+        name=name,
+        env=env,
+        timeout=90,
+        pause=1.0,
+        transient=True,
+    ) as service:
+        yield GizmoSQLService(
+            host=service.host,
+            port=service.port,
+            container=service.container,
+            username=gizmosql_username,
+            password=gizmosql_password,
+        )
+
+
+@pytest.fixture(scope="session")
+def adbc_gizmosql_connection_config(gizmosql_service: "GizmoSQLService") -> "dict[str, Any]":
+    """Shared connection configuration for DuckDB-backed GizmoSQL tests."""
+
+    return _gizmosql_connection_config(gizmosql_service, backend="duckdb")
+
+
+@pytest.fixture(scope="session")
+def adbc_gizmosql_config(adbc_gizmosql_connection_config: "dict[str, Any]") -> "Generator[AdbcConfig, None, None]":
+    """Provide an ADBC config targeting DuckDB-backed GizmoSQL."""
+
+    config = AdbcConfig(connection_config=dict(adbc_gizmosql_connection_config))
+    try:
+        yield config
+    finally:
+        config.close_pool()
+
+
+@pytest.fixture(scope="function")
+def adbc_gizmosql_session(adbc_gizmosql_config: "AdbcConfig") -> "Generator[AdbcDriver, None, None]":
+    """Create a DuckDB-backed GizmoSQL ADBC session."""
+
+    with adbc_gizmosql_config.provide_session() as session:
+        _prepare_gizmosql_test_table(session)
+        yield session
+
+
+@pytest.fixture(scope="session")
+def adbc_gizmosql_sqlite_connection_config(gizmosql_sqlite_service: "GizmoSQLService") -> "dict[str, Any]":
+    """Shared connection configuration for SQLite-backed GizmoSQL tests."""
+
+    return _gizmosql_connection_config(gizmosql_sqlite_service, backend="sqlite")
+
+
+@pytest.fixture(scope="session")
+def adbc_gizmosql_sqlite_config(
+    adbc_gizmosql_sqlite_connection_config: "dict[str, Any]",
+) -> "Generator[AdbcConfig, None, None]":
+    """Provide an ADBC config targeting SQLite-backed GizmoSQL."""
+
+    config = AdbcConfig(connection_config=dict(adbc_gizmosql_sqlite_connection_config))
+    try:
+        yield config
+    finally:
+        config.close_pool()
+
+
+@pytest.fixture(scope="function")
+def adbc_gizmosql_sqlite_session(adbc_gizmosql_sqlite_config: "AdbcConfig") -> "Generator[AdbcDriver, None, None]":
+    """Create a SQLite-backed GizmoSQL ADBC session."""
+
+    with adbc_gizmosql_sqlite_config.provide_session() as session:
+        _prepare_gizmosql_test_table(session)
+        yield session
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/adapters/adbc/test_gizmosql.py
+++ b/tests/integration/adapters/adbc/test_gizmosql.py
@@ -1,0 +1,213 @@
+"""GizmoSQL integration tests for the ADBC adapter."""
+
+from typing import TypeAlias
+
+import pytest
+
+from sqlspec import SQLResult
+from sqlspec.adapters.adbc import AdbcConfig, AdbcDriver
+from sqlspec.adapters.adbc.core import detect_dialect
+from sqlspec.exceptions import SQLParsingError, UniqueViolationError
+from tests.integration.adapters.adbc.conftest import xfail_if_driver_missing
+
+pytestmark = [pytest.mark.adbc, pytest.mark.xdist_group("gizmosql")]
+
+SQLITE_FLIGHTSQL_RESULT_XFAIL = (
+    "Tracked in sqlspec-z5q3.1: GizmoSQL SQLite FlightSQL result streams return inconsistent schemas with ADBC 1.11"
+)
+DUCKDB_DUPLICATE_KEY_XFAIL = (
+    "Tracked in sqlspec-z5q3.2: GizmoSQL DuckDB suppresses duplicate-key errors over FlightSQL ADBC 1.11"
+)
+
+GizmoSQLSessionCase: TypeAlias = tuple[AdbcDriver, str]
+GizmoSQLConfigCase: TypeAlias = tuple[AdbcConfig, str]
+
+
+@pytest.fixture(params=[pytest.param(("adbc_gizmosql_session", "duckdb"), id="duckdb")])
+def gizmosql_session_case(request: pytest.FixtureRequest) -> GizmoSQLSessionCase:
+    """Return a GizmoSQL session and expected backend dialect."""
+
+    fixture_name, expected_dialect = request.param
+    return request.getfixturevalue(fixture_name), expected_dialect
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(("adbc_gizmosql_config", "duckdb"), id="duckdb"),
+        pytest.param(("adbc_gizmosql_sqlite_config", "sqlite"), id="sqlite"),
+    ]
+)
+def gizmosql_config_case(request: pytest.FixtureRequest) -> GizmoSQLConfigCase:
+    """Return a GizmoSQL config and expected backend dialect."""
+
+    fixture_name, expected_dialect = request.param
+    return request.getfixturevalue(fixture_name), expected_dialect
+
+
+def _count_rows(session: AdbcDriver, name: str) -> int:
+    result = session.execute("SELECT COUNT(*) AS count FROM test_table_adbc WHERE name = ?", (name,))
+    assert result.data is not None
+    return int(result.get_data()[0]["count"])
+
+
+@xfail_if_driver_missing
+def test_gizmosql_provides_connection_and_session(gizmosql_config_case: GizmoSQLConfigCase) -> None:
+    """GizmoSQL configs should provide raw ADBC connections and sqlspec sessions."""
+    config, expected_dialect = gizmosql_config_case
+
+    with config.provide_connection() as connection:
+        assert connection is not None
+        assert detect_dialect(connection) == expected_dialect
+
+    with config.provide_session() as session:
+        assert isinstance(session, AdbcDriver)
+        assert session.dialect == expected_dialect
+
+
+@xfail_if_driver_missing
+@pytest.mark.xfail(reason=SQLITE_FLIGHTSQL_RESULT_XFAIL, strict=False)
+def test_gizmosql_sqlite_result_streams_fetch(adbc_gizmosql_sqlite_config: AdbcConfig) -> None:
+    """GizmoSQL SQLite should return stable FlightSQL result schemas."""
+    with adbc_gizmosql_sqlite_config.provide_session() as session:
+        result = session.execute("SELECT 1 AS value")
+
+    assert result.data is not None
+    assert result.get_data() == [{"value": 1}]
+
+
+@xfail_if_driver_missing
+def test_gizmosql_basic_crud(gizmosql_session_case: GizmoSQLSessionCase) -> None:
+    """GizmoSQL should support basic CRUD through the ADBC driver."""
+    session, _expected_dialect = gizmosql_session_case
+
+    insert_result = session.execute("INSERT INTO test_table_adbc (id, name, value) VALUES (?, ?, ?)", (1, "one", 10))
+    assert isinstance(insert_result, SQLResult)
+    assert insert_result.rows_affected in (-1, 0, 1)
+
+    select_result = session.execute("SELECT name, value FROM test_table_adbc WHERE id = ?", (1,))
+    assert select_result.data is not None
+    assert select_result.get_data() == [{"name": "one", "value": 10}]
+
+    update_result = session.execute("UPDATE test_table_adbc SET value = ? WHERE id = ?", (20, 1))
+    assert isinstance(update_result, SQLResult)
+    assert update_result.rows_affected in (-1, 0, 1)
+
+    verify_result = session.execute("SELECT value FROM test_table_adbc WHERE id = ?", (1,))
+    assert verify_result.data is not None
+    assert verify_result.get_data()[0]["value"] == 20
+
+    delete_result = session.execute("DELETE FROM test_table_adbc WHERE id = ?", (1,))
+    assert isinstance(delete_result, SQLResult)
+    assert delete_result.rows_affected in (-1, 0, 1)
+    assert _count_rows(session, "one") == 0
+
+
+@xfail_if_driver_missing
+def test_gizmosql_execute_script_consumes_count_streams(gizmosql_session_case: GizmoSQLSessionCase) -> None:
+    """GizmoSQL script execution should consume FlightSQL DDL/DML count streams."""
+    session, _expected_dialect = gizmosql_session_case
+
+    result = session.execute_script(
+        """
+            DROP TABLE IF EXISTS gizmosql_script_test_adbc;
+            CREATE TABLE gizmosql_script_test_adbc (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                value INTEGER
+            );
+            INSERT INTO gizmosql_script_test_adbc (id, name, value) VALUES (1, 'script-one', 1);
+            UPDATE gizmosql_script_test_adbc SET value = 2 WHERE id = 1;
+        """
+    )
+
+    assert isinstance(result, SQLResult)
+    select_result = session.execute("SELECT name, value FROM gizmosql_script_test_adbc WHERE id = ?", (1,))
+    assert select_result.data is not None
+    assert select_result.get_data() == [{"name": "script-one", "value": 2}]
+
+
+@xfail_if_driver_missing
+def test_gizmosql_qmark_parameters_accept_positional_lists(gizmosql_session_case: GizmoSQLSessionCase) -> None:
+    """GizmoSQL should execute qmark parameters with positional list values."""
+    session, _expected_dialect = gizmosql_session_case
+
+    session.execute("INSERT INTO test_table_adbc (id, name, value) VALUES (?, ?, ?)", [2, "list-bind", 30])
+
+    result = session.execute("SELECT value FROM test_table_adbc WHERE name = ?", ["list-bind"])
+    assert result.data is not None
+    assert result.get_data()[0]["value"] == 30
+
+
+@xfail_if_driver_missing
+def test_gizmosql_numeric_parameters_execute(gizmosql_session_case: GizmoSQLSessionCase) -> None:
+    """GizmoSQL should execute numeric parameters through FlightSQL."""
+    session, _expected_dialect = gizmosql_session_case
+
+    session.execute("INSERT INTO test_table_adbc (id, name, value) VALUES ($1, $2, $3)", (3, "numeric-bind", 40))
+
+    result = session.execute("SELECT value FROM test_table_adbc WHERE name = $1", ("numeric-bind",))
+    assert result.data is not None
+    assert result.get_data()[0]["value"] == 40
+
+
+@xfail_if_driver_missing
+def test_gizmosql_execute_many_reports_bulk_count(gizmosql_session_case: GizmoSQLSessionCase) -> None:
+    """GizmoSQL executemany should report the submitted parameter-set count."""
+    session, _expected_dialect = gizmosql_session_case
+    parameters = [(10, "bulk-one", 1), (11, "bulk-two", 2), (12, "bulk-three", 3)]
+
+    result = session.execute_many("INSERT INTO test_table_adbc (id, name, value) VALUES (?, ?, ?)", parameters)
+
+    assert result.rows_affected == len(parameters)
+    count_result = session.execute("SELECT COUNT(*) AS count FROM test_table_adbc WHERE name LIKE ?", ("bulk-%",))
+    assert count_result.data is not None
+    assert count_result.get_data()[0]["count"] == len(parameters)
+
+
+@xfail_if_driver_missing
+def test_gizmosql_transactions_commit_and_rollback(gizmosql_session_case: GizmoSQLSessionCase) -> None:
+    """GizmoSQL should honor explicit begin, commit, and rollback calls."""
+    session, _expected_dialect = gizmosql_session_case
+
+    session.begin()
+    session.execute("INSERT INTO test_table_adbc (id, name, value) VALUES (?, ?, ?)", (20, "rolled-back", 1))
+    session.rollback()
+    assert _count_rows(session, "rolled-back") == 0
+
+    session.begin()
+    session.execute("INSERT INTO test_table_adbc (id, name, value) VALUES (?, ?, ?)", (21, "committed", 2))
+    session.commit()
+    assert _count_rows(session, "committed") == 1
+
+
+@xfail_if_driver_missing
+@pytest.mark.xfail(reason=DUCKDB_DUPLICATE_KEY_XFAIL, strict=False)
+def test_gizmosql_unique_violation_maps_to_sqlspec_exception(gizmosql_session_case: GizmoSQLSessionCase) -> None:
+    """GizmoSQL duplicate primary keys should map to UniqueViolationError."""
+    session, _expected_dialect = gizmosql_session_case
+
+    session.execute("INSERT INTO test_table_adbc (id, name, value) VALUES (?, ?, ?)", (30, "unique-one", 1))
+
+    with pytest.raises(UniqueViolationError):
+        session.execute("INSERT INTO test_table_adbc (id, name, value) VALUES (?, ?, ?)", (30, "unique-two", 2))
+
+
+@xfail_if_driver_missing
+def test_gizmosql_syntax_error_maps_to_sql_parsing_error(gizmosql_session_case: GizmoSQLSessionCase) -> None:
+    """GizmoSQL parser errors should map to SQLParsingError."""
+    session, _expected_dialect = gizmosql_session_case
+
+    with pytest.raises(SQLParsingError):
+        session.execute("SELCT * FROM test_table_adbc")
+
+
+@xfail_if_driver_missing
+def test_gizmosql_explain_select(gizmosql_session_case: GizmoSQLSessionCase) -> None:
+    """GizmoSQL should execute EXPLAIN SELECT end to end."""
+    session, _expected_dialect = gizmosql_session_case
+
+    result = session.execute("EXPLAIN SELECT * FROM test_table_adbc")
+
+    assert isinstance(result, SQLResult)
+    assert result.data is not None
+    assert len(result.data) >= 1

--- a/tests/integration/adapters/adbc/test_gizmosql_arrow.py
+++ b/tests/integration/adapters/adbc/test_gizmosql_arrow.py
@@ -1,0 +1,106 @@
+"""GizmoSQL Arrow and storage bridge integration tests for ADBC."""
+
+from pathlib import Path
+
+import pyarrow as pa
+import pytest
+
+from sqlspec.adapters.adbc import AdbcDriver
+from sqlspec.storage.registry import storage_registry
+from tests.integration.adapters.adbc.conftest import xfail_if_driver_missing
+
+pytestmark = [pytest.mark.adbc, pytest.mark.xdist_group("gizmosql")]
+
+
+def _seed_arrow_rows(session: AdbcDriver) -> None:
+    rows = [(101, "arrow-one", 11), (102, "arrow-two", 22), (103, "arrow-three", 33)]
+    session.execute_many("INSERT INTO test_table_adbc (id, name, value) VALUES (?, ?, ?)", rows)
+
+
+@xfail_if_driver_missing
+def test_gizmosql_select_to_arrow_table(adbc_gizmosql_session: AdbcDriver) -> None:
+    """GizmoSQL should expose FlightSQL results through sqlspec's Arrow API."""
+    _seed_arrow_rows(adbc_gizmosql_session)
+
+    result = adbc_gizmosql_session.select_to_arrow(
+        "SELECT id, name, value FROM test_table_adbc WHERE id >= ? ORDER BY id", (101,)
+    )
+    table = result.get_data()
+
+    assert result.rows_affected == 3
+    assert result.column_names == ["id", "name", "value"]
+    assert table.to_pylist() == [
+        {"id": 101, "name": "arrow-one", "value": 11},
+        {"id": 102, "name": "arrow-two", "value": 22},
+        {"id": 103, "name": "arrow-three", "value": 33},
+    ]
+
+
+@xfail_if_driver_missing
+def test_gizmosql_select_to_arrow_record_batches(adbc_gizmosql_session: AdbcDriver) -> None:
+    """GizmoSQL Arrow results should support batch-shaped returns."""
+    _seed_arrow_rows(adbc_gizmosql_session)
+
+    result = adbc_gizmosql_session.select_to_arrow(
+        "SELECT id, name FROM test_table_adbc WHERE id >= ? ORDER BY id", (101,), return_format="batches", batch_size=2
+    )
+    batches = result.get_data()
+
+    assert len(batches) == 2
+    assert sum(batch.num_rows for batch in batches) == 3
+    assert batches[0].schema.names == ["id", "name"]
+
+
+@xfail_if_driver_missing
+def test_gizmosql_load_from_arrow_round_trip(adbc_gizmosql_session: AdbcDriver) -> None:
+    """GizmoSQL should ingest Arrow tables through the ADBC storage bridge."""
+    arrow_table = pa.table({
+        "id": [201, 202, 203],
+        "label": ["ingest-one", "ingest-two", "ingest-three"],
+        "amount": [1.5, 2.5, 3.5],
+    })
+
+    job = adbc_gizmosql_session.load_from_arrow("gizmosql_arrow_ingest_adbc", arrow_table, overwrite=True)
+
+    assert job.telemetry["rows_processed"] == 3
+    result = adbc_gizmosql_session.execute("SELECT id, label, amount FROM gizmosql_arrow_ingest_adbc ORDER BY id")
+    assert result.get_data() == [
+        {"id": 201, "label": "ingest-one", "amount": 1.5},
+        {"id": 202, "label": "ingest-two", "amount": 2.5},
+        {"id": 203, "label": "ingest-three", "amount": 3.5},
+    ]
+
+
+@xfail_if_driver_missing
+def test_gizmosql_storage_bridge_round_trip(tmp_path: Path, adbc_gizmosql_session: AdbcDriver) -> None:
+    """GizmoSQL should export to local Parquet and load it back through ADBC."""
+    _seed_arrow_rows(adbc_gizmosql_session)
+    alias = "gizmosql_storage_bridge_local"
+    storage_registry.register_alias(alias, f"file://{tmp_path}", backend="local")
+    destination = f"alias://{alias}/gizmosql_storage_bridge.parquet"
+
+    try:
+        export_job = adbc_gizmosql_session.select_to_storage(
+            "SELECT id, name, value FROM test_table_adbc WHERE id >= ? ORDER BY id",
+            destination,
+            (101,),
+            format_hint="parquet",
+        )
+        assert export_job.telemetry["rows_processed"] == 3
+        assert (tmp_path / "gizmosql_storage_bridge.parquet").exists()
+
+        load_job = adbc_gizmosql_session.load_from_storage(
+            "gizmosql_storage_bridge_target_adbc", destination, file_format="parquet", overwrite=True
+        )
+        assert load_job.telemetry["rows_processed"] == 3
+
+        result = adbc_gizmosql_session.execute(
+            "SELECT id, name, value FROM gizmosql_storage_bridge_target_adbc ORDER BY id"
+        )
+        assert result.get_data() == [
+            {"id": 101, "name": "arrow-one", "value": 11},
+            {"id": 102, "name": "arrow-two", "value": 22},
+            {"id": 103, "name": "arrow-three", "value": 33},
+        ]
+    finally:
+        storage_registry.clear()

--- a/tests/integration/adapters/adbc/test_gizmosql_data_dictionary.py
+++ b/tests/integration/adapters/adbc/test_gizmosql_data_dictionary.py
@@ -1,0 +1,126 @@
+"""GizmoSQL data dictionary and migration integration tests for ADBC."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from sqlspec.adapters.adbc import AdbcConfig, AdbcDriver
+from sqlspec.data_dictionary import VersionInfo
+from sqlspec.migrations.commands import AsyncMigrationCommands, SyncMigrationCommands, create_migration_commands
+from tests.integration.adapters.adbc.conftest import xfail_if_driver_missing
+
+pytestmark = [pytest.mark.adbc, pytest.mark.xdist_group("gizmosql")]
+
+
+@xfail_if_driver_missing
+def test_gizmosql_data_dictionary_tables_columns_and_indexes(adbc_gizmosql_session: AdbcDriver) -> None:
+    """GizmoSQL should expose DuckDB table and column metadata through the ADBC dictionary."""
+    adbc_gizmosql_session.execute_script(
+        """
+            DROP TABLE IF EXISTS gizmosql_dd_child_adbc;
+            DROP TABLE IF EXISTS gizmosql_dd_parent_adbc;
+            CREATE TABLE gizmosql_dd_parent_adbc (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE
+            );
+            CREATE TABLE gizmosql_dd_child_adbc (
+                id INTEGER PRIMARY KEY,
+                parent_id INTEGER NOT NULL,
+                amount DOUBLE,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (parent_id) REFERENCES gizmosql_dd_parent_adbc (id)
+            );
+        """
+    )
+    adbc_gizmosql_session.commit()
+
+    dictionary = adbc_gizmosql_session.data_dictionary
+    version = dictionary.get_version(adbc_gizmosql_session)
+    assert isinstance(version, VersionInfo)
+    assert version.major >= 1
+
+    schema_rows = adbc_gizmosql_session.execute(
+        """
+            SELECT DISTINCT table_schema
+            FROM information_schema.tables
+            WHERE table_name IN ('gizmosql_dd_parent_adbc', 'gizmosql_dd_child_adbc')
+            ORDER BY table_schema
+        """
+    ).get_data()
+    assert schema_rows
+    schema_name = schema_rows[0]["table_schema"]
+
+    table_names = {table["table_name"] for table in dictionary.get_tables(adbc_gizmosql_session, schema=schema_name)}
+    assert {"gizmosql_dd_parent_adbc", "gizmosql_dd_child_adbc"}.issubset(table_names)
+
+    columns = dictionary.get_columns(adbc_gizmosql_session, table="gizmosql_dd_child_adbc", schema=schema_name)
+    columns_by_name = {column["column_name"]: column for column in columns}
+    assert set(columns_by_name) == {"id", "parent_id", "amount", "created_at"}
+    assert columns_by_name["id"]["data_type"].upper() == "INTEGER"
+    assert columns_by_name["amount"]["data_type"].upper() == "DOUBLE"
+    assert columns_by_name["parent_id"]["is_nullable"] == "NO"
+
+    foreign_keys = dictionary.get_foreign_keys(
+        adbc_gizmosql_session, table="gizmosql_dd_child_adbc", schema=schema_name
+    )
+    assert any(
+        key.column_name == "parent_id" and key.referenced_table == "gizmosql_dd_parent_adbc" for key in foreign_keys
+    )
+
+    indexes = dictionary.get_indexes(adbc_gizmosql_session, table="gizmosql_dd_child_adbc", schema=schema_name)
+    assert indexes == []
+
+
+@xfail_if_driver_missing
+def test_gizmosql_migration_smoke(tmp_path: Path, adbc_gizmosql_connection_config: dict[str, Any]) -> None:
+    """GizmoSQL should run sqlspec migrations and no-op repeated upgrades."""
+    migration_dir = tmp_path / "gizmosql_migrations"
+    version_table = "gizmosql_migrations_adbc"
+    migrated_table = "gizmosql_migrated_items_adbc"
+    config = AdbcConfig(
+        connection_config=dict(adbc_gizmosql_connection_config),
+        migration_config={"script_location": str(migration_dir), "version_table_name": version_table},
+    )
+    commands: SyncMigrationCommands[Any] | AsyncMigrationCommands[Any] = create_migration_commands(config)
+
+    try:
+        with config.provide_session() as driver:
+            driver.execute(f"DROP TABLE IF EXISTS {migrated_table}")
+            driver.execute(f"DROP TABLE IF EXISTS {version_table}")
+
+        commands.init(str(migration_dir), package=True)
+        migration_content = f'''"""Create GizmoSQL migration smoke table."""
+
+
+def up():
+    """Create and seed migration smoke table."""
+    return [
+        """CREATE TABLE {migrated_table} (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL
+        )""",
+        "INSERT INTO {migrated_table} (id, name) VALUES (1, 'created-by-migration')",
+    ]
+
+
+def down():
+    """Drop migration smoke table."""
+    return ["DROP TABLE IF EXISTS {migrated_table}"]
+'''
+        (migration_dir / "0001_create_gizmosql_items.py").write_text(migration_content)
+
+        commands.upgrade()
+        commands.upgrade()
+
+        with config.provide_session() as driver:
+            data = driver.execute(f"SELECT id, name FROM {migrated_table} ORDER BY id").get_data()
+            assert data == [{"id": 1, "name": "created-by-migration"}]
+
+            versions = driver.execute(f"SELECT version_num FROM {version_table} ORDER BY version_num").get_data()
+            assert versions == [{"version_num": "0001"}]
+    finally:
+        with config.provide_session() as driver:
+            driver.execute(f"DROP TABLE IF EXISTS {migrated_table}")
+            driver.execute(f"DROP TABLE IF EXISTS {version_table}")
+        config.close_pool()

--- a/tests/unit/adapters/test_adbc/test_adbc_config_normalization.py
+++ b/tests/unit/adapters/test_adbc/test_adbc_config_normalization.py
@@ -119,6 +119,86 @@ def test_connection_config_dict_flattens_db_kwargs_for_non_bigquery() -> None:
     assert resolved["foo"] == "bar"
 
 
+def test_flightsql_lifts_username_password_into_db_kwargs() -> None:
+    """Top-level username/password move into db_kwargs for GizmoSQL."""
+    config = AdbcConfig(connection_config={"driver_name": "gizmosql", "username": "alice", "password": "secret"})
+    resolved = _get_connection_config_dict(config)
+
+    assert resolved["db_kwargs"] == {"username": "alice", "password": "secret"}
+    assert "username" not in resolved
+    assert "password" not in resolved
+
+
+def test_flightsql_lifts_tls_skip_verify_true() -> None:
+    """tls_skip_verify=True maps to the FlightSQL ADBC option key."""
+    config = AdbcConfig(connection_config={"driver_name": "gizmosql", "tls_skip_verify": True})
+    resolved = _get_connection_config_dict(config)
+
+    assert resolved["db_kwargs"]["adbc.flight.sql.client_option.tls_skip_verify"] == "true"
+
+
+def test_flightsql_lifts_tls_skip_verify_false() -> None:
+    """tls_skip_verify=False maps to the FlightSQL ADBC option key."""
+    config = AdbcConfig(connection_config={"driver_name": "gizmosql", "tls_skip_verify": False})
+    resolved = _get_connection_config_dict(config)
+
+    assert resolved["db_kwargs"]["adbc.flight.sql.client_option.tls_skip_verify"] == "false"
+
+
+def test_flightsql_lifts_authorization_header() -> None:
+    """authorization_header maps to the FlightSQL ADBC option key."""
+    config = AdbcConfig(connection_config={"driver_name": "gizmosql", "authorization_header": "Bearer token"})
+    resolved = _get_connection_config_dict(config)
+
+    assert resolved["db_kwargs"]["adbc.flight.sql.authorization_header"] == "Bearer token"
+
+
+def test_flightsql_explicit_db_kwargs_wins_over_top_level_shortcuts() -> None:
+    """User-supplied db_kwargs entries take precedence over top-level shortcuts."""
+    config = AdbcConfig(
+        connection_config={
+            "driver_name": "gizmosql",
+            "username": "alice",
+            "tls_skip_verify": False,
+            "db_kwargs": {"username": "override", "adbc.flight.sql.client_option.tls_skip_verify": "true"},
+        }
+    )
+    resolved = _get_connection_config_dict(config)
+
+    assert resolved["db_kwargs"]["username"] == "override"
+    assert resolved["db_kwargs"]["adbc.flight.sql.client_option.tls_skip_verify"] == "true"
+
+
+def test_flightsql_gizmosql_backend_is_stripped_from_outgoing_config() -> None:
+    """gizmosql_backend drives dialect selection but does not leak to FlightSQL."""
+    config = AdbcConfig(connection_config={"driver_name": "gizmosql", "gizmosql_backend": "sqlite"})
+    resolved = _get_connection_config_dict(config)
+
+    assert "gizmosql_backend" not in resolved
+    assert config.statement_config.dialect == "sqlite"
+
+
+def test_postgres_config_unchanged_by_flightsql_branch() -> None:
+    """PostgreSQL keeps historical non-BigQuery db_kwargs flattening behavior."""
+    config = AdbcConfig(
+        connection_config={"driver_name": "postgres", "username": "alice", "db_kwargs": {"sslmode": "require"}}
+    )
+    resolved = _get_connection_config_dict(config)
+
+    assert resolved["username"] == "alice"
+    assert resolved["sslmode"] == "require"
+    assert "db_kwargs" not in resolved
+
+
+def test_duckdb_config_unchanged_by_flightsql_branch() -> None:
+    """DuckDB configs are not affected by the FlightSQL branch."""
+    config = AdbcConfig(connection_config={"driver_name": "duckdb", "path": "/tmp/sqlspec-test.duckdb"})
+    resolved = _get_connection_config_dict(config)
+
+    assert resolved["path"] == "/tmp/sqlspec-test.duckdb"
+    assert "db_kwargs" not in resolved
+
+
 def test_gizmosql_default_dialect_is_duckdb() -> None:
     """Default GizmoSQL connections to DuckDB dialect."""
     config = AdbcConfig(connection_config={"driver_name": "gizmosql"})

--- a/tests/unit/adapters/test_adbc/test_core.py
+++ b/tests/unit/adapters/test_adbc/test_core.py
@@ -2,8 +2,9 @@
 
 from collections.abc import Sequence
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
+from sqlspec.adapters.adbc import AdbcDriver
 from sqlspec.adapters.adbc import core as adbc_core
 from sqlspec.adapters.adbc.core import (
     _prepare_batch_with_casts,
@@ -163,6 +164,40 @@ def test_prepare_parameters_with_casts_supports_virtual_abc_dispatch() -> None:
     assert prepared == [(1, 2)]
 
 
+def test_adbc_driver_resolves_count_stream_rowcount_from_tuple() -> None:
+    """FlightSQL count streams should be consumed and used as rowcount."""
+    cursor = SimpleNamespace(description=[("rows",)], fetchall=lambda: [(3,)])
+
+    rowcount = AdbcDriver._resolve_count_result_rowcount(cast("Any", cursor), fallback=-1)
+
+    assert rowcount == 3
+
+
+def test_adbc_driver_resolves_count_stream_rowcount_from_dict() -> None:
+    """FlightSQL count streams may return dict-shaped rows."""
+    cursor = SimpleNamespace(description=[("rows",)], fetchall=lambda: [{"rows": 4}])
+
+    rowcount = AdbcDriver._resolve_count_result_rowcount(cast("Any", cursor), fallback=-1)
+
+    assert rowcount == 4
+
+
+def test_adbc_driver_count_stream_rowcount_uses_fallback_without_description() -> None:
+    """Non-FlightSQL cursors without count streams should keep fallback rowcount."""
+    cursor = SimpleNamespace(description=None, fetchall=lambda: [(3,)])
+
+    rowcount = AdbcDriver._resolve_count_result_rowcount(cast("Any", cursor), fallback=2)
+
+    assert rowcount == 2
+
+
+def test_adbc_driver_detects_flightsql_connection() -> None:
+    """FlightSQL connections should use the row-by-row execute-many path."""
+    connection = SimpleNamespace(adbc_get_info=lambda: {"driver_name": "Flight SQL"})
+
+    assert AdbcDriver._detect_flightsql_connection(cast("Any", connection)) is True
+
+
 def test_detect_dialect_uses_fallback_when_introspection_returns_unknown() -> None:
     """detect_dialect honors fallback_dialect when GetInfo yields no pattern match."""
 
@@ -185,6 +220,34 @@ def test_detect_dialect_introspection_match_beats_fallback() -> None:
     conn = SimpleNamespace(adbc_get_info=lambda: {"vendor_name": "duckdb", "driver_name": ""})
     result = adbc_core.detect_dialect(conn, fallback_dialect="sqlite")
     assert result == "duckdb"
+
+
+def test_detect_dialect_uses_gizmosql_duckdb_vendor_version() -> None:
+    """GizmoSQL DuckDB metadata should beat the generic Flight SQL driver name."""
+
+    conn = SimpleNamespace(
+        adbc_get_info=lambda: {
+            "vendor_name": "GizmoSQL",
+            "vendor_version": "GizmoSQL DuckDB backend",
+            "driver_name": "Flight SQL",
+        }
+    )
+    result = adbc_core.detect_dialect(conn, fallback_dialect="sqlite")
+    assert result == "duckdb"
+
+
+def test_detect_dialect_uses_gizmosql_sqlite_vendor_version() -> None:
+    """GizmoSQL SQLite metadata should preserve SQLite backend detection."""
+
+    conn = SimpleNamespace(
+        adbc_get_info=lambda: {
+            "vendor_name": "GizmoSQL",
+            "vendor_version": "GizmoSQL SQLite backend",
+            "driver_name": "Flight SQL",
+        }
+    )
+    result = adbc_core.detect_dialect(conn, fallback_dialect="duckdb")
+    assert result == "sqlite"
 
 
 def test_handle_postgres_rollback_issues_rollback_for_pgvector() -> None:

--- a/tests/unit/driver/test_data_dictionary.py
+++ b/tests/unit/driver/test_data_dictionary.py
@@ -24,7 +24,7 @@ from sqlspec.adapters.psycopg.data_dictionary import PsycopgAsyncDataDictionary,
 from sqlspec.adapters.pymysql.data_dictionary import PyMysqlDataDictionary
 from sqlspec.adapters.spanner.data_dictionary import SpannerDataDictionary
 from sqlspec.adapters.sqlite.data_dictionary import SqliteDataDictionary
-from sqlspec.data_dictionary import VersionInfo
+from sqlspec.data_dictionary import IndexMetadata, VersionInfo
 from sqlspec.driver import SyncDriverAdapterBase
 from tests.conftest import requires_interpreted
 
@@ -363,6 +363,18 @@ def test_adbc_get_version_duckdb() -> None:
     assert version.major == 0
     assert version.minor == 9
     assert version.patch == 2
+
+
+def test_adbc_duckdb_indexes_use_parameterless_query() -> None:
+    """DuckDB ADBC index queries should not receive unused bind parameters."""
+    mock_driver = Mock()
+    mock_driver.dialect = "duckdb"
+    mock_driver.select.return_value = []
+
+    indexes = AdbcDataDictionary().get_indexes(mock_driver, table="example", schema="main")
+
+    assert indexes == []
+    assert mock_driver.select.call_args.kwargs == {"schema_type": IndexMetadata}
 
 
 def test_adbc_get_version_bigquery() -> None:


### PR DESCRIPTION
## Summary

- Add GizmoSQL ADBC configuration/runtime coverage: Flight SQL `db_kwargs` normalization, backend detection, count-stream rowcount handling, and Flight SQL execute-many behavior.
- Register and wire pytest-databases GizmoSQL fixtures, including DuckDB and SQLite backend paths, plus focused core, Arrow, storage bridge, data dictionary, and migration smoke coverage.
- Add CI image pre-pull and rework the ADBC reference page into a backend-oriented configuration guide that documents GizmoSQL alongside the other ADBC backends.
- Move new ADBC private helpers below the public APIs, matching the repo member-ordering convention.

## Flow / Beads

- Closed `sqlspec-z5q3.3` with commit `297b71a4255e794011b9ffb1b41cf0673cbbabd6`.
- Synced ignored Flow markdown locally under `.agents/`.
- Existing follow-ups remain open and are represented as expected xfails: `sqlspec-z5q3.1` and `sqlspec-z5q3.2`.

## Verification

- `uv run pytest tests/unit/adapters/test_adbc/test_core.py tests/unit/adapters/test_adbc/test_adbc_config_normalization.py tests/unit/driver/test_data_dictionary.py::test_adbc_duckdb_indexes_use_parameterless_query tests/integration/adapters/adbc/test_gizmosql.py tests/integration/adapters/adbc/test_gizmosql_arrow.py tests/integration/adapters/adbc/test_gizmosql_data_dictionary.py -q`
- `make lint`
- `make docs`

Full `make test` was not run locally; the focused live GizmoSQL integration suite, lint/type gate, and docs build covered the changed surface.
