### PR TITLE
feat(driver): add cache and fetch tuning

### DIFF
--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -84,6 +84,12 @@ Choose a topic
 
       Move data between databases with Arrow-based bulk transfer.
 
+   .. grid-item-card:: Performance Tuning
+      :link: performance
+      :link-type: doc
+
+      Choose cache and fetch controls by adapter and workload shape.
+
    .. grid-item-card:: Extensions
       :link: ../extensions/index
       :link-type: doc
@@ -115,4 +121,5 @@ Recommended Path
    filtering
    testing
    etl
+   performance
    ../extensions/index

--- a/docs/usage/performance.rst
+++ b/docs/usage/performance.rst
@@ -1,0 +1,101 @@
+==================
+Performance Tuning
+==================
+
+SQLSpec keeps adapter defaults conservative. Most performance controls are opt-in
+because the right value depends on query shape, connection lifetime, network
+latency, and the database service in front of the driver.
+
+Start by measuring the query path you want to improve. The optional benchmark
+helper documents service-backed scenarios for the cache and fetch controls:
+
+.. code-block:: bash
+
+   uv run python tools/scripts/bench_tuning.py --list
+
+Cache and fetch controls
+========================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 24 20 24 24
+
+   * - Adapter
+     - Knob
+     - Classification
+     - Use when
+     - Avoid when
+   * - All drivers
+     - ``driver_features={"sqlspec_statement_cache_size": N}``
+     - SQLSpec statement cache
+     - The same raw SQL text runs repeatedly with simple parameters and no per-call transformers.
+     - SQL text is high-cardinality, DDL changes affect cached result shapes, or you need to isolate query preparation behavior. Set ``0`` to disable.
+   * - ``asyncpg``
+     - ``connection_config={"statement_cache_size": N}``
+     - Native asyncpg prepared-statement cache
+     - A long-lived connection repeats parameterized statements and talks directly to PostgreSQL.
+     - PgBouncer uses transaction or statement pooling, or schema changes happen inside transactions on the same connection. Use ``0`` to disable.
+   * - ``psycopg``
+     - ``connection_config={"prepare_threshold": N}``
+     - Native psycopg server-side prepare threshold
+     - A query repeats enough times on the same pooled connection to amortize server-side planning.
+     - Queries are rarely repeated, connection middleware cannot keep prepared statements session-local, or schema churn is expected. Use ``None`` to disable.
+   * - ``oracledb``
+     - ``connection_config={"stmtcachesize": N}``
+     - python-oracledb statement cache
+     - The same statement text is executed frequently on pooled Oracle sessions.
+     - Statement text has high cardinality or memory pressure matters more than parse reuse.
+   * - ``oracledb``
+     - ``driver_features={"arraysize": N, "prefetchrows": N}``
+     - Cursor fetch buffering
+     - Large result sets spend more time on network round trips than row materialization.
+     - Single-row lookups dominate, rows are very wide, or larger buffers increase memory pressure.
+   * - ``oracledb``
+     - ``driver_features={"fetch_lobs": False, "fetch_decimals": True}``
+     - Per-statement fetch representation
+     - You want python-oracledb's native LOB or NUMBER fetch mode for result conversion.
+     - Application code depends on the default LOB locator or numeric representation.
+   * - ``bigquery``
+     - ``driver_features={"query_page_size": N, "query_max_results": N}``
+     - Query result paging
+     - SELECT result consumption should bound per-page fetch size or cap rows returned by ``QueryJob.result()``.
+     - Running DML or scripts. These controls only apply to SELECT-style result fetching and native table Arrow export completion.
+   * - ``arrow_odbc``
+     - ``driver_features={"chunk_size": N, "max_bytes_per_batch": N}``
+     - Native Arrow batch sizing
+     - ODBC Arrow reads should trade memory for fewer batches or smaller batches for steadier memory.
+     - Downstream processing expects a particular batch size, or the driver/database already determines a better batch shape.
+   * - ``arrow_odbc``
+     - ``driver_features={"max_text_size": N, "max_binary_size": N, "fetch_concurrently": bool}``
+     - ODBC Arrow fetch behavior
+     - Text or binary columns need explicit bounds, or concurrent fetch improves a high-latency ODBC source.
+     - Column sizes are unknown and truncation is unacceptable, or the ODBC source is unstable under concurrent fetch.
+
+Avoid-when guidance
+===================
+
+Prepared-statement and statement-cache controls help only when statement text is
+reused on the same connection. They can be counterproductive when SQL is generated
+with many literal variations, when schema changes run on long-lived sessions, or
+when a proxy changes the server session behind a client connection.
+
+Fetch-size controls help only after the query is already correct and indexed. They
+do not fix slow plans. Use them to tune memory and network behavior for known
+result shapes, then verify with representative row widths.
+
+BigQuery result paging controls are SELECT-result controls. They are intentionally
+not applied to DML or script completion calls, so minimal BigQuery configs keep the
+client's default result behavior.
+
+``arrow_odbc`` divergence
+=========================
+
+``arrow_odbc`` does not follow DB-API cursor buffering patterns. Its fetch controls
+are passed to the driver's Arrow batch reader, where ``chunk_size`` and
+``max_bytes_per_batch`` shape Arrow batches directly. This differs from Oracle
+``arraysize`` and ``prefetchrows``, which tune cursor buffering before SQLSpec
+materializes rows.
+
+For ``arrow_odbc``, benchmark both memory and wall time. A larger batch can reduce
+driver round trips but increase peak memory, while smaller batches can make
+streaming steadier for downstream Arrow consumers.

--- a/sqlspec/adapters/bigquery/config.py
+++ b/sqlspec/adapters/bigquery/config.py
@@ -98,6 +98,9 @@ class BigQueryDriverFeatures(TypedDict):
             query jobs. Bounds each request so a server that accepts the request but never responds
             (e.g. a wedged emulator) raises instead of blocking indefinitely. Defaults to
             ``job_result_timeout`` when that is numeric, else 120.0.
+        query_page_size: Optional page size passed through ``QueryJob.result()`` for SELECT result fetching.
+            Non-positive values are ignored by the BigQuery client.
+        query_max_results: Optional total row limit passed through ``QueryJob.result()`` for SELECT result fetching.
     """
 
     connection_instance: NotRequired["BigQueryConnection"]
@@ -109,6 +112,8 @@ class BigQueryDriverFeatures(TypedDict):
     job_retry_deadline: NotRequired[float]
     job_result_timeout: NotRequired[float]
     request_timeout: NotRequired[float]
+    query_page_size: NotRequired[int]
+    query_max_results: NotRequired[int]
 
 
 class BigQueryConnectionContext(SyncPoolConnectionContext):

--- a/sqlspec/adapters/bigquery/driver.py
+++ b/sqlspec/adapters/bigquery/driver.py
@@ -104,6 +104,7 @@ class BigQueryDriver(SyncDriverAdapterBase):
         "_column_name_cache",
         "_data_dictionary",
         "_default_query_job_config",
+        "_job_result_kwargs",
         "_job_result_timeout",
         "_job_retry",
         "_job_retry_deadline",
@@ -137,6 +138,7 @@ class BigQueryDriver(SyncDriverAdapterBase):
         self._default_query_job_config: QueryJobConfig | None = (driver_features or {}).get("default_query_job_config")
         self._data_dictionary: BigQueryDataDictionary | None = None
         self._column_name_cache: dict[int, tuple[Any, list[str]]] = {}
+        self._job_result_kwargs = self._build_job_result_kwargs(features)
         self._job_retry_deadline = float(features.get("job_retry_deadline", 60.0))
         self._job_retry: Retry | None = build_retry(self._job_retry_deadline) if self._job_retry_deadline > 0 else None
         self._job_result_timeout: float | object = features.get("job_result_timeout", POLLING_DEFAULT_VALUE)
@@ -149,6 +151,17 @@ class BigQueryDriver(SyncDriverAdapterBase):
         if isinstance(timeout, (int, float)) and not isinstance(timeout, bool):
             return float(timeout)
         return DEFAULT_REQUEST_TIMEOUT
+
+    def _build_job_result_kwargs(self, features: dict[str, Any]) -> dict[str, Any]:
+        """Build QueryJob.result keyword arguments for SELECT fetches."""
+        job_result_kwargs: dict[str, Any] = {}
+        query_page_size = features.get("query_page_size")
+        if query_page_size is not None:
+            job_result_kwargs["page_size"] = query_page_size
+        query_max_results = features.get("query_max_results")
+        if query_max_results is not None:
+            job_result_kwargs["max_results"] = query_max_results
+        return job_result_kwargs
 
     def _run_query_job(self, connection: "BigQueryConnection", sql: str, parameters: Any) -> "QueryJob":
         return run_query_job(
@@ -179,13 +192,15 @@ class BigQueryDriver(SyncDriverAdapterBase):
         """
         sql, parameters = self._get_compiled_sql(statement, self.statement_config)
         cursor.job = self._run_query_job(cursor, sql, parameters)
-        job_result = cursor.job.result(job_retry=self._job_retry, timeout=self._job_result_timeout)
         statement_type = str(cursor.job.statement_type or "").upper()
         is_select_like = (
             statement.returns_rows() or statement_type == "SELECT" or self._should_force_select(statement, cursor)
         )
 
         if is_select_like:
+            job_result = cursor.job.result(
+                job_retry=self._job_retry, timeout=self._job_result_timeout, **self._job_result_kwargs
+            )
             job_schema = cursor.job.schema or getattr(job_result, "schema", None)
             column_names = resolve_column_names(job_schema, self._column_name_cache)
             rows_list, _ = collect_rows(job_result, job_schema, column_names=column_names)
@@ -430,7 +445,9 @@ class BigQueryDriver(SyncDriverAdapterBase):
 
         with exc_handler:
             query_job = self._run_query_job(self.connection, sql, driver_params)
-            query_job.result(job_retry=self._job_retry, timeout=self._job_result_timeout)  # Wait for completion
+            query_job.result(
+                job_retry=self._job_retry, timeout=self._job_result_timeout, **self._job_result_kwargs
+            )  # Wait for completion
 
             # Native Arrow via Storage API
             arrow_table = query_job.to_arrow()

--- a/sqlspec/driver/_common.py
+++ b/sqlspec/driver/_common.py
@@ -791,6 +791,7 @@ class CommonDriverAttributesMixin:
         "_statement_pool",
         "_stmt_cache",
         "_stmt_cache_enabled",
+        "_stmt_cache_max_size",
         "connection",
         "driver_features",
         "statement_config",
@@ -819,7 +820,8 @@ class CommonDriverAttributesMixin:
         self.driver_features = driver_features or {}
         self._observability = observability
         self._statement_cache: dict[str, SQL] = {}
-        self._stmt_cache = QueryCache(STMT_CACHE_MAX_SIZE)
+        self._stmt_cache_max_size = self._resolve_stmt_cache_max_size()
+        self._stmt_cache = QueryCache(self._stmt_cache_max_size)
         self._stmt_cache_enabled = False
         self._statement_pool = get_sql_pool()
         self._processed_state_pool = get_processed_state_pool()
@@ -893,6 +895,15 @@ class CommonDriverAttributesMixin:
             is_many=False,
             apply_wrap_types=cached.applied_wrap_types,
         )
+
+    def _resolve_stmt_cache_max_size(self) -> int:
+        """Return the configured statement-cache capacity."""
+        cache_size = self.driver_features.get("sqlspec_statement_cache_size", STMT_CACHE_MAX_SIZE)
+        try:
+            resolved_size = int(cache_size)
+        except (TypeError, ValueError):
+            return STMT_CACHE_MAX_SIZE
+        return max(0, resolved_size)
 
     @overload
     @staticmethod
@@ -1187,7 +1198,9 @@ class CommonDriverAttributesMixin:
         return _find_filter_impl(filter_type, filters)
 
     def _update_stmt_cache_flag(self) -> None:
-        self._stmt_cache_enabled = bool(not self.statement_config._has_transformers and self.observability.is_idle)
+        self._stmt_cache_enabled = bool(
+            self._stmt_cache_max_size > 0 and not self.statement_config._has_transformers and self.observability.is_idle
+        )
 
     def _require_capability(self, capability_flag: str) -> None:
         """Check that a storage capability is enabled.

--- a/sqlspec/driver/_query_cache.py
+++ b/sqlspec/driver/_query_cache.py
@@ -89,6 +89,8 @@ class QueryCache:
         return entry
 
     def set(self, sql: str, entry: "CachedQuery") -> None:
+        if self._max_size <= 0:
+            return
         if sql in self._cache:
             self._cache.move_to_end(sql)
         elif len(self._cache) >= self._max_size:

--- a/tests/integration/adapters/asyncpg/test_driver.py
+++ b/tests/integration/adapters/asyncpg/test_driver.py
@@ -526,9 +526,7 @@ async def test_asyncpg_pool_concurrency(postgres_service: PostgresService) -> No
     assert all(p is first_pool for p in pools)
 
 
-async def test_asyncpg_statement_cache_size_zero_survives_ddl_shape_change(
-    postgres_service: PostgresService,
-) -> None:
+async def test_asyncpg_statement_cache_size_zero_survives_ddl_shape_change(postgres_service: PostgresService) -> None:
     """Disabling asyncpg's native statement cache avoids stale plans after DDL shape changes."""
     table_name = f"asyncpg_stmt_cache_shape_{random.randint(1000, 9999)}"
     dsn = (
@@ -537,11 +535,7 @@ async def test_asyncpg_statement_cache_size_zero_survives_ddl_shape_change(
     )
 
     async def run_shape_change(statement_cache_size: int | None) -> None:
-        connection_config: dict[str, object] = {
-            "dsn": dsn,
-            "min_size": 1,
-            "max_size": 1,
-        }
+        connection_config: dict[str, object] = {"dsn": dsn, "min_size": 1, "max_size": 1}
         if statement_cache_size is not None:
             connection_config["statement_cache_size"] = statement_cache_size
 

--- a/tests/integration/adapters/asyncpg/test_driver.py
+++ b/tests/integration/adapters/asyncpg/test_driver.py
@@ -11,6 +11,7 @@ from pytest_databases.docker.postgres import PostgresService
 
 from sqlspec import SQLResult, StatementStack, sql
 from sqlspec.adapters.asyncpg import AsyncpgConfig, AsyncpgDriver, AsyncpgPoolConfig
+from sqlspec.exceptions import SQLSpecError
 
 if TYPE_CHECKING:
     from sqlspec.adapters.asyncpg import AsyncpgPool
@@ -523,3 +524,53 @@ async def test_asyncpg_pool_concurrency(postgres_service: PostgresService) -> No
 
     assert len(unique_pools) == 1, f"Race condition detected! {len(unique_pools)} unique pools created."
     assert all(p is first_pool for p in pools)
+
+
+async def test_asyncpg_statement_cache_size_zero_survives_ddl_shape_change(
+    postgres_service: PostgresService,
+) -> None:
+    """Disabling asyncpg's native statement cache avoids stale plans after DDL shape changes."""
+    table_name = f"asyncpg_stmt_cache_shape_{random.randint(1000, 9999)}"
+    dsn = (
+        f"postgres://{postgres_service.user}:{postgres_service.password}@"
+        f"{postgres_service.host}:{postgres_service.port}/{postgres_service.database}"
+    )
+
+    async def run_shape_change(statement_cache_size: int | None) -> None:
+        connection_config: dict[str, object] = {
+            "dsn": dsn,
+            "min_size": 1,
+            "max_size": 1,
+        }
+        if statement_cache_size is not None:
+            connection_config["statement_cache_size"] = statement_cache_size
+
+        config = AsyncpgConfig(connection_config=connection_config)
+        try:
+            async with config.provide_session() as session:
+                await session.execute_script(f"""
+                    DROP TABLE IF EXISTS {table_name};
+                    CREATE TABLE {table_name} (id INTEGER);
+                    INSERT INTO {table_name} (id) VALUES (1);
+                """)
+                await session.execute(f"SELECT * FROM {table_name} WHERE id = $1", (1,))
+                await session.begin()
+                try:
+                    await session.execute_script(f"""
+                        ALTER TABLE {table_name} ADD COLUMN name TEXT;
+                        UPDATE {table_name} SET name = 'changed' WHERE id = 1;
+                    """)
+                    await session.execute(f"SELECT * FROM {table_name} WHERE id = $1", (1,))
+                    await session.commit()
+                except Exception:
+                    await session.rollback()
+                    raise
+        finally:
+            async with config.provide_session() as cleanup:
+                await cleanup.execute_script(f"DROP TABLE IF EXISTS {table_name}")
+            await config.close_pool()
+
+    with pytest.raises(SQLSpecError, match="cached statement plan is invalid"):
+        await run_shape_change(None)
+
+    await run_shape_change(0)

--- a/tests/integration/adapters/psycopg/test_driver.py
+++ b/tests/integration/adapters/psycopg/test_driver.py
@@ -105,6 +105,39 @@ def test_psycopg_sync_connection(postgres_service: "PostgresService") -> None:
         another_config.close_pool()
 
 
+def test_psycopg_prepare_threshold_routes_to_pooled_connection(postgres_service: "PostgresService") -> None:
+    """Connection prepare_threshold should control server-side prepared statements."""
+    conninfo = (
+        f"postgres://{postgres_service.user}:{postgres_service.password}@"
+        f"{postgres_service.host}:{postgres_service.port}/{postgres_service.database}"
+    )
+    query = "SELECT %s::int AS value"
+
+    def prepared_statement_count(prepare_threshold: int | None) -> int:
+        config = PsycopgSyncConfig(
+            connection_config={
+                "conninfo": conninfo,
+                "min_size": 1,
+                "max_size": 1,
+                "prepare_threshold": prepare_threshold,
+            }
+        )
+        try:
+            with config.provide_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute("DEALLOCATE ALL", prepare=False)
+                    cur.execute(query, (1,))
+                    cur.fetchone()
+                    cur.execute("SELECT COUNT(*) FROM pg_prepared_statements", prepare=False)
+                    row = cast("tuple[int]", cur.fetchone())
+                    return row[0]
+        finally:
+            config.close_pool()
+
+    assert prepared_statement_count(0) >= 1
+    assert prepared_statement_count(None) == 0
+
+
 def test_psycopg_statement_stack_continue_on_error(psycopg_session: "PsycopgSyncDriver") -> None:
     """Pipeline execution should continue when instructed to handle errors."""
 

--- a/tests/unit/adapters/test_async_adapters.py
+++ b/tests/unit/adapters/test_async_adapters.py
@@ -169,6 +169,32 @@ async def test_async_driver_dispatch_uses_observability_slot(
     assert result.operation_type == "SELECT"
 
 
+async def test_async_driver_statement_cache_size_threads_through() -> None:
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        driver = AiosqliteDriver(conn, driver_features={"sqlspec_statement_cache_size": 7})
+
+        assert driver._stmt_cache_max_size == 7
+        assert driver._stmt_cache_enabled is True
+    finally:
+        await conn.close()
+
+
+async def test_async_driver_zero_statement_cache_size_disables_fast_path() -> None:
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        driver = AiosqliteDriver(conn, driver_features={"sqlspec_statement_cache_size": 0})
+
+        assert driver._stmt_cache_max_size == 0
+        assert driver._stmt_cache_enabled is False
+
+        result = await driver.execute("SELECT 1")
+
+        assert result.operation_type == "SELECT"
+    finally:
+        await conn.close()
+
+
 async def test_async_driver_dispatch_statement_execution_insert(aiosqlite_async_driver: AiosqliteDriver) -> None:
     """Test async dispatch_statement_execution with INSERT statement."""
     statement = SQL(

--- a/tests/unit/adapters/test_asyncpg/test_config.py
+++ b/tests/unit/adapters/test_asyncpg/test_config.py
@@ -133,6 +133,27 @@ async def test_asyncpg_create_pool_routes_current_connect_and_pool_kwargs(monkey
     assert "reset" not in captured_connect_kwargs
 
 
+async def test_asyncpg_minimal_create_pool_omits_tuning_kwargs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Minimal pool config should not forward optional cache tuning keys."""
+    import sqlspec.adapters.asyncpg.config as config_mod
+
+    captured_connect_kwargs: dict[str, Any] = {}
+    captured_pool_kwargs: dict[str, Any] = {}
+
+    async def fake_create_pool(*, init: Any = None, **kwargs: Any) -> object:
+        captured_pool_kwargs.update({"init": init})
+        captured_connect_kwargs.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(config_mod, "asyncpg_create_pool", fake_create_pool)
+
+    config = AsyncpgConfig(connection_config={"dsn": "postgresql://localhost/test"})
+    await config._create_pool()  # pyright: ignore[reportPrivateUsage]
+
+    assert captured_pool_kwargs["init"].__func__ is config._init_connection.__func__  # pyright: ignore[reportPrivateUsage]
+    assert captured_connect_kwargs == {"dsn": "postgresql://localhost/test"}
+
+
 def test_asyncpg_build_postgres_extension_probe_names_filters_disabled_features() -> None:
     """Only enabled extension probes should be returned."""
     assert build_postgres_extension_probe_names({"enable_pgvector": True, "enable_paradedb": False}) == ["vector"]

--- a/tests/unit/adapters/test_bigquery/test_arrow_streaming.py
+++ b/tests/unit/adapters/test_bigquery/test_arrow_streaming.py
@@ -41,6 +41,16 @@ class _FakeQueryJob:
         raise AssertionError(msg)
 
 
+class _FakeQueryJobWithTable(_FakeQueryJob):
+    def __init__(self, table: pa.Table) -> None:
+        super().__init__(table)
+        self.to_arrow_calls = 0
+
+    def to_arrow(self) -> pa.Table:
+        self.to_arrow_calls += 1
+        return self.row_iterator.table
+
+
 class _FakeBigQueryConnection:
     def __init__(self, job: _FakeQueryJob) -> None:
         self.job = job
@@ -99,3 +109,26 @@ def test_select_to_arrow_table_uses_conversion_path_for_local_endpoint(monkeypat
     assert result is fallback_result
     assert fallback_calls
     assert job.result_calls == []
+
+
+def test_select_to_arrow_table_applies_query_result_kwargs(monkeypatch: pytest.MonkeyPatch) -> None:
+    table = pa.table({"x": [1, 2, 3]})
+    job = _FakeQueryJobWithTable(table)
+    connection = _FakeBigQueryConnection(job)
+    driver = BigQueryDriver(
+        cast("BigQueryConnection", connection),
+        driver_features={"query_page_size": 13, "query_max_results": 4, "job_retry_deadline": 1.0, "job_result_timeout": 3.0},
+    )
+
+    monkeypatch.setattr("sqlspec.adapters.bigquery.driver.storage_api_available", lambda: True)
+
+    result = driver.select_to_arrow("SELECT 1 AS x", return_format="table")
+
+    assert result.get_data().to_pydict() == {"x": [1, 2, 3]}
+    assert job.result_calls[0] == {
+        "page_size": 13,
+        "max_results": 4,
+        "job_retry": driver._job_retry,
+        "timeout": 3.0,
+    }
+    assert job.to_arrow_calls == 1

--- a/tests/unit/adapters/test_bigquery/test_arrow_streaming.py
+++ b/tests/unit/adapters/test_bigquery/test_arrow_streaming.py
@@ -117,7 +117,12 @@ def test_select_to_arrow_table_applies_query_result_kwargs(monkeypatch: pytest.M
     connection = _FakeBigQueryConnection(job)
     driver = BigQueryDriver(
         cast("BigQueryConnection", connection),
-        driver_features={"query_page_size": 13, "query_max_results": 4, "job_retry_deadline": 1.0, "job_result_timeout": 3.0},
+        driver_features={
+            "query_page_size": 13,
+            "query_max_results": 4,
+            "job_retry_deadline": 1.0,
+            "job_result_timeout": 3.0,
+        },
     )
 
     monkeypatch.setattr("sqlspec.adapters.bigquery.driver.storage_api_available", lambda: True)
@@ -125,10 +130,5 @@ def test_select_to_arrow_table_applies_query_result_kwargs(monkeypatch: pytest.M
     result = driver.select_to_arrow("SELECT 1 AS x", return_format="table")
 
     assert result.get_data().to_pydict() == {"x": [1, 2, 3]}
-    assert job.result_calls[0] == {
-        "page_size": 13,
-        "max_results": 4,
-        "job_retry": driver._job_retry,
-        "timeout": 3.0,
-    }
+    assert job.result_calls[0] == {"page_size": 13, "max_results": 4, "job_retry": driver._job_retry, "timeout": 3.0}
     assert job.to_arrow_calls == 1

--- a/tests/unit/adapters/test_bigquery/test_core.py
+++ b/tests/unit/adapters/test_bigquery/test_core.py
@@ -283,7 +283,8 @@ def test_bigquery_driver_select_result_passes_job_result_kwargs() -> None:
     connection = _RecordingConnection()
     connection.job = _RecordingSelectJob([{"id": 1}])
     driver = BigQueryDriver(
-        cast(Any, connection), driver_features={"query_page_size": 17, "query_max_results": 11, "job_result_timeout": 3.0}
+        cast(Any, connection),
+        driver_features={"query_page_size": 17, "query_max_results": 11, "job_result_timeout": 3.0},
     )
 
     result = driver.dispatch_execute(cast(Any, connection), driver.prepare_statement("SELECT 1"))
@@ -305,32 +306,31 @@ def test_bigquery_driver_minimal_select_result_omits_paging_kwargs() -> None:
     result = driver.dispatch_execute(cast(Any, connection), driver.prepare_statement("SELECT 1"))
 
     assert result.is_select_result is True
-    assert connection.job.result_calls[0] == {
-        "job_retry": driver._job_retry,
-        "timeout": 3.0,
-    }
+    assert connection.job.result_calls[0] == {"job_retry": driver._job_retry, "timeout": 3.0}
 
 
 def test_bigquery_driver_dml_and_script_do_not_pass_job_result_kwargs() -> None:
     connection = _RecordingConnection()
     driver = BigQueryDriver(
-        cast(Any, connection), driver_features={"query_page_size": 17, "query_max_results": 11, "job_result_timeout": 3.0}
+        cast(Any, connection),
+        driver_features={"query_page_size": 17, "query_max_results": 11, "job_result_timeout": 3.0},
     )
 
     connection.job = _RecordingDmlJob(num_dml_affected_rows=1)
-    dml_result = driver.dispatch_execute(cast(Any, connection), driver.prepare_statement("INSERT INTO t (id) VALUES (1)"))
+    dml_result = driver.dispatch_execute(
+        cast(Any, connection), driver.prepare_statement("INSERT INTO t (id) VALUES (1)")
+    )
 
     assert dml_result.is_select_result is False
     assert connection.job.result_calls == []
 
     connection.job = _RecordingScriptJob(num_dml_affected_rows=1)
-    script_result = driver.dispatch_execute_script(cast(Any, connection), driver.prepare_statement("INSERT INTO t (id) VALUES (1);"))
+    script_result = driver.dispatch_execute_script(
+        cast(Any, connection), driver.prepare_statement("INSERT INTO t (id) VALUES (1);")
+    )
 
     assert script_result.is_script_result is True
-    assert connection.job.result_calls[0] == {
-        "job_retry": driver._job_retry,
-        "timeout": 3.0,
-    }
+    assert connection.job.result_calls[0] == {"job_retry": driver._job_retry, "timeout": 3.0}
 
 
 def test_stream_source_local_endpoint_uses_single_page_and_bounded_retry() -> None:

--- a/tests/unit/adapters/test_bigquery/test_core.py
+++ b/tests/unit/adapters/test_bigquery/test_core.py
@@ -297,6 +297,20 @@ def test_bigquery_driver_select_result_passes_job_result_kwargs() -> None:
     }
 
 
+def test_bigquery_driver_minimal_select_result_omits_paging_kwargs() -> None:
+    connection = _RecordingConnection()
+    connection.job = _RecordingSelectJob([{"id": 1}])
+    driver = BigQueryDriver(cast(Any, connection), driver_features={"job_result_timeout": 3.0})
+
+    result = driver.dispatch_execute(cast(Any, connection), driver.prepare_statement("SELECT 1"))
+
+    assert result.is_select_result is True
+    assert connection.job.result_calls[0] == {
+        "job_retry": driver._job_retry,
+        "timeout": 3.0,
+    }
+
+
 def test_bigquery_driver_dml_and_script_do_not_pass_job_result_kwargs() -> None:
     connection = _RecordingConnection()
     driver = BigQueryDriver(

--- a/tests/unit/adapters/test_bigquery/test_core.py
+++ b/tests/unit/adapters/test_bigquery/test_core.py
@@ -36,6 +36,43 @@ class _RecordingConnection:
         return self.job
 
 
+class _RecordingSelectJob:
+    statement_type = "SELECT"
+    schema = [SimpleNamespace(name="id")]
+
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self.rows = rows
+        self.result_calls: list[dict[str, Any]] = []
+
+    def result(self, **kwargs: Any) -> list[dict[str, object]]:
+        self.result_calls.append(kwargs)
+        return self.rows
+
+
+class _RecordingDmlJob:
+    statement_type = "INSERT"
+
+    def __init__(self, *, num_dml_affected_rows: int = 1) -> None:
+        self.num_dml_affected_rows = num_dml_affected_rows
+        self.result_calls: list[dict[str, Any]] = []
+
+    def result(self, **kwargs: Any) -> None:
+        self.result_calls.append(kwargs)
+        msg = "DML job.result() should not be called in this test"
+        raise AssertionError(msg)
+
+
+class _RecordingScriptJob:
+    statement_type = "SCRIPT"
+
+    def __init__(self, *, num_dml_affected_rows: int = 1) -> None:
+        self.num_dml_affected_rows = num_dml_affected_rows
+        self.result_calls: list[dict[str, Any]] = []
+
+    def result(self, **kwargs: Any) -> None:
+        self.result_calls.append(kwargs)
+
+
 class _RecordingRow:
     def __init__(self, values: dict[str, object]) -> None:
         self._values = values
@@ -240,6 +277,46 @@ def test_bigquery_driver_zero_job_retry_deadline_disables_retries() -> None:
     _, kwargs = connection.queries[0]
     assert kwargs["retry"] is None
     assert kwargs["job_retry"] is None
+
+
+def test_bigquery_driver_select_result_passes_job_result_kwargs() -> None:
+    connection = _RecordingConnection()
+    connection.job = _RecordingSelectJob([{"id": 1}])
+    driver = BigQueryDriver(
+        cast(Any, connection), driver_features={"query_page_size": 17, "query_max_results": 11, "job_result_timeout": 3.0}
+    )
+
+    result = driver.dispatch_execute(cast(Any, connection), driver.prepare_statement("SELECT 1"))
+
+    assert result.is_select_result is True
+    assert connection.job.result_calls[0] == {
+        "page_size": 17,
+        "max_results": 11,
+        "job_retry": driver._job_retry,
+        "timeout": 3.0,
+    }
+
+
+def test_bigquery_driver_dml_and_script_do_not_pass_job_result_kwargs() -> None:
+    connection = _RecordingConnection()
+    driver = BigQueryDriver(
+        cast(Any, connection), driver_features={"query_page_size": 17, "query_max_results": 11, "job_result_timeout": 3.0}
+    )
+
+    connection.job = _RecordingDmlJob(num_dml_affected_rows=1)
+    dml_result = driver.dispatch_execute(cast(Any, connection), driver.prepare_statement("INSERT INTO t (id) VALUES (1)"))
+
+    assert dml_result.is_select_result is False
+    assert connection.job.result_calls == []
+
+    connection.job = _RecordingScriptJob(num_dml_affected_rows=1)
+    script_result = driver.dispatch_execute_script(cast(Any, connection), driver.prepare_statement("INSERT INTO t (id) VALUES (1);"))
+
+    assert script_result.is_script_result is True
+    assert connection.job.result_calls[0] == {
+        "job_retry": driver._job_retry,
+        "timeout": 3.0,
+    }
 
 
 def test_stream_source_local_endpoint_uses_single_page_and_bounded_retry() -> None:

--- a/tests/unit/adapters/test_oracledb/test_config.py
+++ b/tests/unit/adapters/test_oracledb/test_config.py
@@ -164,6 +164,25 @@ def test_oracle_sync_create_pool_merges_extra_and_drops_stale_threaded(monkeypat
     assert "threaded" not in seen_kwargs
 
 
+def test_oracle_sync_minimal_pool_omits_tuning_kwargs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Minimal pool config should not inject statement-cache or fetch tuning keys."""
+    seen_kwargs: dict[str, object] = {}
+
+    def fake_create_pool(**kwargs: object) -> object:
+        seen_kwargs.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(oracle_config_module.oracledb, "create_pool", fake_create_pool)
+
+    OracleSyncConfig(connection_config={"user": "scott"})._create_pool()  # pyright: ignore[reportPrivateUsage]
+
+    assert seen_kwargs["user"] == "scott"
+    assert callable(seen_kwargs["session_callback"])
+    assert "stmtcachesize" not in seen_kwargs
+    assert "arraysize" not in seen_kwargs
+    assert "prefetchrows" not in seen_kwargs
+
+
 def test_oracle_sync_connection_config_session_callback_is_preserved(monkeypatch: pytest.MonkeyPatch) -> None:
     """Native pool ``session_callback`` should run in addition to SQLSpec setup."""
     calls: list[str] = []

--- a/tests/unit/adapters/test_oracledb/test_fetch_tuning.py
+++ b/tests/unit/adapters/test_oracledb/test_fetch_tuning.py
@@ -63,6 +63,11 @@ def test_oracle_sync_cursor_leaves_defaults_when_options_absent() -> None:
         assert raw_cursor.prefetchrows == 2
 
 
+def test_oracle_fetch_kwargs_omit_absent_fetch_tuning_keys() -> None:
+    """Per-statement fetch kwargs should stay empty unless fetch tuning is explicit."""
+    assert build_fetch_kwargs({"arraysize": 100, "prefetchrows": 200}) == {}
+
+
 @pytest.mark.anyio
 async def test_oracle_async_cursor_applies_arraysize_and_prefetchrows() -> None:
     raw_cursor = _RawCursor()

--- a/tests/unit/adapters/test_psycopg/test_config.py
+++ b/tests/unit/adapters/test_psycopg/test_config.py
@@ -168,9 +168,7 @@ def test_psycopg_sync_minimal_pool_omits_prepare_threshold(monkeypatch: pytest.M
     _CapturedSyncPool.calls.clear()
     monkeypatch.setattr(psycopg_config, "ConnectionPool", _CapturedSyncPool)
 
-    PsycopgSyncConfig(
-        connection_config={"conninfo": "postgresql://user:pass@localhost/db"}
-    )._create_pool()  # pyright: ignore[reportPrivateUsage]
+    PsycopgSyncConfig(connection_config={"conninfo": "postgresql://user:pass@localhost/db"})._create_pool()  # pyright: ignore[reportPrivateUsage]
 
     conninfo, pool_kwargs = _CapturedSyncPool.calls[-1]
     assert conninfo == "postgresql://user:pass@localhost/db"
@@ -184,9 +182,7 @@ async def test_psycopg_async_minimal_pool_omits_prepare_threshold(monkeypatch: p
     _CapturedAsyncPool.open_calls = 0
     monkeypatch.setattr(psycopg_config, "AsyncConnectionPool", _CapturedAsyncPool)
 
-    await PsycopgAsyncConfig(
-        connection_config={"conninfo": "postgresql://user:pass@localhost/db"}
-    )._create_pool()  # pyright: ignore[reportPrivateUsage]
+    await PsycopgAsyncConfig(connection_config={"conninfo": "postgresql://user:pass@localhost/db"})._create_pool()  # pyright: ignore[reportPrivateUsage]
 
     conninfo, pool_kwargs = _CapturedAsyncPool.calls[-1]
     assert conninfo == "postgresql://user:pass@localhost/db"

--- a/tests/unit/adapters/test_psycopg/test_config.py
+++ b/tests/unit/adapters/test_psycopg/test_config.py
@@ -163,6 +163,36 @@ def test_psycopg_sync_pool_preserves_conninfo_with_explicit_connection_kwargs(mo
     }
 
 
+def test_psycopg_sync_minimal_pool_omits_prepare_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Minimal sync pool config should not inject prepare_threshold."""
+    _CapturedSyncPool.calls.clear()
+    monkeypatch.setattr(psycopg_config, "ConnectionPool", _CapturedSyncPool)
+
+    PsycopgSyncConfig(
+        connection_config={"conninfo": "postgresql://user:pass@localhost/db"}
+    )._create_pool()  # pyright: ignore[reportPrivateUsage]
+
+    conninfo, pool_kwargs = _CapturedSyncPool.calls[-1]
+    assert conninfo == "postgresql://user:pass@localhost/db"
+    assert pool_kwargs["kwargs"] == {}
+
+
+@pytest.mark.anyio
+async def test_psycopg_async_minimal_pool_omits_prepare_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Minimal async pool config should not inject prepare_threshold."""
+    _CapturedAsyncPool.calls.clear()
+    _CapturedAsyncPool.open_calls = 0
+    monkeypatch.setattr(psycopg_config, "AsyncConnectionPool", _CapturedAsyncPool)
+
+    await PsycopgAsyncConfig(
+        connection_config={"conninfo": "postgresql://user:pass@localhost/db"}
+    )._create_pool()  # pyright: ignore[reportPrivateUsage]
+
+    conninfo, pool_kwargs = _CapturedAsyncPool.calls[-1]
+    assert conninfo == "postgresql://user:pass@localhost/db"
+    assert pool_kwargs["kwargs"] == {}
+
+
 @pytest.mark.anyio
 async def test_psycopg_async_pool_preserves_conninfo_with_explicit_connection_kwargs(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/adapters/test_spanner/test_driver.py
+++ b/tests/unit/adapters/test_spanner/test_driver.py
@@ -86,6 +86,22 @@ def test_execute_statement_select_forwards_retry_and_timeout(mock_connection: Ma
     )
 
 
+def test_execute_statement_select_minimal_features_omit_retry_and_timeout(mock_connection: MagicMock) -> None:
+    driver = SpannerSyncDriver(mock_connection)
+
+    mock_result = MagicMock(spec=StreamedResultSet)
+    field = Mock()
+    field.name = "id"
+    mock_result.metadata.row_type.fields = [field]
+    mock_result.__iter__.return_value = iter([(1,)])
+    mock_connection.execute_sql.return_value = mock_result
+
+    statement = driver.prepare_statement("SELECT id FROM users", statement_config=driver.statement_config)
+    driver.dispatch_execute(mock_connection, statement)  # type: ignore[protected-access]
+
+    mock_connection.execute_sql.assert_called_once_with("SELECT id FROM users", params=None, param_types={})
+
+
 def test_execute_statement_dml_in_transaction(mock_transaction: MagicMock) -> None:
     driver = SpannerSyncDriver(mock_transaction)
     mock_transaction.execute_update.return_value = 10
@@ -107,6 +123,18 @@ def test_execute_statement_dml_forwards_retry_and_timeout(mock_transaction: Magi
 
     mock_transaction.execute_update.assert_called_once_with(
         "UPDATE users SET name = 'Bob'", params=None, param_types={}, retry=retry, timeout=12.5
+    )
+
+
+def test_execute_statement_dml_minimal_features_omit_retry_and_timeout(mock_transaction: MagicMock) -> None:
+    driver = SpannerSyncDriver(mock_transaction)
+    mock_transaction.execute_update.return_value = 10
+
+    statement = driver.prepare_statement("UPDATE users SET name = 'Bob'", statement_config=driver.statement_config)
+    driver.dispatch_execute(mock_transaction, statement)  # type: ignore[protected-access]
+
+    mock_transaction.execute_update.assert_called_once_with(
+        "UPDATE users SET name = 'Bob'", params=None, param_types={}
     )
 
 

--- a/tests/unit/adapters/test_sync_adapters.py
+++ b/tests/unit/adapters/test_sync_adapters.py
@@ -94,6 +94,32 @@ def test_sync_driver_fast_path_flag_disabled_by_observability() -> None:
         conn.close()
 
 
+def test_sync_driver_statement_cache_size_threads_through() -> None:
+    conn = sqlite3.connect(":memory:")
+    try:
+        driver = SqliteDriver(conn, driver_features={"sqlspec_statement_cache_size": 7})
+
+        assert driver._stmt_cache_max_size == 7
+        assert driver._stmt_cache_enabled is True
+    finally:
+        conn.close()
+
+
+def test_sync_driver_zero_statement_cache_size_disables_fast_path() -> None:
+    conn = sqlite3.connect(":memory:")
+    try:
+        driver = SqliteDriver(conn, driver_features={"sqlspec_statement_cache_size": 0})
+
+        assert driver._stmt_cache_max_size == 0
+        assert driver._stmt_cache_enabled is False
+
+        result = driver.execute("SELECT 1")
+
+        assert result.operation_type == "SELECT"
+    finally:
+        conn.close()
+
+
 def test_sync_driver_with_cursor(sqlite_sync_driver: SqliteDriver) -> None:
     """Test cursor context manager functionality."""
     with sqlite_sync_driver.with_cursor(sqlite_sync_driver.connection) as cursor:

--- a/tests/unit/driver/test_query_cache.py
+++ b/tests/unit/driver/test_query_cache.py
@@ -345,6 +345,16 @@ def test_query_cache_lru_eviction_after_final() -> None:
     assert cache.get("SELECT 3") is not None
 
 
+def test_query_cache_zero_size_is_noop() -> None:
+    """Zero-sized caches should ignore inserts instead of raising."""
+    cache = QueryCache(max_size=0)
+
+    cache.set("SELECT 1", _make_cached("SELECT 1"))
+
+    assert len(cache) == 0
+    assert cache.get("SELECT 1") is None
+
+
 def test_release_pooled_statement_uses_direct_pooled_attribute(sqlite_sync_driver: Any) -> None:
     """_release_pooled_statement reads SQL._pooled directly."""
     statement = SQL("SELECT 1")

--- a/tests/unit/utils/test_bench_tuning.py
+++ b/tests/unit/utils/test_bench_tuning.py
@@ -1,0 +1,35 @@
+"""Tests for adapter tuning benchmark metadata."""
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_bench_tuning_module() -> ModuleType:
+    module_path = Path(__file__).resolve().parents[3] / "tools" / "scripts" / "bench_tuning.py"
+    spec = importlib.util.spec_from_file_location("bench_tuning_for_tests", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_bench_tuning_defaults_match_runtime_tuning_plan() -> None:
+    module = _load_bench_tuning_module()
+    args = module.build_parser().parse_args([])
+
+    assert module.DEFAULT_ITERATIONS == 15
+    assert module.DEFAULT_WARMUP == 3
+    assert args.iterations == 15
+    assert args.warmup == 3
+
+
+def test_bench_tuning_documents_conditional_scenarios() -> None:
+    module = _load_bench_tuning_module()
+
+    assert set(module.SCENARIOS) == {"asyncpg_stmt_cache", "oracle_stmtcache", "arrow_odbc_fetch"}
+    for scenario in module.SCENARIOS.values():
+        assert scenario.requires
+        assert scenario.description
+        assert scenario.skip_message

--- a/tools/scripts/bench_tuning.py
+++ b/tools/scripts/bench_tuning.py
@@ -1,0 +1,291 @@
+"""Manual adapter tuning benchmarks for cache and fetch controls.
+
+The scenarios in this script are intentionally conditional: each one requires a
+real service and is skipped unless its documented environment variables are set.
+
+Examples:
+    uv run python tools/scripts/bench_tuning.py --list
+    SQLSPEC_BENCH_ASYNCPG_DSN=postgresql://... uv run python tools/scripts/bench_tuning.py --scenario asyncpg_stmt_cache
+    SQLSPEC_BENCH_ORACLE_DSN=... SQLSPEC_BENCH_ORACLE_USER=... SQLSPEC_BENCH_ORACLE_PASSWORD=... \
+        uv run python tools/scripts/bench_tuning.py --scenario oracle_stmtcache
+    SQLSPEC_BENCH_ARROW_ODBC_CONNECTION_STRING='Driver=...;Server=...' \
+        uv run python tools/scripts/bench_tuning.py --scenario arrow_odbc_fetch
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import statistics
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+
+import click
+
+from sqlspec.adapters.arrow_odbc import ArrowOdbcConfig
+
+DEFAULT_ITERATIONS = 15
+DEFAULT_WARMUP = 3
+
+
+@dataclass(frozen=True)
+class BenchmarkOptions:
+    """Runtime options shared by tuning benchmarks."""
+
+    iterations: int
+    warmup: int
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    """Timing result for one scenario variant."""
+
+    scenario: str
+    variant: str
+    iterations: int
+    median_seconds: float | None
+    min_seconds: float | None
+    skipped: bool
+    message: str = ""
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """Description and runner for a conditional tuning scenario."""
+
+    name: str
+    description: str
+    requires: str
+    skip_message: str
+    runner: Callable[[BenchmarkOptions], list[BenchmarkResult]]
+
+
+def _summarize(scenario: str, variant: str, samples: list[float]) -> BenchmarkResult:
+    return BenchmarkResult(
+        scenario=scenario,
+        variant=variant,
+        iterations=len(samples),
+        median_seconds=statistics.median(samples),
+        min_seconds=min(samples),
+        skipped=False,
+    )
+
+
+def _skipped(scenario: str, variant: str, options: BenchmarkOptions, message: str) -> BenchmarkResult:
+    return BenchmarkResult(
+        scenario=scenario,
+        variant=variant,
+        iterations=options.iterations,
+        median_seconds=None,
+        min_seconds=None,
+        skipped=True,
+        message=message,
+    )
+
+
+def _measure_sync(call: Callable[[], object], options: BenchmarkOptions) -> list[float]:
+    for _ in range(options.warmup):
+        call()
+    samples: list[float] = []
+    for _ in range(options.iterations):
+        started = time.perf_counter()
+        call()
+        samples.append(time.perf_counter() - started)
+    return samples
+
+
+async def _measure_async(call: Callable[[], object], options: BenchmarkOptions) -> list[float]:
+    for _ in range(options.warmup):
+        result = call()
+        if hasattr(result, "__await__"):
+            await result
+    samples: list[float] = []
+    for _ in range(options.iterations):
+        started = time.perf_counter()
+        result = call()
+        if hasattr(result, "__await__"):
+            await result
+        samples.append(time.perf_counter() - started)
+    return samples
+
+
+async def _run_asyncpg_variant(dsn: str, statement_cache_size: int, options: BenchmarkOptions) -> BenchmarkResult:
+    import asyncpg
+
+    pool = await asyncpg.create_pool(dsn=dsn, min_size=1, max_size=1, statement_cache_size=statement_cache_size)
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute("DROP TABLE IF EXISTS sqlspec_bench_tuning_asyncpg")
+            await conn.execute("CREATE TEMP TABLE sqlspec_bench_tuning_asyncpg (id int PRIMARY KEY, value text)")
+            await conn.executemany(
+                "INSERT INTO sqlspec_bench_tuning_asyncpg (id, value) VALUES ($1, $2)",
+                [(idx, f"value-{idx}") for idx in range(100)],
+            )
+
+            async def fetch_one() -> None:
+                await conn.fetchval("SELECT value FROM sqlspec_bench_tuning_asyncpg WHERE id = $1", 42)
+
+            samples = await _measure_async(fetch_one, options)
+    finally:
+        await pool.close()
+
+    return _summarize("asyncpg_stmt_cache", f"statement_cache_size={statement_cache_size}", samples)
+
+
+def run_asyncpg_stmt_cache(options: BenchmarkOptions) -> list[BenchmarkResult]:
+    """Benchmark asyncpg native statement cache enabled vs disabled."""
+    dsn = os.getenv("SQLSPEC_BENCH_ASYNCPG_DSN")
+    if not dsn:
+        return [
+            _skipped(
+                "asyncpg_stmt_cache",
+                "statement_cache_size=100",
+                options,
+                "set SQLSPEC_BENCH_ASYNCPG_DSN to run asyncpg statement-cache tuning",
+            )
+        ]
+
+    async def run() -> list[BenchmarkResult]:
+        enabled = await _run_asyncpg_variant(dsn, 100, options)
+        disabled = await _run_asyncpg_variant(dsn, 0, options)
+        return [enabled, disabled]
+
+    return asyncio.run(run())
+
+
+def _run_oracle_variant(stmtcachesize: int, options: BenchmarkOptions) -> BenchmarkResult:
+    import oracledb
+
+    dsn = os.environ["SQLSPEC_BENCH_ORACLE_DSN"]
+    user = os.environ["SQLSPEC_BENCH_ORACLE_USER"]
+    password = os.environ["SQLSPEC_BENCH_ORACLE_PASSWORD"]
+    connection = oracledb.connect(user=user, password=password, dsn=dsn, stmtcachesize=stmtcachesize)
+    try:
+        with connection.cursor() as cursor:
+            samples = _measure_sync(lambda: cursor.execute("SELECT :value FROM dual", value=42).fetchone(), options)
+    finally:
+        connection.close()
+    return _summarize("oracle_stmtcache", f"stmtcachesize={stmtcachesize}", samples)
+
+
+def run_oracle_stmtcache(options: BenchmarkOptions) -> list[BenchmarkResult]:
+    """Benchmark python-oracledb statement cache enabled vs disabled."""
+    required = ("SQLSPEC_BENCH_ORACLE_DSN", "SQLSPEC_BENCH_ORACLE_USER", "SQLSPEC_BENCH_ORACLE_PASSWORD")
+    missing = [name for name in required if not os.getenv(name)]
+    if missing:
+        return [
+            _skipped(
+                "oracle_stmtcache",
+                "stmtcachesize=20",
+                options,
+                f"set {', '.join(required)} to run Oracle statement-cache tuning",
+            )
+        ]
+    return [_run_oracle_variant(20, options), _run_oracle_variant(0, options)]
+
+
+def _run_arrow_odbc_variant(chunk_size: int, options: BenchmarkOptions) -> BenchmarkResult:
+    connection_string = os.environ["SQLSPEC_BENCH_ARROW_ODBC_CONNECTION_STRING"]
+    query = os.getenv("SQLSPEC_BENCH_ARROW_ODBC_QUERY", "SELECT 1 AS value")
+    config = ArrowOdbcConfig(
+        connection_config={"connection_string": connection_string},
+        driver_features={"chunk_size": chunk_size},
+    )
+    with config.provide_session() as session:
+        samples = _measure_sync(lambda: session.select_to_arrow(query, return_format="table"), options)
+    return _summarize("arrow_odbc_fetch", f"chunk_size={chunk_size}", samples)
+
+
+def run_arrow_odbc_fetch(options: BenchmarkOptions) -> list[BenchmarkResult]:
+    """Benchmark arrow-odbc fetch chunk size on a user-supplied query."""
+    if not os.getenv("SQLSPEC_BENCH_ARROW_ODBC_CONNECTION_STRING"):
+        return [
+            _skipped(
+                "arrow_odbc_fetch",
+                "chunk_size=65536",
+                options,
+                "set SQLSPEC_BENCH_ARROW_ODBC_CONNECTION_STRING to run arrow-odbc fetch tuning",
+            )
+        ]
+    return [_run_arrow_odbc_variant(65_536, options), _run_arrow_odbc_variant(8_192, options)]
+
+
+SCENARIOS: dict[str, Scenario] = {
+    "asyncpg_stmt_cache": Scenario(
+        name="asyncpg_stmt_cache",
+        description="Compare asyncpg native statement cache enabled vs disabled on one pooled connection.",
+        requires="SQLSPEC_BENCH_ASYNCPG_DSN",
+        skip_message="Skipped unless SQLSPEC_BENCH_ASYNCPG_DSN points at a PostgreSQL database.",
+        runner=run_asyncpg_stmt_cache,
+    ),
+    "oracle_stmtcache": Scenario(
+        name="oracle_stmtcache",
+        description="Compare python-oracledb stmtcachesize enabled vs disabled.",
+        requires="SQLSPEC_BENCH_ORACLE_DSN, SQLSPEC_BENCH_ORACLE_USER, SQLSPEC_BENCH_ORACLE_PASSWORD",
+        skip_message="Skipped unless Oracle connection environment variables are set.",
+        runner=run_oracle_stmtcache,
+    ),
+    "arrow_odbc_fetch": Scenario(
+        name="arrow_odbc_fetch",
+        description="Compare arrow-odbc fetch chunk sizes for a user-supplied Arrow query.",
+        requires="SQLSPEC_BENCH_ARROW_ODBC_CONNECTION_STRING; optional SQLSPEC_BENCH_ARROW_ODBC_QUERY",
+        skip_message="Skipped unless an arrow-odbc connection string is set.",
+        runner=run_arrow_odbc_fetch,
+    ),
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iterations", type=int, default=DEFAULT_ITERATIONS)
+    parser.add_argument("--warmup", type=int, default=DEFAULT_WARMUP)
+    parser.add_argument("--scenario", action="append", choices=sorted(SCENARIOS), help="Scenario to run")
+    parser.add_argument("--list", action="store_true", help="List scenarios and required environment")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+    return parser
+
+
+def _print_scenarios() -> None:
+    click.echo("scenario             requires")
+    for scenario in SCENARIOS.values():
+        click.echo(f"{scenario.name:<20} {scenario.requires}")
+        click.echo(f"  {scenario.description}")
+
+
+def _print_results(results: list[BenchmarkResult]) -> None:
+    click.echo("scenario             variant                    median_s   min_s      status")
+    for result in results:
+        if result.skipped:
+            click.echo(f"{result.scenario:<20} {result.variant:<26} {'-':>8} {'-':>8} skipped: {result.message}")
+            continue
+        click.echo(
+            f"{result.scenario:<20} {result.variant:<26} "
+            f"{result.median_seconds:>8.6f} {result.min_seconds:>8.6f} ok"
+        )
+
+
+def main() -> None:
+    """Run selected tuning benchmark scenarios."""
+    parser = build_parser()
+    args = parser.parse_args()
+    if args.list:
+        _print_scenarios()
+        return
+
+    options = BenchmarkOptions(iterations=args.iterations, warmup=args.warmup)
+    selected = args.scenario or list(SCENARIOS)
+    results: list[BenchmarkResult] = []
+    for name in selected:
+        results.extend(SCENARIOS[name].runner(options))
+
+    if args.json:
+        click.echo(json.dumps([asdict(result) for result in results], indent=2, sort_keys=True))
+        return
+
+    _print_results(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/scripts/bench_tuning.py
+++ b/tools/scripts/bench_tuning.py
@@ -189,8 +189,7 @@ def _run_arrow_odbc_variant(chunk_size: int, options: BenchmarkOptions) -> Bench
     connection_string = os.environ["SQLSPEC_BENCH_ARROW_ODBC_CONNECTION_STRING"]
     query = os.getenv("SQLSPEC_BENCH_ARROW_ODBC_QUERY", "SELECT 1 AS value")
     config = ArrowOdbcConfig(
-        connection_config={"connection_string": connection_string},
-        driver_features={"chunk_size": chunk_size},
+        connection_config={"connection_string": connection_string}, driver_features={"chunk_size": chunk_size}
     )
     with config.provide_session() as session:
         samples = _measure_sync(lambda: session.select_to_arrow(query, return_format="table"), options)
@@ -261,8 +260,7 @@ def _print_results(results: list[BenchmarkResult]) -> None:
             click.echo(f"{result.scenario:<20} {result.variant:<26} {'-':>8} {'-':>8} skipped: {result.message}")
             continue
         click.echo(
-            f"{result.scenario:<20} {result.variant:<26} "
-            f"{result.median_seconds:>8.6f} {result.min_seconds:>8.6f} ok"
+            f"{result.scenario:<20} {result.variant:<26} {result.median_seconds:>8.6f} {result.min_seconds:>8.6f} ok"
         )
 
 


### PR DESCRIPTION
## Summary

- Added configurable SQLSpec statement-cache sizing via `driver_features={"sqlspec_statement_cache_size": N}`.
- Added BigQuery `query_page_size` and `query_max_results` result-fetch controls for SELECT-style fetches and native table Arrow completion, while keeping DML and script completion behavior unchanged.
- Added asyncpg and psycopg runtime regression coverage for native statement and prepared-statement tuning behavior.
- Added default-forwarding guards for asyncpg, psycopg, oracledb, BigQuery, and Spanner tuning kwargs.
- Added `tools/scripts/bench_tuning.py` for manual asyncpg, oracledb, and arrow_odbc tuning scenarios.
- Added usage docs covering cache/fetch knob classification, avoid guidance, and `arrow_odbc` behavior differences.

## Validation

- `make install`
- `make docs`
- `uv run pytest tests/unit/driver/test_query_cache.py tests/unit/adapters/test_sync_adapters.py tests/unit/adapters/test_async_adapters.py tests/unit/adapters/test_bigquery/test_core.py tests/unit/adapters/test_bigquery/test_arrow_streaming.py tests/integration/adapters/asyncpg/test_driver.py::test_asyncpg_statement_cache_size_zero_survives_ddl_shape_change tests/integration/adapters/psycopg/test_driver.py::test_psycopg_prepare_threshold_routes_to_pooled_connection tests/unit/utils/test_bench_tuning.py tests/unit/adapters/test_asyncpg/test_config.py tests/unit/adapters/test_psycopg/test_config.py tests/unit/adapters/test_oracledb/test_config.py tests/unit/adapters/test_oracledb/test_fetch_tuning.py tests/unit/adapters/test_spanner/test_driver.py -q`
- `make type-check`
- `make lint`
