### PR TITLE
fix(pymysql): modernize adapter config

### DIFF
--- a/sqlspec/adapters/pymysql/config.py
+++ b/sqlspec/adapters/pymysql/config.py
@@ -1,10 +1,12 @@
 """PyMySQL database configuration."""
 
+import ssl
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 
 from typing_extensions import NotRequired
 
-from sqlspec.adapters.pymysql._typing import PyMysqlConnection, PyMysqlCursor, PyMysqlSessionContext
+from sqlspec.adapters.pymysql._typing import PyMysqlConnection, PyMysqlCursor, PyMysqlRawCursor, PyMysqlSessionContext
 from sqlspec.adapters.pymysql.core import apply_driver_features, default_statement_config
 from sqlspec.adapters.pymysql.driver import PyMysqlDriver, PyMysqlExceptionHandler
 from sqlspec.adapters.pymysql.pool import PyMysqlConnectionPool
@@ -14,12 +16,43 @@ from sqlspec.extensions.events import EventRuntimeHints
 from sqlspec.utils.config_tools import normalize_connection_config
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from sqlspec.core import StatementConfig
     from sqlspec.observability import ObservabilityConfig
 
-__all__ = ("PyMysqlConfig", "PyMysqlConnectionParams", "PyMysqlDriverFeatures", "PyMysqlPoolParams")
+__all__ = (
+    "PyMysqlConfig",
+    "PyMysqlConnectionParams",
+    "PyMysqlConverter",
+    "PyMysqlDriverFeatures",
+    "PyMysqlPoolParams",
+    "PyMysqlSslConfig",
+    "PyMysqlSslParams",
+    "PyMysqlTimeout",
+)
+
+
+PyMysqlConverter = Mapping[int | type[Any], Callable[..., Any]]
+PyMysqlTimeout = int | float
+
+
+class PyMysqlSslParams(TypedDict):
+    """Mapping-style PyMySQL SSL parameters.
+
+    Passing an ``ssl`` mapping is deprecated by PyMySQL but remains supported
+    for compatibility with existing SQLSpec configs.
+    """
+
+    ca: NotRequired[str]
+    capath: NotRequired[str]
+    cert: NotRequired[str]
+    key: NotRequired[str]
+    password: NotRequired[str]
+    cipher: NotRequired[str]
+    check_hostname: NotRequired[bool]
+    verify_mode: NotRequired[bool | int | str]
+
+
+PyMysqlSslConfig = ssl.SSLContext | PyMysqlSslParams | Mapping[str, Any]
 
 
 class PyMysqlConnectionParams(TypedDict):
@@ -32,15 +65,35 @@ class PyMysqlConnectionParams(TypedDict):
     port: NotRequired[int]
     unix_socket: NotRequired[str]
     charset: NotRequired[str]
-    connect_timeout: NotRequired[int]
-    read_timeout: NotRequired[int]
-    write_timeout: NotRequired[int]
-    autocommit: NotRequired[bool]
-    ssl: NotRequired["dict[str, Any]"]
-    client_flag: NotRequired[int]
-    cursorclass: NotRequired[type]
-    init_command: NotRequired[str]
+    collation: NotRequired[str]
     sql_mode: NotRequired[str]
+    read_default_file: NotRequired[str]
+    read_default_group: NotRequired[str]
+    conv: NotRequired[PyMysqlConverter]
+    use_unicode: NotRequired[bool]
+    client_flag: NotRequired[int]
+    cursorclass: NotRequired[type[PyMysqlRawCursor]]
+    init_command: NotRequired[str]
+    connect_timeout: NotRequired[PyMysqlTimeout]
+    read_timeout: NotRequired[PyMysqlTimeout]
+    write_timeout: NotRequired[PyMysqlTimeout]
+    autocommit: NotRequired[bool]
+    local_infile: NotRequired[bool]
+    max_allowed_packet: NotRequired[int]
+    defer_connect: NotRequired[bool]
+    auth_plugin_map: NotRequired[Mapping[str, type[Any]]]
+    bind_address: NotRequired[str]
+    binary_prefix: NotRequired[bool]
+    program_name: NotRequired[str]
+    server_public_key: NotRequired[str | bytes]
+    ssl: NotRequired[PyMysqlSslConfig]
+    ssl_ca: NotRequired[str]
+    ssl_cert: NotRequired[str]
+    ssl_disabled: NotRequired[bool]
+    ssl_key: NotRequired[str]
+    ssl_key_password: NotRequired[str]
+    ssl_verify_cert: NotRequired[bool]
+    ssl_verify_identity: NotRequired[bool]
     extra: NotRequired["dict[str, Any]"]
 
 
@@ -113,6 +166,7 @@ class PyMysqlConfig(SyncDatabaseConfig[PyMysqlConnection, PyMysqlConnectionPool,
         connection_config = normalize_connection_config(connection_config)
         connection_config.setdefault("host", "localhost")
         connection_config.setdefault("port", 3306)
+        connection_config.setdefault("local_infile", False)
 
         statement_config = statement_config or default_statement_config
         statement_config, driver_features = apply_driver_features(statement_config, driver_features)

--- a/tests/unit/adapters/test_pymysql/__init__.py
+++ b/tests/unit/adapters/test_pymysql/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for PyMySQL adapter behavior."""

--- a/tests/unit/adapters/test_pymysql/test_config.py
+++ b/tests/unit/adapters/test_pymysql/test_config.py
@@ -1,0 +1,112 @@
+"""PyMySQL adapter configuration tests."""
+
+import ssl
+from collections.abc import Mapping
+from typing import get_args, get_origin, get_type_hints
+
+from typing_extensions import NotRequired
+
+from sqlspec.adapters.pymysql.config import PyMysqlConfig, PyMysqlConnectionParams
+
+
+def _unwrap_not_required(annotation: object) -> object:
+    if get_origin(annotation) is NotRequired:
+        return get_args(annotation)[0]
+    return annotation
+
+
+def test_connection_params_type_current_pymysql_options() -> None:
+    """Connection params should cover current PyMySQL connection kwargs."""
+    expected_keys = {
+        "host",
+        "user",
+        "password",
+        "database",
+        "port",
+        "unix_socket",
+        "charset",
+        "collation",
+        "sql_mode",
+        "read_default_file",
+        "read_default_group",
+        "conv",
+        "use_unicode",
+        "client_flag",
+        "cursorclass",
+        "init_command",
+        "connect_timeout",
+        "read_timeout",
+        "write_timeout",
+        "autocommit",
+        "local_infile",
+        "max_allowed_packet",
+        "defer_connect",
+        "auth_plugin_map",
+        "bind_address",
+        "binary_prefix",
+        "program_name",
+        "server_public_key",
+        "ssl",
+        "ssl_ca",
+        "ssl_cert",
+        "ssl_disabled",
+        "ssl_key",
+        "ssl_key_password",
+        "ssl_verify_cert",
+        "ssl_verify_identity",
+        "extra",
+    }
+
+    assert expected_keys <= set(PyMysqlConnectionParams.__annotations__)
+
+
+def test_ssl_connection_param_accepts_ssl_context_and_mapping() -> None:
+    """The ssl parameter should accept both SSLContext and mapping-style config."""
+    ssl_annotation = _unwrap_not_required(get_type_hints(PyMysqlConnectionParams, include_extras=True)["ssl"])
+    ssl_args = set(get_args(ssl_annotation))
+
+    assert ssl.SSLContext in ssl_args
+    assert any(get_origin(arg) in {dict, Mapping} or arg in {dict, Mapping} for arg in ssl_args)
+
+
+def test_create_pool_defaults_local_infile_off() -> None:
+    """LOAD DATA LOCAL INFILE must be disabled unless explicitly opted in."""
+    config = PyMysqlConfig(connection_config={})
+    pool = config._create_pool()
+
+    assert pool._connection_parameters["local_infile"] is False
+
+
+def test_create_pool_preserves_local_infile_opt_in() -> None:
+    """Explicit local infile opt-in should still pass through to PyMySQL."""
+    config = PyMysqlConfig(connection_config={"local_infile": True})
+    pool = config._create_pool()
+
+    assert pool._connection_parameters["local_infile"] is True
+
+
+def test_create_pool_preserves_ssl_context_and_flat_tls_options() -> None:
+    """SSLContext and flat TLS kwargs should pass through to the driver config."""
+    context = ssl.create_default_context()
+    config = PyMysqlConfig(
+        connection_config={
+            "ssl": context,
+            "ssl_ca": "/certs/ca.pem",
+            "ssl_cert": "/certs/client.pem",
+            "ssl_key": "/certs/client-key.pem",
+            "ssl_key_password": "secret",
+            "ssl_verify_cert": True,
+            "ssl_verify_identity": True,
+            "ssl_disabled": False,
+        }
+    )
+    pool = config._create_pool()
+
+    assert pool._connection_parameters["ssl"] is context
+    assert pool._connection_parameters["ssl_ca"] == "/certs/ca.pem"
+    assert pool._connection_parameters["ssl_cert"] == "/certs/client.pem"
+    assert pool._connection_parameters["ssl_key"] == "/certs/client-key.pem"
+    assert pool._connection_parameters["ssl_key_password"] == "secret"
+    assert pool._connection_parameters["ssl_verify_cert"] is True
+    assert pool._connection_parameters["ssl_verify_identity"] is True
+    assert pool._connection_parameters["ssl_disabled"] is False


### PR DESCRIPTION
## Summary
Modernizes the PyMySQL adapter config surface against current PyMySQL connection kwargs while keeping the change scoped to PyMySQL.

## Changes
- Adds typed PyMySQL TLS, auth, timeout, converter, cursor, charset, and metadata connection options.
- Allows `ssl.SSLContext` while preserving mapping-style SSL config support, and keeps flat TLS kwargs as driver passthrough.
- Defaults `local_infile` to `False` unless explicitly enabled, with focused unit coverage for the security gate.