### PR TITLE
fix(asyncmy): modernize adapter config

### DIFF
--- a/sqlspec/adapters/asyncmy/__init__.py
+++ b/sqlspec/adapters/asyncmy/__init__.py
@@ -4,6 +4,7 @@ from sqlspec.adapters.asyncmy.config import (
     AsyncmyConnectionParams,
     AsyncmyDriverFeatures,
     AsyncmyPoolParams,
+    AsyncmySSLParams,
 )
 from sqlspec.adapters.asyncmy.core import default_statement_config
 from sqlspec.adapters.asyncmy.driver import AsyncmyDriver, AsyncmyExceptionHandler
@@ -17,5 +18,6 @@ __all__ = (
     "AsyncmyDriverFeatures",
     "AsyncmyExceptionHandler",
     "AsyncmyPoolParams",
+    "AsyncmySSLParams",
     "default_statement_config",
 )

--- a/sqlspec/adapters/asyncmy/config.py
+++ b/sqlspec/adapters/asyncmy/config.py
@@ -1,5 +1,6 @@
 """Asyncmy database configuration."""
 
+import inspect
 from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 from weakref import WeakSet
 
@@ -19,18 +20,47 @@ from sqlspec.adapters.asyncmy.core import apply_driver_features, default_stateme
 from sqlspec.adapters.asyncmy.driver import AsyncmyDriver, AsyncmyExceptionHandler
 from sqlspec.config import AsyncDatabaseConfig, ExtensionConfigs
 from sqlspec.driver._async import AsyncPoolConnectionContext, AsyncPoolSessionFactory
+from sqlspec.exceptions import ImproperConfigurationError
 from sqlspec.extensions.events import EventRuntimeHints
 from sqlspec.utils.config_tools import normalize_connection_config
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    import ssl
+    from collections.abc import Awaitable, Callable, Mapping
     from types import TracebackType
 
     from sqlspec.core import StatementConfig
     from sqlspec.observability import ObservabilityConfig
 
 
-__all__ = ("AsyncmyConfig", "AsyncmyConnectionParams", "AsyncmyDriverFeatures", "AsyncmyPoolParams")
+__all__ = ("AsyncmyConfig", "AsyncmyConnectionParams", "AsyncmyDriverFeatures", "AsyncmyPoolParams", "AsyncmySSLParams")
+
+
+_ASYNCMY_POOL_ONLY_KEYS = frozenset(("minsize", "maxsize", "pool_recycle"))
+_ASYNCMY_POOL_KEYS = _ASYNCMY_POOL_ONLY_KEYS | {"echo"}
+_ASYNCMY_LOCAL_INFILE_GATE = "allow_local_infile"
+
+
+def _get_asyncmy_connect_parameter_names() -> "frozenset[str]":
+    try:
+        return frozenset(inspect.signature(asyncmy.connect).parameters)
+    except (TypeError, ValueError):
+        return frozenset()
+
+
+_ASYNCMY_CONNECT_PARAMETER_NAMES = _get_asyncmy_connect_parameter_names()
+
+
+class AsyncmySSLParams(TypedDict):
+    """Asyncmy TLS parameters."""
+
+    ca: NotRequired[str]
+    capath: NotRequired[str]
+    cert: NotRequired[str]
+    key: NotRequired[str]
+    cipher: NotRequired[str]
+    check_hostname: NotRequired[bool]
+    verify_mode: NotRequired[bool | int | str]
 
 
 class AsyncmyConnectionParams(TypedDict):
@@ -40,18 +70,31 @@ class AsyncmyConnectionParams(TypedDict):
     user: NotRequired[str]
     password: NotRequired[str]
     database: NotRequired[str]
+    db: NotRequired[str]
     port: NotRequired[int]
     unix_socket: NotRequired[str]
     charset: NotRequired[str]
-    connect_timeout: NotRequired[int]
+    connect_timeout: NotRequired[int | float]
     read_default_file: NotRequired[str]
     read_default_group: NotRequired[str]
     autocommit: NotRequired[bool]
+    allow_local_infile: NotRequired[bool]
     local_infile: NotRequired[bool]
-    ssl: NotRequired[Any]
+    ssl: NotRequired["AsyncmySSLParams | ssl.SSLContext | dict[str, Any]"]
     sql_mode: NotRequired[str]
     init_command: NotRequired[str]
+    auth_plugin_map: NotRequired["dict[str | bytes, type[Any]]"]
+    binary_prefix: NotRequired[bool]
+    client_flag: NotRequired[int]
+    conv: NotRequired["dict[Any, Any]"]
     cursor_class: NotRequired[type["AsyncmyRawCursor"] | type["AsyncmyDictCursor"]]
+    cursor_cls: NotRequired[type["AsyncmyRawCursor"] | type["AsyncmyDictCursor"]]
+    max_allowed_packet: NotRequired[int]
+    program_name: NotRequired[str]
+    read_timeout: NotRequired[int | float]
+    server_public_key: NotRequired[str | bytes]
+    use_unicode: NotRequired[bool]
+    write_timeout: NotRequired[int | float]
     extra: NotRequired["dict[str, Any]"]
 
 
@@ -62,6 +105,51 @@ class AsyncmyPoolParams(AsyncmyConnectionParams):
     maxsize: NotRequired[int]
     echo: NotRequired[bool]
     pool_recycle: NotRequired[int]
+
+
+def _normalize_asyncmy_connection_config(connection_config: "Mapping[str, Any] | None") -> "dict[str, Any]":
+    """Normalize SQLSpec asyncmy config keys before storing them."""
+    config = normalize_connection_config(connection_config)
+
+    if "cursor_class" in config:
+        cursor_class = config.pop("cursor_class")
+        existing_cursor_cls = config.get("cursor_cls")
+        if existing_cursor_cls is not None and existing_cursor_cls is not cursor_class:
+            msg = "Asyncmy connection_config received conflicting 'cursor_cls' and legacy 'cursor_class' values."
+            raise ImproperConfigurationError(msg)
+        config["cursor_cls"] = cursor_class
+
+    allow_local_infile = bool(config.pop(_ASYNCMY_LOCAL_INFILE_GATE, False))
+    local_infile = bool(config.get("local_infile", False))
+    if local_infile and not allow_local_infile:
+        msg = "Asyncmy local_infile=True requires allow_local_infile=True because LOAD DATA LOCAL INFILE can read client files."
+        raise ImproperConfigurationError(msg)
+    config["local_infile"] = bool(local_infile and allow_local_infile)
+
+    return config
+
+
+def _split_asyncmy_pool_config(connection_config: "Mapping[str, Any]") -> "tuple[dict[str, Any], dict[str, Any]]":
+    """Split pool constructor settings from connection settings."""
+    pool_kwargs: dict[str, Any] = {}
+    connection_kwargs: dict[str, Any] = {}
+
+    for key, value in connection_config.items():
+        if value is None:
+            continue
+        if key in _ASYNCMY_POOL_KEYS:
+            pool_kwargs[key] = value
+            continue
+        if key == "write_timeout" and key not in _ASYNCMY_CONNECT_PARAMETER_NAMES:
+            continue
+        connection_kwargs[key] = value
+
+    return pool_kwargs, connection_kwargs
+
+
+def _build_asyncmy_pool_config(connection_config: "Mapping[str, Any]") -> "dict[str, Any]":
+    pool_kwargs, connection_kwargs = _split_asyncmy_pool_config(connection_config)
+    return {**connection_kwargs, **pool_kwargs}
 
 
 class AsyncmyDriverFeatures(TypedDict):
@@ -190,7 +278,7 @@ class AsyncmyConfig(AsyncDatabaseConfig[AsyncmyConnection, "AsyncmyPool", Asyncm
             observability_config: Adapter-level observability overrides for lifecycle hooks and observers
             **kwargs: Additional keyword arguments
         """
-        connection_config = normalize_connection_config(connection_config)
+        connection_config = _normalize_asyncmy_connection_config(connection_config)
 
         connection_config.setdefault("host", "localhost")
         connection_config.setdefault("port", 3306)
@@ -227,7 +315,7 @@ class AsyncmyConfig(AsyncDatabaseConfig[AsyncmyConnection, "AsyncmyPool", Asyncm
 
         Future driver_features can be added here if needed.
         """
-        return cast("AsyncmyPool", await asyncmy.create_pool(**dict(self.connection_config)))
+        return cast("AsyncmyPool", await asyncmy.create_pool(**_build_asyncmy_pool_config(self.connection_config)))
 
     async def _ensure_connection_initialized(self, connection: "AsyncmyConnection") -> None:
         """Ensure connection callback has been called exactly once for this connection.

--- a/tests/unit/adapters/test_asyncmy/test_config.py
+++ b/tests/unit/adapters/test_asyncmy/test_config.py
@@ -1,7 +1,13 @@
 """Asyncmy configuration tests covering statement config builders."""
 
+from typing import Any
+
+import pytest
+
+from sqlspec.adapters.asyncmy._typing import AsyncmyDictCursor
 from sqlspec.adapters.asyncmy.config import AsyncmyConfig
 from sqlspec.adapters.asyncmy.core import build_statement_config
+from sqlspec.exceptions import ImproperConfigurationError
 
 
 def test_build_default_statement_config_custom_serializers() -> None:
@@ -34,6 +40,116 @@ def test_asyncmy_config_applies_driver_feature_serializers() -> None:
     parameter_config = config.statement_config.parameter_config
     assert parameter_config.json_serializer is serializer
     assert parameter_config.json_deserializer is deserializer
+
+
+def test_asyncmy_connection_params_type_modern_driver_options() -> None:
+    """Typed connection params should include current asyncmy connection options."""
+    from sqlspec.adapters.asyncmy.config import AsyncmyConnectionParams
+
+    expected_options = {
+        "auth_plugin_map",
+        "binary_prefix",
+        "client_flag",
+        "conv",
+        "cursor_cls",
+        "db",
+        "max_allowed_packet",
+        "program_name",
+        "read_timeout",
+        "server_public_key",
+        "use_unicode",
+        "write_timeout",
+    }
+
+    assert expected_options <= set(AsyncmyConnectionParams.__annotations__)
+    assert "cursor_class" in AsyncmyConnectionParams.__annotations__
+
+
+def test_asyncmy_cursor_cls_is_canonical_and_cursor_class_is_compatibility_alias() -> None:
+    """The legacy cursor_class key should normalize to upstream cursor_cls."""
+    config = AsyncmyConfig(connection_config={"cursor_class": AsyncmyDictCursor})
+
+    assert config.connection_config["cursor_cls"] is AsyncmyDictCursor
+    assert "cursor_class" not in config.connection_config
+
+
+def test_asyncmy_cursor_cls_and_cursor_class_conflict_raises() -> None:
+    """Conflicting cursor aliases should not silently choose one."""
+    with pytest.raises(ImproperConfigurationError, match="cursor_cls"):
+        AsyncmyConfig(connection_config={"cursor_cls": object, "cursor_class": AsyncmyDictCursor})
+
+
+def test_asyncmy_local_infile_requires_explicit_security_gate() -> None:
+    """LOAD DATA LOCAL INFILE should stay disabled unless separately gated."""
+    with pytest.raises(ImproperConfigurationError, match="allow_local_infile=True"):
+        AsyncmyConfig(connection_config={"local_infile": True})
+
+    config = AsyncmyConfig(connection_config={"allow_local_infile": True, "local_infile": True})
+
+    assert config.connection_config["local_infile"] is True
+    assert "allow_local_infile" not in config.connection_config
+
+
+async def test_asyncmy_create_pool_normalizes_connection_and_pool_kwargs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pool-only and SQLSpec-only settings should not leak into asyncmy connection kwargs."""
+    import sqlspec.adapters.asyncmy.config as config_mod
+
+    captured_connection_kwargs: dict[str, Any] = {}
+    captured_pool_kwargs: dict[str, Any] = {}
+    auth_plugin_map = {"mysql_clear_password": object}
+    conv = {str: str}
+    ssl_config = {"ca": "/tmp/ca.pem", "check_hostname": True}
+
+    async def fake_create_pool(
+        *, minsize: int = 1, maxsize: int = 10, echo: bool = False, pool_recycle: int = 3600, **kwargs: Any
+    ) -> object:
+        captured_pool_kwargs.update({
+            "minsize": minsize,
+            "maxsize": maxsize,
+            "echo": echo,
+            "pool_recycle": pool_recycle,
+        })
+        captured_connection_kwargs.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(config_mod.asyncmy, "create_pool", fake_create_pool)
+
+    config = AsyncmyConfig(
+        connection_config={
+            "allow_local_infile": True,
+            "auth_plugin_map": auth_plugin_map,
+            "charset": "utf8mb4",
+            "conv": conv,
+            "cursor_class": AsyncmyDictCursor,
+            "db": "legacy_db",
+            "echo": True,
+            "local_infile": True,
+            "maxsize": 8,
+            "minsize": 2,
+            "pool_recycle": 120,
+            "read_timeout": 5.5,
+            "ssl": ssl_config,
+            "write_timeout": 6.5,
+        }
+    )
+
+    await config._create_pool()  # pyright: ignore[reportPrivateUsage]
+
+    assert captured_pool_kwargs == {"minsize": 2, "maxsize": 8, "echo": True, "pool_recycle": 120}
+    assert captured_connection_kwargs["auth_plugin_map"] is auth_plugin_map
+    assert captured_connection_kwargs["charset"] == "utf8mb4"
+    assert captured_connection_kwargs["conv"] is conv
+    assert captured_connection_kwargs["cursor_cls"] is AsyncmyDictCursor
+    assert captured_connection_kwargs["db"] == "legacy_db"
+    assert captured_connection_kwargs["local_infile"] is True
+    assert captured_connection_kwargs["read_timeout"] == 5.5
+    assert captured_connection_kwargs["ssl"] is ssl_config
+    assert "allow_local_infile" not in captured_connection_kwargs
+    assert "cursor_class" not in captured_connection_kwargs
+    assert "minsize" not in captured_connection_kwargs
+    assert "maxsize" not in captured_connection_kwargs
+    assert "pool_recycle" not in captured_connection_kwargs
+    assert "write_timeout" not in captured_connection_kwargs
 
 
 def test_asyncmy_typing_all_exports_pool_and_dict_cursor() -> None:


### PR DESCRIPTION
## Summary
- Modernize asyncmy adapter configuration against current asyncmy connection and pool options.

## Changes
- Add typed asyncmy options for auth plugins, converters, TLS, db aliasing, charset handling, packet/auth settings, and read/write timeout shape.
- Normalize legacy `cursor_class` to canonical upstream `cursor_cls` with conflict detection.
- Add an explicit `allow_local_infile` gate and build pool kwargs without leaking SQLSpec-only or pool-only fields into connection kwargs.