### PR TITLE
fix(sqlite): modernize adapter config

### DIFF
--- a/sqlspec/adapters/sqlite/_typing.py
+++ b/sqlspec/adapters/sqlite/_typing.py
@@ -19,13 +19,15 @@ if TYPE_CHECKING:
     from sqlspec.core import StatementConfig
 
     SqliteConnection: TypeAlias = _SqliteConnection
+    SqliteConnectionFactory: TypeAlias = type[sqlite3.Connection]
     SqliteRawCursor: TypeAlias = sqlite3.Cursor
 
 if not TYPE_CHECKING:
     SqliteConnection = _SqliteConnection
+    SqliteConnectionFactory = type[sqlite3.Connection]
     SqliteRawCursor = sqlite3.Cursor
 
-__all__ = ("SqliteConnection", "SqliteCursor", "SqliteRawCursor", "SqliteSessionContext")
+__all__ = ("SqliteConnection", "SqliteConnectionFactory", "SqliteCursor", "SqliteRawCursor", "SqliteSessionContext")
 
 
 class SqliteCursor:

--- a/sqlspec/adapters/sqlite/config.py
+++ b/sqlspec/adapters/sqlite/config.py
@@ -6,7 +6,12 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict
 
 from typing_extensions import NotRequired
 
-from sqlspec.adapters.sqlite._typing import SqliteConnection, SqliteCursor, SqliteSessionContext
+from sqlspec.adapters.sqlite._typing import (
+    SqliteConnection,
+    SqliteConnectionFactory,
+    SqliteCursor,
+    SqliteSessionContext,
+)
 from sqlspec.adapters.sqlite.core import apply_driver_features, build_connection_config, default_statement_config
 from sqlspec.adapters.sqlite.driver import SqliteDriver, SqliteExceptionHandler
 from sqlspec.adapters.sqlite.pool import SqliteConnectionPool
@@ -34,7 +39,7 @@ class SqliteConnectionParams(TypedDict):
     detect_types: NotRequired[int]
     isolation_level: NotRequired[Literal["DEFERRED", "IMMEDIATE", "EXCLUSIVE"] | None]
     check_same_thread: NotRequired[bool]
-    factory: "NotRequired[type[SqliteConnection] | None]"
+    factory: "NotRequired[SqliteConnectionFactory | None]"
     cached_statements: NotRequired[int]
     uri: NotRequired[bool]
     autocommit: NotRequired[bool]
@@ -226,6 +231,7 @@ class SqliteConfig(SyncDatabaseConfig[SqliteConnection, SqliteConnectionPool, Sq
             "Literal": Literal,
             "SqliteConnectionContext": SqliteConnectionContext,
             "SqliteConnection": SqliteConnection,
+            "SqliteConnectionFactory": SqliteConnectionFactory,
             "SqliteConnectionParams": SqliteConnectionParams,
             "SqliteConnectionPool": SqliteConnectionPool,
             "SqliteCursor": SqliteCursor,

--- a/sqlspec/adapters/sqlite/config.py
+++ b/sqlspec/adapters/sqlite/config.py
@@ -1,7 +1,8 @@
 """SQLite database configuration with thread-local connections."""
 
 import uuid
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict
+from os import PathLike
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict
 
 from typing_extensions import NotRequired
 
@@ -28,14 +29,19 @@ __all__ = ("SqliteConfig", "SqliteConnectionParams", "SqliteDriverFeatures")
 class SqliteConnectionParams(TypedDict):
     """SQLite connection parameters."""
 
-    database: NotRequired[str]
+    database: NotRequired[str | PathLike[str]]
     timeout: NotRequired[float]
     detect_types: NotRequired[int]
-    isolation_level: "NotRequired[str | None]"
+    isolation_level: NotRequired[Literal["DEFERRED", "IMMEDIATE", "EXCLUSIVE"] | None]
     check_same_thread: NotRequired[bool]
     factory: "NotRequired[type[SqliteConnection] | None]"
     cached_statements: NotRequired[int]
     uri: NotRequired[bool]
+    autocommit: NotRequired[bool]
+    pool_recycle_seconds: NotRequired[int]
+    health_check_interval: NotRequired[float]
+    enable_optimizations: NotRequired[bool]
+    extra: NotRequired[dict[str, Any]]
 
 
 class SqliteDriverFeatures(TypedDict):
@@ -216,6 +222,8 @@ class SqliteConfig(SyncDatabaseConfig[SqliteConnection, SqliteConnectionPool, Sq
         """
         namespace = super().get_signature_namespace()
         namespace.update({
+            "PathLike": PathLike,
+            "Literal": Literal,
             "SqliteConnectionContext": SqliteConnectionContext,
             "SqliteConnection": SqliteConnection,
             "SqliteConnectionParams": SqliteConnectionParams,

--- a/sqlspec/adapters/sqlite/core.py
+++ b/sqlspec/adapters/sqlite/core.py
@@ -1,5 +1,7 @@
 """SQLite adapter compiled helpers."""
 
+import sys
+from collections.abc import Mapping
 from datetime import date, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, cast
@@ -26,7 +28,7 @@ from sqlspec.utils.type_converters import build_decimal_converter, build_uuid_co
 from sqlspec.utils.type_guards import has_sqlite_error
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping, Sequence
+    from collections.abc import Callable, Sequence
 
 __all__ = (
     "apply_driver_features",
@@ -57,6 +59,7 @@ SQLITE_LOCKED_CODE = 6
 SQLITE_INTERRUPT_CODE = 9
 SQLITE_PERM_CODE = 3
 SQLITE_READONLY_CODE = 8
+SQLITE_CONNECT_SUPPORTS_AUTOCOMMIT = sys.version_info >= (3, 12)
 
 
 _TIME_TO_ISO = time_iso_convert
@@ -167,7 +170,24 @@ def build_connection_config(connection_config: "Mapping[str, Any]") -> "dict[str
         "pool_recycle_seconds",
         "extra",
     }
-    return {key: value for key, value in connection_config.items() if value is not None and key not in excluded_keys}
+    connection_parameters = {
+        key: value
+        for key, value in connection_config.items()
+        if key not in excluded_keys
+        and (value is not None or key == "isolation_level")
+        and (key != "autocommit" or SQLITE_CONNECT_SUPPORTS_AUTOCOMMIT)
+    }
+
+    extra = connection_config.get("extra")
+    if isinstance(extra, Mapping):
+        connection_parameters.update({
+            key: value
+            for key, value in extra.items()
+            if (value is not None or key == "isolation_level")
+            and (key != "autocommit" or SQLITE_CONNECT_SUPPORTS_AUTOCOMMIT)
+        })
+
+    return connection_parameters
 
 
 def _create_sqlite_error(

--- a/tests/unit/adapters/test_sqlite/test_config.py
+++ b/tests/unit/adapters/test_sqlite/test_config.py
@@ -1,0 +1,103 @@
+"""SQLite configuration normalization tests."""
+
+from os import PathLike
+from pathlib import Path
+from typing import Literal, get_args, get_origin, get_type_hints
+
+import pytest
+
+import sqlspec.adapters.sqlite.core as sqlite_core
+from sqlspec.adapters.sqlite.config import SqliteConfig, SqliteConnectionParams
+from sqlspec.adapters.sqlite.core import build_connection_config
+
+
+def _annotation_contains(annotation: object, expected: object) -> bool:
+    """Return whether an annotation tree contains the expected object."""
+    if annotation is expected:
+        return True
+    return any(_annotation_contains(arg, expected) for arg in get_args(annotation))
+
+
+def _annotation_has_origin(annotation: object, expected: object) -> bool:
+    """Return whether an annotation tree contains a node with the expected origin."""
+    if get_origin(annotation) is expected:
+        return True
+    return any(_annotation_has_origin(arg, expected) for arg in get_args(annotation))
+
+
+def test_build_connection_config_preserves_explicit_isolation_level_none() -> None:
+    """isolation_level=None must reach sqlite3.connect() to disable implicit transactions."""
+    connection_config = build_connection_config({"database": ":memory:", "isolation_level": None})
+
+    assert connection_config["isolation_level"] is None
+
+
+def test_build_connection_config_drops_other_none_values() -> None:
+    """None-valued optional settings should still be omitted unless sqlite3 treats None as meaningful."""
+    connection_config = build_connection_config({
+        "database": ":memory:",
+        "timeout": None,
+        "factory": None,
+        "isolation_level": None,
+    })
+
+    assert connection_config == {"database": ":memory:", "isolation_level": None}
+
+
+def test_build_connection_config_merges_extra_as_driver_kwargs() -> None:
+    """extra should be a normalized escape hatch for sqlite3.connect() keyword arguments."""
+    connection_config = build_connection_config({
+        "database": ":memory:",
+        "timeout": 1.0,
+        "extra": {"cached_statements": 32, "timeout": 2.0, "uri": None},
+    })
+
+    assert connection_config == {"database": ":memory:", "cached_statements": 32, "timeout": 2.0}
+
+
+def test_build_connection_config_gates_autocommit_on_python_support(monkeypatch: pytest.MonkeyPatch) -> None:
+    """autocommit should only be passed to sqlite3.connect() on Python versions that support it."""
+    monkeypatch.setattr(sqlite_core, "SQLITE_CONNECT_SUPPORTS_AUTOCOMMIT", False, raising=False)
+
+    connection_config = build_connection_config({"database": ":memory:", "autocommit": True})
+
+    assert "autocommit" not in connection_config
+
+
+@pytest.mark.skipif(
+    not getattr(sqlite_core, "SQLITE_CONNECT_SUPPORTS_AUTOCOMMIT", True),
+    reason="sqlite3.connect() autocommit is available on Python 3.12+",
+)
+def test_build_connection_config_keeps_autocommit_when_supported() -> None:
+    """Supported runtimes should forward the modern sqlite3 autocommit argument."""
+    connection_config = build_connection_config({"database": ":memory:", "autocommit": True})
+
+    assert connection_config["autocommit"] is True
+
+
+def test_sqlite_connection_params_describe_current_sync_config_surface() -> None:
+    """TypedDict coverage should include current sqlite3 and SQLSpec sync pool settings."""
+    annotations = get_type_hints(SqliteConnectionParams, include_extras=True)
+
+    assert _annotation_has_origin(annotations["database"], PathLike)
+    assert _annotation_contains(annotations["isolation_level"], type(None))
+    assert _annotation_has_origin(annotations["isolation_level"], Literal)
+    assert annotations["autocommit"] is not None
+    assert annotations["pool_recycle_seconds"] is not None
+    assert annotations["health_check_interval"] is not None
+    assert annotations["enable_optimizations"] is not None
+    assert annotations["extra"] is not None
+
+
+def test_sqlite_config_accepts_pathlike_database(tmp_path: Path) -> None:
+    """PathLike database values should be preserved for sqlite3.connect()."""
+    database_path = tmp_path / "sqlspec.sqlite"
+    config = SqliteConfig(connection_config={"database": database_path, "enable_optimizations": False})
+
+    connection_config = build_connection_config(config.connection_config)
+
+    assert connection_config["database"] is database_path
+    with config.provide_session() as session:
+        session.execute("CREATE TABLE pathlike_config_test (id INTEGER PRIMARY KEY)")
+    config.close_pool()
+    assert database_path.exists()

--- a/tests/unit/adapters/test_sqlite/test_config.py
+++ b/tests/unit/adapters/test_sqlite/test_config.py
@@ -7,6 +7,7 @@ from typing import Literal, get_args, get_origin, get_type_hints
 import pytest
 
 import sqlspec.adapters.sqlite.core as sqlite_core
+from sqlspec.adapters.sqlite._typing import SqliteConnectionFactory
 from sqlspec.adapters.sqlite.config import SqliteConfig, SqliteConnectionParams
 from sqlspec.adapters.sqlite.core import build_connection_config
 
@@ -80,6 +81,7 @@ def test_sqlite_connection_params_describe_current_sync_config_surface() -> None
     annotations = get_type_hints(SqliteConnectionParams, include_extras=True)
 
     assert _annotation_has_origin(annotations["database"], PathLike)
+    assert _annotation_contains(annotations["factory"], SqliteConnectionFactory)
     assert _annotation_contains(annotations["isolation_level"], type(None))
     assert _annotation_has_origin(annotations["isolation_level"], Literal)
     assert annotations["autocommit"] is not None


### PR DESCRIPTION
## Summary

This PR modernizes the sync SQLite adapter config so sqlite connection kwargs are typed and normalized consistently across supported Python versions.

## Changes

- Adds typed support for `PathLike` database values.
- Narrows `isolation_level` typing while preserving explicit `None` during normalization.
- Adds Python 3.12+ `autocommit` handling and omits it on older Python versions.
- Normalizes `extra` as a driver-kwargs escape hatch.
- Keeps consumed sync pool settings typed on the config surface.
- Adds focused unit coverage for SQLite config normalization and Python-version-specific behavior.
