### PR TITLE
test: cover GizmoSQL native metadata fallback

### DIFF
--- a/docs/reference/adapters/adbc.rst
+++ b/docs/reference/adapters/adbc.rst
@@ -267,7 +267,11 @@ SQLSpec does not define a portable SQL statistics contract. It wraps
      - Unsupported (raises ``OperationalError``)
    * - Flight SQL / GizmoSQL
      - Native overlay is server dependent; central dialect fallback applies
-       when the backend dialect is mapped
+       when the backend dialect is mapped. DuckDB-backed GizmoSQL exposes
+       catalogs, schemas, tables, columns, and constraints through
+       ``GetObjects`` when the server returns a complete payload; incomplete
+       constraint or nullability metadata falls back to SQLSpec's central
+       dialect SQL.
      - Server dependent
    * - BigQuery
      - Central BigQuery SQL fallback

--- a/tests/integration/adapters/adbc/test_gizmosql_data_dictionary.py
+++ b/tests/integration/adapters/adbc/test_gizmosql_data_dictionary.py
@@ -1,7 +1,7 @@
 """GizmoSQL data dictionary and migration integration tests for ADBC."""
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -13,10 +13,16 @@ from tests.integration.adapters.adbc.conftest import xfail_if_driver_missing
 pytestmark = [pytest.mark.adbc, pytest.mark.xdist_group("gizmosql")]
 
 
+def _get_objects_dict_list(value: object) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [cast("dict[str, Any]", item) for item in value if isinstance(item, dict)]
+
+
 def _find_get_objects_table(rows: list[dict[str, Any]], table_name: str) -> dict[str, Any] | None:
     for catalog in rows:
-        for db_schema in catalog.get("catalog_db_schemas") or []:
-            for table in db_schema.get("db_schema_tables") or []:
+        for db_schema in _get_objects_dict_list(catalog.get("catalog_db_schemas")):
+            for table in _get_objects_dict_list(db_schema.get("db_schema_tables")):
                 if table.get("table_name") == table_name:
                     return table
     return None

--- a/tests/integration/adapters/adbc/test_gizmosql_data_dictionary.py
+++ b/tests/integration/adapters/adbc/test_gizmosql_data_dictionary.py
@@ -13,6 +13,15 @@ from tests.integration.adapters.adbc.conftest import xfail_if_driver_missing
 pytestmark = [pytest.mark.adbc, pytest.mark.xdist_group("gizmosql")]
 
 
+def _find_get_objects_table(rows: list[dict[str, Any]], table_name: str) -> dict[str, Any] | None:
+    for catalog in rows:
+        for db_schema in catalog.get("catalog_db_schemas") or []:
+            for table in db_schema.get("db_schema_tables") or []:
+                if table.get("table_name") == table_name:
+                    return table
+    return None
+
+
 @xfail_if_driver_missing
 def test_gizmosql_data_dictionary_tables_columns_and_indexes(adbc_gizmosql_session: AdbcDriver) -> None:
     """GizmoSQL should expose DuckDB table and column metadata through the ADBC dictionary."""
@@ -50,6 +59,26 @@ def test_gizmosql_data_dictionary_tables_columns_and_indexes(adbc_gizmosql_sessi
     ).get_data()
     assert schema_rows
     schema_name = schema_rows[0]["table_schema"]
+
+    raw_objects = (
+        adbc_gizmosql_session.connection
+        .adbc_get_objects(depth="all", db_schema_filter=schema_name, table_name_filter="gizmosql_dd_child_adbc")
+        .read_all()
+        .to_pylist()
+    )
+    assert isinstance(raw_objects, list)
+    raw_child = _find_get_objects_table(raw_objects, "gizmosql_dd_child_adbc")
+    assert raw_child is not None
+    assert {column["column_name"] for column in raw_child.get("table_columns") or []} == {
+        "id",
+        "parent_id",
+        "amount",
+        "created_at",
+    }
+    constraints = raw_child.get("table_constraints") or []
+    if not constraints:
+        pytest.xfail("GizmoSQL FlightSQL GetObjects did not return constraints; SQLSpec must use central fallback")
+    assert any(str(constraint.get("constraint_type")).upper() == "FOREIGN KEY" for constraint in constraints)
 
     table_names = {table["table_name"] for table in dictionary.get_tables(adbc_gizmosql_session, schema=schema_name)}
     assert {"gizmosql_dd_parent_adbc", "gizmosql_dd_child_adbc"}.issubset(table_names)


### PR DESCRIPTION
## Summary
- add live GizmoSQL/FlightSQL `GetObjects` coverage for catalog/schema/table/column payload shape
- document that DuckDB-backed GizmoSQL native metadata is used only when complete, with central dialect SQL fallback for incomplete constraints/nullability
- keep the follow-up separate from merged PR #522

## Validation
- `uv run pytest tests/unit/adapters/test_adbc/test_data_dictionary.py tests/integration/adapters/adbc/test_gizmosql_data_dictionary.py` (`26 passed, 1 xfailed`)
- `make docs`
- `make lint`