### PR TITLE
fix(service): make begin_transaction context managers non-suppressing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ maintainers = [{ name = "Litestar Developers", email = "hello@litestar.dev" }]
 name = "sqlspec"
 readme = "README.md"
 requires-python = ">=3.10, <4.0"
-version = "0.49.0"
+version = "0.49.1"
 
 [project.urls]
 Discord = "https://discord.gg/litestar"
@@ -193,6 +193,7 @@ packages = ["sqlspec"]
 packages = []
 
 
+
 [tool.hatch.build.targets.wheel.hooks.mypyc]
 dependencies = ["hatch-mypyc", "hatch-cython", "mypy>=2.0.0"]
 enable-by-default = false
@@ -293,7 +294,7 @@ opt_level = "3"   # Maximum optimization (0-3)
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.49.0"
+current_version = "0.49.1"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to v{new_version}"

--- a/sqlspec/service.py
+++ b/sqlspec/service.py
@@ -1,7 +1,6 @@
 """Service base classes for SQLSpec application services."""
 
-from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Generic, cast, overload
+from typing import TYPE_CHECKING, Any, Generic, Literal, cast, overload
 
 from mypy_extensions import mypyc_attr
 from typing_extensions import TypeVar
@@ -14,7 +13,6 @@ from sqlspec.exceptions import NotFoundError
 from sqlspec.typing import SchemaT
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
     from types import TracebackType
 
     from sqlspec.builder import QueryBuilder
@@ -412,21 +410,13 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
         """Roll back the current database transaction."""
         self._session.rollback()
 
-    @contextmanager
-    def begin_transaction(self) -> "Iterator[SyncDriverT]":
+    def begin_transaction(self) -> "_SyncBeginTransactionContext[SyncDriverT]":
         """Context manager that commits on success and rolls back on error.
 
-        Yields:
+        Returns:
             The underlying driver session bound to the active transaction.
         """
-        self.begin()
-        try:
-            yield self._session
-        except Exception:
-            self.rollback()
-            raise
-        else:
-            self.commit()
+        return _SyncBeginTransactionContext(self)
 
 
 class _AsyncBeginTransactionContext(Generic[AsyncDriverT]):
@@ -442,10 +432,32 @@ class _AsyncBeginTransactionContext(Generic[AsyncDriverT]):
 
     async def __aexit__(
         self, exc_type: "type[BaseException] | None", exc: "BaseException | None", traceback: "TracebackType | None"
-    ) -> bool:
+    ) -> "Literal[False]":
         service = self._service
         if exc_type is None:
             await service.commit()
         else:
             await service.rollback()
+        return False
+
+
+class _SyncBeginTransactionContext(Generic[SyncDriverT]):
+    __slots__ = ("_service",)
+
+    def __init__(self, service: "SQLSpecSyncService[SyncDriverT]") -> None:
+        self._service = service
+
+    def __enter__(self) -> SyncDriverT:
+        service = self._service
+        service.begin()
+        return service.session
+
+    def __exit__(
+        self, exc_type: "type[BaseException] | None", exc: "BaseException | None", traceback: "TracebackType | None"
+    ) -> "Literal[False]":
+        service = self._service
+        if exc_type is None:
+            service.commit()
+        else:
+            service.rollback()
         return False

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -1,0 +1,66 @@
+"""Transaction-context semantics for the SQLSpec service base classes.
+
+These tests lock in the commit-on-success / rollback-on-error behavior of
+``begin_transaction`` for both the sync and async service bases, and assert that
+neither context manager suppresses exceptions raised inside the ``with`` body.
+The non-suppression guarantee is what lets callers ``return`` from inside the
+block without a trailing unreachable ``raise`` to satisfy type checkers.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from sqlspec.service import SQLSpecAsyncService, SQLSpecSyncService
+
+pytestmark = pytest.mark.anyio
+
+
+async def test_async_begin_transaction_commits_on_success() -> None:
+    session = AsyncMock()
+    service: SQLSpecAsyncService = SQLSpecAsyncService(session)
+
+    async with service.begin_transaction() as bound:
+        assert bound is session
+
+    session.begin.assert_awaited_once()
+    session.commit.assert_awaited_once()
+    session.rollback.assert_not_awaited()
+
+
+async def test_async_begin_transaction_rolls_back_and_propagates() -> None:
+    session = AsyncMock()
+    service: SQLSpecAsyncService = SQLSpecAsyncService(session)
+
+    with pytest.raises(ValueError, match="boom"):
+        async with service.begin_transaction():
+            raise ValueError("boom")
+
+    session.begin.assert_awaited_once()
+    session.rollback.assert_awaited_once()
+    session.commit.assert_not_awaited()
+
+
+def test_sync_begin_transaction_commits_on_success() -> None:
+    session = MagicMock()
+    service: SQLSpecSyncService = SQLSpecSyncService(session)
+
+    with service.begin_transaction() as bound:
+        assert bound is session
+
+    session.begin.assert_called_once()
+    session.commit.assert_called_once()
+    session.rollback.assert_not_called()
+
+
+def test_sync_begin_transaction_rolls_back_and_propagates() -> None:
+    session = MagicMock()
+    service: SQLSpecSyncService = SQLSpecSyncService(session)
+
+    with pytest.raises(ValueError, match="boom"):
+        with service.begin_transaction():
+            raise ValueError("boom")
+
+    session.begin.assert_called_once()
+    session.rollback.assert_called_once()
+    session.commit.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1482,7 +1482,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -6697,7 +6697,7 @@ wheels = [
 
 [[package]]
 name = "sqlspec"
-version = "0.49.0"
+version = "0.49.1"
 source = { editable = "." }
 dependencies = [
     { name = "mypy-extensions" },


### PR DESCRIPTION
## Summary

`SQLSpecAsyncService.begin_transaction` / `SQLSpecSyncService.begin_transaction` returned context managers whose exit methods were typed (directly or via `@contextmanager`) as returning `bool`. A context manager whose exit return type can be truthy is treated by mypy/pyright as **potentially suppressing exceptions**, so a `with` block whose only exit is a `return` is considered non-terminal. That forced downstream callers to append a dead `raise RuntimeError("Unreachable")` just to silence "missing return" diagnostics:

```python
async with self.begin_transaction():
    ...
    return await self.paginate(...)
msg = "Unreachable"
raise RuntimeError(msg)   # only there to satisfy the type checker
```

Both context managers always `return False` and never suppress, so this PR annotates them accordingly.

## Changes

- **Async**: `_AsyncBeginTransactionContext.__aexit__` return type `bool` → `Literal[False]`.
- **Sync**: replaced the `@contextmanager` generator with a hand-written `_SyncBeginTransactionContext` class whose `__exit__` returns `Literal[False]` (typeshed types `@contextmanager`'s `__exit__` as `bool`, which can't be narrowed). Drops the now-unused `contextmanager` / `Iterator` imports.
- **Tests**: new `tests/unit/test_service.py` covering commit-on-success and rollback-and-propagate for both sync and async bases (the rollback case asserts the exception still propagates — i.e. no suppression).

After this, callers can drop the trailing unreachable `raise` from every `with self.begin_transaction(): return ...` method.

### Behavior note
The sync rewrite now rolls back on **any** `BaseException` (matching the async sibling), whereas the old `@contextmanager` only rolled back on `Exception`. No public API change.

## Verification

- ruff, ruff-format, mypy, pyright: clean on `sqlspec/service.py`
- `pytest tests/unit/test_service.py tests/unit/extensions/test_service_reexports.py` → 9 passed
- `make release bump=patch` → docs build, package build, and version bump to `v0.49.1` all succeeded
