### PR TITLE
feat(utils): add bounded async bridge controls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ test-mypyc:                                        ## Test mypyc compilation on 
 	@echo "${INFO} Testing mypyc compilation... 🔧"
 	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/utils/text.py
 	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/utils/sync_tools.py
+	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/utils/env.py
 	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/utils/module_loader.py
 	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/core/cache.py
 	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/core/hashing.py

--- a/Makefile
+++ b/Makefile
@@ -142,8 +142,6 @@ test-mypyc:                                        ## Test mypyc compilation on 
 	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/extensions/adk/_types.py
 	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/extensions/adk/memory/_types.py
 	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/extensions/adk/artifact/_types.py
-	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/extensions/fastapi/providers.py
-	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/extensions/litestar/providers.py
 	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/migrations/version.py
 	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/observability/_formatting.py
 	@echo "${OK} Mypyc compilation tests passed ✨"

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,8 @@ test-mypyc:                                        ## Test mypyc compilation on 
 	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/extensions/adk/_types.py
 	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/extensions/adk/memory/_types.py
 	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/extensions/adk/artifact/_types.py
+	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/extensions/fastapi/providers.py
+	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/extensions/litestar/providers.py
 	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/migrations/version.py
 	@uv run mypyc --check-untyped-defs --no-warn-unused-configs sqlspec/observability/_formatting.py
 	@echo "${OK} Mypyc compilation tests passed ✨"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,25 @@ important operational fixes.
 Recent Updates
 ==============
 
+Unreleased
+------------------------------------------------------------------------------
+
+**Added:**
+
+* Added typed environment parsing helpers in ``sqlspec.utils.env``.
+* Added ``executor=`` support to ``sqlspec.utils.sync_tools.async_()`` and
+  opt-in process-wide bounded async bridge controls via
+  ``SQLSPEC_ASYNC_THREAD_LIMIT``, ``enable_default_async_thread_pool()``,
+  ``set_default_async_executor()``, ``get_default_async_executor()``, and
+  ``shutdown_default_async_executor()``.
+
+**Fixed:**
+
+* Preserved ``contextvars`` when ``async_()`` routes sync work through
+  explicit or shared executors.
+* Documented the migration path for downstream applications that used local
+  async bridge shims only to cap thread usage.
+
 v0.51.0 - ADK 2.0 clean-break store contract
 ------------------------------------------------------------------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,25 +9,6 @@ important operational fixes.
 Recent Updates
 ==============
 
-Unreleased
-------------------------------------------------------------------------------
-
-**Added:**
-
-* Added typed environment parsing helpers in ``sqlspec.utils.env``.
-* Added ``ThreadPoolExecutor`` support to ``sqlspec.utils.sync_tools.async_()``
-  and opt-in process-wide bounded async bridge controls via
-  ``SQLSPEC_ASYNC_THREAD_LIMIT``, ``enable_default_async_thread_pool()``,
-  ``set_default_async_executor()``, ``get_default_async_executor()``, and
-  ``shutdown_default_async_executor()``.
-
-**Fixed:**
-
-* Preserved ``contextvars`` when ``async_()`` routes sync work through
-  explicit or shared executors.
-* Documented the migration path for downstream applications that used local
-  async bridge shims only to cap thread usage.
-
 v0.51.0 - ADK 2.0 clean-break store contract
 ------------------------------------------------------------------------------
 
@@ -53,6 +34,12 @@ v0.51.0 - ADK 2.0 clean-break store contract
 
 **Added:**
 
+* Typed environment parsing helpers in ``sqlspec.utils.env``.
+* ``ThreadPoolExecutor`` support for ``sqlspec.utils.sync_tools.async_()``, plus
+  opt-in bounded async bridge controls through
+  ``SQLSPEC_ASYNC_THREAD_LIMIT``, ``enable_default_async_thread_pool()``,
+  ``set_default_async_executor()``, ``get_default_async_executor()``, and
+  ``shutdown_default_async_executor()``.
 * Scoped-state accessors on every ADK store: ``get_app_state``,
   ``get_user_state``, ``upsert_app_state``, ``upsert_user_state``,
   ``get_metadata``, and ``set_metadata``.
@@ -62,6 +49,8 @@ v0.51.0 - ADK 2.0 clean-break store contract
 
 **Fixed:**
 
+* Preserved ``contextvars`` when ``async_()`` routes sync work through explicit
+  or shared thread executors.
 * Removed a dead ``storage_uri`` key from the artifact-store config
   normalization; the artifact storage URI is supplied to ``ADKArtifactService``
   through its constructor and was never read from the store config.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,12 +31,17 @@ v0.51.0 - ADK 2.0 clean-break store contract
 * Migration ``0002_reset_adk_tables`` is destructive: it unconditionally drops
   legacy ADK tables (sessions, events, app/user state, metadata, memory) and
   recreates them in the 2.0 shape. Back up ADK data before upgrading.
+* ``sqlspec.utils.sync_tools.async_()`` now uses SQLSpec's managed
+  ``ThreadPoolExecutor`` by default instead of delegating to the event loop's
+  default executor through ``asyncio.to_thread()``. Configure the worker limit
+  with ``SQLSPEC_ASYNC_THREAD_LIMIT`` or
+  ``enable_default_async_thread_pool()``.
 
 **Added:**
 
 * Typed environment parsing helpers in ``sqlspec.utils.env``.
 * ``ThreadPoolExecutor`` support for ``sqlspec.utils.sync_tools.async_()``, plus
-  opt-in bounded async bridge controls through
+  bounded async bridge controls through
   ``SQLSPEC_ASYNC_THREAD_LIMIT``, ``enable_default_async_thread_pool()``,
   ``set_default_async_executor()``, ``get_default_async_executor()``, and
   ``shutdown_default_async_executor()``.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,8 +15,8 @@ Unreleased
 **Added:**
 
 * Added typed environment parsing helpers in ``sqlspec.utils.env``.
-* Added ``executor=`` support to ``sqlspec.utils.sync_tools.async_()`` and
-  opt-in process-wide bounded async bridge controls via
+* Added ``ThreadPoolExecutor`` support to ``sqlspec.utils.sync_tools.async_()``
+  and opt-in process-wide bounded async bridge controls via
   ``SQLSPEC_ASYNC_THREAD_LIMIT``, ``enable_default_async_thread_pool()``,
   ``set_default_async_executor()``, ``get_default_async_executor()``, and
   ``shutdown_default_async_executor()``.

--- a/docs/usage/performance.rst
+++ b/docs/usage/performance.rst
@@ -13,16 +13,16 @@ helper documents service-backed scenarios for the cache and fetch controls:
 
    uv run python tools/scripts/bench_tuning.py --list
 
-Async bridge thread limits
-==========================
+Async bridge executor limits
+============================
 
-``sqlspec.utils.sync_tools.async_()`` keeps its historical default behavior unless
-you opt into a shared executor. With no ``executor`` argument and no SQLSpec
-default executor configured, SQLSpec delegates to ``asyncio.to_thread()`` and uses
-the current event loop's default executor.
+``sqlspec.utils.sync_tools.async_()`` wraps blocking callables for async code.
+By default it delegates to ``asyncio.to_thread()`` and uses the event loop's
+default executor. Configure a SQLSpec executor only when you need a bounded
+thread pool for sync work that is called from async contexts, such as framework
+stores backed by sync drivers.
 
-Use an explicit ``ThreadPoolExecutor`` when one call site or service already
-owns the worker pool:
+Pass an explicit ``ThreadPoolExecutor`` when one call site owns the worker pool:
 
 .. code-block:: python
 
@@ -30,68 +30,50 @@ owns the worker pool:
 
    from sqlspec.utils.sync_tools import async_
 
-   executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="app-sql")
-   run_blocking_query = async_(blocking_query, executor=executor)
+   executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="sqlspec")
+   run_query = async_(blocking_query, executor=executor)
 
-   result = await run_blocking_query()
+   result = await run_query()
 
-For process-wide control, set ``SQLSPEC_ASYNC_THREAD_LIMIT`` before SQLSpec first
-uses ``async_()``:
+Set ``SQLSPEC_ASYNC_THREAD_LIMIT`` before the first ``async_()`` call when the
+whole process should share one SQLSpec-managed pool:
 
 .. code-block:: bash
 
-   SQLSPEC_ASYNC_THREAD_LIMIT=8
+   export SQLSPEC_ASYNC_THREAD_LIMIT=8
 
-The environment variable opts ``async_()`` into a SQLSpec-managed
-``ThreadPoolExecutor`` shared by every event loop in the process. This is useful
-for services that run multiple long-lived loops and want one bounded async bridge
-pool instead of one default executor per loop.
-
-Programmatic controls are available when environment configuration is not a good
-fit:
+Use the programmatic API when application startup already centralizes runtime
+settings:
 
 .. code-block:: python
 
+   from concurrent.futures import ThreadPoolExecutor
+
    from sqlspec.utils.sync_tools import (
        enable_default_async_thread_pool,
+       get_default_async_executor,
        set_default_async_executor,
        shutdown_default_async_executor,
    )
 
    enable_default_async_thread_pool(max_workers=8)
 
-   # Or route through an application-owned ThreadPoolExecutor. SQLSpec will not
-   # shut this executor down for you.
+   app_executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="sqlspec")
    set_default_async_executor(app_executor)
 
-   # Optional during application shutdown; SQLSpec also registers an atexit hook.
+   assert get_default_async_executor() is app_executor
    shutdown_default_async_executor(wait=False)
 
-Explicit ``executor=`` values must be ``ThreadPoolExecutor`` instances and win
-over every configured default. A caller-owned default thread executor set with
-``set_default_async_executor()`` wins over the environment-managed pool. SQLSpec
-only shuts down pools it creates; caller-owned executors are cleared from SQLSpec
-state, not shut down. Both caller-owned and managed defaults are PID-aware, so
-forked children never reuse a parent process's worker pool.
+Executor precedence is explicit: ``async_(fn, executor=...)`` wins over
+``set_default_async_executor()``, which wins over the environment-managed pool,
+which wins over ``asyncio.to_thread()``. SQLSpec only shuts down executors it
+creates; caller-owned executors are removed from SQLSpec state but not shut
+down. Managed and caller-owned defaults are PID-aware, so forked children do not
+reuse a parent process's pool.
 
-All async bridge paths preserve ``contextvars``. ``asyncio.to_thread()`` provides
-that behavior on the default path, and SQLSpec copies the caller context before
-using ``run_in_executor()`` for explicit or shared executors.
-
-Downstream shim migration
--------------------------
-
-Applications that carried a local ``async_`` shim only to cap worker threads can
-usually remove it:
-
-* Replace local shim imports with ``from sqlspec.utils.sync_tools import async_``.
-* Set ``SQLSPEC_ASYNC_THREAD_LIMIT`` for process-wide bounded behavior, or call
-  ``enable_default_async_thread_pool(max_workers=...)`` during startup.
-* If the application already owns a shared ``ThreadPoolExecutor``, pass it with
-  ``async_(fn, executor=executor)`` or register it with
-  ``set_default_async_executor(executor)``.
-* Remove local ``contextvars.copy_context()`` wrapping; SQLSpec preserves caller
-  context on every offload path.
+Only ``ThreadPoolExecutor`` instances are accepted. Process executors are
+rejected because SQLSpec preserves ``contextvars`` for every async bridge path,
+including explicit and shared executor calls.
 
 Cache and fetch controls
 ========================

--- a/docs/usage/performance.rst
+++ b/docs/usage/performance.rst
@@ -17,10 +17,10 @@ Async bridge executor limits
 ============================
 
 ``sqlspec.utils.sync_tools.async_()`` wraps blocking callables for async code.
-By default it delegates to ``asyncio.to_thread()`` and uses the event loop's
-default executor. Configure a SQLSpec executor only when you need a bounded
-thread pool for sync work that is called from async contexts, such as framework
-stores backed by sync drivers.
+By default SQLSpec routes this work through a process-local managed
+``ThreadPoolExecutor`` capped at eight workers. This keeps sync work called from
+async contexts, such as framework stores backed by sync drivers, from creating
+one unbounded event-loop executor per long-lived loop.
 
 Pass an explicit ``ThreadPoolExecutor`` when one call site owns the worker pool:
 
@@ -35,15 +35,14 @@ Pass an explicit ``ThreadPoolExecutor`` when one call site owns the worker pool:
 
    result = await run_query()
 
-Set ``SQLSPEC_ASYNC_THREAD_LIMIT`` before the first ``async_()`` call when the
-whole process should share one SQLSpec-managed pool:
+Set ``SQLSPEC_ASYNC_THREAD_LIMIT`` before the first ``async_()`` call to change
+the worker limit for SQLSpec's managed pool:
 
 .. code-block:: bash
 
    export SQLSPEC_ASYNC_THREAD_LIMIT=8
 
-Use the programmatic API when application startup already centralizes runtime
-settings:
+Use the programmatic API when application startup centralizes runtime settings:
 
 .. code-block:: python
 
@@ -65,11 +64,14 @@ settings:
    shutdown_default_async_executor(wait=False)
 
 Executor precedence is explicit: ``async_(fn, executor=...)`` wins over
-``set_default_async_executor()``, which wins over the environment-managed pool,
-which wins over ``asyncio.to_thread()``. SQLSpec only shuts down executors it
+``set_default_async_executor()``, which wins over SQLSpec's managed pool. The
+managed pool uses ``SQLSPEC_ASYNC_THREAD_LIMIT`` when set and otherwise falls
+back to ``DEFAULT_ASYNC_THREAD_LIMIT``. SQLSpec only shuts down executors it
 creates; caller-owned executors are removed from SQLSpec state but not shut
 down. Managed and caller-owned defaults are PID-aware, so forked children do not
-reuse a parent process's pool.
+reuse a parent process's pool. Calling ``shutdown_default_async_executor()``
+tears down the current managed pool and clears caller-owned defaults; the next
+``async_()`` call creates a new managed pool from the current configuration.
 
 Only ``ThreadPoolExecutor`` instances are accepted. Process executors are
 rejected because SQLSpec preserves ``contextvars`` for every async bridge path,

--- a/docs/usage/performance.rst
+++ b/docs/usage/performance.rst
@@ -21,8 +21,8 @@ you opt into a shared executor. With no ``executor`` argument and no SQLSpec
 default executor configured, SQLSpec delegates to ``asyncio.to_thread()`` and uses
 the current event loop's default executor.
 
-Use an explicit executor when one call site or service already owns the worker
-pool:
+Use an explicit ``ThreadPoolExecutor`` when one call site or service already
+owns the worker pool:
 
 .. code-block:: python
 
@@ -60,19 +60,19 @@ fit:
 
    enable_default_async_thread_pool(max_workers=8)
 
-   # Or route through an application-owned executor. SQLSpec will not shut this
-   # executor down for you.
+   # Or route through an application-owned ThreadPoolExecutor. SQLSpec will not
+   # shut this executor down for you.
    set_default_async_executor(app_executor)
 
    # Optional during application shutdown; SQLSpec also registers an atexit hook.
    shutdown_default_async_executor(wait=False)
 
-Explicit ``executor=`` values win over every configured default. A caller-owned
-default executor set with ``set_default_async_executor()`` wins over the
-environment-managed pool. SQLSpec only shuts down pools it creates; caller-owned
-executors are cleared from SQLSpec state, not shut down. Both caller-owned and
-managed defaults are PID-aware, so forked children never reuse a parent process's
-worker pool.
+Explicit ``executor=`` values must be ``ThreadPoolExecutor`` instances and win
+over every configured default. A caller-owned default thread executor set with
+``set_default_async_executor()`` wins over the environment-managed pool. SQLSpec
+only shuts down pools it creates; caller-owned executors are cleared from SQLSpec
+state, not shut down. Both caller-owned and managed defaults are PID-aware, so
+forked children never reuse a parent process's worker pool.
 
 All async bridge paths preserve ``contextvars``. ``asyncio.to_thread()`` provides
 that behavior on the default path, and SQLSpec copies the caller context before
@@ -87,7 +87,7 @@ usually remove it:
 * Replace local shim imports with ``from sqlspec.utils.sync_tools import async_``.
 * Set ``SQLSPEC_ASYNC_THREAD_LIMIT`` for process-wide bounded behavior, or call
   ``enable_default_async_thread_pool(max_workers=...)`` during startup.
-* If the application already owns a shared executor, pass it with
+* If the application already owns a shared ``ThreadPoolExecutor``, pass it with
   ``async_(fn, executor=executor)`` or register it with
   ``set_default_async_executor(executor)``.
 * Remove local ``contextvars.copy_context()`` wrapping; SQLSpec preserves caller

--- a/docs/usage/performance.rst
+++ b/docs/usage/performance.rst
@@ -13,6 +13,86 @@ helper documents service-backed scenarios for the cache and fetch controls:
 
    uv run python tools/scripts/bench_tuning.py --list
 
+Async bridge thread limits
+==========================
+
+``sqlspec.utils.sync_tools.async_()`` keeps its historical default behavior unless
+you opt into a shared executor. With no ``executor`` argument and no SQLSpec
+default executor configured, SQLSpec delegates to ``asyncio.to_thread()`` and uses
+the current event loop's default executor.
+
+Use an explicit executor when one call site or service already owns the worker
+pool:
+
+.. code-block:: python
+
+   from concurrent.futures import ThreadPoolExecutor
+
+   from sqlspec.utils.sync_tools import async_
+
+   executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="app-sql")
+   run_blocking_query = async_(blocking_query, executor=executor)
+
+   result = await run_blocking_query()
+
+For process-wide control, set ``SQLSPEC_ASYNC_THREAD_LIMIT`` before SQLSpec first
+uses ``async_()``:
+
+.. code-block:: bash
+
+   SQLSPEC_ASYNC_THREAD_LIMIT=8
+
+The environment variable opts ``async_()`` into a SQLSpec-managed
+``ThreadPoolExecutor`` shared by every event loop in the process. This is useful
+for services that run multiple long-lived loops and want one bounded async bridge
+pool instead of one default executor per loop.
+
+Programmatic controls are available when environment configuration is not a good
+fit:
+
+.. code-block:: python
+
+   from sqlspec.utils.sync_tools import (
+       enable_default_async_thread_pool,
+       set_default_async_executor,
+       shutdown_default_async_executor,
+   )
+
+   enable_default_async_thread_pool(max_workers=8)
+
+   # Or route through an application-owned executor. SQLSpec will not shut this
+   # executor down for you.
+   set_default_async_executor(app_executor)
+
+   # Optional during application shutdown; SQLSpec also registers an atexit hook.
+   shutdown_default_async_executor(wait=False)
+
+Explicit ``executor=`` values win over every configured default. A caller-owned
+default executor set with ``set_default_async_executor()`` wins over the
+environment-managed pool. SQLSpec only shuts down pools it creates; caller-owned
+executors are cleared from SQLSpec state, not shut down. Both caller-owned and
+managed defaults are PID-aware, so forked children never reuse a parent process's
+worker pool.
+
+All async bridge paths preserve ``contextvars``. ``asyncio.to_thread()`` provides
+that behavior on the default path, and SQLSpec copies the caller context before
+using ``run_in_executor()`` for explicit or shared executors.
+
+Downstream shim migration
+-------------------------
+
+Applications that carried a local ``async_`` shim only to cap worker threads can
+usually remove it:
+
+* Replace local shim imports with ``from sqlspec.utils.sync_tools import async_``.
+* Set ``SQLSPEC_ASYNC_THREAD_LIMIT`` for process-wide bounded behavior, or call
+  ``enable_default_async_thread_pool(max_workers=...)`` during startup.
+* If the application already owns a shared executor, pass it with
+  ``async_(fn, executor=executor)`` or register it with
+  ``set_default_async_executor(executor)``.
+* Remove local ``contextvars.copy_context()`` wrapping; SQLSpec preserves caller
+  context on every offload path.
+
 Cache and fetch controls
 ========================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -266,6 +266,7 @@ include = [
   "sqlspec/adapters/oracledb/_vector_handlers.py", # DB_TYPE_VECTOR inputtypehandler / outputtypehandler dispatch
   "sqlspec/utils/text.py",                         # Text utilities
   "sqlspec/utils/sync_tools.py",                   # Synchronous utility functions
+  "sqlspec/utils/env.py",                          # Environment variable parsing utilities
   "sqlspec/utils/module_loader.py",                # Optional dependency loader helpers
   "sqlspec/utils/type_guards.py",                  # Type guard utilities
   "sqlspec/utils/fixtures.py",                     # File fixture loading

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,6 +255,8 @@ include = [
   "sqlspec/extensions/events/_names.py",           # Event channel/table name validators
   "sqlspec/extensions/events/_payload.py",         # Event JSON payload codec helpers
   "sqlspec/extensions/events/_queue.py",           # Table-backed event queue
+  "sqlspec/extensions/fastapi/providers.py",       # FastAPI filter provider construction
+  "sqlspec/extensions/litestar/providers.py",      # Litestar filter provider construction
   "sqlspec/extensions/adk/_types.py",              # ADK session/event record types
   "sqlspec/extensions/adk/memory/_types.py",       # ADK memory record types
   "sqlspec/extensions/adk/artifact/_types.py",     # ADK artifact record types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,8 +255,6 @@ include = [
   "sqlspec/extensions/events/_names.py",           # Event channel/table name validators
   "sqlspec/extensions/events/_payload.py",         # Event JSON payload codec helpers
   "sqlspec/extensions/events/_queue.py",           # Table-backed event queue
-  "sqlspec/extensions/fastapi/providers.py",       # FastAPI filter provider construction
-  "sqlspec/extensions/litestar/providers.py",      # Litestar filter provider construction
   "sqlspec/extensions/adk/_types.py",              # ADK session/event record types
   "sqlspec/extensions/adk/memory/_types.py",       # ADK memory record types
   "sqlspec/extensions/adk/artifact/_types.py",     # ADK artifact record types

--- a/sqlspec/utils/env.py
+++ b/sqlspec/utils/env.py
@@ -1,0 +1,352 @@
+"""Environment variable parsing utilities."""
+
+import json
+import os
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any, Final, Generic, TypeVar, cast, get_args, get_origin, overload
+
+__all__ = (
+    "get_config_val",
+    "get_config_val_with_aliases",
+    "get_env",
+    "get_env_with_aliases",
+    "is_env_set",
+)
+
+TRUE_VALUES: Final[frozenset[str]] = frozenset({"1", "true", "yes", "y", "on", "t"})
+FALSE_VALUES: Final[frozenset[str]] = frozenset({"0", "false", "no", "n", "off", "f"})
+
+T = TypeVar("T")
+ParseType = bool | int | float | str | Path | list[Any] | dict[str, Any] | None
+
+
+class _UnsetType:
+    """Sentinel for an omitted type hint."""
+
+    __slots__ = ()
+
+
+_UNSET = _UnsetType()
+
+
+class _EnvFactory(Generic[T]):
+    """Callable factory for delayed environment parsing."""
+
+    __slots__ = ("_aliases", "_default", "_key", "_type_hint")
+
+    def __init__(self, key: str, aliases: "Sequence[str]", default: T, type_hint: object) -> None:
+        self._aliases = aliases
+        self._default = default
+        self._key = key
+        self._type_hint = type_hint
+
+    def __call__(self) -> T:
+        if self._aliases:
+            return get_config_val_with_aliases(self._key, self._aliases, self._default, self._type_hint)
+        return get_config_val(self._key, self._default, self._type_hint)
+
+
+@overload
+def get_env(key: str, default: bool, type_hint: "_UnsetType" = _UNSET) -> "Callable[[], bool]": ...
+
+
+@overload
+def get_env(key: str, default: int, type_hint: "_UnsetType" = _UNSET) -> "Callable[[], int]": ...
+
+
+@overload
+def get_env(key: str, default: float, type_hint: "_UnsetType" = _UNSET) -> "Callable[[], float]": ...
+
+
+@overload
+def get_env(key: str, default: str, type_hint: "_UnsetType" = _UNSET) -> "Callable[[], str]": ...
+
+
+@overload
+def get_env(key: str, default: Path, type_hint: "_UnsetType" = _UNSET) -> "Callable[[], Path]": ...
+
+
+@overload
+def get_env(key: str, default: list[Any], type_hint: "_UnsetType" = _UNSET) -> "Callable[[], list[Any]]": ...
+
+
+@overload
+def get_env(
+    key: str, default: dict[str, Any], type_hint: "_UnsetType" = _UNSET
+) -> "Callable[[], dict[str, Any]]": ...
+
+
+@overload
+def get_env(key: str, default: None, type_hint: "_UnsetType" = _UNSET) -> "Callable[[], None]": ...
+
+
+@overload
+def get_env(key: str, default: ParseType, type_hint: object) -> "Callable[[], Any]": ...
+
+
+def get_env(key: str, default: ParseType, type_hint: object = _UNSET) -> "Callable[[], Any]":
+    """Return a callable that parses an environment variable on demand.
+
+    Args:
+        key: Environment variable name.
+        default: Value returned when the variable is unset.
+        type_hint: Optional parse target, including generic aliases such as ``list[int]``.
+
+    Returns:
+        Callable that returns the parsed value.
+    """
+    return _EnvFactory(key, (), default, type_hint)
+
+
+@overload
+def get_env_with_aliases(
+    key: str, aliases: "Sequence[str]", default: bool, type_hint: "_UnsetType" = _UNSET
+) -> "Callable[[], bool]": ...
+
+
+@overload
+def get_env_with_aliases(
+    key: str, aliases: "Sequence[str]", default: int, type_hint: "_UnsetType" = _UNSET
+) -> "Callable[[], int]": ...
+
+
+@overload
+def get_env_with_aliases(
+    key: str, aliases: "Sequence[str]", default: float, type_hint: "_UnsetType" = _UNSET
+) -> "Callable[[], float]": ...
+
+
+@overload
+def get_env_with_aliases(
+    key: str, aliases: "Sequence[str]", default: str, type_hint: "_UnsetType" = _UNSET
+) -> "Callable[[], str]": ...
+
+
+@overload
+def get_env_with_aliases(
+    key: str, aliases: "Sequence[str]", default: Path, type_hint: "_UnsetType" = _UNSET
+) -> "Callable[[], Path]": ...
+
+
+@overload
+def get_env_with_aliases(
+    key: str, aliases: "Sequence[str]", default: list[Any], type_hint: "_UnsetType" = _UNSET
+) -> "Callable[[], list[Any]]": ...
+
+
+@overload
+def get_env_with_aliases(
+    key: str, aliases: "Sequence[str]", default: dict[str, Any], type_hint: "_UnsetType" = _UNSET
+) -> "Callable[[], dict[str, Any]]": ...
+
+
+@overload
+def get_env_with_aliases(
+    key: str, aliases: "Sequence[str]", default: None, type_hint: "_UnsetType" = _UNSET
+) -> "Callable[[], None]": ...
+
+
+@overload
+def get_env_with_aliases(
+    key: str, aliases: "Sequence[str]", default: ParseType, type_hint: object
+) -> "Callable[[], Any]": ...
+
+
+def get_env_with_aliases(
+    key: str, aliases: "Sequence[str]", default: ParseType, type_hint: object = _UNSET
+) -> "Callable[[], Any]":
+    """Return a callable that parses a canonical environment key plus aliases.
+
+    Args:
+        key: Canonical environment variable name.
+        aliases: Fallback variable names checked in order.
+        default: Value returned when none of the variables are set.
+        type_hint: Optional parse target, including generic aliases such as ``list[int]``.
+
+    Returns:
+        Callable that returns the parsed value.
+    """
+    return _EnvFactory(key, aliases, default, type_hint)
+
+
+def get_config_val(key: str, default: T, type_hint: object = _UNSET) -> T:
+    """Parse an environment variable value.
+
+    Args:
+        key: Environment variable name.
+        default: Value returned when the variable is unset.
+        type_hint: Optional parse target, including generic aliases such as ``list[int]``.
+
+    Returns:
+        Parsed value or the supplied default.
+    """
+    if key not in os.environ:
+        return default
+    return _parse_value(key, os.path.expandvars(os.environ[key]), default, type_hint)
+
+
+def get_config_val_with_aliases(key: str, aliases: "Sequence[str]", default: T, type_hint: object = _UNSET) -> T:
+    """Parse a canonical environment variable, falling back to aliases.
+
+    Args:
+        key: Canonical environment variable name.
+        aliases: Fallback variable names checked in order.
+        default: Value returned when none of the variables are set.
+        type_hint: Optional parse target, including generic aliases such as ``list[int]``.
+
+    Returns:
+        Parsed value or the supplied default.
+    """
+    for env_key in (key, *aliases):
+        if env_key in os.environ:
+            return get_config_val(env_key, default, type_hint)
+    return default
+
+
+def is_env_set(key: str, aliases: "Sequence[str]" = ()) -> bool:
+    """Return whether a canonical environment variable or alias is present.
+
+    Args:
+        key: Canonical environment variable name.
+        aliases: Fallback variable names to check.
+
+    Returns:
+        ``True`` when any key is present in ``os.environ``.
+    """
+    return any(env_key in os.environ for env_key in (key, *aliases))
+
+
+def _coerce_bool(key: str, value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    normalized = str(value).strip().lower()
+    if normalized in TRUE_VALUES:
+        return True
+    if normalized in FALSE_VALUES:
+        return False
+    msg = f"Cannot convert value for key '{key}' to bool: {value!r}"
+    raise ValueError(msg)
+
+
+def _coerce_item(key: str, value: Any, item_type: object) -> Any:
+    if item_type is bool:
+        return _coerce_bool(key, value)
+    if item_type is Path:
+        return Path(str(value))
+    if item_type is int:
+        try:
+            return int(value)
+        except (TypeError, ValueError) as e:
+            msg = f"Cannot convert list item for key '{key}' to int: {value!r}"
+            raise ValueError(msg) from e
+    if item_type is float:
+        try:
+            return float(value)
+        except (TypeError, ValueError) as e:
+            msg = f"Cannot convert list item for key '{key}' to float: {value!r}"
+            raise ValueError(msg) from e
+    if item_type is str or item_type is _UNSET:
+        return str(value)
+    if isinstance(item_type, type):
+        try:
+            return item_type(value)
+        except (TypeError, ValueError) as e:
+            msg = f"Cannot convert list item for key '{key}': {value!r}"
+            raise ValueError(msg) from e
+    return value
+
+
+def _parse_basic_type(key: str, value: str, target_type: object) -> Any:
+    if target_type is bool:
+        return _coerce_bool(key, value)
+    if target_type is int:
+        try:
+            return int(value)
+        except ValueError as e:
+            msg = f"Cannot convert value for key '{key}' to int: {value!r}"
+            raise ValueError(msg) from e
+    if target_type is float:
+        try:
+            return float(value)
+        except ValueError as e:
+            msg = f"Cannot convert value for key '{key}' to float: {value!r}"
+            raise ValueError(msg) from e
+    if target_type is Path:
+        return Path(value)
+    return value
+
+
+def _parse_dict(key: str, value: str) -> dict[str, Any]:
+    stripped = value.strip()
+    if stripped.startswith("{"):
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError as e:
+            msg = f"'{key}' is not valid JSON"
+            raise ValueError(msg) from e
+        if not isinstance(parsed, dict):
+            msg = f"'{key}' is not a valid dict representation"
+            raise ValueError(msg)
+        return parsed
+
+    result: dict[str, Any] = {}
+    for item in value.split(","):
+        stripped_item = item.strip()
+        if not stripped_item:
+            continue
+        if "=" not in stripped_item:
+            msg = f"'{key}' invalid dict format: missing '=' in {stripped_item!r}"
+            raise ValueError(msg)
+        item_key, item_value = stripped_item.split("=", 1)
+        result[item_key.strip()] = item_value.strip()
+    return result
+
+
+def _parse_list(key: str, value: str, item_type: object) -> list[Any]:
+    stripped = value.strip()
+    if stripped.startswith("["):
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError as e:
+            msg = f"'{key}' is not valid JSON"
+            raise ValueError(msg) from e
+        if not isinstance(parsed, list):
+            msg = f"'{key}' is not a valid list representation"
+            raise ValueError(msg)
+        return [_coerce_item(key, item, item_type) for item in parsed]
+    if stripped.startswith("{"):
+        msg = f"'{key}' is not a valid list representation"
+        raise ValueError(msg)
+    return [_coerce_item(key, item.strip(), item_type) for item in value.split(",") if item.strip()]
+
+
+def _resolve_target(default: Any, type_hint: object) -> tuple[object, object]:
+    if type_hint is not _UNSET:
+        origin = get_origin(type_hint)
+        if origin is list:
+            args = get_args(type_hint)
+            item_type = args[0] if args else str
+            return list, item_type
+        if origin is dict:
+            return dict, _UNSET
+        return type_hint, _UNSET
+    if isinstance(default, list):
+        item_type = type(default[0]) if default else str
+        return list, item_type
+    if isinstance(default, dict):
+        return dict, _UNSET
+    if isinstance(default, Path):
+        return Path, _UNSET
+    if default is None:
+        return str, _UNSET
+    return type(default), _UNSET
+
+
+def _parse_value(key: str, value: str, default: T, type_hint: object) -> T:
+    target_type, item_type = _resolve_target(default, type_hint)
+    if target_type is list:
+        return cast("T", _parse_list(key, value, item_type))
+    if target_type is dict:
+        return cast("T", _parse_dict(key, value))
+    return cast("T", _parse_basic_type(key, value, target_type))

--- a/sqlspec/utils/env.py
+++ b/sqlspec/utils/env.py
@@ -2,22 +2,17 @@
 
 import json
 import os
-from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Any, Final, Generic, TypeVar, cast, get_args, get_origin, overload
+from typing import TYPE_CHECKING, Any, Final, get_args, get_origin, overload
 
-__all__ = (
-    "get_config_val",
-    "get_config_val_with_aliases",
-    "get_env",
-    "get_env_with_aliases",
-    "is_env_set",
-)
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+__all__ = ("get_config_val", "get_config_val_with_aliases", "get_env", "get_env_with_aliases", "is_env_set")
 
 TRUE_VALUES: Final[frozenset[str]] = frozenset({"1", "true", "yes", "y", "on", "t"})
 FALSE_VALUES: Final[frozenset[str]] = frozenset({"0", "false", "no", "n", "off", "f"})
 
-T = TypeVar("T")
 ParseType = bool | int | float | str | Path | list[Any] | dict[str, Any] | None
 
 
@@ -30,18 +25,18 @@ class _UnsetType:
 _UNSET = _UnsetType()
 
 
-class _EnvFactory(Generic[T]):
+class _EnvFactory:
     """Callable factory for delayed environment parsing."""
 
     __slots__ = ("_aliases", "_default", "_key", "_type_hint")
 
-    def __init__(self, key: str, aliases: "Sequence[str]", default: T, type_hint: object) -> None:
+    def __init__(self, key: str, aliases: "Sequence[str]", default: ParseType, type_hint: object) -> None:
         self._aliases = aliases
         self._default = default
         self._key = key
         self._type_hint = type_hint
 
-    def __call__(self) -> T:
+    def __call__(self) -> Any:
         if self._aliases:
             return get_config_val_with_aliases(self._key, self._aliases, self._default, self._type_hint)
         return get_config_val(self._key, self._default, self._type_hint)
@@ -72,13 +67,11 @@ def get_env(key: str, default: list[Any], type_hint: "_UnsetType" = _UNSET) -> "
 
 
 @overload
-def get_env(
-    key: str, default: dict[str, Any], type_hint: "_UnsetType" = _UNSET
-) -> "Callable[[], dict[str, Any]]": ...
+def get_env(key: str, default: dict[str, Any], type_hint: "_UnsetType" = _UNSET) -> "Callable[[], dict[str, Any]]": ...
 
 
 @overload
-def get_env(key: str, default: None, type_hint: "_UnsetType" = _UNSET) -> "Callable[[], None]": ...
+def get_env(key: str, default: None, type_hint: "_UnsetType" = _UNSET) -> "Callable[[], str | None]": ...
 
 
 @overload
@@ -144,7 +137,7 @@ def get_env_with_aliases(
 @overload
 def get_env_with_aliases(
     key: str, aliases: "Sequence[str]", default: None, type_hint: "_UnsetType" = _UNSET
-) -> "Callable[[], None]": ...
+) -> "Callable[[], str | None]": ...
 
 
 @overload
@@ -170,7 +163,43 @@ def get_env_with_aliases(
     return _EnvFactory(key, aliases, default, type_hint)
 
 
-def get_config_val(key: str, default: T, type_hint: object = _UNSET) -> T:
+@overload
+def get_config_val(key: str, default: bool, type_hint: "_UnsetType" = _UNSET) -> bool: ...
+
+
+@overload
+def get_config_val(key: str, default: int, type_hint: "_UnsetType" = _UNSET) -> int: ...
+
+
+@overload
+def get_config_val(key: str, default: float, type_hint: "_UnsetType" = _UNSET) -> float: ...
+
+
+@overload
+def get_config_val(key: str, default: str, type_hint: "_UnsetType" = _UNSET) -> str: ...
+
+
+@overload
+def get_config_val(key: str, default: Path, type_hint: "_UnsetType" = _UNSET) -> Path: ...
+
+
+@overload
+def get_config_val(key: str, default: list[Any], type_hint: "_UnsetType" = _UNSET) -> list[Any]: ...
+
+
+@overload
+def get_config_val(key: str, default: dict[str, Any], type_hint: "_UnsetType" = _UNSET) -> dict[str, Any]: ...
+
+
+@overload
+def get_config_val(key: str, default: None, type_hint: "_UnsetType" = _UNSET) -> "str | None": ...
+
+
+@overload
+def get_config_val(key: str, default: ParseType, type_hint: object) -> Any: ...
+
+
+def get_config_val(key: str, default: ParseType, type_hint: object = _UNSET) -> Any:
     """Parse an environment variable value.
 
     Args:
@@ -186,7 +215,61 @@ def get_config_val(key: str, default: T, type_hint: object = _UNSET) -> T:
     return _parse_value(key, os.path.expandvars(os.environ[key]), default, type_hint)
 
 
-def get_config_val_with_aliases(key: str, aliases: "Sequence[str]", default: T, type_hint: object = _UNSET) -> T:
+@overload
+def get_config_val_with_aliases(
+    key: str, aliases: "Sequence[str]", default: bool, type_hint: "_UnsetType" = _UNSET
+) -> bool: ...
+
+
+@overload
+def get_config_val_with_aliases(
+    key: str, aliases: "Sequence[str]", default: int, type_hint: "_UnsetType" = _UNSET
+) -> int: ...
+
+
+@overload
+def get_config_val_with_aliases(
+    key: str, aliases: "Sequence[str]", default: float, type_hint: "_UnsetType" = _UNSET
+) -> float: ...
+
+
+@overload
+def get_config_val_with_aliases(
+    key: str, aliases: "Sequence[str]", default: str, type_hint: "_UnsetType" = _UNSET
+) -> str: ...
+
+
+@overload
+def get_config_val_with_aliases(
+    key: str, aliases: "Sequence[str]", default: Path, type_hint: "_UnsetType" = _UNSET
+) -> Path: ...
+
+
+@overload
+def get_config_val_with_aliases(
+    key: str, aliases: "Sequence[str]", default: list[Any], type_hint: "_UnsetType" = _UNSET
+) -> list[Any]: ...
+
+
+@overload
+def get_config_val_with_aliases(
+    key: str, aliases: "Sequence[str]", default: dict[str, Any], type_hint: "_UnsetType" = _UNSET
+) -> dict[str, Any]: ...
+
+
+@overload
+def get_config_val_with_aliases(
+    key: str, aliases: "Sequence[str]", default: None, type_hint: "_UnsetType" = _UNSET
+) -> "str | None": ...
+
+
+@overload
+def get_config_val_with_aliases(key: str, aliases: "Sequence[str]", default: ParseType, type_hint: object) -> Any: ...
+
+
+def get_config_val_with_aliases(
+    key: str, aliases: "Sequence[str]", default: ParseType, type_hint: object = _UNSET
+) -> Any:
     """Parse a canonical environment variable, falling back to aliases.
 
     Args:
@@ -343,10 +426,10 @@ def _resolve_target(default: Any, type_hint: object) -> tuple[object, object]:
     return type(default), _UNSET
 
 
-def _parse_value(key: str, value: str, default: T, type_hint: object) -> T:
+def _parse_value(key: str, value: str, default: ParseType, type_hint: object) -> Any:
     target_type, item_type = _resolve_target(default, type_hint)
     if target_type is list:
-        return cast("T", _parse_list(key, value, item_type))
+        return _parse_list(key, value, item_type)
     if target_type is dict:
-        return cast("T", _parse_dict(key, value))
-    return cast("T", _parse_basic_type(key, value, target_type))
+        return _parse_dict(key, value)
+    return _parse_basic_type(key, value, target_type)

--- a/sqlspec/utils/sync_tools.py
+++ b/sqlspec/utils/sync_tools.py
@@ -6,16 +6,20 @@ for adapter implementations that need to support both sync and async patterns.
 """
 
 import asyncio
+import atexit
 import concurrent.futures
+import contextvars
 import functools
 import inspect
 import os
 import sys
+import threading
 from contextlib import AbstractAsyncContextManager, AbstractContextManager
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 from typing_extensions import ParamSpec
 
+from sqlspec.utils.env import get_env
 from sqlspec.utils.module_loader import module_available
 from sqlspec.utils.portal import get_global_portal
 
@@ -32,6 +36,10 @@ else:
 ReturnT = TypeVar("ReturnT")
 ParamSpecT = ParamSpec("ParamSpecT")
 T = TypeVar("T")
+
+DEFAULT_ASYNC_THREAD_LIMIT = 8
+ASYNC_THREAD_LIMIT_ENV = "SQLSPEC_ASYNC_THREAD_LIMIT"
+_ASYNC_THREAD_NAME_PREFIX = "sqlspec-async"
 
 
 class NoValue:
@@ -99,6 +107,106 @@ class CapacityLimiter:
 
 
 _default_limiter = CapacityLimiter(1000)
+_default_async_executor: concurrent.futures.Executor | None = None
+_default_async_executor_pid: int | None = None
+_managed_async_executor: concurrent.futures.ThreadPoolExecutor | None = None
+_managed_async_executor_enabled: bool = False
+_managed_async_executor_lock = threading.Lock()
+_managed_async_executor_max_workers: int | None = None
+_managed_async_executor_pid: int | None = None
+
+
+def set_default_async_executor(executor: "concurrent.futures.Executor | None") -> None:
+    """Set a caller-owned process-local default executor for ``async_``.
+
+    SQLSpec never shuts down caller-provided executors. If a process fork is
+    detected later, the stored executor is cleared instead of reused.
+
+    Args:
+        executor: Caller-owned executor to use by default, or ``None`` to clear it.
+    """
+    global _default_async_executor, _default_async_executor_pid  # noqa: PLW0603
+    with _managed_async_executor_lock:
+        _default_async_executor = executor
+        _default_async_executor_pid = os.getpid() if executor is not None else None
+
+
+def enable_default_async_thread_pool(max_workers: int | None = None) -> None:
+    """Enable SQLSpec's managed default executor for ``async_``.
+
+    Args:
+        max_workers: Optional worker limit. When omitted, ``SQLSPEC_ASYNC_THREAD_LIMIT``
+            is read, falling back to ``DEFAULT_ASYNC_THREAD_LIMIT``.
+    """
+    global _managed_async_executor_enabled, _managed_async_executor_max_workers  # noqa: PLW0603
+    with _managed_async_executor_lock:
+        _managed_async_executor_enabled = True
+        _managed_async_executor_max_workers = max_workers
+        _ensure_managed_async_executor_locked(os.getpid())
+
+
+def get_default_async_executor() -> "concurrent.futures.Executor | None":
+    """Return the configured or managed default executor for ``async_``.
+
+    Returns:
+        Caller-owned default executor, SQLSpec-managed executor, or ``None``.
+    """
+    global _default_async_executor, _default_async_executor_pid  # noqa: PLW0603
+    current_pid = os.getpid()
+    with _managed_async_executor_lock:
+        if _default_async_executor is not None:
+            if _default_async_executor_pid == current_pid:
+                return _default_async_executor
+            _default_async_executor = None
+            _default_async_executor_pid = None
+
+        if _managed_async_executor_enabled or ASYNC_THREAD_LIMIT_ENV in os.environ:
+            return _ensure_managed_async_executor_locked(current_pid)
+    return None
+
+
+def shutdown_default_async_executor(wait: bool = False) -> None:
+    """Clear default async executors and shut down SQLSpec-owned pools.
+
+    Args:
+        wait: Whether to wait for SQLSpec-managed executor tasks to finish.
+    """
+    global _default_async_executor, _default_async_executor_pid  # noqa: PLW0603
+    global _managed_async_executor, _managed_async_executor_enabled, _managed_async_executor_max_workers
+    global _managed_async_executor_pid
+    with _managed_async_executor_lock:
+        if _managed_async_executor is not None:
+            _managed_async_executor.shutdown(wait=wait)
+        _managed_async_executor = None
+        _managed_async_executor_enabled = False
+        _managed_async_executor_max_workers = None
+        _managed_async_executor_pid = None
+        _default_async_executor = None
+        _default_async_executor_pid = None
+
+
+def _ensure_managed_async_executor_locked(current_pid: int) -> concurrent.futures.ThreadPoolExecutor:
+    global _managed_async_executor, _managed_async_executor_pid  # noqa: PLW0603
+    if _managed_async_executor is None or _managed_async_executor_pid != current_pid:
+        if _managed_async_executor is not None:
+            _managed_async_executor.shutdown(wait=False)
+        max_workers = _resolve_managed_async_thread_limit()
+        _managed_async_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=max_workers, thread_name_prefix=_ASYNC_THREAD_NAME_PREFIX
+        )
+        _managed_async_executor_pid = current_pid
+    return _managed_async_executor
+
+
+def _resolve_managed_async_thread_limit() -> int:
+    if _managed_async_executor_max_workers is None:
+        max_workers = get_env(ASYNC_THREAD_LIMIT_ENV, DEFAULT_ASYNC_THREAD_LIMIT)()
+    else:
+        max_workers = _managed_async_executor_max_workers
+    return max(1, max_workers)
+
+
+atexit.register(shutdown_default_async_executor)
 
 
 class _RunWrapper(Generic[ParamSpecT, ReturnT]):
@@ -161,19 +269,23 @@ def await_(
 
 
 def async_(
-    function: "Callable[ParamSpecT, ReturnT]", *, limiter: "CapacityLimiter | None" = None
+    function: "Callable[ParamSpecT, ReturnT]",
+    *,
+    limiter: "CapacityLimiter | None" = None,
+    executor: "concurrent.futures.Executor | None" = None,
 ) -> "Callable[ParamSpecT, Awaitable[ReturnT]]":
     """Convert a blocking function to an async one using asyncio.to_thread().
 
     Args:
         function: The blocking function to convert.
         limiter: Limit the total number of threads.
+        executor: Optional executor to use instead of the event loop's default thread executor.
 
     Returns:
         An async function that runs the original function in a thread.
     """
 
-    return _AsyncWrapper(function, limiter)
+    return _AsyncWrapper(function, limiter, executor)
 
 
 def ensure_async_(
@@ -238,19 +350,40 @@ class _AwaitWrapper(Generic[ParamSpecT, ReturnT]):
 
 
 class _AsyncWrapper(Generic[ParamSpecT, ReturnT]):
-    __slots__ = ("__dict__", "_function", "_limiter")
+    __slots__ = ("__dict__", "_executor", "_function", "_limiter")
 
-    def __init__(self, function: "Callable[ParamSpecT, ReturnT]", limiter: "CapacityLimiter | None") -> None:
+    def __init__(
+        self,
+        function: "Callable[ParamSpecT, ReturnT]",
+        limiter: "CapacityLimiter | None",
+        executor: "concurrent.futures.Executor | None",
+    ) -> None:
+        self._executor = executor
         self._function = function
         self._limiter = limiter
         functools.update_wrapper(self, function)
 
     async def __call__(self, *args: "ParamSpecT.args", **kwargs: "ParamSpecT.kwargs") -> "ReturnT":
-        partial_f = functools.partial(self._function, *args, **kwargs)
+        executor = self._executor if self._executor is not None else get_default_async_executor()
         if self._limiter is not None:
             async with self._limiter:
-                return await asyncio.to_thread(partial_f)
-        return await asyncio.to_thread(partial_f)
+                return await self._run_sync(executor, *args, **kwargs)
+        return await self._run_sync(executor, *args, **kwargs)
+
+    async def _run_sync(
+        self,
+        executor: "concurrent.futures.Executor | None",
+        *args: "ParamSpecT.args",
+        **kwargs: "ParamSpecT.kwargs",
+    ) -> "ReturnT":
+        if executor is None:
+            partial_f = functools.partial(self._function, *args, **kwargs)
+            return await asyncio.to_thread(partial_f)
+
+        loop = asyncio.get_running_loop()
+        ctx = contextvars.copy_context()
+        call = functools.partial(ctx.run, self._function, *args, **kwargs)
+        return await loop.run_in_executor(executor, call)
 
 
 class _EnsureAsyncWrapper(Generic[ParamSpecT, ReturnT]):

--- a/sqlspec/utils/sync_tools.py
+++ b/sqlspec/utils/sync_tools.py
@@ -107,7 +107,7 @@ class CapacityLimiter:
 
 
 _default_limiter = CapacityLimiter(1000)
-_default_async_executor: concurrent.futures.Executor | None = None
+_default_async_executor: concurrent.futures.ThreadPoolExecutor | None = None
 _default_async_executor_pid: int | None = None
 _managed_async_executor: concurrent.futures.ThreadPoolExecutor | None = None
 _managed_async_executor_enabled: bool = False
@@ -116,19 +116,20 @@ _managed_async_executor_max_workers: int | None = None
 _managed_async_executor_pid: int | None = None
 
 
-def set_default_async_executor(executor: "concurrent.futures.Executor | None") -> None:
-    """Set a caller-owned process-local default executor for ``async_``.
+def set_default_async_executor(executor: "concurrent.futures.ThreadPoolExecutor | None") -> None:
+    """Set a caller-owned process-local default thread executor for ``async_``.
 
     SQLSpec never shuts down caller-provided executors. If a process fork is
     detected later, the stored executor is cleared instead of reused.
 
     Args:
-        executor: Caller-owned executor to use by default, or ``None`` to clear it.
+        executor: Caller-owned thread executor to use by default, or ``None`` to clear it.
     """
-    global _default_async_executor, _default_async_executor_pid  # noqa: PLW0603
+    global _default_async_executor, _default_async_executor_pid
+    validated_executor = _validate_async_thread_executor(executor)
     with _managed_async_executor_lock:
-        _default_async_executor = executor
-        _default_async_executor_pid = os.getpid() if executor is not None else None
+        _default_async_executor = validated_executor
+        _default_async_executor_pid = os.getpid() if validated_executor is not None else None
 
 
 def enable_default_async_thread_pool(max_workers: int | None = None) -> None:
@@ -138,20 +139,20 @@ def enable_default_async_thread_pool(max_workers: int | None = None) -> None:
         max_workers: Optional worker limit. When omitted, ``SQLSPEC_ASYNC_THREAD_LIMIT``
             is read, falling back to ``DEFAULT_ASYNC_THREAD_LIMIT``.
     """
-    global _managed_async_executor_enabled, _managed_async_executor_max_workers  # noqa: PLW0603
+    global _managed_async_executor_enabled, _managed_async_executor_max_workers
     with _managed_async_executor_lock:
         _managed_async_executor_enabled = True
         _managed_async_executor_max_workers = max_workers
         _ensure_managed_async_executor_locked(os.getpid())
 
 
-def get_default_async_executor() -> "concurrent.futures.Executor | None":
+def get_default_async_executor() -> "concurrent.futures.ThreadPoolExecutor | None":
     """Return the configured or managed default executor for ``async_``.
 
     Returns:
-        Caller-owned default executor, SQLSpec-managed executor, or ``None``.
+        Caller-owned default thread executor, SQLSpec-managed executor, or ``None``.
     """
-    global _default_async_executor, _default_async_executor_pid  # noqa: PLW0603
+    global _default_async_executor, _default_async_executor_pid
     current_pid = os.getpid()
     with _managed_async_executor_lock:
         if _default_async_executor is not None:
@@ -171,7 +172,7 @@ def shutdown_default_async_executor(wait: bool = False) -> None:
     Args:
         wait: Whether to wait for SQLSpec-managed executor tasks to finish.
     """
-    global _default_async_executor, _default_async_executor_pid  # noqa: PLW0603
+    global _default_async_executor, _default_async_executor_pid
     global _managed_async_executor, _managed_async_executor_enabled, _managed_async_executor_max_workers
     global _managed_async_executor_pid
     with _managed_async_executor_lock:
@@ -186,7 +187,7 @@ def shutdown_default_async_executor(wait: bool = False) -> None:
 
 
 def _ensure_managed_async_executor_locked(current_pid: int) -> concurrent.futures.ThreadPoolExecutor:
-    global _managed_async_executor, _managed_async_executor_pid  # noqa: PLW0603
+    global _managed_async_executor, _managed_async_executor_pid
     if _managed_async_executor is None or _managed_async_executor_pid != current_pid:
         if _managed_async_executor is not None:
             _managed_async_executor.shutdown(wait=False)
@@ -196,6 +197,13 @@ def _ensure_managed_async_executor_locked(current_pid: int) -> concurrent.future
         )
         _managed_async_executor_pid = current_pid
     return _managed_async_executor
+
+
+def _validate_async_thread_executor(executor: object) -> "concurrent.futures.ThreadPoolExecutor | None":
+    if executor is None or isinstance(executor, concurrent.futures.ThreadPoolExecutor):
+        return executor
+    msg = "async_ executors must be concurrent.futures.ThreadPoolExecutor instances to preserve contextvars"
+    raise TypeError(msg)
 
 
 def _resolve_managed_async_thread_limit() -> int:
@@ -272,14 +280,14 @@ def async_(
     function: "Callable[ParamSpecT, ReturnT]",
     *,
     limiter: "CapacityLimiter | None" = None,
-    executor: "concurrent.futures.Executor | None" = None,
+    executor: "concurrent.futures.ThreadPoolExecutor | None" = None,
 ) -> "Callable[ParamSpecT, Awaitable[ReturnT]]":
     """Convert a blocking function to an async one using asyncio.to_thread().
 
     Args:
         function: The blocking function to convert.
         limiter: Limit the total number of threads.
-        executor: Optional executor to use instead of the event loop's default thread executor.
+        executor: Optional thread executor to use instead of the event loop's default thread executor.
 
     Returns:
         An async function that runs the original function in a thread.
@@ -356,9 +364,9 @@ class _AsyncWrapper(Generic[ParamSpecT, ReturnT]):
         self,
         function: "Callable[ParamSpecT, ReturnT]",
         limiter: "CapacityLimiter | None",
-        executor: "concurrent.futures.Executor | None",
+        executor: "concurrent.futures.ThreadPoolExecutor | None",
     ) -> None:
-        self._executor = executor
+        self._executor = _validate_async_thread_executor(executor)
         self._function = function
         self._limiter = limiter
         functools.update_wrapper(self, function)
@@ -372,7 +380,7 @@ class _AsyncWrapper(Generic[ParamSpecT, ReturnT]):
 
     async def _run_sync(
         self,
-        executor: "concurrent.futures.Executor | None",
+        executor: "concurrent.futures.ThreadPoolExecutor | None",
         *args: "ParamSpecT.args",
         **kwargs: "ParamSpecT.kwargs",
     ) -> "ReturnT":

--- a/sqlspec/utils/sync_tools.py
+++ b/sqlspec/utils/sync_tools.py
@@ -110,20 +110,22 @@ _default_limiter = CapacityLimiter(1000)
 _default_async_executor: concurrent.futures.ThreadPoolExecutor | None = None
 _default_async_executor_pid: int | None = None
 _managed_async_executor: concurrent.futures.ThreadPoolExecutor | None = None
-_managed_async_executor_enabled: bool = False
 _managed_async_executor_lock = threading.Lock()
 _managed_async_executor_max_workers: int | None = None
 _managed_async_executor_pid: int | None = None
+_managed_async_executor_resolved_max_workers: int | None = None
 
 
 def set_default_async_executor(executor: "concurrent.futures.ThreadPoolExecutor | None") -> None:
     """Set a caller-owned process-local default thread executor for ``async_``.
 
     SQLSpec never shuts down caller-provided executors. If a process fork is
-    detected later, the stored executor is cleared instead of reused.
+    detected later, the stored executor is cleared instead of reused, and
+    ``async_`` falls back to SQLSpec's managed default pool.
 
     Args:
-        executor: Caller-owned thread executor to use by default, or ``None`` to clear it.
+        executor: Caller-owned thread executor to use by default, or ``None``
+            to clear it and use SQLSpec's managed pool.
     """
     global _default_async_executor, _default_async_executor_pid
     validated_executor = _validate_async_thread_executor(executor)
@@ -133,24 +135,23 @@ def set_default_async_executor(executor: "concurrent.futures.ThreadPoolExecutor 
 
 
 def enable_default_async_thread_pool(max_workers: int | None = None) -> None:
-    """Enable SQLSpec's managed default executor for ``async_``.
+    """Configure and eagerly create SQLSpec's managed default executor for ``async_``.
 
     Args:
         max_workers: Optional worker limit. When omitted, ``SQLSPEC_ASYNC_THREAD_LIMIT``
             is read, falling back to ``DEFAULT_ASYNC_THREAD_LIMIT``.
     """
-    global _managed_async_executor_enabled, _managed_async_executor_max_workers
+    global _managed_async_executor_max_workers
     with _managed_async_executor_lock:
-        _managed_async_executor_enabled = True
         _managed_async_executor_max_workers = max_workers
         _ensure_managed_async_executor_locked(os.getpid())
 
 
-def get_default_async_executor() -> "concurrent.futures.ThreadPoolExecutor | None":
+def get_default_async_executor() -> concurrent.futures.ThreadPoolExecutor:
     """Return the configured or managed default executor for ``async_``.
 
     Returns:
-        Caller-owned default thread executor, SQLSpec-managed executor, or ``None``.
+        Caller-owned default thread executor or SQLSpec-managed executor.
     """
     global _default_async_executor, _default_async_executor_pid
     current_pid = os.getpid()
@@ -161,41 +162,46 @@ def get_default_async_executor() -> "concurrent.futures.ThreadPoolExecutor | Non
             _default_async_executor = None
             _default_async_executor_pid = None
 
-        if _managed_async_executor_enabled or ASYNC_THREAD_LIMIT_ENV in os.environ:
-            return _ensure_managed_async_executor_locked(current_pid)
-    return None
+        return _ensure_managed_async_executor_locked(current_pid)
 
 
 def shutdown_default_async_executor(wait: bool = False) -> None:
     """Clear default async executors and shut down SQLSpec-owned pools.
 
+    The next ``async_`` call recreates SQLSpec's managed default pool.
+
     Args:
         wait: Whether to wait for SQLSpec-managed executor tasks to finish.
     """
     global _default_async_executor, _default_async_executor_pid
-    global _managed_async_executor, _managed_async_executor_enabled, _managed_async_executor_max_workers
-    global _managed_async_executor_pid
+    global _managed_async_executor, _managed_async_executor_max_workers, _managed_async_executor_pid
+    global _managed_async_executor_resolved_max_workers
     with _managed_async_executor_lock:
         if _managed_async_executor is not None:
             _managed_async_executor.shutdown(wait=wait)
         _managed_async_executor = None
-        _managed_async_executor_enabled = False
         _managed_async_executor_max_workers = None
         _managed_async_executor_pid = None
+        _managed_async_executor_resolved_max_workers = None
         _default_async_executor = None
         _default_async_executor_pid = None
 
 
 def _ensure_managed_async_executor_locked(current_pid: int) -> concurrent.futures.ThreadPoolExecutor:
-    global _managed_async_executor, _managed_async_executor_pid
-    if _managed_async_executor is None or _managed_async_executor_pid != current_pid:
+    global _managed_async_executor, _managed_async_executor_pid, _managed_async_executor_resolved_max_workers
+    max_workers = _resolve_managed_async_thread_limit()
+    if (
+        _managed_async_executor is None
+        or _managed_async_executor_pid != current_pid
+        or _managed_async_executor_resolved_max_workers != max_workers
+    ):
         if _managed_async_executor is not None:
             _managed_async_executor.shutdown(wait=False)
-        max_workers = _resolve_managed_async_thread_limit()
         _managed_async_executor = concurrent.futures.ThreadPoolExecutor(
             max_workers=max_workers, thread_name_prefix=_ASYNC_THREAD_NAME_PREFIX
         )
         _managed_async_executor_pid = current_pid
+        _managed_async_executor_resolved_max_workers = max_workers
     return _managed_async_executor
 
 
@@ -282,12 +288,12 @@ def async_(
     limiter: "CapacityLimiter | None" = None,
     executor: "concurrent.futures.ThreadPoolExecutor | None" = None,
 ) -> "Callable[ParamSpecT, Awaitable[ReturnT]]":
-    """Convert a blocking function to an async one using asyncio.to_thread().
+    """Convert a blocking function to an async one using a thread executor.
 
     Args:
         function: The blocking function to convert.
         limiter: Limit the total number of threads.
-        executor: Optional thread executor to use instead of the event loop's default thread executor.
+        executor: Optional thread executor to use instead of SQLSpec's managed default thread executor.
 
     Returns:
         An async function that runs the original function in a thread.
@@ -379,15 +385,8 @@ class _AsyncWrapper(Generic[ParamSpecT, ReturnT]):
         return await self._run_sync(executor, *args, **kwargs)
 
     async def _run_sync(
-        self,
-        executor: "concurrent.futures.ThreadPoolExecutor | None",
-        *args: "ParamSpecT.args",
-        **kwargs: "ParamSpecT.kwargs",
+        self, executor: "concurrent.futures.ThreadPoolExecutor", *args: "ParamSpecT.args", **kwargs: "ParamSpecT.kwargs"
     ) -> "ReturnT":
-        if executor is None:
-            partial_f = functools.partial(self._function, *args, **kwargs)
-            return await asyncio.to_thread(partial_f)
-
         loop = asyncio.get_running_loop()
         ctx = contextvars.copy_context()
         call = functools.partial(ctx.run, self._function, *args, **kwargs)

--- a/tests/unit/utils/test_env.py
+++ b/tests/unit/utils/test_env.py
@@ -1,17 +1,13 @@
 """Tests for environment variable parsing utilities."""
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 import pytest
+from typing_extensions import assert_type
 
-from sqlspec.utils.env import (
-    get_config_val,
-    get_config_val_with_aliases,
-    get_env,
-    get_env_with_aliases,
-    is_env_set,
-)
+from sqlspec.utils.env import get_config_val, get_config_val_with_aliases, get_env, get_env_with_aliases, is_env_set
 
 
 def test_get_env_returns_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -121,6 +117,25 @@ def test_get_env_uses_list_type_hint_with_none_default(monkeypatch: pytest.Monke
     monkeypatch.setenv("SQLSPEC_LIST_VALUE", "1,2,3")
 
     assert get_env("SQLSPEC_LIST_VALUE", None, list[int])() == [1, 2, 3]
+
+
+def test_get_env_none_default_returns_optional_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_STRING_VALUE", "configured")
+
+    factory = get_env("SQLSPEC_STRING_VALUE", None)
+    alias_factory = get_env_with_aliases("SQLSPEC_MISSING_VALUE", ("SQLSPEC_STRING_VALUE",), None)
+    config_value = get_config_val("SQLSPEC_STRING_VALUE", None)
+    alias_config_value = get_config_val_with_aliases("SQLSPEC_MISSING_VALUE", ("SQLSPEC_STRING_VALUE",), None)
+
+    assert_type(factory, Callable[[], str | None])
+    assert_type(alias_factory, Callable[[], str | None])
+    assert_type(config_value, str | None)
+    assert_type(alias_config_value, str | None)
+
+    assert factory() == "configured"
+    assert alias_factory() == "configured"
+    assert config_value == "configured"
+    assert alias_config_value == "configured"
 
 
 def test_get_env_parses_json_dict(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/utils/test_env.py
+++ b/tests/unit/utils/test_env.py
@@ -1,0 +1,168 @@
+"""Tests for environment variable parsing utilities."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from sqlspec.utils.env import (
+    get_config_val,
+    get_config_val_with_aliases,
+    get_env,
+    get_env_with_aliases,
+    is_env_set,
+)
+
+
+def test_get_env_returns_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SQLSPEC_TEST_VALUE", raising=False)
+
+    assert get_env("SQLSPEC_TEST_VALUE", 42)() == 42
+
+
+def test_get_env_parses_override_from_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_TEST_VALUE", "42")
+
+    assert get_env("SQLSPEC_TEST_VALUE", 1)() == 42
+
+
+def test_get_env_expands_environment_references(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_ROOT", "/tmp/sqlspec")
+    monkeypatch.setenv("SQLSPEC_PATH", "$SQLSPEC_ROOT/data")
+
+    assert get_env("SQLSPEC_PATH", "")() == "/tmp/sqlspec/data"
+
+
+def test_get_env_with_aliases_prefers_canonical_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_ALIAS_VALUE", "1")
+    monkeypatch.setenv("SQLSPEC_CANONICAL_VALUE", "2")
+
+    assert get_env_with_aliases("SQLSPEC_CANONICAL_VALUE", ("SQLSPEC_ALIAS_VALUE",), 0)() == 2
+
+
+def test_get_env_with_aliases_uses_alias_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SQLSPEC_CANONICAL_VALUE", raising=False)
+    monkeypatch.setenv("SQLSPEC_ALIAS_VALUE", "2")
+
+    assert get_env_with_aliases("SQLSPEC_CANONICAL_VALUE", ("SQLSPEC_ALIAS_VALUE",), 0)() == 2
+
+
+def test_is_env_set_checks_canonical_and_aliases(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SQLSPEC_CANONICAL_VALUE", raising=False)
+    monkeypatch.delenv("SQLSPEC_ALIAS_VALUE", raising=False)
+
+    assert is_env_set("SQLSPEC_CANONICAL_VALUE", ("SQLSPEC_ALIAS_VALUE",)) is False
+
+    monkeypatch.setenv("SQLSPEC_ALIAS_VALUE", "")
+
+    assert is_env_set("SQLSPEC_CANONICAL_VALUE", ("SQLSPEC_ALIAS_VALUE",)) is True
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "Y", "on", "t"])
+def test_get_env_parses_true_bool_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("SQLSPEC_BOOL_VALUE", value)
+
+    assert get_env("SQLSPEC_BOOL_VALUE", False)() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "FALSE", "no", "N", "off", "f"])
+def test_get_env_parses_false_bool_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("SQLSPEC_BOOL_VALUE", value)
+
+    assert get_env("SQLSPEC_BOOL_VALUE", True)() is False
+
+
+def test_get_env_rejects_invalid_bool_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_BOOL_VALUE", "maybe")
+
+    with pytest.raises(ValueError, match="SQLSPEC_BOOL_VALUE"):
+        get_env("SQLSPEC_BOOL_VALUE", False)()
+
+
+def test_get_env_reports_int_parse_errors_with_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_INT_VALUE", "not-int")
+
+    with pytest.raises(ValueError, match="SQLSPEC_INT_VALUE"):
+        get_env("SQLSPEC_INT_VALUE", 1)()
+
+
+def test_get_env_reports_float_parse_errors_with_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_FLOAT_VALUE", "not-float")
+
+    with pytest.raises(ValueError, match="SQLSPEC_FLOAT_VALUE"):
+        get_env("SQLSPEC_FLOAT_VALUE", 1.0)()
+
+
+def test_get_env_parses_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_PATH_VALUE", "/tmp/sqlspec")
+
+    assert get_env("SQLSPEC_PATH_VALUE", Path("."))() == Path("/tmp/sqlspec")
+
+
+def test_get_env_parses_comma_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_LIST_VALUE", "a, b,c")
+
+    assert get_env("SQLSPEC_LIST_VALUE", [])() == ["a", "b", "c"]
+
+
+def test_get_env_parses_json_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_LIST_VALUE", "[1, 2, 3]")
+
+    assert get_env("SQLSPEC_LIST_VALUE", [], list[int])() == [1, 2, 3]
+
+
+def test_get_env_uses_list_type_hint_with_empty_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_LIST_VALUE", "1,2,3")
+
+    assert get_env("SQLSPEC_LIST_VALUE", [], list[int])() == [1, 2, 3]
+
+
+def test_get_env_uses_list_type_hint_with_none_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_LIST_VALUE", "1,2,3")
+
+    assert get_env("SQLSPEC_LIST_VALUE", None, list[int])() == [1, 2, 3]
+
+
+def test_get_env_parses_json_dict(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_DICT_VALUE", '{"a": 1, "b": "two"}')
+
+    assert get_env("SQLSPEC_DICT_VALUE", {})() == {"a": 1, "b": "two"}
+
+
+def test_get_env_parses_key_value_dict(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_DICT_VALUE", "a=1,b=two")
+
+    assert get_env("SQLSPEC_DICT_VALUE", {})() == {"a": "1", "b": "two"}
+
+
+def test_get_env_reports_invalid_list_format_with_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_LIST_VALUE", '{"not": "a list"}')
+
+    with pytest.raises(ValueError, match="SQLSPEC_LIST_VALUE"):
+        get_env("SQLSPEC_LIST_VALUE", [], list[int])()
+
+
+def test_get_env_reports_invalid_dict_format_with_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_DICT_VALUE", "not-a-pair")
+
+    with pytest.raises(ValueError, match="SQLSPEC_DICT_VALUE"):
+        get_env("SQLSPEC_DICT_VALUE", {})()
+
+
+def test_get_config_val_matches_get_env_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_CONFIG_VALUE", "3")
+
+    assert get_config_val("SQLSPEC_CONFIG_VALUE", 1) == 3
+
+
+def test_get_config_val_with_aliases_uses_canonical_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_CONFIG_ALIAS", "1")
+    monkeypatch.setenv("SQLSPEC_CONFIG_VALUE", "3")
+
+    assert get_config_val_with_aliases("SQLSPEC_CONFIG_VALUE", ("SQLSPEC_CONFIG_ALIAS",), 1) == 3
+
+
+def test_get_env_parses_dict_type_hint_with_none_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SQLSPEC_DICT_VALUE", "a=1")
+
+    assert get_env("SQLSPEC_DICT_VALUE", None, dict[str, Any])() == {"a": "1"}

--- a/tests/unit/utils/test_mypyc_inventory.py
+++ b/tests/unit/utils/test_mypyc_inventory.py
@@ -95,6 +95,8 @@ def test_makefile_test_mypyc_targets_live_smoke_modules() -> None:
         "sqlspec/extensions/adk/_types.py",
         "sqlspec/extensions/adk/memory/_types.py",
         "sqlspec/extensions/adk/artifact/_types.py",
+        "sqlspec/extensions/fastapi/providers.py",
+        "sqlspec/extensions/litestar/providers.py",
         "sqlspec/migrations/version.py",
         "sqlspec/observability/_formatting.py",
     ]
@@ -131,6 +133,8 @@ def test_inventory_records_rest_of_mypyc_boundary_decisions() -> None:
     assert "sqlspec/extensions/adk/_types.py" in payload["compiled_modules"]
     assert "sqlspec/extensions/adk/memory/_types.py" in payload["compiled_modules"]
     assert "sqlspec/extensions/adk/artifact/_types.py" in payload["compiled_modules"]
+    assert "sqlspec/extensions/fastapi/providers.py" in payload["compiled_modules"]
+    assert "sqlspec/extensions/litestar/providers.py" in payload["compiled_modules"]
     assert "sqlspec/migrations/runner.py" in payload["compiled_modules"]
     assert "sqlspec/observability/_formatting.py" in payload["compiled_modules"]
     assert "sqlspec/utils/env.py" in payload["compiled_modules"]
@@ -146,8 +150,6 @@ def test_inventory_records_rest_of_mypyc_boundary_decisions() -> None:
     assert "sqlspec/dialects/spanner/_spangres.py" in payload["interpreted_modules"]
     assert "sqlspec/dialects/spanner/_spanner.py" in payload["interpreted_modules"]
     assert "sqlspec/extensions/adk/converters.py" in payload["interpreted_modules"]
-    assert "sqlspec/extensions/fastapi/providers.py" in payload["interpreted_modules"]
-    assert "sqlspec/extensions/litestar/providers.py" in payload["interpreted_modules"]
     assert "sqlspec/storage/_arrow_payload.py" in payload["interpreted_modules"]
     assert "sqlspec/extensions/adk/converters.py" in payload["preserved_exclusions"]
     assert payload["adapter_pool_runtimes"]["status"] == "compiled"

--- a/tests/unit/utils/test_mypyc_inventory.py
+++ b/tests/unit/utils/test_mypyc_inventory.py
@@ -62,6 +62,7 @@ def test_makefile_test_mypyc_targets_live_smoke_modules() -> None:
     assert smoke_invocations == [
         "sqlspec/utils/text.py",
         "sqlspec/utils/sync_tools.py",
+        "sqlspec/utils/env.py",
         "sqlspec/utils/module_loader.py",
         "sqlspec/core/cache.py",
         "sqlspec/core/hashing.py",
@@ -132,6 +133,7 @@ def test_inventory_records_rest_of_mypyc_boundary_decisions() -> None:
     assert "sqlspec/extensions/adk/artifact/_types.py" in payload["compiled_modules"]
     assert "sqlspec/migrations/runner.py" in payload["compiled_modules"]
     assert "sqlspec/observability/_formatting.py" in payload["compiled_modules"]
+    assert "sqlspec/utils/env.py" in payload["compiled_modules"]
     assert "sqlspec/adapters/asyncpg/driver.py" in payload["interpreted_modules"]
     assert "sqlspec/adapters/psycopg/driver.py" in payload["interpreted_modules"]
     assert "sqlspec/adapters/cockroach_asyncpg/driver.py" in payload["interpreted_modules"]

--- a/tests/unit/utils/test_mypyc_inventory.py
+++ b/tests/unit/utils/test_mypyc_inventory.py
@@ -95,8 +95,6 @@ def test_makefile_test_mypyc_targets_live_smoke_modules() -> None:
         "sqlspec/extensions/adk/_types.py",
         "sqlspec/extensions/adk/memory/_types.py",
         "sqlspec/extensions/adk/artifact/_types.py",
-        "sqlspec/extensions/fastapi/providers.py",
-        "sqlspec/extensions/litestar/providers.py",
         "sqlspec/migrations/version.py",
         "sqlspec/observability/_formatting.py",
     ]
@@ -133,8 +131,6 @@ def test_inventory_records_rest_of_mypyc_boundary_decisions() -> None:
     assert "sqlspec/extensions/adk/_types.py" in payload["compiled_modules"]
     assert "sqlspec/extensions/adk/memory/_types.py" in payload["compiled_modules"]
     assert "sqlspec/extensions/adk/artifact/_types.py" in payload["compiled_modules"]
-    assert "sqlspec/extensions/fastapi/providers.py" in payload["compiled_modules"]
-    assert "sqlspec/extensions/litestar/providers.py" in payload["compiled_modules"]
     assert "sqlspec/migrations/runner.py" in payload["compiled_modules"]
     assert "sqlspec/observability/_formatting.py" in payload["compiled_modules"]
     assert "sqlspec/utils/env.py" in payload["compiled_modules"]
@@ -150,6 +146,8 @@ def test_inventory_records_rest_of_mypyc_boundary_decisions() -> None:
     assert "sqlspec/dialects/spanner/_spangres.py" in payload["interpreted_modules"]
     assert "sqlspec/dialects/spanner/_spanner.py" in payload["interpreted_modules"]
     assert "sqlspec/extensions/adk/converters.py" in payload["interpreted_modules"]
+    assert "sqlspec/extensions/fastapi/providers.py" in payload["interpreted_modules"]
+    assert "sqlspec/extensions/litestar/providers.py" in payload["interpreted_modules"]
     assert "sqlspec/storage/_arrow_payload.py" in payload["interpreted_modules"]
     assert "sqlspec/extensions/adk/converters.py" in payload["preserved_exclusions"]
     assert payload["adapter_pool_runtimes"]["status"] == "compiled"

--- a/tests/unit/utils/test_mypyc_smoke.py
+++ b/tests/unit/utils/test_mypyc_smoke.py
@@ -69,8 +69,6 @@ def test_smoke_matrix_covers_compiled_wheel_import_surfaces() -> None:
         "env_utils",
         "event_payload",
         "event_queue",
-        "fastapi_providers",
-        "litestar_providers",
         "migration_runner",
         "sqlite_pool",
         "sqlite_type_converter",

--- a/tests/unit/utils/test_mypyc_smoke.py
+++ b/tests/unit/utils/test_mypyc_smoke.py
@@ -1,10 +1,16 @@
 """Tests for the compiled-wheel smoke matrix."""
 
 import importlib.util
+from collections.abc import Sequence
 from pathlib import Path
 from types import ModuleType
 
 from pytest import MonkeyPatch
+
+try:
+    import tomllib  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
@@ -17,6 +23,20 @@ def _load_mypyc_smoke_module() -> ModuleType:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def _load_mypyc_include_paths() -> set[str]:
+    pyproject = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text())
+    include_patterns: Sequence[str] = pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["hooks"]["mypyc"][
+        "include"
+    ]
+    paths: set[str] = set()
+    for pattern in include_patterns:
+        if any(marker in pattern for marker in "*?["):
+            paths.update(path.relative_to(PROJECT_ROOT).as_posix() for path in PROJECT_ROOT.glob(pattern))
+        else:
+            paths.add(pattern)
+    return paths
 
 
 def test_smoke_matrix_covers_compiled_wheel_import_surfaces() -> None:
@@ -60,6 +80,16 @@ def test_smoke_matrix_covers_compiled_wheel_import_surfaces() -> None:
     }
 
 
+def test_compiled_smoke_requirements_are_in_mypyc_include_list() -> None:
+    module = _load_mypyc_smoke_module()
+    included_paths = _load_mypyc_include_paths()
+
+    missing = [entry.module.replace(".", "/") + ".py" for entry in module.SMOKE_IMPORTS if entry.require_compiled]
+    missing = [path for path in missing if path not in included_paths]
+
+    assert missing == []
+
+
 def test_smoke_runner_imports_matrix_without_requiring_compilation() -> None:
     module = _load_mypyc_smoke_module()
 
@@ -72,6 +102,15 @@ def test_smoke_runner_imports_matrix_without_requiring_compilation() -> None:
     assert any(result["module"] == "sqlspec.migrations.runner" for result in results)
     assert any(result["module"] == "sqlspec.utils.env" for result in results)
     assert any(result["module"] == "sqlspec.utils.sync_tools" for result in results)
+
+
+def test_construction_checks_build_provider_signatures_without_requiring_compilation() -> None:
+    module = _load_mypyc_smoke_module()
+
+    results = module.run_construction_checks(require_compiled=False)
+
+    assert all(result["imported"] or result["skipped"] for result in results)
+    assert {result["name"] for result in results} == {"fastapi_filter_construction", "litestar_filter_construction"}
 
 
 def test_smoke_runner_skips_optional_adk_dependency(monkeypatch: MonkeyPatch) -> None:

--- a/tests/unit/utils/test_mypyc_smoke.py
+++ b/tests/unit/utils/test_mypyc_smoke.py
@@ -26,8 +26,10 @@ def test_smoke_matrix_covers_compiled_wheel_import_surfaces() -> None:
 
     assert {
         "package",
+        "async_bridge",
         "core_statement",
         "builder_select",
+        "env_utils",
         "sync_driver",
         "async_driver",
         "storage_registry",
@@ -39,10 +41,12 @@ def test_smoke_matrix_covers_compiled_wheel_import_surfaces() -> None:
     assert compiled_required == {
         "async_driver",
         "adk_record_types",
+        "async_bridge",
         "builder_select",
         "core_statement",
         "data_dictionary_loader",
         "data_dictionary_registry",
+        "env_utils",
         "event_payload",
         "event_queue",
         "fastapi_providers",
@@ -66,6 +70,8 @@ def test_smoke_runner_imports_matrix_without_requiring_compilation() -> None:
     assert any(result["module"] == "sqlspec.adapters.sqlite.type_converter" for result in results)
     assert any(result["module"] == "sqlspec.storage.pipeline" for result in results)
     assert any(result["module"] == "sqlspec.migrations.runner" for result in results)
+    assert any(result["module"] == "sqlspec.utils.env" for result in results)
+    assert any(result["module"] == "sqlspec.utils.sync_tools" for result in results)
 
 
 def test_smoke_runner_skips_optional_adk_dependency(monkeypatch: MonkeyPatch) -> None:

--- a/tests/unit/utils/test_portal.py
+++ b/tests/unit/utils/test_portal.py
@@ -1,6 +1,7 @@
 """Unit tests for portal provider and portal manager."""
 
 import asyncio
+import contextvars
 import queue
 from collections.abc import Callable, Coroutine, Generator
 from typing import Any
@@ -97,6 +98,23 @@ def test_portal_provider_call(async_multiply: Callable[[int], Coroutine[Any, Any
     assert result == 10
 
     provider.stop()
+
+
+def test_portal_provider_call_preserves_caller_contextvars() -> None:
+    """PortalProvider.call propagates caller context into the portal coroutine."""
+    request_id: contextvars.ContextVar[str] = contextvars.ContextVar("portal_request_id")
+    token = request_id.set("portal-context")
+
+    async def read_context() -> str:
+        return request_id.get()
+
+    provider = PortalProvider()
+    provider.start()
+    try:
+        assert provider.call(read_context) == "portal-context"
+    finally:
+        provider.stop()
+        request_id.reset(token)
 
 
 def test_portal_provider_call_after_stop(async_add: Callable[[int, int], Coroutine[Any, Any, int]]) -> None:
@@ -254,6 +272,8 @@ def test_portal_manager_restarts_after_pid_change(monkeypatch: Any) -> None:
 
     assert portal2 is not portal1
     assert provider2 is not provider1
+    assert provider1 is not None
+    assert not provider1.is_running
 
     manager.stop()
 

--- a/tests/unit/utils/test_sync_tools.py
+++ b/tests/unit/utils/test_sync_tools.py
@@ -7,6 +7,10 @@ capacity limiting, and async context management.
 """
 
 import asyncio
+import concurrent.futures
+import contextvars
+import threading
+import time
 from typing import Any
 
 import pytest
@@ -200,6 +204,193 @@ async def test_async_with_limiter() -> None:
     async_version = async_(sync_function, limiter=limiter)
     result = await async_version(2)
     assert result == 10
+
+
+async def test_async_default_path_preserves_contextvars() -> None:
+    """Default async_ offload keeps asyncio.to_thread context propagation."""
+    request_id: contextvars.ContextVar[str] = contextvars.ContextVar("request_id")
+    request_id.set("default-context")
+
+    def sync_function() -> str:
+        return request_id.get()
+
+    async_version = async_(sync_function)
+
+    assert await async_version() == "default-context"
+
+
+async def test_async_explicit_executor_runs_on_that_executor() -> None:
+    """Explicit executor routes sync work through the caller-provided pool."""
+
+    def sync_function() -> str:
+        return threading.current_thread().name
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1, thread_name_prefix="sqlspec-test-explicit") as executor:
+        async_version = async_(sync_function, executor=executor)
+
+        assert (await async_version()).startswith("sqlspec-test-explicit")
+
+
+async def test_async_explicit_executor_preserves_contextvars() -> None:
+    """Explicit run_in_executor path copies caller contextvars."""
+    request_id: contextvars.ContextVar[str] = contextvars.ContextVar("request_id")
+    request_id.set("explicit-context")
+
+    def sync_function() -> str:
+        return request_id.get()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        async_version = async_(sync_function, executor=executor)
+
+        assert await async_version() == "explicit-context"
+
+
+async def test_async_limiter_wraps_executor_backed_calls() -> None:
+    """CapacityLimiter applies before dispatching to explicit executors."""
+    active = 0
+    max_active = 0
+    lock = threading.Lock()
+    limiter = CapacityLimiter(1)
+
+    def sync_function() -> int:
+        nonlocal active, max_active
+        with lock:
+            active += 1
+            max_active = max(max_active, active)
+        time.sleep(0.01)
+        with lock:
+            active -= 1
+        return max_active
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+        async_version = async_(sync_function, limiter=limiter, executor=executor)
+
+        results = await asyncio.gather(*(async_version() for _ in range(5)))
+
+    assert results == [1, 1, 1, 1, 1]
+    assert max_active == 1
+
+
+async def test_async_explicit_executor_propagates_exceptions() -> None:
+    """Exceptions from executor-backed calls propagate unchanged."""
+
+    def sync_function() -> None:
+        raise ValueError("executor error")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        async_version = async_(sync_function, executor=executor)
+
+        with pytest.raises(ValueError, match="executor error"):
+            await async_version()
+
+
+async def test_async_env_thread_limit_enables_managed_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SQLSPEC_ASYNC_THREAD_LIMIT opts async_ into SQLSpec's managed executor."""
+    monkeypatch.setenv("SQLSPEC_ASYNC_THREAD_LIMIT", "1")
+
+    def sync_function() -> str:
+        return threading.current_thread().name
+
+    try:
+        async_version = async_(sync_function)
+
+        thread_name = await async_version()
+        executor = _sync_tools_module.get_default_async_executor()
+
+        assert thread_name.startswith("sqlspec-async")
+        assert isinstance(executor, concurrent.futures.ThreadPoolExecutor)
+        assert executor._max_workers == 1  # pyright: ignore[reportPrivateUsage]
+    finally:
+        _sync_tools_module.shutdown_default_async_executor()
+
+
+def test_enable_default_async_thread_pool_reuses_pool_across_event_loops() -> None:
+    """Programmatic managed pool is process-wide instead of per-event-loop."""
+
+    def sync_function() -> int:
+        return threading.get_ident()
+
+    async def run_sync_function() -> int:
+        return await async_(sync_function)()
+
+    try:
+        _sync_tools_module.enable_default_async_thread_pool(max_workers=1)
+
+        first_thread = asyncio.run(run_sync_function())
+        second_thread = asyncio.run(run_sync_function())
+
+        assert first_thread == second_thread
+    finally:
+        _sync_tools_module.shutdown_default_async_executor()
+
+
+async def test_set_default_async_executor_wins_over_env_managed_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Caller-owned default executor takes precedence over env-managed pools."""
+    monkeypatch.setenv("SQLSPEC_ASYNC_THREAD_LIMIT", "1")
+
+    def sync_function() -> str:
+        return threading.current_thread().name
+
+    caller_executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="sqlspec-test-caller-owned"
+    )
+    try:
+        _sync_tools_module.set_default_async_executor(caller_executor)
+        async_version = async_(sync_function)
+
+        assert (await async_version()).startswith("sqlspec-test-caller-owned")
+    finally:
+        _sync_tools_module.shutdown_default_async_executor()
+        caller_executor.shutdown(wait=False)
+
+
+def test_default_async_executor_pid_change_rebuilds_managed_and_clears_caller_owned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PID changes rebuild managed pools and clear caller-owned defaults."""
+    try:
+        _sync_tools_module.enable_default_async_thread_pool(max_workers=1)
+        managed_executor = _sync_tools_module.get_default_async_executor()
+        monkeypatch.setattr(_sync_tools_module, "_managed_async_executor_pid", -1)
+
+        rebuilt_executor = _sync_tools_module.get_default_async_executor()
+
+        assert rebuilt_executor is not managed_executor
+    finally:
+        _sync_tools_module.shutdown_default_async_executor()
+
+    caller_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        _sync_tools_module.set_default_async_executor(caller_executor)
+        monkeypatch.setattr(_sync_tools_module, "_default_async_executor_pid", -1)
+
+        assert _sync_tools_module.get_default_async_executor() is None
+    finally:
+        _sync_tools_module.shutdown_default_async_executor()
+        caller_executor.shutdown(wait=False)
+
+
+def test_shutdown_default_async_executor_shuts_down_only_managed_pool() -> None:
+    """Shutdown owns managed pools but leaves caller-owned executors running."""
+    _sync_tools_module.enable_default_async_thread_pool(max_workers=1)
+    managed_executor = _sync_tools_module.get_default_async_executor()
+
+    _sync_tools_module.shutdown_default_async_executor()
+
+    assert isinstance(managed_executor, concurrent.futures.ThreadPoolExecutor)
+    with pytest.raises(RuntimeError, match="cannot schedule new futures"):
+        managed_executor.submit(lambda: None)
+
+    caller_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        _sync_tools_module.set_default_async_executor(caller_executor)
+
+        _sync_tools_module.shutdown_default_async_executor()
+
+        assert caller_executor.submit(lambda: 1).result() == 1
+        assert _sync_tools_module.get_default_async_executor() is None
+    finally:
+        caller_executor.shutdown(wait=False)
 
 
 async def test_ensure_async_with_async_function() -> None:

--- a/tests/unit/utils/test_sync_tools.py
+++ b/tests/unit/utils/test_sync_tools.py
@@ -9,6 +9,7 @@ capacity limiting, and async context management.
 import asyncio
 import concurrent.futures
 import contextvars
+import inspect
 import threading
 import time
 from typing import Any
@@ -100,6 +101,30 @@ def test_run_basic() -> None:
 
     result = async_function(5)
     assert result == 10
+
+
+def test_async_public_signature_exposes_executor_parameter() -> None:
+    """async_ keeps executor as an additive keyword-only parameter."""
+    signature = inspect.signature(async_)
+
+    assert list(signature.parameters) == ["function", "limiter", "executor"]
+    assert signature.parameters["limiter"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert signature.parameters["executor"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert signature.parameters["executor"].default is None
+
+
+def test_wrappers_preserve_wrapped_function_signature_metadata() -> None:
+    """Public wrapper factories preserve callable metadata for introspection."""
+
+    def sync_function(value: int, *, flag: bool = False) -> str:
+        return f"{value}:{flag}"
+
+    async def async_function(value: int, *, flag: bool = False) -> str:
+        return f"{value}:{flag}"
+
+    for wrapper in (async_(sync_function), ensure_async_(sync_function), run_(async_function), await_(async_function)):
+        assert wrapper.__name__ in {"sync_function", "async_function"}
+        assert inspect.signature(wrapper) == inspect.signature(sync_function)
 
 
 def test_run_with_exception() -> None:

--- a/tests/unit/utils/test_sync_tools.py
+++ b/tests/unit/utils/test_sync_tools.py
@@ -12,7 +12,7 @@ import contextvars
 import inspect
 import threading
 import time
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from typing_extensions import Self
@@ -256,6 +256,14 @@ async def test_async_explicit_executor_runs_on_that_executor() -> None:
         assert (await async_version()).startswith("sqlspec-test-explicit")
 
 
+def test_async_rejects_process_pool_executor() -> None:
+    """async_ requires thread executors because it preserves contextvars."""
+
+    with concurrent.futures.ProcessPoolExecutor(max_workers=1) as executor:
+        with pytest.raises(TypeError, match="ThreadPoolExecutor"):
+            async_(lambda: None, executor=cast("concurrent.futures.ThreadPoolExecutor", executor))
+
+
 async def test_async_explicit_executor_preserves_contextvars() -> None:
     """Explicit run_in_executor path copies caller contextvars."""
     request_id: contextvars.ContextVar[str] = contextvars.ContextVar("request_id")
@@ -367,6 +375,14 @@ async def test_set_default_async_executor_wins_over_env_managed_pool(monkeypatch
     finally:
         _sync_tools_module.shutdown_default_async_executor()
         caller_executor.shutdown(wait=False)
+
+
+def test_set_default_async_executor_rejects_process_pool_executor() -> None:
+    """Process pools are not valid defaults for the context-preserving bridge."""
+
+    with concurrent.futures.ProcessPoolExecutor(max_workers=1) as executor:
+        with pytest.raises(TypeError, match="ThreadPoolExecutor"):
+            _sync_tools_module.set_default_async_executor(cast("concurrent.futures.ThreadPoolExecutor", executor))
 
 
 def test_default_async_executor_pid_change_rebuilds_managed_and_clears_caller_owned(

--- a/tests/unit/utils/test_sync_tools.py
+++ b/tests/unit/utils/test_sync_tools.py
@@ -232,7 +232,7 @@ async def test_async_with_limiter() -> None:
 
 
 async def test_async_default_path_preserves_contextvars() -> None:
-    """Default async_ offload keeps asyncio.to_thread context propagation."""
+    """Default async_ offload keeps context propagation through SQLSpec's managed pool."""
     request_id: contextvars.ContextVar[str] = contextvars.ContextVar("request_id")
     request_id.set("default-context")
 
@@ -242,6 +242,26 @@ async def test_async_default_path_preserves_contextvars() -> None:
     async_version = async_(sync_function)
 
     assert await async_version() == "default-context"
+
+
+async def test_async_default_uses_managed_pool_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """async_ uses SQLSpec's bounded managed pool by default."""
+    monkeypatch.delenv("SQLSPEC_ASYNC_THREAD_LIMIT", raising=False)
+
+    def sync_function() -> str:
+        return threading.current_thread().name
+
+    try:
+        async_version = async_(sync_function)
+
+        thread_name = await async_version()
+        executor = _sync_tools_module.get_default_async_executor()
+
+        assert thread_name.startswith("sqlspec-async")
+        assert isinstance(executor, concurrent.futures.ThreadPoolExecutor)
+        assert executor._max_workers == _sync_tools_module.DEFAULT_ASYNC_THREAD_LIMIT
+    finally:
+        _sync_tools_module.shutdown_default_async_executor()
 
 
 async def test_async_explicit_executor_runs_on_that_executor() -> None:
@@ -318,7 +338,7 @@ async def test_async_explicit_executor_propagates_exceptions() -> None:
 
 
 async def test_async_env_thread_limit_enables_managed_pool(monkeypatch: pytest.MonkeyPatch) -> None:
-    """SQLSPEC_ASYNC_THREAD_LIMIT opts async_ into SQLSpec's managed executor."""
+    """SQLSPEC_ASYNC_THREAD_LIMIT configures SQLSpec's managed executor."""
     monkeypatch.setenv("SQLSPEC_ASYNC_THREAD_LIMIT", "1")
 
     def sync_function() -> str:
@@ -405,7 +425,10 @@ def test_default_async_executor_pid_change_rebuilds_managed_and_clears_caller_ow
         _sync_tools_module.set_default_async_executor(caller_executor)
         monkeypatch.setattr(_sync_tools_module, "_default_async_executor_pid", -1)
 
-        assert _sync_tools_module.get_default_async_executor() is None
+        fallback_executor = _sync_tools_module.get_default_async_executor()
+
+        assert fallback_executor is not caller_executor
+        assert isinstance(fallback_executor, concurrent.futures.ThreadPoolExecutor)
     finally:
         _sync_tools_module.shutdown_default_async_executor()
         caller_executor.shutdown(wait=False)
@@ -429,9 +452,13 @@ def test_shutdown_default_async_executor_shuts_down_only_managed_pool() -> None:
         _sync_tools_module.shutdown_default_async_executor()
 
         assert caller_executor.submit(lambda: 1).result() == 1
-        assert _sync_tools_module.get_default_async_executor() is None
+        next_executor = _sync_tools_module.get_default_async_executor()
+
+        assert next_executor is not caller_executor
+        assert isinstance(next_executor, concurrent.futures.ThreadPoolExecutor)
     finally:
         caller_executor.shutdown(wait=False)
+        _sync_tools_module.shutdown_default_async_executor()
 
 
 async def test_ensure_async_with_async_function() -> None:

--- a/tools/scripts/mypyc_inventory.py
+++ b/tools/scripts/mypyc_inventory.py
@@ -174,12 +174,12 @@ HOT_SURFACE_CLASSIFICATIONS: dict[str, dict[str, str]] = {
         "reason": "Imports Google ADK models at module import time and keeps Pydantic model reconstruction interpreted.",
     },
     "sqlspec/extensions/fastapi/providers.py": {
-        "classification": "keep_interpreted",
-        "reason": "Compiled providers crash on copy.deepcopy via mypyc native cls.__new__ -> __init__() chain; providers precompute signatures once per FilterConfig and are cached in dep_cache, so the mypyc win is boot-only.",
+        "classification": "compile_now",
+        "reason": "Compiled provider construction is covered by the wheel smoke; dependency signatures are cached per FilterConfig.",
     },
     "sqlspec/extensions/litestar/providers.py": {
-        "classification": "keep_interpreted",
-        "reason": "Compiled providers crash on copy.deepcopy via mypyc native cls.__new__ -> __init__() chain; providers precompute signatures once per FilterConfig and are cached in dep_cache, so the mypyc win is boot-only.",
+        "classification": "compile_now",
+        "reason": "Compiled provider construction is covered by the wheel smoke; dependency signatures are cached per FilterConfig.",
     },
     "sqlspec/migrations/commands.py": {
         "classification": "keep_interpreted",

--- a/tools/scripts/mypyc_inventory.py
+++ b/tools/scripts/mypyc_inventory.py
@@ -174,12 +174,18 @@ HOT_SURFACE_CLASSIFICATIONS: dict[str, dict[str, str]] = {
         "reason": "Imports Google ADK models at module import time and keeps Pydantic model reconstruction interpreted.",
     },
     "sqlspec/extensions/fastapi/providers.py": {
-        "classification": "compile_now",
-        "reason": "Compiled provider construction is covered by the wheel smoke; dependency signatures are cached per FilterConfig.",
+        "classification": "keep_interpreted",
+        "reason": (
+            "Provider signature construction stays interpreted; direct mypyc compilation has passed historically, "
+            "but the runtime provider boundary has had compiled-wheel issues."
+        ),
     },
     "sqlspec/extensions/litestar/providers.py": {
-        "classification": "compile_now",
-        "reason": "Compiled provider construction is covered by the wheel smoke; dependency signatures are cached per FilterConfig.",
+        "classification": "keep_interpreted",
+        "reason": (
+            "Provider signature construction stays interpreted; direct mypyc compilation has passed historically, "
+            "but the runtime provider boundary has had compiled-wheel issues."
+        ),
     },
     "sqlspec/migrations/commands.py": {
         "classification": "keep_interpreted",

--- a/tools/scripts/mypyc_inventory.py
+++ b/tools/scripts/mypyc_inventory.py
@@ -233,6 +233,10 @@ HOT_SURFACE_CLASSIFICATIONS: dict[str, dict[str, str]] = {
         "classification": "compile_now",
         "reason": "Hot async bridge helpers are already in the include set.",
     },
+    "sqlspec/utils/env.py": {
+        "classification": "compile_now",
+        "reason": "Typed environment parsing utility is pure runtime logic and feeds compiled async bridge configuration.",
+    },
     "sqlspec/utils/schema.py": {
         "classification": "compile_now",
         "reason": "Core schema conversion path is already compiled and actively optimized.",

--- a/tools/scripts/mypyc_smoke.py
+++ b/tools/scripts/mypyc_smoke.py
@@ -24,8 +24,10 @@ class SmokeImport(NamedTuple):
 
 SMOKE_IMPORTS: tuple[SmokeImport, ...] = (
     SmokeImport("package", "sqlspec"),
+    SmokeImport("async_bridge", "sqlspec.utils.sync_tools", "async_", True),
     SmokeImport("core_statement", "sqlspec.core.statement", "SQL", True),
     SmokeImport("builder_select", "sqlspec.builder._select", "Select", True),
+    SmokeImport("env_utils", "sqlspec.utils.env", "get_env", True),
     SmokeImport("sync_driver", "sqlspec.driver._sync", "SyncDriverAdapterBase", True),
     SmokeImport("async_driver", "sqlspec.driver._async", "AsyncDriverAdapterBase", True),
     SmokeImport("storage_registry", "sqlspec.storage.registry", "StorageRegistry", True),

--- a/tools/scripts/mypyc_smoke.py
+++ b/tools/scripts/mypyc_smoke.py
@@ -167,9 +167,92 @@ def _check_litestar_filter_construction(*, require_compiled: bool) -> dict[str, 
     return result
 
 
+def _check_fastapi_filter_construction(*, require_compiled: bool) -> dict[str, Any]:
+    """Construct every generated FastAPI filter provider under the compiled wheel."""
+    result: dict[str, Any] = {
+        "name": "fastapi_filter_construction",
+        "module": "sqlspec.extensions.fastapi.providers",
+        "attribute": "provide_filters",
+        "imported": False,
+        "compiled": False,
+        "compiled_required": require_compiled,
+        "error": None,
+        "skipped": False,
+        "skip_reason": None,
+    }
+    try:
+        providers = importlib.import_module("sqlspec.extensions.fastapi.providers")
+    except ModuleNotFoundError as exc:
+        if _is_missing_optional_dependency(exc.name or "", "fastapi"):
+            result["skipped"] = True
+            result["skip_reason"] = "optional dependency missing: fastapi"
+            return result
+        result["error"] = f"{type(exc).__name__}: {exc}"
+        return result
+    except Exception as exc:
+        result["error"] = f"{type(exc).__name__}: {exc}"
+        return result
+
+    result["imported"] = True
+    result["compiled"] = is_compiled_module(providers)
+    if require_compiled and not result["compiled"]:
+        result["error"] = "module was imported from Python source, not a compiled extension"
+        return result
+
+    config = providers.FilterConfig(
+        id_filter=int,
+        created_at=True,
+        updated_at=True,
+        pagination_type="limit_offset",
+        pagination_size=25,
+        search=["name", "email"],
+        search_ignore_case=True,
+        sort_field=["created_at", "name"],
+        sort_order="asc",
+        not_in_fields=[providers.FieldNameType("status")],
+        in_fields=[providers.FieldNameType("role")],
+        null_fields=["deleted_at"],
+        not_null_fields=["published_at"],
+        boolean_fields=["active"],
+        choice_fields=[providers.ChoiceField("kind", ["a", "b"])],
+    )
+    try:
+        dependency = providers.provide_filters(config)
+    except Exception as exc:
+        result["error"] = f"{type(exc).__name__}: {exc}"
+        return result
+
+    signature = getattr(dependency, "__signature__", None)
+    if signature is None:
+        result["error"] = "provide_filters returned dependency without __signature__"
+        return result
+
+    expected = {
+        "active_boolean_filter",
+        "created_filter",
+        "deleted_at_null_filter",
+        "id_filter",
+        "kind_choices_filter",
+        "limit_offset_filter",
+        "order_by_filter",
+        "published_at_not_null_filter",
+        "role_in_filter",
+        "search_filter",
+        "status_not_in_filter",
+        "updated_filter",
+    }
+    missing = sorted(expected - signature.parameters.keys())
+    if missing:
+        result["error"] = f"provide_filters returned without expected parameters: {missing}"
+    return result
+
+
 def run_construction_checks(*, require_compiled: bool = False) -> list[dict[str, Any]]:
     """Run construction-time smoke checks for compiled provider classes."""
-    return [_check_litestar_filter_construction(require_compiled=require_compiled)]
+    return [
+        _check_fastapi_filter_construction(require_compiled=require_compiled),
+        _check_litestar_filter_construction(require_compiled=require_compiled),
+    ]
 
 
 def _failed_results(results: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tools/scripts/mypyc_smoke.py
+++ b/tools/scripts/mypyc_smoke.py
@@ -37,9 +37,9 @@ SMOKE_IMPORTS: tuple[SmokeImport, ...] = (
     SmokeImport("data_dictionary_loader", "sqlspec.data_dictionary._loader", "DataDictionaryLoader", True),
     SmokeImport("pgvector_dialect", "sqlspec.dialects.postgres._pgvector", "PGVector"),
     SmokeImport("spanner_dialect", "sqlspec.dialects.spanner._spanner", "Spanner"),
-    SmokeImport("fastapi_providers", "sqlspec.extensions.fastapi.providers", "provide_filters", True, "fastapi"),
+    SmokeImport("fastapi_providers", "sqlspec.extensions.fastapi.providers", "provide_filters", False, "fastapi"),
     SmokeImport(
-        "litestar_providers", "sqlspec.extensions.litestar.providers", "create_filter_dependencies", True, "litestar"
+        "litestar_providers", "sqlspec.extensions.litestar.providers", "create_filter_dependencies", False, "litestar"
     ),
     SmokeImport("event_payload", "sqlspec.extensions.events._payload", "encode_notify_payload", True),
     SmokeImport("event_queue", "sqlspec.extensions.events._queue", "SyncTableEventQueue", True),
@@ -102,17 +102,14 @@ def run_smoke(*, require_compiled: bool = False) -> list[dict[str, Any]]:
     return results
 
 
-def _check_litestar_filter_construction(*, require_compiled: bool) -> dict[str, Any]:
+def _check_litestar_filter_construction() -> dict[str, Any]:
     """Construct every paired-annotation Litestar filter provider (issue #475).
 
-    The originally reported failure — ``UnboundLocalError: local variable
-    "before_annotation" referenced before assignment`` — only fires when
-    ``_BeforeAfterFilterProvider.__init__`` runs under a mypyc-compiled wheel.
-    Plain imports do not trigger it, so this check invokes
-    ``create_filter_dependencies`` with a config that drives every provider
-    class with two ``Annotated`` locals: ``_BeforeAfterFilterProvider`` (twice,
-    via ``created_at`` and ``updated_at``), ``_LimitOffsetFilterProvider``,
-    ``_SearchFilterProvider``, and ``_OrderByProvider``.
+    This invokes ``create_filter_dependencies`` with a config that drives every
+    provider class with two ``Annotated`` locals: ``_BeforeAfterFilterProvider``
+    (twice, via ``created_at`` and ``updated_at``),
+    ``_LimitOffsetFilterProvider``, ``_SearchFilterProvider``, and
+    ``_OrderByProvider``. The provider module intentionally remains interpreted.
     """
     result: dict[str, Any] = {
         "name": "litestar_filter_construction",
@@ -120,7 +117,7 @@ def _check_litestar_filter_construction(*, require_compiled: bool) -> dict[str, 
         "attribute": "create_filter_dependencies",
         "imported": False,
         "compiled": False,
-        "compiled_required": require_compiled,
+        "compiled_required": False,
         "error": None,
         "skipped": False,
         "skip_reason": None,
@@ -140,10 +137,6 @@ def _check_litestar_filter_construction(*, require_compiled: bool) -> dict[str, 
 
     result["imported"] = True
     result["compiled"] = is_compiled_module(providers)
-    if require_compiled and not result["compiled"]:
-        result["error"] = "module was imported from Python source, not a compiled extension"
-        return result
-
     config = providers.FilterConfig(
         created_at=True,
         updated_at=True,
@@ -167,15 +160,15 @@ def _check_litestar_filter_construction(*, require_compiled: bool) -> dict[str, 
     return result
 
 
-def _check_fastapi_filter_construction(*, require_compiled: bool) -> dict[str, Any]:
-    """Construct every generated FastAPI filter provider under the compiled wheel."""
+def _check_fastapi_filter_construction() -> dict[str, Any]:
+    """Construct every generated FastAPI filter provider."""
     result: dict[str, Any] = {
         "name": "fastapi_filter_construction",
         "module": "sqlspec.extensions.fastapi.providers",
         "attribute": "provide_filters",
         "imported": False,
         "compiled": False,
-        "compiled_required": require_compiled,
+        "compiled_required": False,
         "error": None,
         "skipped": False,
         "skip_reason": None,
@@ -195,10 +188,6 @@ def _check_fastapi_filter_construction(*, require_compiled: bool) -> dict[str, A
 
     result["imported"] = True
     result["compiled"] = is_compiled_module(providers)
-    if require_compiled and not result["compiled"]:
-        result["error"] = "module was imported from Python source, not a compiled extension"
-        return result
-
     config = providers.FilterConfig(
         id_filter=int,
         created_at=True,
@@ -248,11 +237,9 @@ def _check_fastapi_filter_construction(*, require_compiled: bool) -> dict[str, A
 
 
 def run_construction_checks(*, require_compiled: bool = False) -> list[dict[str, Any]]:
-    """Run construction-time smoke checks for compiled provider classes."""
-    return [
-        _check_fastapi_filter_construction(require_compiled=require_compiled),
-        _check_litestar_filter_construction(require_compiled=require_compiled),
-    ]
+    """Run construction-time smoke checks for provider classes."""
+    del require_compiled
+    return [_check_fastapi_filter_construction(), _check_litestar_filter_construction()]
 
 
 def _failed_results(results: list[dict[str, Any]]) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary

- add typed environment helpers for SQLSpec runtime settings
- add bounded `ThreadPoolExecutor` controls for `sqlspec.utils.sync_tools.async_()`, including `SQLSPEC_ASYNC_THREAD_LIMIT` and programmatic executor APIs
- preserve `contextvars` through explicit and shared thread executors, and continue rejecting process executors