### PR TITLE
fix(cockroach-asyncpg): align adapter config typing

### DIFF
--- a/sqlspec/adapters/cockroach_asyncpg/config.py
+++ b/sqlspec/adapters/cockroach_asyncpg/config.py
@@ -1,7 +1,8 @@
 """CockroachDB AsyncPG configuration."""
 
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
 
+from asyncpg import Record
 from asyncpg import create_pool as asyncpg_create_pool
 from typing_extensions import NotRequired
 
@@ -26,6 +27,7 @@ from sqlspec.utils.config_tools import normalize_connection_config
 from sqlspec.utils.serializers import from_json, to_json
 
 if TYPE_CHECKING:
+    from asyncio.events import AbstractEventLoop
     from collections.abc import Awaitable, Callable
 
     from sqlspec.core import StatementConfig
@@ -35,8 +37,14 @@ __all__ = (
     "CockroachAsyncpgConfig",
     "CockroachAsyncpgConnectionConfig",
     "CockroachAsyncpgDriverFeatures",
+    "CockroachAsyncpgGSSLib",
     "CockroachAsyncpgPoolConfig",
+    "CockroachAsyncpgTargetSessionAttrs",
 )
+
+
+CockroachAsyncpgTargetSessionAttrs = Literal["any", "primary", "standby", "read-write", "read-only", "prefer-standby"]
+CockroachAsyncpgGSSLib = Literal["gssapi", "sspi"]
 
 
 class CockroachAsyncpgConnectionConfig(TypedDict):
@@ -47,16 +55,22 @@ class CockroachAsyncpgConnectionConfig(TypedDict):
     port: NotRequired[int]
     user: NotRequired[str]
     password: NotRequired[str]
+    service: NotRequired[str]
+    servicefile: NotRequired[str]
     database: NotRequired[str]
     ssl: NotRequired[Any]
     passfile: NotRequired[str]
     direct_tls: NotRequired[bool]
+    timeout: NotRequired[float]
     connect_timeout: NotRequired[float]
     command_timeout: NotRequired[float]
     statement_cache_size: NotRequired[int]
     max_cached_statement_lifetime: NotRequired[int]
     max_cacheable_statement_size: NotRequired[int]
     server_settings: NotRequired["dict[str, str]"]
+    target_session_attrs: NotRequired[CockroachAsyncpgTargetSessionAttrs]
+    krbsrvname: NotRequired[str]
+    gsslib: NotRequired[CockroachAsyncpgGSSLib]
 
 
 class CockroachAsyncpgPoolConfig(CockroachAsyncpgConnectionConfig):
@@ -66,8 +80,13 @@ class CockroachAsyncpgPoolConfig(CockroachAsyncpgConnectionConfig):
     max_size: NotRequired[int]
     max_queries: NotRequired[int]
     max_inactive_connection_lifetime: NotRequired[float]
+    connect: NotRequired["Callable[..., Awaitable[CockroachAsyncpgConnection]]"]
     setup: NotRequired["Callable[[CockroachAsyncpgConnection], Awaitable[None]]"]
     init: NotRequired["Callable[[CockroachAsyncpgConnection], Awaitable[None]]"]
+    reset: NotRequired["Callable[[CockroachAsyncpgConnection], Awaitable[None]]"]
+    loop: NotRequired["AbstractEventLoop"]
+    connection_class: NotRequired[type["CockroachAsyncpgConnection"]]
+    record_class: NotRequired[type[Record]]
     extra: NotRequired["dict[str, Any]"]
 
 

--- a/tests/unit/adapters/test_cockroach_asyncpg/test_config.py
+++ b/tests/unit/adapters/test_cockroach_asyncpg/test_config.py
@@ -6,13 +6,17 @@ Tests cover:
 - Connection config normalization
 """
 
+from typing import Any, cast, get_args, get_origin
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from typing_extensions import NotRequired
 
 from sqlspec.adapters.cockroach_asyncpg import (
     CockroachAsyncpgConfig,
+    CockroachAsyncpgConnectionConfig,
     CockroachAsyncpgDriverFeatures,
+    CockroachAsyncpgPoolConfig,
     CockroachAsyncpgRetryConfig,
 )
 from sqlspec.core import StatementConfig
@@ -87,6 +91,100 @@ def test_cockroach_asyncpg_config_bind_key_configuration() -> None:
     """Bind key should be stored for multi-database setups."""
     config = CockroachAsyncpgConfig(bind_key="cockroach_primary")
     assert config.bind_key == "cockroach_primary"
+
+
+def test_cockroach_asyncpg_connection_config_describes_current_asyncpg_connect_keys() -> None:
+    """Typed config should include current asyncpg connection keywords."""
+    annotations = CockroachAsyncpgConnectionConfig.__annotations__
+
+    assert annotations["service"] is not None
+    assert annotations["servicefile"] is not None
+    assert annotations["timeout"] is not None
+    assert annotations["target_session_attrs"] is not None
+    assert annotations["krbsrvname"] is not None
+    assert annotations["gsslib"] is not None
+
+    target_session_attrs_annotation = cast("Any", annotations["target_session_attrs"])
+    assert get_origin(target_session_attrs_annotation) is NotRequired
+    assert set(get_args(get_args(target_session_attrs_annotation)[0])) == {
+        "any",
+        "primary",
+        "standby",
+        "read-write",
+        "read-only",
+        "prefer-standby",
+    }
+
+    gsslib_annotation = cast("Any", annotations["gsslib"])
+    assert get_origin(gsslib_annotation) is NotRequired
+    assert set(get_args(get_args(gsslib_annotation)[0])) == {"gssapi", "sspi"}
+
+
+def test_cockroach_asyncpg_pool_config_describes_current_asyncpg_pool_keys() -> None:
+    """Typed pool config should include asyncpg pool-only keywords."""
+    annotations = CockroachAsyncpgPoolConfig.__annotations__
+
+    assert annotations["connect"] is not None
+    assert annotations["reset"] is not None
+    assert annotations["loop"] is not None
+    assert annotations["connection_class"] is not None
+    assert annotations["record_class"] is not None
+
+
+@pytest.mark.anyio
+async def test_cockroach_asyncpg_create_pool_forwards_current_asyncpg_config_keys() -> None:
+    """Pool creation should pass through current asyncpg connection and pool keywords."""
+
+    async def reset(connection: object) -> None:
+        _ = connection
+
+    async def connect_factory(**_: Any) -> object:
+        return object()
+
+    loop = object()
+    connection_class = object()
+    record_class = object()
+    pool = object()
+    config = CockroachAsyncpgConfig(
+        connection_config={
+            "connect": connect_factory,
+            "host": "localhost",
+            "port": 26257,
+            "database": "defaultdb",
+            "service": "cockroach",
+            "servicefile": "/tmp/pg_service.conf",
+            "timeout": 3.5,
+            "target_session_attrs": "read-write",
+            "krbsrvname": "postgres",
+            "gsslib": "gssapi",
+            "reset": reset,
+            "loop": loop,
+            "connection_class": connection_class,
+            "record_class": record_class,
+        }
+    )
+
+    with patch(
+        "sqlspec.adapters.cockroach_asyncpg.config.asyncpg_create_pool", new=AsyncMock(return_value=pool)
+    ) as mock:
+        result = await config._create_pool()
+
+    assert result is pool
+    await_args = mock.await_args
+    assert await_args is not None
+    kwargs = await_args.kwargs
+    assert kwargs["service"] == "cockroach"
+    assert kwargs["servicefile"] == "/tmp/pg_service.conf"
+    assert kwargs["timeout"] == 3.5
+    assert kwargs["target_session_attrs"] == "read-write"
+    assert kwargs["krbsrvname"] == "postgres"
+    assert kwargs["gsslib"] == "gssapi"
+    assert kwargs["connect"] is connect_factory
+    assert kwargs["reset"] is reset
+    assert kwargs["loop"] is loop
+    assert kwargs["connection_class"] is connection_class
+    assert kwargs["record_class"] is record_class
+    assert kwargs["init"] == config._init_connection
 
 
 async def test_cockroach_asyncpg_config_init_connection_registers_json_codecs_before_user_hook() -> None:


### PR DESCRIPTION
## Summary

Aligns the CockroachDB asyncpg adapter config with the current asyncpg connection and pool option surface.

## Details

- Adds typed support for newer asyncpg connection keys such as `service`, `servicefile`, `timeout`, `target_session_attrs`, `krbsrvname`, and `gsslib`.
- Adds pool-only configuration entries for custom `connect`, `reset`, event loop, connection class, and record class handling.
- Ensures `CockroachAsyncpgConfig._create_pool()` forwards those connection and pool kwargs to `asyncpg.create_pool()` alongside SQLSpec's initialization hook.
- Adds unit coverage for the typed config surface and actual `create_pool()` forwarding behavior.

## Review Notes

This branch is rebased onto the latest `main` and stays focused on CockroachDB asyncpg config typing and routing.
