### PR TITLE
fix(psycopg): modernize adapter config

### DIFF
--- a/sqlspec/adapters/psycopg/config.py
+++ b/sqlspec/adapters/psycopg/config.py
@@ -1,6 +1,6 @@
 """Psycopg database configuration with direct field-based configuration."""
 
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
 
 from mypy_extensions import mypyc_attr
 from psycopg_pool import AsyncConnectionPool, ConnectionPool
@@ -39,6 +39,11 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
     from types import TracebackType
 
+    from psycopg import AsyncConnection, AsyncCursor, Connection, Cursor
+    from psycopg.abc import AdaptContext
+    from psycopg.rows import AsyncRowFactory, RowFactory
+    from psycopg_pool.abc import AsyncConnectFailedCB, AsyncConnectionCB, ConnectFailedCB, ConnectionCB
+
     from sqlspec.core import StatementConfig
 
 __all__ = (
@@ -50,6 +55,9 @@ __all__ = (
     "PsycopgSyncConfig",
     "PsycopgSyncCursor",
 )
+
+
+PsycopgSSLMode = Literal["disable", "allow", "prefer", "require", "verify-ca", "verify-full"]
 
 
 class PsycopgConnectionParams(TypedDict):
@@ -64,11 +72,15 @@ class PsycopgConnectionParams(TypedDict):
     connect_timeout: NotRequired[int]
     options: NotRequired[str]
     application_name: NotRequired[str]
-    sslmode: NotRequired[str]
+    sslmode: NotRequired[PsycopgSSLMode]
     sslcert: NotRequired[str]
     sslkey: NotRequired[str]
     sslrootcert: NotRequired[str]
     autocommit: NotRequired[bool]
+    prepare_threshold: NotRequired[int | None]
+    context: NotRequired["AdaptContext | None"]
+    row_factory: NotRequired["RowFactory[Any] | AsyncRowFactory[Any] | None"]
+    cursor_factory: NotRequired["type[Cursor[Any] | AsyncCursor[Any]] | None"]
     extra: NotRequired["dict[str, Any]"]
 
 
@@ -77,6 +89,7 @@ class PsycopgPoolParams(PsycopgConnectionParams):
 
     min_size: NotRequired[int]
     max_size: NotRequired[int]
+    connection_class: NotRequired["type[Connection[Any] | AsyncConnection[Any]]"]
     name: NotRequired[str]
     timeout: NotRequired[float]
     max_waiting: NotRequired[int]
@@ -84,7 +97,12 @@ class PsycopgPoolParams(PsycopgConnectionParams):
     max_idle: NotRequired[float]
     reconnect_timeout: NotRequired[float]
     num_workers: NotRequired[int]
-    configure: NotRequired["Callable[..., Any]"]
+    open: NotRequired[bool | None]
+    configure: NotRequired["ConnectionCB[PsycopgSyncConnection] | AsyncConnectionCB[PsycopgAsyncConnection] | None"]
+    check: NotRequired["ConnectionCB[PsycopgSyncConnection] | AsyncConnectionCB[PsycopgAsyncConnection] | None"]
+    reset: NotRequired["ConnectionCB[PsycopgSyncConnection] | AsyncConnectionCB[PsycopgAsyncConnection] | None"]
+    close_returns: NotRequired[bool]
+    reconnect_failed: NotRequired["ConnectFailedCB | AsyncConnectFailedCB | None"]
     kwargs: NotRequired["dict[str, Any]"]
 
 
@@ -252,6 +270,7 @@ class PsycopgSyncConfig(SyncDatabaseConfig[PsycopgSyncConnection, ConnectionPool
         all_config = dict(self.connection_config)
 
         pool_parameters = {
+            "connection_class": all_config.pop("connection_class", None),
             "min_size": all_config.pop("min_size", 4),
             "max_size": all_config.pop("max_size", None),
             "name": all_config.pop("name", None),
@@ -260,7 +279,12 @@ class PsycopgSyncConfig(SyncDatabaseConfig[PsycopgSyncConnection, ConnectionPool
             "max_lifetime": all_config.pop("max_lifetime", 3600.0),
             "max_idle": all_config.pop("max_idle", 600.0),
             "reconnect_timeout": all_config.pop("reconnect_timeout", 300.0),
+            "reconnect_failed": all_config.pop("reconnect_failed", None),
             "num_workers": all_config.pop("num_workers", 3),
+            "open": all_config.pop("open", True),
+            "check": all_config.pop("check", None),
+            "reset": all_config.pop("reset", None),
+            "close_returns": all_config.pop("close_returns", False),
         }
 
         pool_parameters["configure"] = all_config.pop("configure", self._configure_connection)
@@ -268,12 +292,12 @@ class PsycopgSyncConfig(SyncDatabaseConfig[PsycopgSyncConnection, ConnectionPool
         pool_parameters = {k: v for k, v in pool_parameters.items() if v is not None}
 
         conninfo = all_config.pop("conninfo", None)
+        kwargs = all_config.pop("kwargs", {})
+        all_config.update(kwargs)
         if conninfo:
-            pool = ConnectionPool(conninfo, open=True, **pool_parameters)
+            pool = ConnectionPool(conninfo, kwargs=all_config, **pool_parameters)
         else:
-            kwargs = all_config.pop("kwargs", {})
-            all_config.update(kwargs)
-            pool = ConnectionPool("", kwargs=all_config, open=True, **pool_parameters)
+            pool = ConnectionPool("", kwargs=all_config, **pool_parameters)
 
         return pool
 
@@ -510,8 +534,11 @@ class PsycopgAsyncConfig(AsyncDatabaseConfig[PsycopgAsyncConnection, AsyncConnec
         """Create the actual async connection pool."""
 
         all_config = dict(self.connection_config)
+        open_provided = "open" in all_config
+        open_setting = all_config.pop("open", None)
 
         pool_parameters = {
+            "connection_class": all_config.pop("connection_class", None),
             "min_size": all_config.pop("min_size", 4),
             "max_size": all_config.pop("max_size", None),
             "name": all_config.pop("name", None),
@@ -520,7 +547,12 @@ class PsycopgAsyncConfig(AsyncDatabaseConfig[PsycopgAsyncConnection, AsyncConnec
             "max_lifetime": all_config.pop("max_lifetime", 3600.0),
             "max_idle": all_config.pop("max_idle", 600.0),
             "reconnect_timeout": all_config.pop("reconnect_timeout", 300.0),
+            "reconnect_failed": all_config.pop("reconnect_failed", None),
             "num_workers": all_config.pop("num_workers", 3),
+            "open": open_setting if open_provided else False,
+            "check": all_config.pop("check", None),
+            "reset": all_config.pop("reset", None),
+            "close_returns": all_config.pop("close_returns", False),
         }
 
         pool_parameters["configure"] = all_config.pop("configure", self._configure_async_connection)
@@ -528,14 +560,15 @@ class PsycopgAsyncConfig(AsyncDatabaseConfig[PsycopgAsyncConnection, AsyncConnec
         pool_parameters = {k: v for k, v in pool_parameters.items() if v is not None}
 
         conninfo = all_config.pop("conninfo", None)
+        kwargs = all_config.pop("kwargs", {})
+        all_config.update(kwargs)
         if conninfo:
-            pool = AsyncConnectionPool(conninfo, open=False, **pool_parameters)
+            pool = AsyncConnectionPool(conninfo, kwargs=all_config, **pool_parameters)
         else:
-            kwargs = all_config.pop("kwargs", {})
-            all_config.update(kwargs)
-            pool = AsyncConnectionPool("", kwargs=all_config, open=False, **pool_parameters)
+            pool = AsyncConnectionPool("", kwargs=all_config, **pool_parameters)
 
-        await pool.open()
+        if not open_provided:
+            await pool.open()
 
         return pool
 

--- a/tests/unit/adapters/test_psycopg/test_config.py
+++ b/tests/unit/adapters/test_psycopg/test_config.py
@@ -1,11 +1,16 @@
 """Psycopg configuration tests covering statement config builders."""
 
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
+from psycopg import AsyncCursor, Connection, Cursor
+from psycopg.abc import AdaptContext
+from psycopg.rows import dict_row
 
+import sqlspec.adapters.psycopg.config as psycopg_config
 from sqlspec.adapters.psycopg._typing import PsycopgAsyncSessionContext, PsycopgSyncSessionContext
-from sqlspec.adapters.psycopg.config import PsycopgAsyncConfig, PsycopgSyncConfig
+from sqlspec.adapters.psycopg.config import PsycopgAsyncConfig, PsycopgPoolParams, PsycopgSyncConfig
 from sqlspec.adapters.psycopg.core import (
     build_postgres_extension_probe_names,
     build_statement_config,
@@ -13,6 +18,64 @@ from sqlspec.adapters.psycopg.core import (
     resolve_postgres_extension_state,
 )
 from sqlspec.core import SQL, StatementConfig
+
+
+class _CapturedSyncPool:
+    """Capture psycopg pool constructor arguments without opening a database connection."""
+
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def __init__(self, conninfo: str = "", **kwargs: Any) -> None:
+        self.conninfo = conninfo
+        self.kwargs = kwargs
+        self.calls.append((conninfo, kwargs))
+
+
+class _CapturedAsyncPool:
+    """Capture psycopg async pool constructor arguments without opening a database connection."""
+
+    calls: list[tuple[str, dict[str, Any]]] = []
+    open_calls: int = 0
+
+    def __init__(self, conninfo: str = "", **kwargs: Any) -> None:
+        self.conninfo = conninfo
+        self.kwargs = kwargs
+        self.calls.append((conninfo, kwargs))
+
+    async def open(self) -> None:
+        type(self).open_calls += 1
+
+
+def _configure_sync(_: object) -> None:
+    return None
+
+
+def _check_sync(_: object) -> None:
+    return None
+
+
+def _reset_sync(_: object) -> None:
+    return None
+
+
+def _reconnect_failed_sync(_: object) -> None:
+    return None
+
+
+async def _configure_async(_: object) -> None:
+    return None
+
+
+async def _check_async(_: object) -> None:
+    return None
+
+
+async def _reset_async(_: object) -> None:
+    return None
+
+
+async def _reconnect_failed_async(_: object) -> None:
+    return None
 
 
 def test_build_default_statement_config_custom_serializer() -> None:
@@ -70,6 +133,126 @@ def test_psycopg_numeric_placeholders_convert_to_pyformat() -> None:
     assert "$1" not in compiled_sql
     assert compiled_sql.count("%s") == 3
     assert parameters == ["alpha", "beta", "gamma"]
+
+
+def test_psycopg_sync_pool_preserves_conninfo_with_explicit_connection_kwargs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sync pool creation should pass conninfo and explicit connection kwargs together."""
+    context = cast("AdaptContext", object())
+    connection_config: PsycopgPoolParams = {
+        "conninfo": "postgresql://user:pass@localhost/db",
+        "user": "explicit_user",
+        "prepare_threshold": 0,
+        "context": context,
+        "row_factory": dict_row,
+        "cursor_factory": Cursor,
+    }
+
+    _CapturedSyncPool.calls.clear()
+    monkeypatch.setattr(psycopg_config, "ConnectionPool", _CapturedSyncPool)
+
+    PsycopgSyncConfig(connection_config=connection_config)._create_pool()  # pyright: ignore[reportPrivateUsage]
+
+    conninfo, pool_kwargs = _CapturedSyncPool.calls[-1]
+    assert conninfo == "postgresql://user:pass@localhost/db"
+    assert pool_kwargs["kwargs"] == {
+        "user": "explicit_user",
+        "prepare_threshold": 0,
+        "context": context,
+        "row_factory": dict_row,
+        "cursor_factory": Cursor,
+    }
+
+
+@pytest.mark.anyio
+async def test_psycopg_async_pool_preserves_conninfo_with_explicit_connection_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Async pool creation should pass conninfo and explicit connection kwargs together."""
+    context = cast("AdaptContext", object())
+    connection_config: PsycopgPoolParams = {
+        "conninfo": "postgresql://user:pass@localhost/db",
+        "user": "explicit_user",
+        "prepare_threshold": None,
+        "context": context,
+        "row_factory": dict_row,
+        "cursor_factory": AsyncCursor,
+    }
+
+    _CapturedAsyncPool.calls.clear()
+    _CapturedAsyncPool.open_calls = 0
+    monkeypatch.setattr(psycopg_config, "AsyncConnectionPool", _CapturedAsyncPool)
+
+    await PsycopgAsyncConfig(connection_config=connection_config)._create_pool()  # pyright: ignore[reportPrivateUsage]
+
+    conninfo, pool_kwargs = _CapturedAsyncPool.calls[-1]
+    assert conninfo == "postgresql://user:pass@localhost/db"
+    assert pool_kwargs["kwargs"] == {
+        "user": "explicit_user",
+        "prepare_threshold": None,
+        "context": context,
+        "row_factory": dict_row,
+        "cursor_factory": AsyncCursor,
+    }
+    assert _CapturedAsyncPool.open_calls == 1
+
+
+def test_psycopg_sync_pool_forwards_lifecycle_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sync pool creation should route psycopg-pool lifecycle options to the pool."""
+    connection_config: PsycopgPoolParams = {
+        "dbname": "app",
+        "connection_class": Connection,
+        "configure": _configure_sync,
+        "check": _check_sync,
+        "reset": _reset_sync,
+        "close_returns": True,
+        "reconnect_failed": _reconnect_failed_sync,
+        "open": False,
+    }
+
+    _CapturedSyncPool.calls.clear()
+    monkeypatch.setattr(psycopg_config, "ConnectionPool", _CapturedSyncPool)
+
+    PsycopgSyncConfig(connection_config=connection_config)._create_pool()  # pyright: ignore[reportPrivateUsage]
+
+    _conninfo, pool_kwargs = _CapturedSyncPool.calls[-1]
+    assert pool_kwargs["kwargs"] == {"dbname": "app"}
+    assert pool_kwargs["connection_class"] is Connection
+    assert pool_kwargs["configure"] is _configure_sync
+    assert pool_kwargs["check"] is _check_sync
+    assert pool_kwargs["reset"] is _reset_sync
+    assert pool_kwargs["close_returns"] is True
+    assert pool_kwargs["reconnect_failed"] is _reconnect_failed_sync
+    assert pool_kwargs["open"] is False
+
+
+@pytest.mark.anyio
+async def test_psycopg_async_pool_forwards_lifecycle_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Async pool creation should route psycopg-pool lifecycle options to the pool."""
+    connection_config: PsycopgPoolParams = {
+        "dbname": "app",
+        "configure": _configure_async,
+        "check": _check_async,
+        "reset": _reset_async,
+        "close_returns": True,
+        "reconnect_failed": _reconnect_failed_async,
+        "open": False,
+    }
+
+    _CapturedAsyncPool.calls.clear()
+    _CapturedAsyncPool.open_calls = 0
+    monkeypatch.setattr(psycopg_config, "AsyncConnectionPool", _CapturedAsyncPool)
+
+    await PsycopgAsyncConfig(connection_config=connection_config)._create_pool()  # pyright: ignore[reportPrivateUsage]
+
+    _conninfo, pool_kwargs = _CapturedAsyncPool.calls[-1]
+    assert pool_kwargs["kwargs"] == {"dbname": "app"}
+    assert pool_kwargs["configure"] is _configure_async
+    assert pool_kwargs["check"] is _check_async
+    assert pool_kwargs["reset"] is _reset_async
+    assert pool_kwargs["close_returns"] is True
+    assert pool_kwargs["reconnect_failed"] is _reconnect_failed_async
+    assert pool_kwargs["open"] is False
+    assert _CapturedAsyncPool.open_calls == 0
 
 
 def test_psycopg_sync_session_context_resolves_callable_statement_config() -> None:


### PR DESCRIPTION
## Summary

Modernizes the psycopg adapter config so sync and async pool construction preserve current psycopg and psycopg-pool options.

## Details

- Adds typed support for current psycopg connection options such as `prepare_threshold`, adaptation context, row factories, cursor factories, and a literal `sslmode` surface.
- Adds pool settings for `connection_class`, `check`, `reset`, `reconnect_failed`, `open`, and `close_returns`.
- Preserves explicit connection kwargs when `conninfo` is provided instead of dropping them before pool construction.
- Keeps async pool default behavior opening the pool, while respecting an explicit `open=False` without immediately opening it.
- Adds unit coverage for sync and async conninfo handling plus lifecycle option forwarding.

## Review Notes

This branch is rebased onto the latest `main` and is scoped to psycopg config typing and pool-construction behavior.
