### PR TITLE
fix(aiomysql): modernize adapter config

### DIFF
--- a/sqlspec/adapters/aiomysql/config.py
+++ b/sqlspec/adapters/aiomysql/config.py
@@ -23,7 +23,8 @@ from sqlspec.extensions.events import EventRuntimeHints
 from sqlspec.utils.config_tools import normalize_connection_config
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Mapping
+    from ssl import SSLContext
     from types import TracebackType
 
     from sqlspec.core import StatementConfig
@@ -32,26 +33,44 @@ if TYPE_CHECKING:
 
 __all__ = ("AiomysqlConfig", "AiomysqlConnectionParams", "AiomysqlDriverFeatures", "AiomysqlPoolParams")
 
+_POOL_ONLY_CONFIG_KEYS = frozenset({"maxsize", "minsize", "pool_recycle"})
+
 
 class AiomysqlConnectionParams(TypedDict):
-    """aiomysql connection parameters."""
+    """aiomysql connection parameters.
+
+    PyMySQL-only flat TLS and read/write timeout kwargs are intentionally excluded
+    until aiomysql accepts them at runtime.
+    """
 
     host: NotRequired[str]
     user: NotRequired[str]
     password: NotRequired[str]
+    passwd: NotRequired[str]
     db: NotRequired[str]
+    database: NotRequired[str]
     port: NotRequired[int]
     unix_socket: NotRequired[str]
     charset: NotRequired[str]
-    connect_timeout: NotRequired[int]
+    connect_timeout: NotRequired[int | float | None]
     read_default_file: NotRequired[str]
     read_default_group: NotRequired[str]
-    autocommit: NotRequired[bool]
+    autocommit: NotRequired[bool | None]
+    echo: NotRequired[bool]
     local_infile: NotRequired[bool]
-    ssl: NotRequired[Any]
+    enable_local_infile: NotRequired[bool]
+    ssl: NotRequired["SSLContext"]
     sql_mode: NotRequired[str]
     init_command: NotRequired[str]
+    conv: NotRequired["dict[int, Callable[[bytes], Any]] | dict[int, type[Any]] | Mapping[int, Any]"]
+    use_unicode: NotRequired[bool | None]
+    client_flag: NotRequired[int]
+    cursorclass: NotRequired[type["AiomysqlRawCursor"] | type["AiomysqlDictCursor"]]
     cursor_class: NotRequired[type["AiomysqlRawCursor"] | type["AiomysqlDictCursor"]]
+    auth_plugin: NotRequired[str]
+    program_name: NotRequired[str]
+    server_public_key: NotRequired[str | bytes]
+    loop: NotRequired[Any]
 
 
 class AiomysqlPoolParams(AiomysqlConnectionParams):
@@ -59,8 +78,34 @@ class AiomysqlPoolParams(AiomysqlConnectionParams):
 
     minsize: NotRequired[int]
     maxsize: NotRequired[int]
-    echo: NotRequired[bool]
     pool_recycle: NotRequired[int]
+
+
+def _normalize_aiomysql_connection_kwargs(connection_config: "Mapping[str, Any]") -> "dict[str, Any]":
+    """Build aiomysql.connect-compatible kwargs from SQLSpec connection config."""
+    config = dict(connection_config)
+
+    for key in _POOL_ONLY_CONFIG_KEYS:
+        config.pop(key, None)
+
+    if "cursor_class" in config and "cursorclass" not in config:
+        config["cursorclass"] = config["cursor_class"]
+    config.pop("cursor_class", None)
+
+    if "database" in config and "db" not in config:
+        config["db"] = config["database"]
+    config.pop("database", None)
+
+    if "passwd" in config and "password" not in config:
+        config["password"] = config["passwd"]
+    config.pop("passwd", None)
+
+    if config.pop("enable_local_infile", False):
+        config["local_infile"] = True
+    else:
+        config.setdefault("local_infile", False)
+
+    return config
 
 
 class AiomysqlDriverFeatures(TypedDict):
@@ -224,7 +269,19 @@ class AiomysqlConfig(AsyncDatabaseConfig[AiomysqlConnection, "AiomysqlPool", Aio
         type handlers. JSON serialization is handled via type_coercion_map in the
         driver's statement_config (see driver.py).
         """
-        return cast("AiomysqlPool", await aiomysql.create_pool(**dict(self.connection_config)))
+        return cast("AiomysqlPool", await aiomysql.create_pool(**self._get_pool_kwargs()))
+
+    def _get_connection_kwargs(self) -> "dict[str, Any]":
+        """Return aiomysql.connect-compatible kwargs without pool-only settings."""
+        return _normalize_aiomysql_connection_kwargs(self.connection_config)
+
+    def _get_pool_kwargs(self) -> "dict[str, Any]":
+        """Return aiomysql.create_pool kwargs with normalized connection settings."""
+        pool_kwargs = self._get_connection_kwargs()
+        for key in _POOL_ONLY_CONFIG_KEYS:
+            if key in self.connection_config:
+                pool_kwargs[key] = self.connection_config[key]
+        return pool_kwargs
 
     async def _ensure_connection_initialized(self, connection: "AiomysqlConnection") -> None:
         """Ensure connection callback has been called exactly once for this connection.

--- a/tests/unit/adapters/test_aiomysql/test_config.py
+++ b/tests/unit/adapters/test_aiomysql/test_config.py
@@ -1,11 +1,12 @@
 """aiomysql configuration tests covering statement config builders."""
 
+from ssl import PROTOCOL_TLS_CLIENT, SSLContext
 from unittest.mock import AsyncMock, MagicMock
 
 import aiomysql  # pyright: ignore
 import pytest
 
-from sqlspec.adapters.aiomysql._typing import AiomysqlCursor, AiomysqlRawCursor
+from sqlspec.adapters.aiomysql._typing import AiomysqlCursor, AiomysqlDictCursor, AiomysqlRawCursor
 from sqlspec.adapters.aiomysql.config import AiomysqlConfig
 from sqlspec.adapters.aiomysql.core import build_statement_config
 
@@ -50,6 +51,124 @@ def test_aiomysql_signature_namespace_exposes_pool_type() -> None:
     namespace = AiomysqlConfig().get_signature_namespace()
     assert "AiomysqlPool" in namespace, "AiomysqlPool missing from DI namespace (parity gap vs asyncmy)"
     assert namespace["AiomysqlPool"] is aiomysql.Pool
+
+
+def test_aiomysql_connection_kwargs_normalize_cursor_alias_and_omit_pool_only_keys() -> None:
+    """Connection kwargs should use upstream names and exclude pool-only settings."""
+    config = AiomysqlConfig(
+        connection_config={
+            "cursor_class": AiomysqlDictCursor,
+            "minsize": 2,
+            "maxsize": 8,
+            "pool_recycle": 30,
+            "enable_local_infile": True,
+        }
+    )
+
+    connect_kwargs = config._get_connection_kwargs()  # pyright: ignore[reportPrivateUsage]
+
+    assert connect_kwargs["cursorclass"] is AiomysqlDictCursor
+    assert "cursor_class" not in connect_kwargs
+    assert "minsize" not in connect_kwargs
+    assert "maxsize" not in connect_kwargs
+    assert "pool_recycle" not in connect_kwargs
+    assert connect_kwargs["local_infile"] is True
+    assert "enable_local_infile" not in connect_kwargs
+
+
+def test_aiomysql_connection_kwargs_default_local_infile_disabled() -> None:
+    """LOAD DATA LOCAL INFILE should stay disabled unless explicitly enabled."""
+    config = AiomysqlConfig()
+
+    connect_kwargs = config._get_connection_kwargs()  # pyright: ignore[reportPrivateUsage]
+
+    assert connect_kwargs["local_infile"] is False
+
+
+def test_aiomysql_connection_kwargs_prefers_canonical_cursorclass() -> None:
+    """The upstream cursorclass key should win over the compatibility alias."""
+    config = AiomysqlConfig(connection_config={"cursorclass": AiomysqlRawCursor, "cursor_class": AiomysqlDictCursor})
+
+    connect_kwargs = config._get_connection_kwargs()  # pyright: ignore[reportPrivateUsage]
+
+    assert connect_kwargs["cursorclass"] is AiomysqlRawCursor
+    assert "cursor_class" not in connect_kwargs
+
+
+def test_aiomysql_connection_kwargs_maps_safe_pymysql_aliases() -> None:
+    """PyMySQL-compatible database and password aliases should map to aiomysql names."""
+    config = AiomysqlConfig(connection_config={"database": "app", "passwd": "secret"})
+
+    connect_kwargs = config._get_connection_kwargs()  # pyright: ignore[reportPrivateUsage]
+
+    assert connect_kwargs["db"] == "app"
+    assert connect_kwargs["password"] == "secret"
+    assert "database" not in connect_kwargs
+    assert "passwd" not in connect_kwargs
+
+
+def test_aiomysql_connection_kwargs_forwards_supported_current_options() -> None:
+    """Current supported aiomysql connection options should stay typed and routed."""
+    conv = {1: int}
+    ssl_context = SSLContext(PROTOCOL_TLS_CLIENT)
+    config = AiomysqlConfig(
+        connection_config={
+            "charset": "utf8mb4",
+            "use_unicode": False,
+            "conv": conv,
+            "ssl": ssl_context,
+            "client_flag": 123,
+            "auth_plugin": "mysql_clear_password",
+            "program_name": "sqlspec",
+            "server_public_key": "public-key",
+            "autocommit": None,
+            "connect_timeout": 5.5,
+        }
+    )
+
+    connect_kwargs = config._get_connection_kwargs()  # pyright: ignore[reportPrivateUsage]
+
+    assert connect_kwargs["charset"] == "utf8mb4"
+    assert connect_kwargs["use_unicode"] is False
+    assert connect_kwargs["conv"] is conv
+    assert connect_kwargs["ssl"] is ssl_context
+    assert connect_kwargs["client_flag"] == 123
+    assert connect_kwargs["auth_plugin"] == "mysql_clear_password"
+    assert connect_kwargs["program_name"] == "sqlspec"
+    assert connect_kwargs["server_public_key"] == "public-key"
+    assert connect_kwargs["autocommit"] is None
+    assert connect_kwargs["connect_timeout"] == 5.5
+
+
+@pytest.mark.anyio
+async def test_aiomysql_create_pool_forwards_sanitized_pool_kwargs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pool creation should receive normalized connection kwargs plus pool-only settings."""
+    seen_kwargs: dict[str, object] = {}
+
+    async def fake_create_pool(**kwargs: object) -> object:
+        seen_kwargs.update(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr(aiomysql, "create_pool", fake_create_pool)
+    config = AiomysqlConfig(
+        connection_config={
+            "cursor_class": AiomysqlDictCursor,
+            "enable_local_infile": True,
+            "minsize": 2,
+            "maxsize": 8,
+            "pool_recycle": 30,
+        }
+    )
+
+    await config._create_pool()  # pyright: ignore[reportPrivateUsage]
+
+    assert seen_kwargs["cursorclass"] is AiomysqlDictCursor
+    assert seen_kwargs["local_infile"] is True
+    assert seen_kwargs["minsize"] == 2
+    assert seen_kwargs["maxsize"] == 8
+    assert seen_kwargs["pool_recycle"] == 30
+    assert "cursor_class" not in seen_kwargs
+    assert "enable_local_infile" not in seen_kwargs
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
Modernizes the aiomysql adapter config normalization against the current aiomysql-supported connection and pool kwargs.

## Changes
- Adds canonical `cursorclass` typing and routing while preserving `cursor_class` as a compatibility alias.
- Adds supported TLS, auth, charset, timeout, conversion, cursor, and autocommit config typing, plus safe `database` and `passwd` alias normalization.
- Adds an explicit `enable_local_infile` opt-in path and keeps `local_infile` disabled by default.
- Separates pool-only settings from connection kwargs before pool creation.