### PR TITLE
feat(#544): expose row-locking capability introspection

### DIFF
--- a/sqlspec/adapters/oracledb/config.py
+++ b/sqlspec/adapters/oracledb/config.py
@@ -33,6 +33,7 @@ from sqlspec.adapters.oracledb.migrations import OracleAsyncMigrationTracker, Or
 from sqlspec.config import AsyncDatabaseConfig, ExtensionConfigs, SyncDatabaseConfig
 from sqlspec.driver._async import AsyncPoolConnectionContext, AsyncPoolSessionFactory
 from sqlspec.driver._sync import SyncPoolConnectionContext, SyncPoolSessionFactory
+from sqlspec.extensions.events import EventRuntimeHints
 from sqlspec.utils.config_tools import normalize_connection_config
 
 if TYPE_CHECKING:
@@ -440,6 +441,11 @@ class OracleSyncConfig(SyncDatabaseConfig[OracleSyncConnection, "OracleSyncConne
         })
         return namespace
 
+    def get_event_runtime_hints(self) -> "EventRuntimeHints":
+        """Return polling defaults for Oracle table-backed event queues."""
+
+        return EventRuntimeHints(select_for_update=True, skip_locked=True)
+
 
 def _extract_oracle_major(connection: Any) -> "int | None":
     """Read the major version digit from ``connection.version``.
@@ -644,3 +650,8 @@ class OracleAsyncConfig(AsyncDatabaseConfig[OracleAsyncConnection, "OracleAsyncC
             "OracleSyncExceptionHandler": OracleSyncExceptionHandler,
         })
         return namespace
+
+    def get_event_runtime_hints(self) -> "EventRuntimeHints":
+        """Return polling defaults for Oracle table-backed event queues."""
+
+        return EventRuntimeHints(select_for_update=True, skip_locked=True)

--- a/sqlspec/data_dictionary/_types.py
+++ b/sqlspec/data_dictionary/_types.py
@@ -213,6 +213,7 @@ class FeatureFlags(TypedDict, total=False):
     supports_clustering: bool
     supports_cte: bool
     supports_generators: bool
+    supports_for_update: bool
     supports_geography: bool
     supports_in_memory: bool
     supports_index_clustering: bool
@@ -223,6 +224,7 @@ class FeatureFlags(TypedDict, total=False):
     supports_prepared_statements: bool
     supports_returning: bool
     supports_schemas: bool
+    supports_skip_locked: bool
     supports_structs: bool
     supports_transactions: bool
     supports_upsert: bool
@@ -238,6 +240,7 @@ class FeatureVersions(TypedDict, total=False):
     supports_jsonb: "VersionInfo"
     supports_partitioning: "VersionInfo"
     supports_returning: "VersionInfo"
+    supports_skip_locked: "VersionInfo"
     supports_upsert: "VersionInfo"
     supports_window_functions: "VersionInfo"
 

--- a/sqlspec/data_dictionary/dialects/bigquery.py
+++ b/sqlspec/data_dictionary/dialects/bigquery.py
@@ -24,6 +24,8 @@ BIGQUERY_FEATURE_FLAGS: "FeatureFlags" = {
     "supports_partitioning": True,
     "supports_clustering": True,
     "supports_uuid": False,
+    "supports_for_update": False,
+    "supports_skip_locked": False,
 }
 
 BIGQUERY_TYPE_MAPPINGS: dict[str, str] = {

--- a/sqlspec/data_dictionary/dialects/cockroachdb.py
+++ b/sqlspec/data_dictionary/dialects/cockroachdb.py
@@ -21,6 +21,8 @@ COCKROACHDB_FEATURE_FLAGS: "FeatureFlags" = {
     "supports_transactions": True,
     "supports_prepared_statements": True,
     "supports_schemas": True,
+    "supports_for_update": True,
+    "supports_skip_locked": True,
 }
 
 COCKROACHDB_TYPE_MAPPINGS: dict[str, str] = {

--- a/sqlspec/data_dictionary/dialects/duckdb.py
+++ b/sqlspec/data_dictionary/dialects/duckdb.py
@@ -20,6 +20,8 @@ DUCKDB_FEATURE_FLAGS: "FeatureFlags" = {
     "supports_prepared_statements": True,
     "supports_schemas": True,
     "supports_uuid": True,
+    "supports_for_update": False,
+    "supports_skip_locked": False,
 }
 
 DUCKDB_TYPE_MAPPINGS: dict[str, str] = {

--- a/sqlspec/data_dictionary/dialects/mssql.py
+++ b/sqlspec/data_dictionary/dialects/mssql.py
@@ -44,6 +44,8 @@ MSSQL_FEATURE_FLAGS: "FeatureFlags" = {
     "supports_prepared_statements": True,
     "supports_schemas": True,
     "supports_in_memory": True,
+    "supports_for_update": False,
+    "supports_skip_locked": False,
 }
 
 MSSQL_TYPE_MAPPINGS: dict[str, str] = {

--- a/sqlspec/data_dictionary/dialects/mysql.py
+++ b/sqlspec/data_dictionary/dialects/mysql.py
@@ -11,6 +11,7 @@ MYSQL_FEATURE_VERSIONS: "FeatureVersions" = {
     "supports_json": VersionInfo(5, 7, 8),
     "supports_cte": VersionInfo(8, 0, 1),
     "supports_window_functions": VersionInfo(8, 0, 2),
+    "supports_skip_locked": VersionInfo(8, 0, 1),
 }
 
 MYSQL_FEATURE_FLAGS: "FeatureFlags" = {
@@ -21,6 +22,7 @@ MYSQL_FEATURE_FLAGS: "FeatureFlags" = {
     "supports_schemas": True,
     "supports_arrays": False,
     "supports_uuid": False,
+    "supports_for_update": True,
 }
 
 MYSQL_TYPE_MAPPINGS: dict[str, str] = {

--- a/sqlspec/data_dictionary/dialects/oracle.py
+++ b/sqlspec/data_dictionary/dialects/oracle.py
@@ -43,6 +43,8 @@ ORACLE_FEATURE_FLAGS: "FeatureFlags" = {
     "supports_prepared_statements": True,
     "supports_schemas": True,
     "supports_in_memory": True,
+    "supports_for_update": True,
+    "supports_skip_locked": True,
 }
 
 ORACLE_TYPE_MAPPINGS: dict[str, str] = {

--- a/sqlspec/data_dictionary/dialects/postgres.py
+++ b/sqlspec/data_dictionary/dialects/postgres.py
@@ -15,6 +15,7 @@ POSTGRES_FEATURE_VERSIONS: "FeatureVersions" = {
     "supports_window_functions": VersionInfo(8, 4, 0),
     "supports_cte": VersionInfo(8, 4, 0),
     "supports_partitioning": VersionInfo(10, 0, 0),
+    "supports_skip_locked": VersionInfo(9, 5, 0),
 }
 
 POSTGRES_FEATURE_FLAGS: "FeatureFlags" = {
@@ -23,6 +24,7 @@ POSTGRES_FEATURE_FLAGS: "FeatureFlags" = {
     "supports_transactions": True,
     "supports_prepared_statements": True,
     "supports_schemas": True,
+    "supports_for_update": True,
 }
 
 POSTGRES_TYPE_MAPPINGS: dict[str, str] = {

--- a/sqlspec/data_dictionary/dialects/spanner.py
+++ b/sqlspec/data_dictionary/dialects/spanner.py
@@ -11,6 +11,8 @@ SPANNER_FEATURE_FLAGS: "FeatureFlags" = {
     "supports_generators": False,
     "supports_index_clustering": True,
     "supports_interleaved_tables": True,
+    "supports_for_update": False,
+    "supports_skip_locked": False,
 }
 
 SPANNER_TYPE_MAPPINGS: dict[str, str] = {

--- a/sqlspec/data_dictionary/dialects/sqlite.py
+++ b/sqlspec/data_dictionary/dialects/sqlite.py
@@ -21,6 +21,8 @@ SQLITE_FEATURE_FLAGS: "FeatureFlags" = {
     "supports_schemas": False,
     "supports_arrays": False,
     "supports_uuid": False,
+    "supports_for_update": False,
+    "supports_skip_locked": False,
 }
 
 SQLITE_TYPE_MAPPINGS: dict[str, str] = {

--- a/tests/unit/core/test_data_dictionary.py
+++ b/tests/unit/core/test_data_dictionary.py
@@ -9,6 +9,7 @@ from sqlspec.core import SQL
 from sqlspec.data_dictionary import (
     DataDictionaryLoader,
     DialectConfig,
+    VersionInfo,
     get_data_dictionary_loader,
     get_dialect_config,
     list_registered_dialects,
@@ -80,6 +81,39 @@ def test_get_dialect_config_features() -> None:
     assert config.get_feature_flag("supports_transactions") is True
     assert config.get_feature_version("supports_json") is not None
     assert config.get_optimal_type("json") == "JSONB"
+
+
+def test_row_locking_capability_flags_are_introspectable() -> None:
+    """Dialect configs expose row-locking support for queue claim logic."""
+    expected_for_update = {
+        "bigquery": False,
+        "cockroachdb": True,
+        "duckdb": False,
+        "mssql": False,
+        "mysql": True,
+        "oracle": True,
+        "postgres": True,
+        "spanner": False,
+        "sqlite": False,
+    }
+    expected_static_skip_locked = {
+        "bigquery": False,
+        "cockroachdb": True,
+        "duckdb": False,
+        "mssql": False,
+        "oracle": True,
+        "spanner": False,
+        "sqlite": False,
+    }
+
+    for dialect, expected in expected_for_update.items():
+        assert get_dialect_config(dialect).get_feature_flag("supports_for_update") is expected
+
+    for dialect, expected in expected_static_skip_locked.items():
+        assert get_dialect_config(dialect).get_feature_flag("supports_skip_locked") is expected
+
+    assert get_dialect_config("postgres").get_feature_version("supports_skip_locked") == VersionInfo(9, 5, 0)
+    assert get_dialect_config("mysql").get_feature_version("supports_skip_locked") == VersionInfo(8, 0, 1)
 
 
 def test_registry_dialects_loaded_annotation_is_bool() -> None:

--- a/tests/unit/driver/test_data_dictionary.py
+++ b/tests/unit/driver/test_data_dictionary.py
@@ -286,6 +286,22 @@ def test_mysql_dialect_resolves_json_type_by_version() -> None:
     assert resolve_mysql_json_type(None) == "TEXT"
 
 
+def test_mysql_skip_locked_feature_is_version_gated() -> None:
+    """MySQL exposes SKIP LOCKED only for versions that support it."""
+    mock_driver = Mock(spec=SyncDriverAdapterBase)
+    data_dict = PyMysqlDataDictionary()
+
+    mock_driver.select_value_or_none.return_value = "8.0.1"
+    assert data_dict.get_feature_flag(mock_driver, "supports_for_update") is True
+    assert data_dict.get_feature_flag(mock_driver, "supports_skip_locked") is True
+
+    mock_driver.select_value_or_none.reset_mock()
+    data_dict = PyMysqlDataDictionary()
+    mock_driver.select_value_or_none.return_value = "8.0.0"
+    assert data_dict.get_feature_flag(mock_driver, "supports_for_update") is True
+    assert data_dict.get_feature_flag(mock_driver, "supports_skip_locked") is False
+
+
 async def test_mysql_family_json_type_selection_matches_adbc() -> None:
     """MySQL-family adapters and ADBC-as-MySQL should agree on JSON type selection."""
     sync_driver = Mock(spec=SyncDriverAdapterBase)

--- a/tests/unit/extensions/test_events/test_hints.py
+++ b/tests/unit/extensions/test_events/test_hints.py
@@ -77,6 +77,16 @@ def test_get_runtime_hints_config_with_provider() -> None:
     assert hints.lease_seconds == 10
 
 
+def test_oracle_event_runtime_hints_enable_row_locking() -> None:
+    """Oracle table-backed event queues use SKIP LOCKED row claims by default."""
+    from sqlspec.adapters.oracledb import OracleAsyncConfig, OracleSyncConfig
+
+    for config in (OracleSyncConfig(), OracleAsyncConfig()):
+        hints = get_runtime_hints("oracledb", config)
+        assert hints.select_for_update is True
+        assert hints.skip_locked is True
+
+
 def test_get_runtime_hints_provider_returns_non_hints() -> None:
     """get_runtime_hints returns defaults if provider returns non-hints."""
 


### PR DESCRIPTION
## Summary

- expose supports_for_update and supports_skip_locked through data-dictionary dialect feature metadata
- version-gate supports_skip_locked for PostgreSQL and MySQL where runtime version detection is required
- align Oracle event runtime hints with its existing FOR UPDATE SKIP LOCKED support
- add focused unit coverage for dialect metadata, MySQL version gating, and Oracle event hints

Closes #544

## Validation

- make lint