### PR TITLE
fix(cockroach): modernize psycopg config

### DIFF
--- a/sqlspec/adapters/cockroach_psycopg/config.py
+++ b/sqlspec/adapters/cockroach_psycopg/config.py
@@ -44,6 +44,12 @@ __all__ = (
 default_statement_config = build_statement_config()
 
 
+def _validate_driver_features(driver_features: "CockroachPsycopgDriverFeatures | dict[str, Any] | None") -> None:
+    if driver_features and "prefer_uuid_keys" in driver_features:
+        msg = "CockroachDB psycopg driver_features no longer supports unused 'prefer_uuid_keys'."
+        raise ImproperConfigurationError(msg)
+
+
 class CockroachPsycopgConnectionConfig(TypedDict):
     """CockroachDB connection parameters."""
 
@@ -61,6 +67,10 @@ class CockroachPsycopgConnectionConfig(TypedDict):
     sslkey: NotRequired[str]
     sslrootcert: NotRequired[str]
     autocommit: NotRequired[bool]
+    prepare_threshold: NotRequired[int | None]
+    row_factory: NotRequired["Callable[..., Any]"]
+    cursor_factory: NotRequired["type[Any]"]
+    context: NotRequired[Any]
     cluster: NotRequired[str]
     extra: NotRequired["dict[str, Any]"]
 
@@ -76,8 +86,13 @@ class CockroachPsycopgPoolConfig(CockroachPsycopgConnectionConfig):
     max_lifetime: NotRequired[float]
     max_idle: NotRequired[float]
     reconnect_timeout: NotRequired[float]
+    reconnect_failed: NotRequired["Callable[..., Any]"]
     num_workers: NotRequired[int]
     configure: NotRequired["Callable[..., Any]"]
+    check: NotRequired["Callable[..., Any]"]
+    reset: NotRequired["Callable[..., Any]"]
+    open: NotRequired[bool | None]
+    close_returns: NotRequired[bool]
     kwargs: NotRequired["dict[str, Any]"]
 
 
@@ -97,7 +112,6 @@ class CockroachPsycopgDriverFeatures(TypedDict):
     enable_retry_logging: NotRequired[bool]
     enable_follower_reads: NotRequired[bool]
     default_staleness: NotRequired[str]
-    prefer_uuid_keys: NotRequired[bool]
     json_serializer: NotRequired["Callable[[Any], str]"]
     json_deserializer: NotRequired["Callable[[str], Any]"]
     on_connection_create: "NotRequired[Callable[..., Any]]"
@@ -191,6 +205,7 @@ class CockroachPsycopgSyncConfig(
     ) -> None:
         connection_config = normalize_connection_config(connection_config)
         statement_config = statement_config or default_statement_config
+        _validate_driver_features(driver_features)
         statement_config, driver_features = apply_driver_features(statement_config, driver_features)
 
         driver_features.setdefault("enable_auto_retry", True)
@@ -225,21 +240,26 @@ class CockroachPsycopgSyncConfig(
             "max_lifetime": all_config.pop("max_lifetime", 3600.0),
             "max_idle": all_config.pop("max_idle", 600.0),
             "reconnect_timeout": all_config.pop("reconnect_timeout", 300.0),
+            "reconnect_failed": all_config.pop("reconnect_failed", None),
             "num_workers": all_config.pop("num_workers", 3),
+            "check": all_config.pop("check", None),
+            "reset": all_config.pop("reset", None),
+            "open": all_config.pop("open", True),
+            "close_returns": all_config.pop("close_returns", False),
         }
 
         pool_parameters["configure"] = all_config.pop("configure", self._configure_connection)
         pool_parameters = {k: v for k, v in pool_parameters.items() if v is not None}
 
         conninfo = all_config.pop("conninfo", None)
-        if conninfo:
-            return ConnectionPool(conninfo, open=True, connection_class=psycopg_crdb.CrdbConnection, **pool_parameters)
-
         kwargs = all_config.pop("kwargs", {})
         all_config.update(kwargs)
-        return ConnectionPool(
-            "", kwargs=all_config, open=True, connection_class=psycopg_crdb.CrdbConnection, **pool_parameters
-        )
+        if conninfo:
+            return ConnectionPool(
+                conninfo, kwargs=all_config, connection_class=psycopg_crdb.CrdbConnection, **pool_parameters
+            )
+
+        return ConnectionPool("", kwargs=all_config, connection_class=psycopg_crdb.CrdbConnection, **pool_parameters)
 
     def _configure_connection(self, conn: "CockroachSyncConnection") -> None:
         autocommit_setting = self.connection_config.get("autocommit")
@@ -392,6 +412,7 @@ class CockroachPsycopgAsyncConfig(
     ) -> None:
         connection_config = normalize_connection_config(connection_config)
         statement_config = statement_config or default_statement_config
+        _validate_driver_features(driver_features)
         statement_config, driver_features = apply_driver_features(statement_config, driver_features)
 
         driver_features.setdefault("enable_auto_retry", True)
@@ -426,25 +447,32 @@ class CockroachPsycopgAsyncConfig(
             "max_lifetime": all_config.pop("max_lifetime", 3600.0),
             "max_idle": all_config.pop("max_idle", 600.0),
             "reconnect_timeout": all_config.pop("reconnect_timeout", 300.0),
+            "reconnect_failed": all_config.pop("reconnect_failed", None),
             "num_workers": all_config.pop("num_workers", 3),
+            "check": all_config.pop("check", None),
+            "reset": all_config.pop("reset", None),
+            "close_returns": all_config.pop("close_returns", False),
         }
+        open_pool = all_config.pop("open", True)
+        pool_parameters["open"] = False if open_pool is True else open_pool
 
         pool_parameters["configure"] = all_config.pop("configure", self._configure_async_connection)
         pool_parameters = {k: v for k, v in pool_parameters.items() if v is not None}
 
         conninfo = all_config.pop("conninfo", None)
+        kwargs = all_config.pop("kwargs", {})
+        all_config.update(kwargs)
         if conninfo:
             pool = AsyncConnectionPool(
-                conninfo, open=False, connection_class=psycopg_crdb.AsyncCrdbConnection, **pool_parameters
+                conninfo, kwargs=all_config, connection_class=psycopg_crdb.AsyncCrdbConnection, **pool_parameters
             )
         else:
-            kwargs = all_config.pop("kwargs", {})
-            all_config.update(kwargs)
             pool = AsyncConnectionPool(
-                "", kwargs=all_config, open=False, connection_class=psycopg_crdb.AsyncCrdbConnection, **pool_parameters
+                "", kwargs=all_config, connection_class=psycopg_crdb.AsyncCrdbConnection, **pool_parameters
             )
 
-        await pool.open()
+        if open_pool is True:
+            await pool.open()
         return cast("AsyncConnectionPool", pool)
 
     async def _configure_async_connection(self, conn: "CockroachAsyncConnection") -> None:

--- a/tests/unit/adapters/test_cockroach_psycopg/test_config.py
+++ b/tests/unit/adapters/test_cockroach_psycopg/test_config.py
@@ -8,6 +8,11 @@ Tests cover:
 - Connection config normalization
 """
 
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
 from sqlspec.adapters.cockroach_psycopg import (
     CockroachPsycopgAsyncConfig,
     CockroachPsycopgDriverFeatures,
@@ -15,6 +20,41 @@ from sqlspec.adapters.cockroach_psycopg import (
     CockroachPsycopgSyncConfig,
 )
 from sqlspec.adapters.cockroach_psycopg.config import default_statement_config
+from sqlspec.exceptions import ImproperConfigurationError
+
+
+class _SyncPoolSpy:
+    calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.args = args
+        self.kwargs = kwargs
+        self.__class__.calls.append((args, kwargs))
+
+    def close(self) -> None:
+        return None
+
+
+class _AsyncPoolSpy:
+    calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.args = args
+        self.kwargs = kwargs
+        self.open_called = False
+        self.__class__.calls.append((args, kwargs))
+
+    async def open(self) -> None:
+        self.open_called = True
+
+    async def close(self) -> None:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def reset_pool_spies() -> None:
+    _SyncPoolSpy.calls = []
+    _AsyncPoolSpy.calls = []
 
 
 def test_cockroach_psycopg_sync_config_default_initialization() -> None:
@@ -78,6 +118,67 @@ def test_cockroach_psycopg_sync_config_conninfo_in_connection_config() -> None:
     """Conninfo string should be accepted in connection config."""
     config = CockroachPsycopgSyncConfig(connection_config={"conninfo": "postgresql://user:pass@localhost:26257/testdb"})
     assert "conninfo" in config.connection_config
+
+
+def test_cockroach_psycopg_sync_pool_preserves_conninfo_connection_kwargs() -> None:
+    """Conninfo should not cause explicit psycopg connection kwargs to be dropped."""
+    config = CockroachPsycopgSyncConfig(
+        connection_config={
+            "conninfo": "postgresql://user:pass@localhost:26257/testdb",
+            "prepare_threshold": 0,
+            "row_factory": "rows",
+            "cursor_factory": "cursor",
+            "context": "adapt-context",
+            "kwargs": {"application_name": "sqlspec-test"},
+        }
+    )
+
+    with patch("sqlspec.adapters.cockroach_psycopg.config.ConnectionPool", _SyncPoolSpy):
+        pool = config.create_pool()
+
+    assert isinstance(pool, _SyncPoolSpy)
+    args, kwargs = _SyncPoolSpy.calls[0]
+    assert args == ("postgresql://user:pass@localhost:26257/testdb",)
+    assert kwargs["kwargs"] == {
+        "prepare_threshold": 0,
+        "row_factory": "rows",
+        "cursor_factory": "cursor",
+        "context": "adapt-context",
+        "application_name": "sqlspec-test",
+    }
+
+
+def test_cockroach_psycopg_sync_pool_forwards_lifecycle_options() -> None:
+    """psycopg-pool lifecycle options should route to ConnectionPool."""
+
+    def check(_: object) -> None:
+        return None
+
+    def reset(_: object) -> None:
+        return None
+
+    def reconnect_failed(_: object) -> None:
+        return None
+
+    config = CockroachPsycopgSyncConfig(
+        connection_config={
+            "host": "localhost",
+            "check": check,
+            "reset": reset,
+            "reconnect_failed": reconnect_failed,
+            "open": False,
+        }
+    )
+
+    with patch("sqlspec.adapters.cockroach_psycopg.config.ConnectionPool", _SyncPoolSpy):
+        config.create_pool()
+
+    _, kwargs = _SyncPoolSpy.calls[0]
+    assert kwargs["check"] is check
+    assert kwargs["reset"] is reset
+    assert kwargs["reconnect_failed"] is reconnect_failed
+    assert kwargs["open"] is False
+    assert kwargs["kwargs"] == {"host": "localhost"}
 
 
 def test_cockroach_psycopg_sync_config_bind_key_configuration() -> None:
@@ -158,6 +259,70 @@ def test_cockroach_psycopg_async_config_bind_key_configuration() -> None:
     assert config.bind_key == "cockroach_async"
 
 
+@pytest.mark.anyio
+async def test_cockroach_psycopg_async_pool_preserves_conninfo_connection_kwargs() -> None:
+    """Conninfo should not cause explicit async psycopg connection kwargs to be dropped."""
+    config = CockroachPsycopgAsyncConfig(
+        connection_config={
+            "conninfo": "postgresql://user:pass@localhost:26257/testdb",
+            "prepare_threshold": None,
+            "row_factory": "async-rows",
+            "cursor_factory": "async-cursor",
+            "context": "async-adapt-context",
+            "kwargs": {"application_name": "sqlspec-async-test"},
+        }
+    )
+
+    with patch("sqlspec.adapters.cockroach_psycopg.config.AsyncConnectionPool", _AsyncPoolSpy):
+        pool = await config.create_pool()
+
+    assert isinstance(pool, _AsyncPoolSpy)
+    args, kwargs = _AsyncPoolSpy.calls[0]
+    assert args == ("postgresql://user:pass@localhost:26257/testdb",)
+    assert kwargs["kwargs"] == {
+        "prepare_threshold": None,
+        "row_factory": "async-rows",
+        "cursor_factory": "async-cursor",
+        "context": "async-adapt-context",
+        "application_name": "sqlspec-async-test",
+    }
+
+
+@pytest.mark.anyio
+async def test_cockroach_psycopg_async_pool_forwards_lifecycle_options() -> None:
+    """psycopg-pool async lifecycle options should route to AsyncConnectionPool."""
+
+    async def check(_: object) -> None:
+        return None
+
+    async def reset(_: object) -> None:
+        return None
+
+    async def reconnect_failed(_: object) -> None:
+        return None
+
+    config = CockroachPsycopgAsyncConfig(
+        connection_config={
+            "host": "cockroach-node",
+            "check": check,
+            "reset": reset,
+            "reconnect_failed": reconnect_failed,
+            "open": False,
+        }
+    )
+
+    with patch("sqlspec.adapters.cockroach_psycopg.config.AsyncConnectionPool", _AsyncPoolSpy):
+        pool = await config.create_pool()
+
+    _, kwargs = _AsyncPoolSpy.calls[0]
+    assert kwargs["check"] is check
+    assert kwargs["reset"] is reset
+    assert kwargs["reconnect_failed"] is reconnect_failed
+    assert kwargs["open"] is False
+    assert kwargs["kwargs"] == {"host": "cockroach-node"}
+    assert pool.open_called is False
+
+
 def test_cockroach_psycopg_async_config_class_attributes() -> None:
     """Config should have correct class attributes."""
     assert CockroachPsycopgAsyncConfig.supports_transactional_ddl is True
@@ -216,7 +381,15 @@ def test_cockroach_psycopg_driver_features_typed_dict_accepts_event_features() -
     assert features["events_backend"] == "table_queue"
 
 
-def test_cockroach_psycopg_driver_features_typed_dict_accepts_uuid_preference() -> None:
-    """TypedDict should accept CockroachDB-specific UUID preference."""
-    features: CockroachPsycopgDriverFeatures = {"prefer_uuid_keys": True}
-    assert features["prefer_uuid_keys"] is True
+def test_cockroach_psycopg_driver_features_rejects_unused_uuid_preference() -> None:
+    """No unused CockroachDB-specific UUID preference should remain as a no-op."""
+    assert "prefer_uuid_keys" not in CockroachPsycopgDriverFeatures.__optional_keys__
+
+
+@pytest.mark.parametrize("config_type", [CockroachPsycopgSyncConfig, CockroachPsycopgAsyncConfig])
+def test_cockroach_psycopg_config_rejects_unused_uuid_preference(
+    config_type: type[CockroachPsycopgSyncConfig] | type[CockroachPsycopgAsyncConfig],
+) -> None:
+    """Raw driver feature mappings should not keep unused UUID preference silently."""
+    with pytest.raises(ImproperConfigurationError, match="prefer_uuid_keys"):
+        config_type(driver_features={"prefer_uuid_keys": True})


### PR DESCRIPTION
## Summary

Modernizes the CockroachDB psycopg adapter config so psycopg and psycopg-pool options are preserved for both sync and async pools.

## Details

- Extends the connection config typing for current psycopg options such as `prepare_threshold`, `row_factory`, `cursor_factory`, and adaptation context.
- Extends pool config routing for lifecycle options including `check`, `reset`, `reconnect_failed`, `open`, and `close_returns`.
- Preserves explicit connection kwargs when `conninfo` is supplied instead of dropping them before constructing the pool.
- Respects async pool `open=False` without immediately opening the pool.
- Removes the unused `prefer_uuid_keys` driver feature and raises a configuration error if callers still pass it as a raw mapping.
- Adds sync and async unit coverage for conninfo handling, lifecycle option forwarding, and the removed no-op driver feature.

## Review Notes

This branch is rebased onto the latest `main` and focuses on CockroachDB psycopg config behavior rather than broader adapter changes.
