### PR TITLE
fix(arrow-odbc): type adapter config keys

### DIFF
--- a/sqlspec/adapters/arrow_odbc/config.py
+++ b/sqlspec/adapters/arrow_odbc/config.py
@@ -14,6 +14,7 @@ from sqlspec.extensions.events import EventRuntimeHints
 from sqlspec.utils.config_tools import normalize_connection_config
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from types import TracebackType
 
     from sqlspec.core import StatementConfig
@@ -35,6 +36,9 @@ class ArrowOdbcConnectionParams(TypedDict):
     pwd: NotRequired[str]
     user: NotRequired[str]
     password: NotRequired[str]
+    trusted_connection: NotRequired[bool | str]
+    trust_server_certificate: NotRequired[bool | str]
+    encrypt: NotRequired[bool | str]
     login_timeout: NotRequired[int]
     login_timeout_sec: NotRequired[int]
     packet_size: NotRequired[int]
@@ -53,6 +57,8 @@ class ArrowOdbcDriverFeatures(TypedDict):
     query_timeout_sec: NotRequired[int]
     connection_string: NotRequired[str]
     dbms_name: NotRequired[str]
+    json_serializer: "NotRequired[Callable[[Any], str]]"
+    json_deserializer: "NotRequired[Callable[[str], Any]]"
     enable_events: NotRequired[bool]
 
 

--- a/tests/unit/adapters/test_arrow_odbc.py
+++ b/tests/unit/adapters/test_arrow_odbc.py
@@ -9,7 +9,10 @@ pytest.importorskip("arrow_odbc")
 
 from sqlspec.adapters.arrow_odbc import (
     ArrowOdbcConfig,
+    ArrowOdbcConnectionParams,
     ArrowOdbcDriver,
+    ArrowOdbcDriverFeatures,
+    build_connection_config,
     odbc_type_to_arrow,
     resolve_dialect_from_dbms_name,
 )
@@ -187,6 +190,43 @@ def test_arrow_odbc_config_connects_with_verified_keyword_names(monkeypatch: Any
 
     assert calls == [("Driver={ODBC Driver 18 for SQL Server};", {"login_timeout_sec": 3, "autocommit": False})]
     assert connection.closed is True
+
+
+def test_arrow_odbc_connection_params_declares_routed_security_keys() -> None:
+    """Connection params should type the ODBC security keys routed by core."""
+    expected_keys = {"trusted_connection", "trust_server_certificate", "encrypt"}
+
+    assert expected_keys.issubset(ArrowOdbcConnectionParams.__annotations__)
+
+
+def test_arrow_odbc_driver_features_declares_json_serializers() -> None:
+    """Driver features should type the JSON hooks already defaulted by core."""
+    expected_keys = {"json_serializer", "json_deserializer"}
+
+    assert expected_keys.issubset(ArrowOdbcDriverFeatures.__annotations__)
+
+
+def test_arrow_odbc_build_connection_config_formats_security_fields_and_kwargs() -> None:
+    """Routed security fields should become canonical ODBC string keys."""
+    connection_string, kwargs = build_connection_config({
+        "driver": "ODBC Driver 18 for SQL Server",
+        "server": "localhost",
+        "database": "app",
+        "uid": "sa",
+        "pwd": "secret",
+        "trusted_connection": True,
+        "trust_server_certificate": True,
+        "encrypt": "mandatory",
+        "login_timeout": 7,
+        "packet_size": 8192,
+        "autocommit": True,
+    })
+
+    assert connection_string == (
+        "Driver=ODBC Driver 18 for SQL Server;Server=localhost;Database=app;UID=sa;PWD=secret;"
+        "Trusted_Connection=yes;TrustServerCertificate=yes;Encrypt=mandatory;"
+    )
+    assert kwargs == {"login_timeout_sec": 7, "packet_size": 8192, "autocommit": True}
 
 
 def test_arrow_odbc_session_release_allows_connections_without_close(monkeypatch: Any) -> None:


### PR DESCRIPTION
## Summary

This PR makes the Arrow ODBC adapter config type the ODBC security and driver-feature keys that the adapter already routes.

## Changes

- Adds typed connection params for `trusted_connection`, `trust_server_certificate`, and `encrypt`.
- Adds typed driver feature hooks for JSON serialization and deserialization.
- Keeps connection string and keyword argument generation behavior explicit for these config keys.
- Adds focused unit coverage for the Arrow ODBC config surface.
