### PR TITLE
feat(adapters): shared allow_* sensitive driver feature gates

### DIFF
--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -51,6 +51,35 @@ Key points:
 - ``ObservabilityConfig`` on the ``SQLSpec`` instance applies to all registered configs.
 - ``load_sql_files()`` accepts multiple paths and loads queries into a shared namespace.
 
+Sensitive Driver Features
+-------------------------
+
+Driver features that can read local files, load code, persist credentials, or
+relax TLS trust are disabled by default. Enabling one requires an explicit
+``allow_*`` flag in ``connection_config``; requesting the feature without the
+flag raises ``ImproperConfigurationError`` naming the exact flag to set.
+
+.. code-block:: python
+
+    from sqlspec.adapters.asyncmy import AsyncmyConfig
+
+    # Raises ImproperConfigurationError: local_infile requires allow_local_infile=True
+    AsyncmyConfig(connection_config={"local_infile": True})
+
+    # Explicit opt-in
+    AsyncmyConfig(connection_config={"allow_local_infile": True, "local_infile": True})
+
+Gated features:
+
+- MySQL family (``asyncmy``, ``aiomysql``, ``pymysql``, ``mysqlconnector``):
+  ``LOAD DATA LOCAL INFILE`` requires ``allow_local_infile=True``.
+- DuckDB: persistent secrets require ``allow_persistent_secrets=True``;
+  ``allow_community_extensions``, ``allow_unsigned_extensions``, and
+  ``enable_external_access`` are forwarded only when explicitly set.
+- SQL Server ODBC (``arrow_odbc``, ``mssql_python``): ``trusted_connection``
+  and ``trust_server_certificate`` are never added to the connection string
+  unless explicitly configured.
+
 Related Guides
 --------------
 

--- a/sqlspec/adapters/aiomysql/config.py
+++ b/sqlspec/adapters/aiomysql/config.py
@@ -20,7 +20,7 @@ from sqlspec.adapters.aiomysql.driver import AiomysqlDriver, AiomysqlExceptionHa
 from sqlspec.config import AsyncDatabaseConfig, ExtensionConfigs
 from sqlspec.driver._async import AsyncPoolConnectionContext, AsyncPoolSessionFactory
 from sqlspec.extensions.events import EventRuntimeHints
-from sqlspec.utils.config_tools import normalize_connection_config
+from sqlspec.utils.config_tools import assert_sensitive_feature_enabled, normalize_connection_config
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Mapping
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
 __all__ = ("AiomysqlConfig", "AiomysqlConnectionParams", "AiomysqlDriverFeatures", "AiomysqlPoolParams")
 
 _POOL_ONLY_CONFIG_KEYS = frozenset({"maxsize", "minsize", "pool_recycle"})
+_AIOMYSQL_LOCAL_INFILE_GATE = "allow_local_infile"
 
 
 class AiomysqlConnectionParams(TypedDict):
@@ -58,7 +59,7 @@ class AiomysqlConnectionParams(TypedDict):
     autocommit: NotRequired[bool | None]
     echo: NotRequired[bool]
     local_infile: NotRequired[bool]
-    enable_local_infile: NotRequired[bool]
+    allow_local_infile: NotRequired[bool]
     ssl: NotRequired["SSLContext"]
     sql_mode: NotRequired[str]
     init_command: NotRequired[str]
@@ -100,10 +101,7 @@ def _normalize_aiomysql_connection_kwargs(connection_config: "Mapping[str, Any]"
         config["password"] = config["passwd"]
     config.pop("passwd", None)
 
-    if config.pop("enable_local_infile", False):
-        config["local_infile"] = True
-    else:
-        config.setdefault("local_infile", False)
+    config.setdefault("local_infile", False)
 
     return config
 
@@ -235,6 +233,17 @@ class AiomysqlConfig(AsyncDatabaseConfig[AiomysqlConnection, "AiomysqlPool", Aio
             **kwargs: Additional keyword arguments
         """
         connection_config = normalize_connection_config(connection_config)
+
+        allow_local_infile = bool(connection_config.pop(_AIOMYSQL_LOCAL_INFILE_GATE, False))
+        local_infile = bool(connection_config.get("local_infile", False))
+        assert_sensitive_feature_enabled(
+            "Aiomysql local_infile=True",
+            local_infile,
+            allow_local_infile,
+            flag_name=_AIOMYSQL_LOCAL_INFILE_GATE,
+            risk="LOAD DATA LOCAL INFILE can read client files",
+        )
+        connection_config["local_infile"] = bool(local_infile and allow_local_infile)
 
         connection_config.setdefault("host", "localhost")
         connection_config.setdefault("port", 3306)

--- a/sqlspec/adapters/asyncmy/config.py
+++ b/sqlspec/adapters/asyncmy/config.py
@@ -22,7 +22,7 @@ from sqlspec.config import AsyncDatabaseConfig, ExtensionConfigs
 from sqlspec.driver._async import AsyncPoolConnectionContext, AsyncPoolSessionFactory
 from sqlspec.exceptions import ImproperConfigurationError
 from sqlspec.extensions.events import EventRuntimeHints
-from sqlspec.utils.config_tools import normalize_connection_config
+from sqlspec.utils.config_tools import assert_sensitive_feature_enabled, normalize_connection_config
 
 if TYPE_CHECKING:
     import ssl
@@ -121,9 +121,13 @@ def _normalize_asyncmy_connection_config(connection_config: "Mapping[str, Any] |
 
     allow_local_infile = bool(config.pop(_ASYNCMY_LOCAL_INFILE_GATE, False))
     local_infile = bool(config.get("local_infile", False))
-    if local_infile and not allow_local_infile:
-        msg = "Asyncmy local_infile=True requires allow_local_infile=True because LOAD DATA LOCAL INFILE can read client files."
-        raise ImproperConfigurationError(msg)
+    assert_sensitive_feature_enabled(
+        "Asyncmy local_infile=True",
+        local_infile,
+        allow_local_infile,
+        flag_name=_ASYNCMY_LOCAL_INFILE_GATE,
+        risk="LOAD DATA LOCAL INFILE can read client files",
+    )
     config["local_infile"] = bool(local_infile and allow_local_infile)
 
     return config

--- a/sqlspec/adapters/duckdb/config.py
+++ b/sqlspec/adapters/duckdb/config.py
@@ -17,7 +17,7 @@ from sqlspec.adapters.duckdb.pool import DuckDBConnectionPool
 from sqlspec.config import ExtensionConfigs, SyncDatabaseConfig
 from sqlspec.driver._sync import SyncPoolConnectionContext, SyncPoolSessionFactory
 from sqlspec.extensions.events import EventRuntimeHints
-from sqlspec.utils.config_tools import normalize_connection_config
+from sqlspec.utils.config_tools import assert_sensitive_feature_enabled, normalize_connection_config
 from sqlspec.utils.serializers import to_json
 
 if TYPE_CHECKING:
@@ -264,6 +264,17 @@ class DuckDBConfig(SyncDatabaseConfig[DuckDBConnection, DuckDBConnectionPool, Du
         self._user_connection_hook = cast(
             "Callable[[DuckDBConnection], DuckDBConnection | None] | None", features.pop("on_connection_create", None)
         )
+        secrets = features.get("secrets")
+        if secrets:
+            allow_persistent_secrets = bool(connection_config.get("allow_persistent_secrets", False))
+            for secret in secrets:
+                assert_sensitive_feature_enabled(
+                    f"DuckDB persistent secret {secret.get('name', '')!r}",
+                    bool(secret.get("persistent", False)),
+                    allow_persistent_secrets,
+                    flag_name="allow_persistent_secrets",
+                    risk="persistent secrets are written to the DuckDB secret directory on disk",
+                )
         features.setdefault("enable_uuid_conversion", True)
         serializer = features.setdefault("json_serializer", to_json)
 

--- a/sqlspec/adapters/pymysql/config.py
+++ b/sqlspec/adapters/pymysql/config.py
@@ -13,7 +13,7 @@ from sqlspec.adapters.pymysql.pool import PyMysqlConnectionPool
 from sqlspec.config import ExtensionConfigs, SyncDatabaseConfig
 from sqlspec.driver._sync import SyncPoolConnectionContext, SyncPoolSessionFactory
 from sqlspec.extensions.events import EventRuntimeHints
-from sqlspec.utils.config_tools import normalize_connection_config
+from sqlspec.utils.config_tools import assert_sensitive_feature_enabled, normalize_connection_config
 
 if TYPE_CHECKING:
     from sqlspec.core import StatementConfig
@@ -33,6 +33,7 @@ __all__ = (
 
 PyMysqlConverter = Mapping[int | type[Any], Callable[..., Any]]
 PyMysqlTimeout = int | float
+_PYMYSQL_LOCAL_INFILE_GATE = "allow_local_infile"
 
 
 class PyMysqlSslParams(TypedDict):
@@ -79,6 +80,7 @@ class PyMysqlConnectionParams(TypedDict):
     write_timeout: NotRequired[PyMysqlTimeout]
     autocommit: NotRequired[bool]
     local_infile: NotRequired[bool]
+    allow_local_infile: NotRequired[bool]
     max_allowed_packet: NotRequired[int]
     defer_connect: NotRequired[bool]
     auth_plugin_map: NotRequired[Mapping[str, type[Any]]]
@@ -166,7 +168,16 @@ class PyMysqlConfig(SyncDatabaseConfig[PyMysqlConnection, PyMysqlConnectionPool,
         connection_config = normalize_connection_config(connection_config)
         connection_config.setdefault("host", "localhost")
         connection_config.setdefault("port", 3306)
-        connection_config.setdefault("local_infile", False)
+        allow_local_infile = bool(connection_config.pop(_PYMYSQL_LOCAL_INFILE_GATE, False))
+        local_infile = bool(connection_config.get("local_infile", False))
+        assert_sensitive_feature_enabled(
+            "PyMySQL local_infile=True",
+            local_infile,
+            allow_local_infile,
+            flag_name=_PYMYSQL_LOCAL_INFILE_GATE,
+            risk="LOAD DATA LOCAL INFILE can read client files",
+        )
+        connection_config["local_infile"] = bool(local_infile and allow_local_infile)
 
         statement_config = statement_config or default_statement_config
         statement_config, driver_features = apply_driver_features(statement_config, driver_features)

--- a/sqlspec/utils/config_tools.py
+++ b/sqlspec/utils/config_tools.py
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
     from sqlspec.config import AsyncDatabaseConfig, SyncDatabaseConfig
 
 __all__ = (
+    "SENSITIVE_FLAG_PREFIX",
+    "assert_sensitive_feature_enabled",
     "discover_config_from_pyproject",
     "find_pyproject_toml",
     "normalize_connection_config",
@@ -312,3 +314,38 @@ def normalize_connection_config(
         raise ImproperConfigurationError(msg)
     normalized.update(extras)
     return normalized
+
+
+# =============================================================================
+# Sensitive Feature Gates
+# =============================================================================
+
+
+SENSITIVE_FLAG_PREFIX = "allow_"
+
+
+def assert_sensitive_feature_enabled(
+    feature: str, requested: bool, allowed: bool, *, flag_name: str, risk: str
+) -> None:
+    """Validate that a sensitive driver feature has been explicitly opted in.
+
+    Sensitive opt-in flags follow the ``allow_*`` naming convention
+    (see ``SENSITIVE_FLAG_PREFIX``). The flag is consumed by the adapter
+    config and never forwarded to the underlying driver unless the driver
+    natively defines it.
+
+    Args:
+        feature: Description of the requested feature, including the
+            requesting adapter (for example ``"Asyncmy local_infile=True"``).
+        requested: Whether the caller requested the feature.
+        allowed: Whether the matching ``allow_*`` flag was set.
+        flag_name: Exact name of the opt-in flag to include in the error.
+        risk: Statement of what the feature can do once enabled.
+
+    Raises:
+        ImproperConfigurationError: If the feature was requested without
+            the opt-in flag.
+    """
+    if requested and not allowed:
+        msg = f"{feature} requires {flag_name}=True because {risk}."
+        raise ImproperConfigurationError(msg)

--- a/tests/unit/adapters/test_aiomysql/test_config.py
+++ b/tests/unit/adapters/test_aiomysql/test_config.py
@@ -9,6 +9,7 @@ import pytest
 from sqlspec.adapters.aiomysql._typing import AiomysqlCursor, AiomysqlDictCursor, AiomysqlRawCursor
 from sqlspec.adapters.aiomysql.config import AiomysqlConfig
 from sqlspec.adapters.aiomysql.core import build_statement_config
+from sqlspec.exceptions import ImproperConfigurationError
 
 
 def test_build_default_statement_config_custom_serializers() -> None:
@@ -61,7 +62,8 @@ def test_aiomysql_connection_kwargs_normalize_cursor_alias_and_omit_pool_only_ke
             "minsize": 2,
             "maxsize": 8,
             "pool_recycle": 30,
-            "enable_local_infile": True,
+            "allow_local_infile": True,
+            "local_infile": True,
         }
     )
 
@@ -73,7 +75,7 @@ def test_aiomysql_connection_kwargs_normalize_cursor_alias_and_omit_pool_only_ke
     assert "maxsize" not in connect_kwargs
     assert "pool_recycle" not in connect_kwargs
     assert connect_kwargs["local_infile"] is True
-    assert "enable_local_infile" not in connect_kwargs
+    assert "allow_local_infile" not in connect_kwargs
 
 
 def test_aiomysql_connection_kwargs_default_local_infile_disabled() -> None:
@@ -83,6 +85,24 @@ def test_aiomysql_connection_kwargs_default_local_infile_disabled() -> None:
     connect_kwargs = config._get_connection_kwargs()  # pyright: ignore[reportPrivateUsage]
 
     assert connect_kwargs["local_infile"] is False
+
+
+def test_aiomysql_local_infile_requires_explicit_security_gate() -> None:
+    with pytest.raises(ImproperConfigurationError, match="allow_local_infile=True"):
+        AiomysqlConfig(connection_config={"local_infile": True})
+
+
+def test_aiomysql_local_infile_enabled_with_gate() -> None:
+    config = AiomysqlConfig(connection_config={"allow_local_infile": True, "local_infile": True})
+
+    assert config.connection_config["local_infile"] is True
+    assert "allow_local_infile" not in config.connection_config
+
+
+def test_aiomysql_gate_alone_does_not_enable_local_infile() -> None:
+    config = AiomysqlConfig(connection_config={"allow_local_infile": True})
+
+    assert config.connection_config["local_infile"] is False
 
 
 def test_aiomysql_connection_kwargs_prefers_canonical_cursorclass() -> None:
@@ -153,7 +173,8 @@ async def test_aiomysql_create_pool_forwards_sanitized_pool_kwargs(monkeypatch: 
     config = AiomysqlConfig(
         connection_config={
             "cursor_class": AiomysqlDictCursor,
-            "enable_local_infile": True,
+            "allow_local_infile": True,
+            "local_infile": True,
             "minsize": 2,
             "maxsize": 8,
             "pool_recycle": 30,
@@ -168,7 +189,7 @@ async def test_aiomysql_create_pool_forwards_sanitized_pool_kwargs(monkeypatch: 
     assert seen_kwargs["maxsize"] == 8
     assert seen_kwargs["pool_recycle"] == 30
     assert "cursor_class" not in seen_kwargs
-    assert "enable_local_infile" not in seen_kwargs
+    assert "allow_local_infile" not in seen_kwargs
 
 
 @pytest.mark.anyio

--- a/tests/unit/adapters/test_arrow_odbc.py
+++ b/tests/unit/adapters/test_arrow_odbc.py
@@ -229,6 +229,17 @@ def test_arrow_odbc_build_connection_config_formats_security_fields_and_kwargs()
     assert kwargs == {"login_timeout_sec": 7, "packet_size": 8192, "autocommit": True}
 
 
+def test_arrow_odbc_build_connection_config_omits_trust_keys_by_default() -> None:
+    connection_string, _ = build_connection_config({
+        "driver": "ODBC Driver 18 for SQL Server",
+        "server": "localhost",
+        "database": "app",
+    })
+
+    assert "Trusted_Connection" not in connection_string
+    assert "TrustServerCertificate" not in connection_string
+
+
 def test_arrow_odbc_session_release_allows_connections_without_close(monkeypatch: Any) -> None:
     """arrow-odbc 10.4 Connection has no close() method, so release should be a no-op."""
     connection = NoCloseConnection()

--- a/tests/unit/adapters/test_duckdb/test_config.py
+++ b/tests/unit/adapters/test_duckdb/test_config.py
@@ -4,6 +4,7 @@ from typing import Any, get_type_hints
 from unittest.mock import patch
 
 import duckdb
+import pytest
 from typing_extensions import NotRequired
 
 from sqlspec.adapters.duckdb.config import (
@@ -20,6 +21,7 @@ from sqlspec.adapters.duckdb.core import (
     default_statement_config,
 )
 from sqlspec.adapters.duckdb.driver import DuckDBDriver
+from sqlspec.exceptions import ImproperConfigurationError
 
 
 def test_build_default_statement_config_custom_serializer() -> None:
@@ -153,3 +155,33 @@ def test_driver_init_apply_driver_features_not_called_per_session_via_config() -
         with config.provide_session():
             pass
     assert mock_apply.call_count == 0
+
+
+def test_duckdb_persistent_secret_requires_explicit_security_gate() -> None:
+    with pytest.raises(ImproperConfigurationError, match="allow_persistent_secrets=True"):
+        DuckDBConfig(
+            connection_config={"database": ":memory:"},
+            driver_features={
+                "secrets": [{"secret_type": "s3", "name": "main", "persistent": True, "value": {"key_id": "k"}}]
+            },
+        )
+
+
+def test_duckdb_persistent_secret_allowed_with_gate() -> None:
+    config = DuckDBConfig(
+        connection_config={"database": ":memory:", "allow_persistent_secrets": True},
+        driver_features={
+            "secrets": [{"secret_type": "s3", "name": "main", "persistent": True, "value": {"key_id": "k"}}]
+        },
+    )
+
+    assert config.connection_config["allow_persistent_secrets"] is True
+
+
+def test_duckdb_temporary_secret_needs_no_gate() -> None:
+    config = DuckDBConfig(
+        connection_config={"database": ":memory:"},
+        driver_features={"secrets": [{"secret_type": "s3", "name": "main", "value": {"key_id": "k"}}]},
+    )
+
+    assert "allow_persistent_secrets" not in config.connection_config

--- a/tests/unit/adapters/test_duckdb/test_extension_flags.py
+++ b/tests/unit/adapters/test_duckdb/test_extension_flags.py
@@ -40,3 +40,16 @@ def test_duckdb_config_merges_existing_extension_flags() -> None:
 
     flags = config.driver_features.get("extension_flags")
     assert flags == {"custom": "value", "allow_community_extensions": True}
+
+
+def test_duckdb_sensitive_flags_absent_by_default() -> None:
+    config = DuckDBConfig(connection_config={"database": ":memory:"})
+
+    for flag in (
+        "allow_community_extensions",
+        "allow_unsigned_extensions",
+        "enable_external_access",
+        "allow_persistent_secrets",
+    ):
+        assert flag not in config.connection_config
+    assert "extension_flags" not in config.driver_features

--- a/tests/unit/adapters/test_mssql_python/test_core.py
+++ b/tests/unit/adapters/test_mssql_python/test_core.py
@@ -38,6 +38,19 @@ def test_build_connection_config_from_parts_formats_odbc_options() -> None:
     assert kwargs == {"autocommit": True}
 
 
+def test_mssql_python_connection_string_omits_trust_keys_by_default() -> None:
+    connection_string, _ = build_connection_config({
+        "server": "localhost",
+        "port": 1433,
+        "database": "app",
+        "uid": "sa",
+        "pwd": "secret",
+    })
+
+    assert "Trusted_Connection" not in connection_string
+    assert "TrustServerCertificate" not in connection_string
+
+
 def test_build_connection_config_no_duplicate_uid() -> None:
     """Passing both 'uid' and 'user' produces exactly one UID= option."""
     connection_string, _ = build_connection_config({"server": "srv", "uid": "user1", "user": "user2"})

--- a/tests/unit/adapters/test_pymysql/test_config.py
+++ b/tests/unit/adapters/test_pymysql/test_config.py
@@ -4,9 +4,11 @@ import ssl
 from collections.abc import Mapping
 from typing import get_args, get_origin, get_type_hints
 
+import pytest
 from typing_extensions import NotRequired
 
 from sqlspec.adapters.pymysql.config import PyMysqlConfig, PyMysqlConnectionParams
+from sqlspec.exceptions import ImproperConfigurationError
 
 
 def _unwrap_not_required(annotation: object) -> object:
@@ -39,6 +41,7 @@ def test_connection_params_type_current_pymysql_options() -> None:
         "write_timeout",
         "autocommit",
         "local_infile",
+        "allow_local_infile",
         "max_allowed_packet",
         "defer_connect",
         "auth_plugin_map",
@@ -79,10 +82,24 @@ def test_create_pool_defaults_local_infile_off() -> None:
 
 def test_create_pool_preserves_local_infile_opt_in() -> None:
     """Explicit local infile opt-in should still pass through to PyMySQL."""
-    config = PyMysqlConfig(connection_config={"local_infile": True})
+    config = PyMysqlConfig(connection_config={"allow_local_infile": True, "local_infile": True})
     pool = config._create_pool()
 
     assert pool._connection_parameters["local_infile"] is True
+    assert "allow_local_infile" not in pool._connection_parameters
+
+
+def test_pymysql_local_infile_requires_explicit_security_gate() -> None:
+    with pytest.raises(ImproperConfigurationError, match="allow_local_infile=True"):
+        PyMysqlConfig(connection_config={"local_infile": True})
+
+
+def test_pymysql_gate_alone_does_not_enable_local_infile() -> None:
+    config = PyMysqlConfig(connection_config={"allow_local_infile": True})
+    pool = config._create_pool()
+
+    assert pool._connection_parameters["local_infile"] is False
+    assert "allow_local_infile" not in pool._connection_parameters
 
 
 def test_create_pool_preserves_ssl_context_and_flat_tls_options() -> None:

--- a/tests/unit/utils/test_config_tools.py
+++ b/tests/unit/utils/test_config_tools.py
@@ -1,0 +1,44 @@
+"""Tests for sqlspec.utils.config_tools sensitive feature gates."""
+
+import pytest
+
+from sqlspec.exceptions import ImproperConfigurationError
+from sqlspec.utils.config_tools import SENSITIVE_FLAG_PREFIX, assert_sensitive_feature_enabled
+
+
+def test_sensitive_flag_prefix_is_allow() -> None:
+    assert SENSITIVE_FLAG_PREFIX == "allow_"
+
+
+def test_gate_raises_when_requested_without_opt_in() -> None:
+    with pytest.raises(ImproperConfigurationError, match="allow_local_infile=True"):
+        assert_sensitive_feature_enabled(
+            "Asyncmy local_infile=True",
+            True,
+            False,
+            flag_name="allow_local_infile",
+            risk="LOAD DATA LOCAL INFILE can read client files",
+        )
+
+
+def test_gate_error_message_format() -> None:
+    with pytest.raises(
+        ImproperConfigurationError,
+        match=r"Asyncmy local_infile=True requires allow_local_infile=True "
+        r"because LOAD DATA LOCAL INFILE can read client files\.",
+    ):
+        assert_sensitive_feature_enabled(
+            "Asyncmy local_infile=True",
+            True,
+            False,
+            flag_name="allow_local_infile",
+            risk="LOAD DATA LOCAL INFILE can read client files",
+        )
+
+
+def test_gate_passes_when_allowed() -> None:
+    assert_sensitive_feature_enabled("feature", True, True, flag_name="allow_x", risk="risk")
+
+
+def test_gate_passes_when_not_requested() -> None:
+    assert_sensitive_feature_enabled("feature", False, False, flag_name="allow_x", risk="risk")


### PR DESCRIPTION
## Summary

First PR of the **Adapter Feature Roadmap** (`sqlspec-gdtl`). Establishes a single, shared opt-in convention for security-sensitive driver features. Sensitive capabilities — local file reads, code/extension loading, persisted credentials, relaxed TLS trust — are now disabled by default and require an explicit `allow_*` flag in `connection_config`; requesting one without the flag raises `ImproperConfigurationError` naming the exact flag.

Implements the binding worksheet `adapter-feature-sensitive-driver-gates/spec.md`, Tasks 1–8 (epic `sqlspec-gdtl.1`).

## Changes

- **Shared helper** (`sqlspec/utils/config_tools.py`): `assert_sensitive_feature_enabled(feature, requested, allowed, *, flag_name, risk)` + `SENSITIVE_FLAG_PREFIX = "allow_"`. mypyc-safe (builtins only); message format `"{feature} requires {flag_name}=True because {risk}."` reproduces the prior asyncmy message verbatim.
- **asyncmy**: existing `local_infile` gate refactored onto the helper (no behavior change; existing test passes unedited).
- **aiomysql**: clean-break rename `enable_local_infile` → `allow_local_infile` with asyncmy-style two-gate raise at config construction. No alias/shim.
- **pymysql**: new `allow_local_infile` gate — `local_infile=True` without the flag now raises.
- **duckdb**: `CREATE PERSISTENT SECRET` gated behind `allow_persistent_secrets` (native key, forwarded not popped); proof tests that all four sensitive flags are absent by default.
- **arrow_odbc / mssql_python**: default-off proof tests for `trusted_connection` / `trust_server_certificate` (no production change — they were already emitted only when configured).
- **docs**: new "Sensitive Driver Features" section in `docs/usage/configuration.rst`.

## Validation

- `make lint` — pre-commit, mypy, pyright, slotscheck all green.
- 207 targeted unit tests pass (utils + asyncmy/aiomysql/pymysql/mysqlconnector/duckdb/arrow_odbc/mssql_python).
- Rename completeness: `grep enable_local_infile sqlspec/ docs/` returns nothing (only descriptive test-fn names remain).
- TDD throughout: each gate test was watched failing before implementation.

## Follow-ups (unblocked by this PR)

This lands the shared helper that sibling flows consume: `allow_extension_loading` (sqlite/aiosqlite), and `allow_*` cloud-billing gates (BigQuery/Spanner) — reserved here, implemented in their own flows.