### PR TITLE
fix(psqlpy): align adapter config flags

### DIFF
--- a/docs/reference/adapters/psqlpy.rst
+++ b/docs/reference/adapters/psqlpy.rst
@@ -23,6 +23,12 @@ PsqlPy supports the :doc:`pgvector and ParadeDB dialects <../dialects>` for vect
 similarity search and full-text search operators. See the :doc:`Dialects <../dialects>`
 reference for operator details.
 
+``driver_features={"enable_pgvector": True}`` enables extension detection and
+promotes the runtime dialect to ``pgvector`` when the PostgreSQL ``vector``
+extension is installed. It does not register automatic psqlpy vector type
+handlers; pass ``psqlpy.extra_types.PgVector`` values or use explicit SQL casts
+for vector parameters.
+
 Driver
 ======
 

--- a/sqlspec/adapters/psqlpy/config.py
+++ b/sqlspec/adapters/psqlpy/config.py
@@ -86,10 +86,14 @@ class PsqlpyPoolParams(PsqlpyConnectionParams):
 class PsqlpyDriverFeatures(TypedDict):
     """Psqlpy driver feature flags.
 
-    enable_pgvector: Enable automatic pgvector extension support for vector similarity search.
-     Requires pgvector-python package installed.
-     Defaults to True when pgvector is installed.
-     Provides automatic conversion between NumPy arrays and PostgreSQL vector types.
+    enable_cast_detection: Enable cast-aware parameter processing.
+     Defaults to True. When enabled, SQL casts in prepared statements guide
+     psqlpy parameter coercion for JSON, UUID, and timestamp-like values.
+    enable_pgvector: Enable pgvector extension detection for vector similarity search.
+     Defaults to True when the pgvector Python package is installed.
+     Detects the PostgreSQL vector extension and promotes the dialect to "pgvector".
+     It does not register psqlpy type handlers; use psqlpy.extra_types.PgVector
+     or explicit SQL casts for vector values.
     enable_paradedb: Enable ParadeDB (pg_search) extension detection.
      When enabled and the pg_search extension is detected, the SQL dialect
      switches to "paradedb" which supports search operators (@@@, &&&, etc.)
@@ -112,6 +116,7 @@ class PsqlpyDriverFeatures(TypedDict):
      Defaults to "table_queue" until native LISTEN/NOTIFY support is implemented.
     """
 
+    enable_cast_detection: NotRequired[bool]
     enable_pgvector: NotRequired[bool]
     enable_paradedb: NotRequired[bool]
     json_serializer: NotRequired["Callable[[Any], str]"]
@@ -262,8 +267,6 @@ class PsqlpyConfig(AsyncDatabaseConfig[PsqlpyConnection, ConnectionPool, PsqlpyD
         conn_id = id(connection)
         if conn_id in self._initialized_connection_ids:
             return
-        if self._pgvector_available:
-            pass
         if self._user_connection_hook is not None:
             await self._user_connection_hook(connection)
         self._initialized_connection_ids.add(conn_id)

--- a/sqlspec/adapters/psqlpy/core.py
+++ b/sqlspec/adapters/psqlpy/core.py
@@ -257,6 +257,7 @@ def apply_driver_features(
     features: dict[str, Any] = dict(driver_features) if driver_features else {}
     serializer = features.get("json_serializer", to_json)
     features.setdefault("json_serializer", serializer)
+    features.setdefault("enable_cast_detection", True)
     features.setdefault("enable_pgvector", PGVECTOR_INSTALLED)
     features.setdefault("enable_paradedb", True)
 

--- a/tests/unit/adapters/test_psqlpy/test_config.py
+++ b/tests/unit/adapters/test_psqlpy/test_config.py
@@ -5,13 +5,31 @@ from unittest.mock import AsyncMock
 import pytest
 
 from sqlspec.adapters.psqlpy._typing import PsqlpySessionContext
-from sqlspec.adapters.psqlpy.config import PsqlpyConfig
+from sqlspec.adapters.psqlpy.config import PsqlpyConfig, PsqlpyDriverFeatures
 from sqlspec.adapters.psqlpy.core import (
     build_postgres_extension_probe_names,
     build_statement_config,
     resolve_postgres_extension_state,
 )
 from sqlspec.core import StatementConfig
+
+
+class _ExtensionQueryResult:
+    def __init__(self, extension_names: set[str]) -> None:
+        self._extension_names = extension_names
+
+    def result(self) -> list[dict[str, str]]:
+        return [{"extname": name} for name in self._extension_names]
+
+
+class _ExtensionConnection:
+    def __init__(self, extension_names: set[str]) -> None:
+        self._extension_names = extension_names
+        self.queries: list[tuple[str, list[list[str]]]] = []
+
+    async def fetch(self, query: str, parameters: list[list[str]]) -> _ExtensionQueryResult:
+        self.queries.append((query, parameters))
+        return _ExtensionQueryResult(self._extension_names)
 
 
 def test_build_default_statement_config_custom_serializer() -> None:
@@ -38,6 +56,25 @@ def test_psqlpy_config_applies_driver_feature_serializer() -> None:
     assert parameter_config.json_serializer is serializer
 
 
+def test_psqlpy_driver_features_declares_cast_detection() -> None:
+    """Driver feature typing should expose every consumed feature flag."""
+    assert "enable_cast_detection" in PsqlpyDriverFeatures.__annotations__
+
+
+def test_psqlpy_config_defaults_cast_detection_feature() -> None:
+    """Cast-aware parameter processing should be declared and enabled by default."""
+    config = PsqlpyConfig()
+
+    assert config.driver_features["enable_cast_detection"] is True
+
+
+def test_psqlpy_config_preserves_cast_detection_override() -> None:
+    """Callers should be able to disable cast-aware parameter processing."""
+    config = PsqlpyConfig(driver_features={"enable_cast_detection": False})
+
+    assert config.driver_features["enable_cast_detection"] is False
+
+
 def test_psqlpy_build_postgres_extension_probe_names_filters_disabled_features() -> None:
     """Only enabled extension probes should be returned."""
     assert build_postgres_extension_probe_names({"enable_pgvector": True, "enable_paradedb": False}) == ["vector"]
@@ -52,6 +89,19 @@ def test_psqlpy_resolve_postgres_extension_state_promotes_paradedb() -> None:
     assert statement_config.dialect == "paradedb"
     assert pgvector_available is True
     assert paradedb_available is True
+
+
+@pytest.mark.anyio
+async def test_psqlpy_enable_pgvector_detects_extension_and_promotes_dialect() -> None:
+    """Psqlpy pgvector support should mean extension detection and dialect promotion."""
+    config = PsqlpyConfig(driver_features={"enable_pgvector": True, "enable_paradedb": False})
+    connection = _ExtensionConnection({"vector"})
+
+    await config._ensure_connection_initialized(connection)  # pyright: ignore[reportPrivateUsage, reportArgumentType]
+
+    assert connection.queries[0][1] == [["vector"]]
+    assert config._pgvector_available is True  # pyright: ignore[reportPrivateUsage]
+    assert config.statement_config.dialect == "pgvector"
 
 
 @pytest.mark.anyio

--- a/tests/unit/adapters/test_psqlpy/test_config.py
+++ b/tests/unit/adapters/test_psqlpy/test_config.py
@@ -1,10 +1,11 @@
 """Psqlpy configuration tests covering statement config builders."""
 
+from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
 
-from sqlspec.adapters.psqlpy._typing import PsqlpySessionContext
+from sqlspec.adapters.psqlpy._typing import PsqlpyConnection, PsqlpySessionContext
 from sqlspec.adapters.psqlpy.config import PsqlpyConfig, PsqlpyDriverFeatures
 from sqlspec.adapters.psqlpy.core import (
     build_postgres_extension_probe_names,
@@ -97,7 +98,7 @@ async def test_psqlpy_enable_pgvector_detects_extension_and_promotes_dialect() -
     config = PsqlpyConfig(driver_features={"enable_pgvector": True, "enable_paradedb": False})
     connection = _ExtensionConnection({"vector"})
 
-    await config._ensure_connection_initialized(connection)  # pyright: ignore[reportPrivateUsage, reportArgumentType]
+    await config._ensure_connection_initialized(cast("PsqlpyConnection", connection))  # pyright: ignore[reportPrivateUsage]
 
     assert connection.queries[0][1] == [["vector"]]
     assert config._pgvector_available is True  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
## Summary

This PR aligns the psqlpy adapter config surface with behavior the adapter already relies on.

## Changes

- Adds `enable_cast_detection` to `PsqlpyDriverFeatures` and keeps it enabled by default.
- Preserves explicit `enable_cast_detection=False` overrides.
- Documents `enable_pgvector` as extension detection and dialect promotion, not automatic vector type-handler registration.
- Removes a dead pgvector initialization branch that did not configure runtime behavior.
- Adds focused coverage for psqlpy config flags, extension detection, and runtime statement config resolution.
