### PR TITLE
fix(duckdb): modernize adapter config

### DIFF
--- a/sqlspec/adapters/duckdb/config.py
+++ b/sqlspec/adapters/duckdb/config.py
@@ -65,11 +65,11 @@ class DuckDBConnectionParams(TypedDict):
     enable_external_access: NotRequired[bool]
     secret_directory: NotRequired[str]
     enable_object_cache: NotRequired[bool]
-    parquet_metadata_cache: NotRequired[str]
+    parquet_metadata_cache: NotRequired[bool]
     enable_external_file_cache: NotRequired[bool]
     checkpoint_threshold: NotRequired[str]
     enable_progress_bar: NotRequired[bool]
-    progress_bar_time: NotRequired[float]
+    progress_bar_time: NotRequired[int]
     enable_logging: NotRequired[bool]
     log_query_path: NotRequired[str]
     logging_level: NotRequired[str]
@@ -86,13 +86,10 @@ class DuckDBConnectionParams(TypedDict):
 class DuckDBPoolParams(DuckDBConnectionParams):
     """Complete pool configuration for DuckDB adapter.
 
-    Extends DuckDBConnectionParams with pool sizing and lifecycle settings so SQLSpec can manage
-    per-thread DuckDB connections safely while honoring DuckDB's thread-safety constraints.
+    Extends DuckDBConnectionParams with lifecycle settings consumed by SQLSpec's
+    thread-local DuckDB connection manager.
     """
 
-    pool_min_size: NotRequired[int]
-    pool_max_size: NotRequired[int]
-    pool_timeout: NotRequired[float]
     pool_recycle_seconds: NotRequired[int]
     health_check_interval: NotRequired[float]
 
@@ -109,6 +106,9 @@ class DuckDBExtensionConfig(TypedDict):
     repository: NotRequired[str]
     """Repository for the extension (core, community, or custom URL)."""
 
+    repository_url: NotRequired[str]
+    """Custom repository URL for the extension."""
+
     force_install: NotRequired[bool]
     """Force reinstallation of the extension."""
 
@@ -122,11 +122,17 @@ class DuckDBSecretConfig(TypedDict):
     name: str
     """Name of the secret."""
 
-    value: "dict[str, Any]"
+    value: NotRequired["dict[str, Any]"]
     """Secret configuration values."""
 
+    provider: NotRequired[str]
+    """Secret provider, such as config or credential_chain."""
+
     scope: NotRequired[str]
-    """Scope of the secret (LOCAL or PERSISTENT)."""
+    """Optional path or storage-prefix scope for the secret."""
+
+    persistent: NotRequired[bool]
+    """Persist the secret to DuckDB's configured secret directory."""
 
 
 class DuckDBDriverFeatures(TypedDict):

--- a/sqlspec/adapters/duckdb/core.py
+++ b/sqlspec/adapters/duckdb/core.py
@@ -77,15 +77,30 @@ def build_connection_config(connection_config: "Mapping[str, Any]") -> "dict[str
     Returns:
         Dictionary with connection parameters.
     """
-    excluded_keys = {
-        "pool_min_size",
-        "pool_max_size",
-        "pool_timeout",
-        "pool_recycle_seconds",
-        "health_check_interval",
-        "extra",
-    }
-    return {key: value for key, value in connection_config.items() if value is not None and key not in excluded_keys}
+    pool_only_keys = {"pool_min_size", "pool_max_size", "pool_timeout", "pool_recycle_seconds", "health_check_interval"}
+    connect_parameters: dict[str, Any] = {}
+    duckdb_config: dict[str, Any] = {}
+
+    nested_config = connection_config.get("config")
+    if isinstance(nested_config, dict):
+        duckdb_config.update({key: value for key, value in nested_config.items() if value is not None})
+
+    for key, value in connection_config.items():
+        if value is None or key in pool_only_keys or key in {"config", "extra"}:
+            continue
+        if key in {"database", "read_only"}:
+            connect_parameters[key] = value
+        else:
+            duckdb_config[key] = value
+
+    extra = connection_config.get("extra")
+    if isinstance(extra, dict):
+        duckdb_config.update({key: value for key, value in extra.items() if value is not None})
+
+    if duckdb_config:
+        connect_parameters["config"] = duckdb_config
+
+    return connect_parameters
 
 
 def normalize_execute_parameters(parameters: Any) -> Any:

--- a/sqlspec/adapters/duckdb/pool.py
+++ b/sqlspec/adapters/duckdb/pool.py
@@ -111,6 +111,8 @@ class DuckDBConnectionPool:
         for key, value in self._connection_config.items():
             if key in {"database", "read_only"}:
                 connect_parameters[key] = value
+            elif key == "config" and isinstance(value, dict):
+                config_dict.update(value)
             else:
                 config_dict[key] = value
 
@@ -131,53 +133,19 @@ class DuckDBConnectionPool:
                 install_kwargs["version"] = ext_config["version"]
             if "repository" in ext_config:
                 install_kwargs["repository"] = ext_config["repository"]
+            if "repository_url" in ext_config:
+                install_kwargs["repository_url"] = ext_config["repository_url"]
             if ext_config.get("force_install", False):
                 install_kwargs["force_install"] = True
 
-            try:
-                if install_kwargs:
-                    connection.install_extension(ext_name, **install_kwargs)
-                connection.load_extension(ext_name)
-            except Exception as e:
-                log_with_context(
-                    logger,
-                    logging.DEBUG,
-                    "pool.extension.load.failed",
-                    adapter=_ADAPTER_NAME,
-                    pool_id=self._pool_id,
-                    database=self._database_name,
-                    extension=ext_name,
-                    error=str(e),
-                )
+            if install_kwargs:
+                connection.install_extension(ext_name, **install_kwargs)
+            else:
+                connection.install_extension(ext_name)
+            connection.load_extension(ext_name)
 
         for secret_config in self._secrets:
-            secret_type = secret_config.get("secret_type")
-            secret_name = secret_config.get("name")
-            secret_value = secret_config.get("value")
-
-            if not (secret_type and secret_name and secret_value):
-                continue
-
-            _validate_sql_identifier(secret_name, "secret_name")
-            _validate_sql_identifier(secret_type, "secret_type")
-
-            value_pairs = []
-            for key, value in secret_value.items():
-                escaped_value = str(value).replace("'", "''")
-                value_pairs.append(f"'{key}' = '{escaped_value}'")
-            value_string = ", ".join(value_pairs)
-            scope_clause = ""
-            if "scope" in secret_config:
-                scope_clause = f" SCOPE '{secret_config['scope']}'"
-
-            sql = f"""
-                CREATE SECRET {secret_name} (
-                    TYPE {secret_type},
-                    {value_string}
-                ){scope_clause}
-            """
-            with suppress(Exception):
-                connection.execute(sql)
+            _create_secret(connection, secret_config)
 
         if self._on_connection_create:
             # Let a failing user hook surface its real error instead of silently returning a
@@ -359,3 +327,81 @@ def _validate_sql_identifier(value: str, field_name: str) -> None:
             "Must start with a letter and contain only letters, digits, and underscores."
         )
         raise ValueError(msg)
+
+
+def _create_secret(connection: DuckDBConnection, secret_config: dict[str, Any]) -> None:
+    secret_name = secret_config.get("name")
+    secret_type = secret_config.get("secret_type")
+    if not (secret_name and secret_type):
+        return
+
+    _validate_sql_identifier(secret_name, "secret_name")
+    _validate_sql_identifier(secret_type, "secret_type")
+
+    sql = _build_secret_sql(secret_config, secret_name, secret_type)
+    connection.execute(sql)
+    _verify_secret(connection, secret_config, secret_name, secret_type)
+
+
+def _build_secret_sql(secret_config: dict[str, Any], secret_name: str, secret_type: str) -> str:
+    parts = [f"TYPE {secret_type}"]
+
+    provider = secret_config.get("provider")
+    if provider:
+        _validate_sql_identifier(str(provider), "secret_provider")
+        parts.append(f"PROVIDER {provider}")
+
+    secret_value = secret_config.get("value") or {}
+    if not isinstance(secret_value, dict):
+        msg = "DuckDB secret value must be a dictionary"
+        raise TypeError(msg)
+
+    for key, value in secret_value.items():
+        parts.append(f"{_format_secret_key(key)} {_format_secret_literal(value)}")
+
+    scope = secret_config.get("scope")
+    if scope is not None:
+        parts.append(f"SCOPE {_format_secret_literal(scope)}")
+
+    create = "CREATE PERSISTENT SECRET" if secret_config.get("persistent", False) else "CREATE SECRET"
+    body = ",\n    ".join(parts)
+    return f"{create} {secret_name} (\n    {body}\n)"
+
+
+def _format_secret_key(key: Any) -> str:
+    key_text = str(key)
+    _validate_sql_identifier(key_text, "secret_value_key")
+    return key_text.upper()
+
+
+def _format_secret_literal(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    escaped = str(value).replace("'", "''")
+    return f"'{escaped}'"
+
+
+def _verify_secret(
+    connection: DuckDBConnection, secret_config: dict[str, Any], secret_name: str, secret_type: str
+) -> None:
+    row = connection.execute(
+        "SELECT name, type, scope, persistent FROM duckdb_secrets() WHERE name = ?", (secret_name,)
+    ).fetchone()
+    if not row:
+        msg = f"DuckDB secret {secret_name!r} was not visible after creation"
+        raise RuntimeError(msg)
+
+    actual_name, actual_type, actual_scope, actual_persistent = row
+    expected_persistent = bool(secret_config.get("persistent", False))
+    scope = secret_config.get("scope")
+    scopes = list(actual_scope or [])
+    if (
+        actual_name != secret_name
+        or str(actual_type).lower() != secret_type.lower()
+        or bool(actual_persistent) != expected_persistent
+        or (scope is not None and scope not in scopes)
+    ):
+        msg = f"DuckDB secret {secret_name!r} verification failed"
+        raise RuntimeError(msg)

--- a/tests/integration/adapters/duckdb/test_connection.py
+++ b/tests/integration/adapters/duckdb/test_connection.py
@@ -208,8 +208,8 @@ def test_config_with_connection_config_parameter(tmp_path: Path) -> None:
     try:
         connection_config = build_connection_config(config.connection_config)
         assert connection_config["database"] == str(db_path)
-        assert connection_config["memory_limit"] == "256MB"
-        assert connection_config["threads"] == 4
+        assert connection_config["config"]["memory_limit"] == "256MB"
+        assert connection_config["config"]["threads"] == 4
 
         assert "pool_min_size" not in connection_config
         assert "pool_max_size" not in connection_config
@@ -278,20 +278,26 @@ def test_config_consistency_with_other_adapters(tmp_path: Path) -> None:
     """Test that DuckDB config behaves consistently with SQLite/aiosqlite."""
 
     db_path = tmp_path / "consistency_test.duckdb"
-    connection_config = DuckDBPoolParams(
-        database=str(db_path), memory_limit="512MB", threads=2, pool_min_size=1, pool_max_size=4
-    )
+    connection_config: dict[str, Any] = {
+        "database": str(db_path),
+        "memory_limit": "512MB",
+        "threads": 2,
+        "pool_min_size": 1,
+        "pool_max_size": 4,
+    }
 
     config = DuckDBConfig(connection_config=connection_config)
 
     try:
         connection_config = build_connection_config(config.connection_config)
         assert connection_config["database"] == str(db_path)
-        assert connection_config["memory_limit"] == "512MB"
-        assert connection_config["threads"] == 2
+        assert connection_config["config"]["memory_limit"] == "512MB"
+        assert connection_config["config"]["threads"] == 2
 
         assert "pool_min_size" not in connection_config
         assert "pool_max_size" not in connection_config
+        assert "pool_min_size" not in connection_config["config"]
+        assert "pool_max_size" not in connection_config["config"]
 
         with config.provide_session() as session:
             session.execute("CREATE TABLE IF NOT EXISTS consistency_test (id INTEGER)")

--- a/tests/unit/adapters/test_duckdb/test_config.py
+++ b/tests/unit/adapters/test_duckdb/test_config.py
@@ -1,12 +1,24 @@
 """DuckDB configuration tests covering statement config builders."""
 
-from typing import Any
+from typing import Any, get_type_hints
 from unittest.mock import patch
 
 import duckdb
+from typing_extensions import NotRequired
 
-from sqlspec.adapters.duckdb.config import DuckDBConfig
-from sqlspec.adapters.duckdb.core import apply_driver_features, build_statement_config, default_statement_config
+from sqlspec.adapters.duckdb.config import (
+    DuckDBConfig,
+    DuckDBConnectionParams,
+    DuckDBExtensionConfig,
+    DuckDBPoolParams,
+    DuckDBSecretConfig,
+)
+from sqlspec.adapters.duckdb.core import (
+    apply_driver_features,
+    build_connection_config,
+    build_statement_config,
+    default_statement_config,
+)
 from sqlspec.adapters.duckdb.driver import DuckDBDriver
 
 
@@ -30,6 +42,74 @@ def test_duckdb_config_applies_driver_feature_serializer() -> None:
     config = DuckDBConfig(driver_features={"json_serializer": serializer})
     parameter_config = config.statement_config.parameter_config
     assert parameter_config.json_serializer is serializer
+
+
+def test_connection_param_types_match_current_duckdb_settings() -> None:
+    """Typed config keys should match DuckDB 1.5 setting types."""
+
+    hints = get_type_hints(DuckDBConnectionParams, include_extras=True)
+
+    assert hints["parquet_metadata_cache"] == NotRequired[bool]
+    assert hints["progress_bar_time"] == NotRequired[int]
+
+
+def test_pool_params_do_not_type_noop_pool_sizing_keys() -> None:
+    """Only pool settings consumed by DuckDBConnectionPool should remain typed."""
+
+    hints = get_type_hints(DuckDBPoolParams, include_extras=True)
+
+    assert "pool_min_size" not in hints
+    assert "pool_max_size" not in hints
+    assert "pool_timeout" not in hints
+    assert hints["pool_recycle_seconds"] == NotRequired[int]
+    assert hints["health_check_interval"] == NotRequired[float]
+
+
+def test_extension_config_types_repository_url() -> None:
+    """DuckDB install_extension supports repository_url as a distinct kwarg."""
+
+    hints = get_type_hints(DuckDBExtensionConfig, include_extras=True)
+
+    assert hints["repository_url"] == NotRequired[str]
+
+
+def test_secret_config_types_scope_provider_persistence_and_optional_values() -> None:
+    """Provider-based DuckDB secrets do not always need inline value pairs."""
+
+    hints = get_type_hints(DuckDBSecretConfig, include_extras=True)
+
+    assert hints["value"] == NotRequired[dict[str, Any]]
+    assert hints["provider"] == NotRequired[str]
+    assert hints["scope"] == NotRequired[str]
+    assert hints["persistent"] == NotRequired[bool]
+
+
+def test_build_connection_config_preserves_nested_config_and_extra() -> None:
+    """DuckDB connect should receive database/read_only plus one merged config dict."""
+
+    connection_config = {
+        "database": "analytics.duckdb",
+        "read_only": True,
+        "config": {"threads": 1, "parquet_metadata_cache": True},
+        "extra": {"custom_user_agent": "sqlspec-tests"},
+        "progress_bar_time": 250,
+        "pool_min_size": 2,
+        "pool_max_size": 4,
+        "pool_timeout": 10.0,
+        "pool_recycle_seconds": 60,
+        "health_check_interval": 5.0,
+    }
+
+    assert build_connection_config(connection_config) == {
+        "database": "analytics.duckdb",
+        "read_only": True,
+        "config": {
+            "threads": 1,
+            "parquet_metadata_cache": True,
+            "custom_user_agent": "sqlspec-tests",
+            "progress_bar_time": 250,
+        },
+    }
 
 
 def test_driver_init_apply_driver_features_called_once_when_statement_config_is_none() -> None:

--- a/tests/unit/adapters/test_duckdb/test_pool.py
+++ b/tests/unit/adapters/test_duckdb/test_pool.py
@@ -1,10 +1,34 @@
 """Unit tests for DuckDB connection pool helpers."""
 
+from typing import Any
+from uuid import uuid4
+
 import pytest
 
 from sqlspec.adapters.duckdb.pool import DuckDBConnectionPool, _validate_sql_identifier
 
 pytest.importorskip("duckdb", reason="DuckDB adapter requires duckdb package")
+
+
+class _FakeDuckDBConnection:
+    def __init__(self, verification_row: tuple[Any, ...] | None = None) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.installed_extensions: list[tuple[str, dict[str, Any]]] = []
+        self.loaded_extensions: list[str] = []
+        self.verification_row = verification_row
+
+    def install_extension(self, extension: str, **kwargs: Any) -> None:
+        self.installed_extensions.append((extension, kwargs))
+
+    def load_extension(self, extension: str) -> None:
+        self.loaded_extensions.append(extension)
+
+    def execute(self, sql: str, parameters: Any = None) -> "_FakeDuckDBConnection":
+        self.executed.append((sql, parameters))
+        return self
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self.verification_row
 
 
 @pytest.mark.parametrize("identifier", ["my_openai_secret", "openai", "S3", "s3", "r2", "secret_1"])
@@ -41,6 +65,107 @@ def test_create_connection_raises_for_malicious_secret_type() -> None:
         ],
     )
     with pytest.raises(ValueError, match="secret_type"):
+        pool._create_connection()
+
+
+def test_create_connection_passes_nested_config_without_rewrapping(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_connect_kwargs: dict[str, Any] = {}
+
+    def fake_connect(**kwargs: Any) -> _FakeDuckDBConnection:
+        captured_connect_kwargs.update(kwargs)
+        return _FakeDuckDBConnection()
+
+    monkeypatch.setattr("sqlspec.adapters.duckdb.pool.duckdb.connect", fake_connect)
+    pool = DuckDBConnectionPool({
+        "database": ":memory:",
+        "read_only": False,
+        "config": {"threads": 1, "parquet_metadata_cache": True, "progress_bar_time": 250},
+    })
+
+    pool._create_connection()
+
+    assert captured_connect_kwargs == {
+        "database": ":memory:",
+        "read_only": False,
+        "config": {"threads": 1, "parquet_metadata_cache": True, "progress_bar_time": 250},
+    }
+
+
+def test_create_connection_passes_repository_url_to_extension_install(monkeypatch: pytest.MonkeyPatch) -> None:
+    connection = _FakeDuckDBConnection()
+
+    def fake_connect(**_: Any) -> _FakeDuckDBConnection:
+        return connection
+
+    monkeypatch.setattr("sqlspec.adapters.duckdb.pool.duckdb.connect", fake_connect)
+    pool = DuckDBConnectionPool(
+        {"database": ":memory:"},
+        extensions=[
+            {"name": "spatial", "force_install": True, "repository_url": "https://extensions.example.test/duckdb"}
+        ],
+    )
+
+    pool._create_connection()
+
+    assert connection.installed_extensions == [
+        ("spatial", {"force_install": True, "repository_url": "https://extensions.example.test/duckdb"})
+    ]
+    assert connection.loaded_extensions == ["spatial"]
+
+
+def test_create_connection_surfaces_extension_install_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FailingInstallConnection(_FakeDuckDBConnection):
+        def install_extension(self, extension: str, **kwargs: Any) -> None:
+            raise RuntimeError("install failed")
+
+    def fake_connect(**_: Any) -> FailingInstallConnection:
+        return FailingInstallConnection()
+
+    monkeypatch.setattr("sqlspec.adapters.duckdb.pool.duckdb.connect", fake_connect)
+    pool = DuckDBConnectionPool({"database": ":memory:"}, extensions=[{"name": "missing_extension"}])
+
+    with pytest.raises(RuntimeError, match="install failed"):
+        pool._create_connection()
+
+
+def test_create_connection_creates_persistent_scoped_secret(tmp_path) -> None:
+    secret_name = f"s3_secret_{uuid4().hex}"
+    pool = DuckDBConnectionPool(
+        {"database": ":memory:", "secret_directory": str(tmp_path)},
+        secrets=[
+            {
+                "name": secret_name,
+                "secret_type": "s3",
+                "provider": "config",
+                "persistent": True,
+                "scope": "s3://sqlspec-test-bucket/",
+                "value": {"key_id": "abc", "secret": "xyz", "region": "us-east-1"},
+            }
+        ],
+    )
+
+    connection = pool._create_connection()
+    try:
+        row = connection.execute(
+            "SELECT name, type, scope, persistent FROM duckdb_secrets() WHERE name = ?", (secret_name,)
+        ).fetchone()
+    finally:
+        connection.close()
+
+    assert row == (secret_name, "s3", ["s3://sqlspec-test-bucket/"], True)
+
+
+def test_create_connection_raises_when_secret_verification_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_connect(**_: Any) -> _FakeDuckDBConnection:
+        return _FakeDuckDBConnection(verification_row=None)
+
+    monkeypatch.setattr("sqlspec.adapters.duckdb.pool.duckdb.connect", fake_connect)
+    pool = DuckDBConnectionPool(
+        {"database": ":memory:"},
+        secrets=[{"name": "missing_secret", "secret_type": "s3", "value": {"key_id": "abc", "secret": "xyz"}}],
+    )
+
+    with pytest.raises(RuntimeError, match="DuckDB secret 'missing_secret' was not visible"):
         pool._create_connection()
 
 

--- a/tests/unit/config/test_connection_config_edge_cases.py
+++ b/tests/unit/config/test_connection_config_edge_cases.py
@@ -24,7 +24,8 @@ def test_connection_config_with_zero_pool_size() -> None:
 
 def test_connection_config_with_negative_pool_size() -> None:
     """Test connection_config with negative pool size parameters."""
-    config = DuckDBConfig(connection_config=DuckDBPoolParams(database=":memory:", pool_min_size=-1, pool_max_size=-1))
+    connection_config: dict[str, Any] = {"database": ":memory:", "pool_min_size": -1, "pool_max_size": -1}
+    config = DuckDBConfig(connection_config=connection_config)
 
     # Negative values are stored but pool creation may validate them
     assert config.connection_config["pool_min_size"] == -1

--- a/tests/unit/config/test_connection_config_parameters.py
+++ b/tests/unit/config/test_connection_config_parameters.py
@@ -228,10 +228,13 @@ def test_aiosqlite_config_accepts_connection_parameters() -> None:
 
 def test_duckdb_config_accepts_connection_parameters() -> None:
     """Test DuckDBConfig accepts connection_config and connection_instance."""
-    config = DuckDBConfig(
-        connection_config=DuckDBPoolParams(database=":memory:", read_only=False, pool_min_size=3, pool_max_size=12),
-        connection_instance=None,
-    )
+    connection_config: dict[str, Any] = {
+        "database": ":memory:",
+        "read_only": False,
+        "pool_min_size": 3,
+        "pool_max_size": 12,
+    }
+    config = DuckDBConfig(connection_config=connection_config, connection_instance=None)
 
     # DuckDB converts :memory: to :memory:shared_db for pooling
     assert "memory" in config.connection_config["database"]


### PR DESCRIPTION
## Summary

This PR modernizes DuckDB adapter config routing so SQLSpec passes connection options, nested DuckDB config, extensions, and secrets through with explicit runtime behavior.

## Changes

- Routes DuckDB connection settings into `duckdb.connect()` as `database`, `read_only`, and a merged nested `config` dict.
- Removes no-op typed pool sizing keys from `DuckDBPoolParams` while keeping consumed lifecycle settings.
- Corrects current DuckDB setting types for `parquet_metadata_cache` and `progress_bar_time`.
- Adds `repository_url` support for extension installation and surfaces extension install failures.
- Reworks secret creation to support provider, scope, persistence, escaped values, and post-create verification.
- Adds focused unit and integration coverage for DuckDB config, pool, extension, and secret behavior.