### PR TITLE
fix(core): land four latent correctness bugs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -65,6 +65,9 @@ v0.51.0 - ADK 2.0 clean-break store contract
 * ``SQLProcessor.clear_cache()`` now resets the single-entry micro-cache, so the
   next compile of a previously compiled statement is recorded as a miss and
   repopulates the cache instead of returning a stale result.
+* The SQL statement splitter caches results on the script text rather than
+  ``hash(sql)``, preventing a hash collision between two distinct scripts from
+  returning the wrong split.
 
 v0.50.1 - DuckDB extension lifecycle and SQLGlot builder modernization
 ------------------------------------------------------------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -59,6 +59,9 @@ v0.51.0 - ADK 2.0 clean-break store contract
 * Removed a dead ``storage_uri`` key from the artifact-store config
   normalization; the artifact storage URI is supplied to ``ADKArtifactService``
   through its constructor and was never read from the store config.
+* ``DMLResult.all()`` and ``one_or_none()`` no longer raise ``AttributeError``
+  when called with ``schema_type``; the fast DML result path now initializes its
+  schema-row caches.
 
 v0.50.1 - DuckDB extension lifecycle and SQLGlot builder modernization
 ------------------------------------------------------------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -62,6 +62,9 @@ v0.51.0 - ADK 2.0 clean-break store contract
 * ``DMLResult.all()`` and ``one_or_none()`` no longer raise ``AttributeError``
   when called with ``schema_type``; the fast DML result path now initializes its
   schema-row caches.
+* ``SQLProcessor.clear_cache()`` now resets the single-entry micro-cache, so the
+  next compile of a previously compiled statement is recorded as a miss and
+  repopulates the cache instead of returning a stale result.
 
 v0.50.1 - DuckDB extension lifecycle and SQLGlot builder modernization
 ------------------------------------------------------------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -68,6 +68,9 @@ v0.51.0 - ADK 2.0 clean-break store contract
 * The SQL statement splitter caches results on the script text rather than
   ``hash(sql)``, preventing a hash collision between two distinct scripts from
   returning the wrong split.
+* ``hash_parameters`` no longer raises ``TypeError`` for named parameters with
+  unhashable values (for example ``set`` or ``bytearray``); such values now fall
+  back to a stable ``repr``-based key, matching the positional path.
 
 v0.50.1 - DuckDB extension lifecycle and SQLGlot builder modernization
 ------------------------------------------------------------------------------

--- a/sqlspec/core/compiler.py
+++ b/sqlspec/core/compiler.py
@@ -1017,6 +1017,8 @@ class SQLProcessor:
         self._cache.clear()
         self._cache_hits = 0
         self._cache_misses = 0
+        self._last_cache_key = None
+        self._last_result = None
         self._parse_cache.clear()
         self._parse_cache_hits = 0
         self._parse_cache_misses = 0

--- a/sqlspec/core/hashing.py
+++ b/sqlspec/core/hashing.py
@@ -129,7 +129,11 @@ def hash_parameters(
             elif isinstance(value, (list, dict)):
                 hashable_items.append((key, (repr(value), "unhashable")))
             else:
-                hashable_items.append((key, (value, "primitive")))
+                try:
+                    hash(value)
+                    hashable_items.append((key, (value, "primitive")))
+                except TypeError:
+                    hashable_items.append((key, (repr(value), "unhashable_repr")))
         param_hash ^= hash(tuple(hashable_items))
 
     if original_parameters is not None:

--- a/sqlspec/core/result/_base.py
+++ b/sqlspec/core/result/_base.py
@@ -948,6 +948,8 @@ class DMLResult(SQLResult):
         self.parameters = None
         self._row_format = "dict"
         self._materialized_dicts = None
+        self._schema_rows_cache = None
+        self._schema_row_cache = None
 
         self.column_names: list[str] = []
         self.total_count = 0

--- a/sqlspec/core/splitter.py
+++ b/sqlspec/core/splitter.py
@@ -831,8 +831,7 @@ class StatementSplitter:
         Returns:
             List of individual SQL statements
         """
-        script_hash = hash(sql)
-        cache_key = CacheKey(("split", self._dialect.name, script_hash, self._strip_trailing_semicolon))
+        cache_key = CacheKey(("split", self._dialect.name, sql, self._strip_trailing_semicolon))
 
         cached_result = self._result_cache.get(cache_key)
         if cached_result is not None:

--- a/tests/unit/core/test_compiler.py
+++ b/tests/unit/core/test_compiler.py
@@ -236,6 +236,21 @@ def test_sql_processor_custom_cache_size(basic_statement_config: "StatementConfi
     assert processor._parse_cache_max_size == 500
 
 
+def test_clear_cache_resets_micro_cache(basic_statement_config: "StatementConfig") -> None:
+    """clear_cache() must reset the micro-cache so the next compile of the same SQL misses and repopulates the cache."""
+    processor = SQLProcessor(basic_statement_config)
+    sql = "SELECT * FROM users WHERE id = 1"
+
+    processor.compile(sql)
+    processor.clear_cache()
+    processor.compile(sql)
+
+    stats = processor.cache_stats
+    assert stats["size"] == 1
+    assert stats["hits"] == 0
+    assert stats["misses"] == 1
+
+
 def test_basic_compilation(basic_statement_config: "StatementConfig", sample_sql_queries: "dict[str, str]") -> None:
     """Test basic SQL compilation functionality."""
     processor = SQLProcessor(basic_statement_config)

--- a/tests/unit/core/test_hashing.py
+++ b/tests/unit/core/test_hashing.py
@@ -157,6 +157,13 @@ def test_hash_parameters_named_only() -> None:
     assert isinstance(result, int)
 
 
+def test_hash_parameters_named_unhashable_values_do_not_raise() -> None:
+    """Named parameters with unhashable values (set/bytearray) must hash to a stable key, not raise TypeError."""
+    result = hash_parameters(named_parameters={"a": {1, 2, 3}, "b": bytearray(b"xyz")})
+    assert isinstance(result, int)
+    assert result == hash_parameters(named_parameters={"a": {1, 2, 3}, "b": bytearray(b"xyz")})
+
+
 def test_hash_parameters_mixed() -> None:
     """Test hash_parameters with both positional and named parameters."""
     pos_params = ["value1", 42]

--- a/tests/unit/core/test_result.py
+++ b/tests/unit/core/test_result.py
@@ -39,6 +39,18 @@ def test_fast_dml_result_alias_is_not_exported() -> None:
     assert not hasattr(result_package, alias_name)
 
 
+def test_dml_result_schema_type_does_not_raise() -> None:
+    """DMLResult must initialize its schema-row cache slots so schema_type access does not raise."""
+
+    @dataclass
+    class _Row:
+        id: int
+
+    result = result_base.DMLResult("INSERT", 1)
+    assert result.all(schema_type=_Row) == []
+    assert result.one_or_none(schema_type=_Row) is None
+
+
 def test_sql_result_helpers_do_not_upper_operation_type() -> None:
     stmt = SQL("INSERT INTO users (id) VALUES (1)")
     result = SQLResult(statement=stmt, operation_type=_operation_type("INSERT"), rows_affected=1)

--- a/tests/unit/core/test_splitter.py
+++ b/tests/unit/core/test_splitter.py
@@ -54,6 +54,19 @@ def test_contains_executable_content_accepts_pre_tokenized_statement(monkeypatch
     assert splitter._contains_executable_content(tokens) is True
 
 
+def test_split_cache_keys_on_script_text_not_hash(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Splitter result cache must key on script text, not hash(sql); a hash collision must not return the wrong split."""
+    splitter = StatementSplitter(GenericDialectConfig())
+    splitter._result_cache.clear()
+    monkeypatch.setattr(splitter_module, "hash", lambda _sql: 0, raising=False)
+
+    result_a = splitter.split("SELECT 1")
+    result_b = splitter.split("SELECT 2")
+
+    assert result_a == ["SELECT 1"]
+    assert result_b == ["SELECT 2"]
+
+
 def test_contains_executable_content_rejects_comment_only_tokens() -> None:
     splitter = StatementSplitter(GenericDialectConfig())
     tokens = [Token(TokenType.COMMENT_LINE, "-- note", 1, 1, 0), Token(TokenType.WHITESPACE, "\n", 1, 8, 7)]


### PR DESCRIPTION
## Summary

Fixes four latent, behavior-affecting correctness bugs in `sqlspec/core/`. 
## Bugs fixed

- **`fix(result)`** — `DMLResult.__init__` bypasses `SQLResult.__init__` and never initialized `_schema_rows_cache` / `_schema_row_cache`, so `DMLResult.all(schema_type=...)` and `.one_or_none(schema_type=...)` raised `AttributeError` via the inherited schema-row path. Now initializes both slots on the fast DML path. (Closes #536)
- **`fix(compiler)`** — `SQLProcessor.clear_cache()` cleared `_cache` but not the single-entry micro-cache (`_last_cache_key` / `_last_result`). The next compile of the same statement hit the stale micro-cache — inflating `_cache_hits` while `cache_stats` reported `size == 0` and `_cache` never repopulated. Now resets the micro-cache too. (Closes #537)
- **`fix(splitter)`** — the split result cache embedded `hash(sql)` (an int) in its `CacheKey`, so a string-hash collision between two distinct scripts returned the wrong cached statement list. Now keyed on the full script text (string compare only on an actual hash collision). (Closes #538)
- **`fix(hashing)`** — `hash_parameters` raised `TypeError` for named parameters with unhashable values (e.g. `set`, `bytearray`), while the positional path already fell back to `repr`. Aligned the named path with the positional path. (Closes #539)
