### PR TITLE
fix(bigquery): modernize adapter config routing

### DIFF
--- a/sqlspec/adapters/bigquery/config.py
+++ b/sqlspec/adapters/bigquery/config.py
@@ -43,8 +43,8 @@ class BigQueryConnectionParams(TypedDict):
 
     default_query_job_config: NotRequired[QueryJobConfig]
     default_load_job_config: NotRequired[LoadJobConfig]
+    default_job_creation_mode: NotRequired[str]
     dataset_id: NotRequired[str]
-    credentials_path: NotRequired[str]
     use_query_cache: NotRequired[bool]
     maximum_bytes_billed: NotRequired[int]
     enable_bigquery_ml: NotRequired[bool]
@@ -73,8 +73,6 @@ class BigQueryDriverFeatures(TypedDict):
 
     Attributes:
         connection_instance: Pre-existing BigQuery connection instance to use.
-        on_job_start: Callback invoked when a query job starts.
-        on_job_complete: Callback invoked when a query job completes.
         on_connection_create: Callback invoked when connection is created.
         json_serializer: Custom JSON serializer for dict/list parameter conversion.
             Defaults to sqlspec.utils.serializers.to_json if not provided.
@@ -97,8 +95,6 @@ class BigQueryDriverFeatures(TypedDict):
     """
 
     connection_instance: NotRequired["BigQueryConnection"]
-    on_job_start: NotRequired["Callable[[str], None]"]
-    on_job_complete: NotRequired["Callable[[str, Any], None]"]
     on_connection_create: NotRequired["Callable[[Any], None]"]
     json_serializer: NotRequired["Callable[[Any], str]"]
     enable_uuid_conversion: NotRequired[bool]
@@ -264,21 +260,22 @@ class BigQueryConfig(NoPoolSyncConfig[BigQueryConnection, BigQueryDriver]):
             return cast("BigQueryConnection", self._connection_instance)
 
         try:
-            client_fields = {"project", "location", "credentials", "client_options", "client_info"}
+            client_fields = {
+                "project",
+                "location",
+                "credentials",
+                "client_options",
+                "client_info",
+                "default_query_job_config",
+                "default_load_job_config",
+                "default_job_creation_mode",
+            }
             config_dict: dict[str, Any] = {
                 field: value
                 for field, value in self.connection_config.items()
                 if field in client_fields and value is not None and value is not Empty
             }
             connection = self.connection_type(**config_dict)
-
-            default_query_job_config = self.connection_config.get("default_query_job_config")
-            if default_query_job_config is not None:
-                self.driver_features["default_query_job_config"] = default_query_job_config
-
-            default_load_job_config = self.connection_config.get("default_load_job_config")
-            if default_load_job_config is not None:
-                self.driver_features["default_load_job_config"] = default_load_job_config
 
             if self._user_connection_hook is not None:
                 self._user_connection_hook(connection)

--- a/tests/unit/adapters/test_bigquery/test_config.py
+++ b/tests/unit/adapters/test_bigquery/test_config.py
@@ -1,7 +1,20 @@
 """BigQuery configuration tests covering statement config builders."""
 
-from sqlspec.adapters.bigquery.config import BigQueryConfig
+from typing import Any, cast
+
+from google.cloud.bigquery import LoadJobConfig, QueryJobConfig
+from pytest import MonkeyPatch
+
+from sqlspec.adapters.bigquery.config import BigQueryConfig, BigQueryConnectionParams, BigQueryDriverFeatures
 from sqlspec.adapters.bigquery.core import build_statement_config
+
+
+class _RecordingBigQueryClient:
+    instances: list["_RecordingBigQueryClient"] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.__class__.instances.append(self)
 
 
 def test_build_statement_config_custom_serializer() -> None:
@@ -49,3 +62,38 @@ def test_bigquery_config_job_timeout_ms_overrides_query_timeout_ms() -> None:
     )
     default_job_config = config.connection_config["default_query_job_config"]
     assert int(default_job_config.job_timeout_ms) == 30000
+
+
+def test_bigquery_config_routes_current_client_level_settings(monkeypatch: MonkeyPatch) -> None:
+    """Current BigQuery Client constructor settings should reach client creation."""
+    _RecordingBigQueryClient.instances.clear()
+    monkeypatch.setattr(BigQueryConfig, "connection_type", _RecordingBigQueryClient)
+    query_job_config = QueryJobConfig()
+    load_job_config = LoadJobConfig()
+
+    config = BigQueryConfig(
+        connection_config={
+            "project": "p",
+            "location": "US",
+            "default_query_job_config": query_job_config,
+            "default_load_job_config": load_job_config,
+            "default_job_creation_mode": "JOB_CREATION_OPTIONAL",
+        }
+    )
+
+    connection = cast(_RecordingBigQueryClient, config.create_connection())
+
+    assert connection.kwargs == {
+        "project": "p",
+        "location": "US",
+        "default_query_job_config": query_job_config,
+        "default_load_job_config": load_job_config,
+        "default_job_creation_mode": "JOB_CREATION_OPTIONAL",
+    }
+
+
+def test_bigquery_config_typed_surfaces_do_not_advertise_inert_settings() -> None:
+    """Typed public settings should only include options that SQLSpec routes."""
+    assert "credentials_path" not in BigQueryConnectionParams.__annotations__
+    assert "on_job_start" not in BigQueryDriverFeatures.__annotations__
+    assert "on_job_complete" not in BigQueryDriverFeatures.__annotations__


### PR DESCRIPTION
## Summary

Updates the BigQuery adapter config routing so client-level BigQuery defaults are passed to the BigQuery client constructor instead of being stored on inert SQLSpec driver feature state.

## Details

- Routes `default_query_job_config`, `default_load_job_config`, and `default_job_creation_mode` through `BigQueryConfig.create_connection()` as BigQuery client constructor kwargs.
- Removes typed public settings that SQLSpec did not actually route, including `credentials_path`, `on_job_start`, and `on_job_complete`.
- Keeps the advertised typed config surface aligned with behavior that the adapter really supports.
- Adds unit coverage with a recording BigQuery client and guards for removed inert settings.

## Review Notes

This branch is rebased onto the latest `main` and is intentionally scoped to BigQuery config routing plus focused unit coverage.
