### PR TITLE
fix(aiosqlite): modernize adapter config

### DIFF
--- a/sqlspec/adapters/aiosqlite/_typing.py
+++ b/sqlspec/adapters/aiosqlite/_typing.py
@@ -6,6 +6,7 @@ compilation to avoid ABI boundary issues.
 """
 
 import contextlib
+import sqlite3
 from typing import TYPE_CHECKING, Any
 
 import aiosqlite
@@ -21,13 +22,21 @@ if TYPE_CHECKING:
     from sqlspec.core import StatementConfig
 
     AiosqliteConnection: TypeAlias = _AiosqliteConnection
+    AiosqliteConnectionFactory: TypeAlias = type[sqlite3.Connection]
     AiosqliteRawCursor: TypeAlias = aiosqlite.Cursor
 
 if not TYPE_CHECKING:
     AiosqliteConnection = _AiosqliteConnection
+    AiosqliteConnectionFactory = type[sqlite3.Connection]
     AiosqliteRawCursor = aiosqlite.Cursor
 
-__all__ = ("AiosqliteConnection", "AiosqliteCursor", "AiosqliteRawCursor", "AiosqliteSessionContext")
+__all__ = (
+    "AiosqliteConnection",
+    "AiosqliteConnectionFactory",
+    "AiosqliteCursor",
+    "AiosqliteRawCursor",
+    "AiosqliteSessionContext",
+)
 
 
 class AiosqliteCursor:

--- a/sqlspec/adapters/aiosqlite/config.py
+++ b/sqlspec/adapters/aiosqlite/config.py
@@ -1,6 +1,5 @@
 """Aiosqlite database configuration."""
 
-import sqlite3
 import uuid
 from os import PathLike
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
@@ -8,7 +7,12 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
 from mypy_extensions import mypyc_attr
 from typing_extensions import NotRequired
 
-from sqlspec.adapters.aiosqlite._typing import AiosqliteConnection, AiosqliteCursor, AiosqliteSessionContext
+from sqlspec.adapters.aiosqlite._typing import (
+    AiosqliteConnection,
+    AiosqliteConnectionFactory,
+    AiosqliteCursor,
+    AiosqliteSessionContext,
+)
 from sqlspec.adapters.aiosqlite.core import apply_driver_features, build_connection_config, default_statement_config
 from sqlspec.adapters.aiosqlite.driver import AiosqliteDriver, AiosqliteExceptionHandler
 from sqlspec.adapters.aiosqlite.pool import (
@@ -45,7 +49,7 @@ class AiosqliteConnectionParams(TypedDict):
     detect_types: NotRequired[int]
     isolation_level: NotRequired[SQLiteIsolationLevel]
     check_same_thread: NotRequired[bool]
-    factory: NotRequired[type[sqlite3.Connection] | None]
+    factory: "NotRequired[AiosqliteConnectionFactory | None]"
     cached_statements: NotRequired[int]
     uri: NotRequired[bool]
     iter_chunk_size: NotRequired[int]
@@ -279,6 +283,7 @@ class AiosqliteConfig(AsyncDatabaseConfig["AiosqliteConnection", AiosqliteConnec
         namespace.update({
             "AiosqliteConnectionContext": AiosqliteConnectionContext,
             "AiosqliteConnection": AiosqliteConnection,
+            "AiosqliteConnectionFactory": AiosqliteConnectionFactory,
             "AiosqliteConnectionParams": AiosqliteConnectionParams,
             "AiosqliteConnectionPool": AiosqliteConnectionPool,
             "AiosqliteCursor": AiosqliteCursor,

--- a/sqlspec/adapters/aiosqlite/config.py
+++ b/sqlspec/adapters/aiosqlite/config.py
@@ -1,7 +1,9 @@
 """Aiosqlite database configuration."""
 
+import sqlite3
 import uuid
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
+from os import PathLike
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
 
 from mypy_extensions import mypyc_attr
 from typing_extensions import NotRequired
@@ -31,26 +33,34 @@ __all__ = ("AiosqliteConfig", "AiosqliteConnectionParams", "AiosqliteDriverFeatu
 
 logger = get_logger("sqlspec.adapters.aiosqlite")
 
+SQLiteIsolationLevel = Literal["DEFERRED", "IMMEDIATE", "EXCLUSIVE"] | None
+SQLiteAutocommitMode = bool | Literal[-1]
+
 
 class AiosqliteConnectionParams(TypedDict):
     """TypedDict for aiosqlite connection parameters."""
 
-    database: NotRequired[str]
+    database: NotRequired[str | PathLike[str]]
     timeout: NotRequired[float]
     detect_types: NotRequired[int]
-    isolation_level: NotRequired[str | None]
+    isolation_level: NotRequired[SQLiteIsolationLevel]
     check_same_thread: NotRequired[bool]
+    factory: NotRequired[type[sqlite3.Connection] | None]
     cached_statements: NotRequired[int]
     uri: NotRequired[bool]
+    iter_chunk_size: NotRequired[int]
+    autocommit: NotRequired[SQLiteAutocommitMode]
 
 
 class AiosqlitePoolParams(AiosqliteConnectionParams):
     """TypedDict for aiosqlite pool parameters, inheriting connection parameters."""
 
     pool_size: NotRequired[int]
+    min_size: NotRequired[int]
     connect_timeout: NotRequired[float]
     idle_timeout: NotRequired[float]
     operation_timeout: NotRequired[float]
+    health_check_interval: NotRequired[float]
     extra: NotRequired["dict[str, Any]"]
 
 
@@ -222,16 +232,24 @@ class AiosqliteConfig(AsyncDatabaseConfig["AiosqliteConnection", AiosqliteConnec
             AiosqliteConnectionPool: The connection pool instance.
         """
         pool_size = self.connection_config.get("pool_size") or 5
+        min_size = self.connection_config.get("min_size")
+        if min_size is None:
+            min_size = 0
         connect_timeout = self.connection_config.get("connect_timeout") or 30.0
         idle_timeout = self.connection_config.get("idle_timeout") or 24 * 60 * 60
         operation_timeout = self.connection_config.get("operation_timeout") or 10.0
+        health_check_interval = self.connection_config.get("health_check_interval")
+        if health_check_interval is None:
+            health_check_interval = 30.0
 
         pool = AiosqliteConnectionPool(
             connection_parameters=build_connection_config(self.connection_config),
             pool_size=pool_size,
+            min_size=min_size,
             connect_timeout=connect_timeout,
             idle_timeout=idle_timeout,
             operation_timeout=operation_timeout,
+            health_check_interval=health_check_interval,
             on_connection_create=self._user_connection_hook,
         )
 

--- a/sqlspec/adapters/aiosqlite/core.py
+++ b/sqlspec/adapters/aiosqlite/core.py
@@ -1,5 +1,6 @@
 """AIOSQLite adapter compiled helpers."""
 
+import sys
 from datetime import date, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, cast
@@ -159,15 +160,19 @@ def build_connection_config(connection_config: "Mapping[str, Any]") -> "dict[str
     """
     excluded_keys = {
         "pool_size",
+        "min_size",
         "connect_timeout",
         "idle_timeout",
         "operation_timeout",
+        "health_check_interval",
         "extra",
         "pool_min_size",
         "pool_max_size",
         "pool_timeout",
         "pool_recycle_seconds",
     }
+    if sys.version_info < (3, 12):
+        excluded_keys.add("autocommit")
     return {key: value for key, value in connection_config.items() if key not in excluded_keys}
 
 

--- a/tests/unit/adapters/test_aiosqlite/test_config.py
+++ b/tests/unit/adapters/test_aiosqlite/test_config.py
@@ -1,0 +1,98 @@
+import sqlite3
+from pathlib import Path
+
+from sqlspec.adapters.aiosqlite.config import AiosqliteConfig, AiosqliteConnectionParams
+from sqlspec.adapters.aiosqlite.core import build_connection_config
+
+
+class CustomConnection(sqlite3.Connection):
+    """Connection subclass used to validate factory passthrough."""
+
+
+def test_connection_params_accept_pathlike_and_modern_connection_options(tmp_path: Path) -> None:
+    db_path = tmp_path / "typed.db"
+
+    params: AiosqliteConnectionParams = {
+        "database": db_path,
+        "factory": CustomConnection,
+        "iter_chunk_size": 128,
+        "autocommit": True,
+        "isolation_level": None,
+    }
+
+    assert params["database"] == db_path
+
+
+def test_build_connection_config_filters_pool_keys_and_gates_autocommit(tmp_path: Path) -> None:
+    db_path = tmp_path / "config.db"
+
+    connection_config = build_connection_config({
+        "database": db_path,
+        "timeout": 1.5,
+        "isolation_level": None,
+        "factory": CustomConnection,
+        "iter_chunk_size": 256,
+        "autocommit": True,
+        "min_size": 2,
+        "health_check_interval": 0.25,
+        "pool_size": 4,
+        "connect_timeout": 0.5,
+        "idle_timeout": 1.0,
+        "operation_timeout": 1.5,
+        "pool_recycle_seconds": 2.0,
+        "extra": {"ignored": True},
+    })
+
+    assert connection_config["database"] == db_path
+    assert connection_config["timeout"] == 1.5
+    assert connection_config["isolation_level"] is None
+    assert connection_config["factory"] is CustomConnection
+    assert connection_config["iter_chunk_size"] == 256
+
+    assert "min_size" not in connection_config
+    assert "health_check_interval" not in connection_config
+    assert "pool_size" not in connection_config
+    assert "connect_timeout" not in connection_config
+    assert "idle_timeout" not in connection_config
+    assert "operation_timeout" not in connection_config
+    assert "pool_recycle_seconds" not in connection_config
+    assert "extra" not in connection_config
+
+    if hasattr(sqlite3, "LEGACY_TRANSACTION_CONTROL"):
+        assert connection_config["autocommit"] is True
+    else:
+        assert "autocommit" not in connection_config
+
+
+async def test_create_pool_routes_pool_settings_without_leaking_to_connect_kwargs(tmp_path: Path) -> None:
+    config = AiosqliteConfig(
+        connection_config={
+            "database": tmp_path / "pool.db",
+            "pool_size": 4,
+            "min_size": 2,
+            "health_check_interval": 0.25,
+            "iter_chunk_size": 512,
+            "isolation_level": None,
+        }
+    )
+
+    pool = await config._create_pool()
+    try:
+        assert pool._pool_size == 4
+        assert pool._min_size == 2
+        assert pool._health_check_interval == 0.25
+        assert pool._connection_parameters["iter_chunk_size"] == 512
+        assert pool._connection_parameters["isolation_level"] is None
+        assert "min_size" not in pool._connection_parameters
+        assert "health_check_interval" not in pool._connection_parameters
+    finally:
+        await pool.close()
+
+
+def test_config_accepts_pathlike_database_without_coercing_connection_value(tmp_path: Path) -> None:
+    db_path = tmp_path / "pathlike.db"
+
+    config = AiosqliteConfig(connection_config={"database": db_path})
+
+    assert config.connection_config["database"] == db_path
+    assert isinstance(config.connection_config["database"], Path)

--- a/tests/unit/adapters/test_aiosqlite/test_config.py
+++ b/tests/unit/adapters/test_aiosqlite/test_config.py
@@ -1,12 +1,21 @@
 import sqlite3
 from pathlib import Path
+from typing import get_args, get_type_hints
 
+from sqlspec.adapters.aiosqlite._typing import AiosqliteConnectionFactory
 from sqlspec.adapters.aiosqlite.config import AiosqliteConfig, AiosqliteConnectionParams
 from sqlspec.adapters.aiosqlite.core import build_connection_config
 
 
 class CustomConnection(sqlite3.Connection):
     """Connection subclass used to validate factory passthrough."""
+
+
+def _annotation_contains(annotation: object, expected: object) -> bool:
+    """Return whether an annotation tree contains the expected object."""
+    if annotation is expected:
+        return True
+    return any(_annotation_contains(arg, expected) for arg in get_args(annotation))
 
 
 def test_connection_params_accept_pathlike_and_modern_connection_options(tmp_path: Path) -> None:
@@ -21,6 +30,12 @@ def test_connection_params_accept_pathlike_and_modern_connection_options(tmp_pat
     }
 
     assert params["database"] == db_path
+
+
+def test_connection_params_factory_uses_adapter_alias() -> None:
+    annotations = get_type_hints(AiosqliteConnectionParams, include_extras=True)
+
+    assert _annotation_contains(annotations["factory"], AiosqliteConnectionFactory)
 
 
 def test_build_connection_config_filters_pool_keys_and_gates_autocommit(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

This PR modernizes the aiosqlite adapter config so connection-only and pool-only settings are typed and routed to the right layer.

## Changes

- Adds typed aiosqlite connection config coverage for `str | PathLike` databases, `factory`, `iter_chunk_size`, Python-gated `autocommit`, and explicit `isolation_level` values.
- Routes pool settings such as `min_size` and `health_check_interval` into `AiosqliteConnectionPool`.
- Prevents pool-only settings from leaking into `aiosqlite.connect()`.
- Preserves explicit `isolation_level=None` during config normalization.
- Adds focused unit coverage for config normalization, pool creation, and type coverage.
