### PR TITLE
fix: correct SQL processing edge cases

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,80 @@ important operational fixes.
 Recent Updates
 ==============
 
+v0.52.1 - SQL processing correctness fixes
+------------------------------------------------------------------------------
+
+**Fixed:**
+
+* Dynamic SQLCommenter context and trace attributes are no longer frozen by the
+  compiled statement cache; repeated compiles now use the current request
+  context.
+* Async migration squash now builds its internal migration runner with a real
+  migration context, matching the synchronous command path.
+* ObStore Arrow streaming no longer resolves cloud ``base_path`` twice for
+  async streams.
+* ``sql.decode()`` now renders a trailing default argument as the ``ELSE``
+  clause documented for DECODE-style expressions.
+* Async drivers can use the statement-cache direct execution path when the
+  cursor supports awaitable ``execute()``, activating adapter row and rowcount
+  hooks that were previously bypassed.
+* aiomysql ADK table DDL now honors generated event columns, covering indexes,
+  and adapter-local MySQL table options.
+* MySQL-family ADK stores now recognize missing-table errors reported through
+  an ``errno`` attribute as well as positional error arguments.
+* Count-query generation no longer infers a missing outer ``FROM`` from tables
+  nested inside scalar subqueries.
+* Data dictionary default driver features now come from the dialect-specific
+  mixin instead of being hidden by the generic compatibility mixin.
+* Explicit ``optimize_expression=True`` now overrides a builder created with
+  optimization disabled.
+* ``where_in()`` now binds plain string values as scalar parameters, matching
+  ``where_not_in()`` and the OR helper variants.
+
+v0.52.0 - SQL Server adapters, ADK profiles, and cloud connectors
+------------------------------------------------------------------------------
+
+**Added:**
+
+* Added the sync ``pymssql`` SQL Server adapter with config, driver, connection
+  pool, data dictionary, migrations, event-store, Litestar session-store, and
+  ADK store support.
+* Added SQL Server support for ``arrow_odbc`` adapter contracts, ADK
+  session/event storage, event queue storage, and Litestar session storage.
+* Added ADK store and tuning profiles across SQLite, DuckDB, PostgreSQL,
+  CockroachDB, MySQL, BigQuery, Spanner, ``mssql-python``, and ``arrow_odbc``.
+  These profiles expose adapter-local table, index, full-text search, retention,
+  and backend-specific DDL options.
+* Added Google Cloud connector support for sync adapters: Cloud SQL for
+  ``pymysql`` and AlloyDB for sync ``psycopg``.
+* Added native Oracle event backends for Advanced Queuing and Transactional
+  Event Queues.
+* Added row-locking capability introspection across data dictionary dialects.
+* Added docs coverage for the new SQL Server adapters, cloud connector setup,
+  ADK backend matrix entries, and package extras parity.
+
+**Changed:**
+
+* Standardized Oracle native event backend names to ``aq`` and ``txeventq``;
+  ``table_queue`` remains the default backend.
+* Moved ADK optimization and storage tuning options into adapter-local config
+  types instead of the shared global config surface.
+* Tightened adapter typing and core pipeline internals for the compiler,
+  splitter, parameter handling, filters, result handling, cache/runtime helpers,
+  and mypyc-ready adapter boundaries.
+* Updated package extras to include current adapter and framework integrations,
+  including ``arrow-odbc``, ``mssql-python``, ``pymssql``, ``sanic``, and
+  ``starlette``.
+
+**Fixed:**
+
+* Removed the obsolete ``aioodbc`` extra and added docs/package parity checks so
+  the installation guide matches available extras.
+* Corrected ``pymysql`` stack transaction-state detection so nested stack
+  execution reflects the real driver transaction state.
+* Localized ADK optimization config to adapter implementations so backend
+  tuning no longer depends on unused shared config keys.
+
 v0.51.0 - ADK 2.0 clean-break store contract
 ------------------------------------------------------------------------------
 

--- a/sqlspec/adapters/aiomysql/adk/__init__.py
+++ b/sqlspec/adapters/aiomysql/adk/__init__.py
@@ -1,5 +1,5 @@
 """aiomysql ADK store for Google Agent Development Kit."""
 
-from sqlspec.adapters.aiomysql.adk.store import AiomysqlADKMemoryStore, AiomysqlADKStore
+from sqlspec.adapters.aiomysql.adk.store import AiomysqlADKConfig, AiomysqlADKMemoryStore, AiomysqlADKStore
 
-__all__ = ("AiomysqlADKMemoryStore", "AiomysqlADKStore")
+__all__ = ("AiomysqlADKConfig", "AiomysqlADKMemoryStore", "AiomysqlADKStore")

--- a/sqlspec/adapters/aiomysql/adk/store.py
+++ b/sqlspec/adapters/aiomysql/adk/store.py
@@ -1,11 +1,14 @@
 """aiomysql ADK store for Google Agent Development Kit session/event storage."""
 
 import re
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Final, cast
 
 import pymysql.err
+from typing_extensions import NotRequired
 
 from sqlspec.adapters.aiomysql._typing import AiomysqlCursor, AiomysqlRawCursor
+from sqlspec.config import ADKConfig
 from sqlspec.extensions.adk import BaseAsyncADKStore, EventRecord, SessionRecord
 from sqlspec.extensions.adk.memory.store import BaseAsyncADKMemoryStore
 from sqlspec.utils.serializers import from_json, to_json
@@ -17,9 +20,37 @@ if TYPE_CHECKING:
     from sqlspec.extensions.adk import MemoryRecord
 
 
-__all__ = ("AiomysqlADKMemoryStore", "AiomysqlADKStore")
+__all__ = ("AiomysqlADKConfig", "AiomysqlADKMemoryStore", "AiomysqlADKStore")
 
 MYSQL_TABLE_NOT_FOUND_ERROR: Final = 1146
+
+
+class AiomysqlADKConfig(ADKConfig):
+    """aiomysql-specific ADK extension settings.
+
+    Use these keys inside ``extension_config["adk"]`` with the aiomysql ADK store.
+    """
+
+    enable_event_generated_columns: NotRequired[bool]
+    """Create MySQL generated columns and indexes for common ADK event JSON paths."""
+
+    enable_covering_indexes: NotRequired[bool]
+    """Add hot-path payload columns to MySQL ADK event replay indexes."""
+
+    session_table_options: NotRequired[str]
+    """Raw MySQL table options appended to the ADK session table."""
+
+    events_table_options: NotRequired[str]
+    """Raw MySQL table options appended to the ADK events table."""
+
+    app_state_table_options: NotRequired[str]
+    """Raw MySQL table options appended to the ADK app state table."""
+
+    user_state_table_options: NotRequired[str]
+    """Raw MySQL table options appended to the ADK user state table."""
+
+    memory_table_options: NotRequired[str]
+    """Raw MySQL table options appended to the ADK memory table."""
 
 
 class AiomysqlADKStore(BaseAsyncADKStore["AiomysqlConfig"]):
@@ -410,19 +441,25 @@ class AiomysqlADKStore(BaseAsyncADKStore["AiomysqlConfig"]):
 
     async def _get_create_sessions_table_sql(self) -> str:
         """Get MySQL CREATE TABLE SQL for sessions."""
-        return _mysql_sessions_ddl(self._session_table, self._owner_id_column_ddl)
+        adk_config = _get_aiomysql_adk_config(self._config)
+        table_options = _mysql_table_options(adk_config, "session_table_options")
+        return _mysql_sessions_ddl(self._session_table, self._owner_id_column_ddl, table_options)
 
     async def _get_create_events_table_sql(self) -> str:
         """Get MySQL CREATE TABLE SQL for events."""
-        return _mysql_events_ddl(self._events_table, self._session_table)
+        return _mysql_events_ddl(self._events_table, self._session_table, _get_aiomysql_adk_config(self._config))
 
     async def _get_create_app_states_table_sql(self) -> str:
         """Get MySQL CREATE TABLE SQL for app-scoped state."""
-        return _mysql_app_state_ddl(self._app_state_table)
+        adk_config = _get_aiomysql_adk_config(self._config)
+        table_options = _mysql_table_options(adk_config, "app_state_table_options")
+        return _mysql_app_state_ddl(self._app_state_table, table_options)
 
     async def _get_create_user_states_table_sql(self) -> str:
         """Get MySQL CREATE TABLE SQL for user-scoped state."""
-        return _mysql_user_state_ddl(self._user_state_table)
+        adk_config = _get_aiomysql_adk_config(self._config)
+        table_options = _mysql_table_options(adk_config, "user_state_table_options")
+        return _mysql_user_state_ddl(self._user_state_table, table_options)
 
     async def _get_create_metadata_table_sql(self) -> str:
         """Get MySQL CREATE TABLE SQL for ADK metadata."""
@@ -611,6 +648,8 @@ class AiomysqlADKMemoryStore(BaseAsyncADKMemoryStore["AiomysqlConfig"]):
 
     async def _get_create_memory_table_sql(self) -> str:
         """Get MySQL CREATE TABLE SQL for memory entries."""
+        adk_config = _get_aiomysql_adk_config(self._config)
+        table_options = _mysql_table_options(adk_config, "memory_table_options")
         owner_id_line = ""
         fk_constraint = ""
         if self._owner_id_column_ddl:
@@ -638,7 +677,7 @@ class AiomysqlADKMemoryStore(BaseAsyncADKMemoryStore["AiomysqlConfig"]):
             inserted_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
             INDEX idx_{self._memory_table}_app_user_time (app_name, user_id, timestamp),
             INDEX idx_{self._memory_table}_session (session_id){fts_index}{fk_constraint}
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci{table_options}
         """
 
     def _get_drop_memory_table_sql(self) -> "list[str]":
@@ -666,9 +705,29 @@ def _parse_owner_id_column_for_mysql(column_ddl: str) -> "tuple[str, str]":
     return (col_def, fk_constraint)
 
 
+def _get_aiomysql_adk_config(config: "AiomysqlConfig") -> AiomysqlADKConfig:
+    adk_config = config.extension_config.get("adk") if config.extension_config else None
+    if not isinstance(adk_config, dict):
+        return {}
+    return cast("AiomysqlADKConfig", adk_config)
+
+
+def _mysql_table_options(adk_config: Mapping[str, Any], key: str) -> str:
+    value = adk_config.get(key)
+    if not isinstance(value, str):
+        return ""
+    value = value.strip()
+    return f" {value}" if value else ""
+
+
 def _is_mysql_table_missing(exc: BaseException) -> bool:
     args = getattr(exc, "args", ())
-    return "doesn't exist" in str(exc) or bool(args and args[0] == MYSQL_TABLE_NOT_FOUND_ERROR)
+    errno = getattr(exc, "errno", None)
+    return (
+        errno == MYSQL_TABLE_NOT_FOUND_ERROR
+        or "doesn't exist" in str(exc)
+        or bool(args and args[0] == MYSQL_TABLE_NOT_FOUND_ERROR)
+    )
 
 
 def _json_for_storage(value: Any) -> str:
@@ -713,7 +772,7 @@ def _event_insert_params(event_record: EventRecord) -> "tuple[Any, ...]":
     )
 
 
-def _mysql_sessions_ddl(session_table: str, owner_id_column_ddl: "str | None") -> str:
+def _mysql_sessions_ddl(session_table: str, owner_id_column_ddl: "str | None", table_options: str = "") -> str:
     owner_id_line = ""
     fk_constraint = ""
     if owner_id_column_ddl:
@@ -732,11 +791,25 @@ def _mysql_sessions_ddl(session_table: str, owner_id_column_ddl: "str | None") -
             update_time TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
             INDEX idx_{session_table}_app_user (app_name, user_id),
             INDEX idx_{session_table}_update_time (update_time DESC){fk_constraint}
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci{table_options}
         """
 
 
-def _mysql_events_ddl(events_table: str, session_table: str) -> str:
+def _mysql_events_ddl(events_table: str, session_table: str, adk_config: Mapping[str, Any] | None = None) -> str:
+    adk_config = adk_config or {}
+    generated_columns = ""
+    generated_indexes = ""
+    if adk_config.get("enable_event_generated_columns", False):
+        generated_columns = """,
+            author_gc VARCHAR(256) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.author'))) STORED,
+            node_path_gc VARCHAR(512) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.node_info.path'))) STORED"""
+        generated_indexes = f""",
+            INDEX idx_{events_table}_author_gc (session_id, author_gc, timestamp ASC),
+            INDEX idx_{events_table}_node_path_gc (session_id, node_path_gc, timestamp ASC)"""
+
+    covering_column = ", invocation_id" if adk_config.get("enable_covering_indexes", False) else ""
+    table_options = _mysql_table_options(adk_config, "events_table_options")
+
     return f"""
         CREATE TABLE IF NOT EXISTS {events_table} (
             id VARCHAR(128) PRIMARY KEY,
@@ -745,25 +818,25 @@ def _mysql_events_ddl(events_table: str, session_table: str) -> str:
             session_id VARCHAR(128) NOT NULL,
             invocation_id VARCHAR(256) NOT NULL,
             timestamp TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-            event_data JSON NOT NULL,
+            event_data JSON NOT NULL{generated_columns},
             FOREIGN KEY (session_id) REFERENCES {session_table}(id) ON DELETE CASCADE,
-            INDEX idx_{events_table}_scope (app_name, user_id, session_id, timestamp ASC),
-            INDEX idx_{events_table}_session (session_id, timestamp ASC)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+            INDEX idx_{events_table}_scope (app_name, user_id, session_id, timestamp ASC{covering_column}),
+            INDEX idx_{events_table}_session (session_id, timestamp ASC{covering_column}){generated_indexes}
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci{table_options}
         """
 
 
-def _mysql_app_state_ddl(app_state_table: str) -> str:
+def _mysql_app_state_ddl(app_state_table: str, table_options: str = "") -> str:
     return f"""
         CREATE TABLE IF NOT EXISTS {app_state_table} (
             app_name VARCHAR(128) PRIMARY KEY,
             state JSON NOT NULL,
             update_time TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci{table_options}
         """
 
 
-def _mysql_user_state_ddl(user_state_table: str) -> str:
+def _mysql_user_state_ddl(user_state_table: str, table_options: str = "") -> str:
     return f"""
         CREATE TABLE IF NOT EXISTS {user_state_table} (
             app_name VARCHAR(128) NOT NULL,
@@ -771,7 +844,7 @@ def _mysql_user_state_ddl(user_state_table: str) -> str:
             state JSON NOT NULL,
             update_time TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
             PRIMARY KEY (app_name, user_id)
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci{table_options}
         """
 
 

--- a/sqlspec/adapters/asyncmy/adk/store.py
+++ b/sqlspec/adapters/asyncmy/adk/store.py
@@ -662,7 +662,12 @@ def _mysql_table_options(adk_config: Mapping[str, Any], key: str) -> str:
 
 def _is_mysql_table_missing(exc: BaseException) -> bool:
     args = getattr(exc, "args", ())
-    return "doesn't exist" in str(exc) or bool(args and args[0] == MYSQL_TABLE_NOT_FOUND_ERROR)
+    errno = getattr(exc, "errno", None)
+    return (
+        errno == MYSQL_TABLE_NOT_FOUND_ERROR
+        or "doesn't exist" in str(exc)
+        or bool(args and args[0] == MYSQL_TABLE_NOT_FOUND_ERROR)
+    )
 
 
 def _json_for_storage(value: Any) -> str:

--- a/sqlspec/adapters/pymysql/adk/store.py
+++ b/sqlspec/adapters/pymysql/adk/store.py
@@ -811,7 +811,12 @@ def _mysql_table_options(adk_config: Mapping[str, Any], key: str) -> str:
 
 def _is_mysql_table_missing(exc: BaseException) -> bool:
     args = getattr(exc, "args", ())
-    return "doesn't exist" in str(exc) or bool(args and args[0] == MYSQL_TABLE_NOT_FOUND_ERROR)
+    errno = getattr(exc, "errno", None)
+    return (
+        errno == MYSQL_TABLE_NOT_FOUND_ERROR
+        or "doesn't exist" in str(exc)
+        or bool(args and args[0] == MYSQL_TABLE_NOT_FOUND_ERROR)
+    )
 
 
 def _json_for_storage(value: Any) -> str:

--- a/sqlspec/builder/_base.py
+++ b/sqlspec/builder/_base.py
@@ -674,16 +674,17 @@ class QueryBuilder(ABC):
 
         return sql
 
-    def _optimize_expression(self, expression: exp.Expr) -> exp.Expr:
+    def _optimize_expression(self, expression: exp.Expr, *, force: bool = False) -> exp.Expr:
         """Apply SQLGlot optimizations to the expression.
 
         Args:
             expression: The expression to optimize
+            force: Optimize even when the builder-level toggle is disabled.
 
         Returns:
             The optimized expression
         """
-        if not self.enable_optimization:
+        if not force and not self.enable_optimization:
             return expression
 
         if not self.optimize_joins and not self.optimize_predicates and not self.simplify_expressions:
@@ -960,7 +961,7 @@ class QueryBuilder(ABC):
                 expr_to_store = expr_candidate.copy() if copy else expr_candidate
                 should_optimize = self.enable_optimization if optimize_expression is None else optimize_expression
                 if should_optimize:
-                    expr_to_store = self._optimize_expression(expr_to_store)
+                    expr_to_store = self._optimize_expression(expr_to_store, force=optimize_expression is True)
                 cache.put_expression(cache_key, expr_to_store)
                 cached_expr = expr_to_store
             expr = cached_expr.copy() if copy else cached_expr
@@ -971,7 +972,7 @@ class QueryBuilder(ABC):
             expr = expression.copy() if copy else expression
             should_optimize = self.enable_optimization if optimize_expression is None else optimize_expression
             if should_optimize:
-                expr = self._optimize_expression(expr)
+                expr = self._optimize_expression(expr, force=optimize_expression is True)
 
         if expr is None:
             self._raise_sql_builder_error("Static expression could not be resolved.")

--- a/sqlspec/builder/_factory.py
+++ b/sqlspec/builder/_factory.py
@@ -1355,14 +1355,14 @@ class SQLFactory:
 
         conditions = []
         default = None
+        paired_args = args
+        if len(args) % 2 == 1:
+            default = to_expression(args[-1])
+            paired_args = args[:-1]
 
-        for i in range(0, len(args) - 1, 2):
-            if i + 1 >= len(args):
-                default = to_expression(args[i])
-                break
-
-            search_val = args[i]
-            result_val = args[i + 1]
+        for i in range(0, len(paired_args), 2):
+            search_val = paired_args[i]
+            result_val = paired_args[i + 1]
 
             search_expr = to_expression(search_val)
             result_expr = to_expression(result_val)

--- a/sqlspec/builder/_select.py
+++ b/sqlspec/builder/_select.py
@@ -889,7 +889,7 @@ class WhereClauseMixin:
     def where_in(self, column: str | exp.Column, values: Any) -> Self:
         builder = cast("SQLBuilderProtocol", self)
         col_expr = parse_column_expression(column) if not isinstance(column, exp.Column) else column
-        if has_parameter_builder(values) or isinstance(values, (exp.Expr, str)):
+        if has_parameter_builder(values) or isinstance(values, exp.Expr):
             subquery_exp = self._normalize_subquery_expression(values, builder)
             return self.where(exp.In(this=col_expr, expressions=[subquery_exp]))
 

--- a/sqlspec/core/compiler.py
+++ b/sqlspec/core/compiler.py
@@ -373,6 +373,9 @@ class SQLProcessor:
         if not self._cache_enabled:
             return self._compile_uncached(sql, parameters, is_many, expression, param_fingerprint=None)
 
+        if self._has_dynamic_sqlcommenter():
+            return self._compile_uncached(sql, parameters, is_many, expression, param_fingerprint=param_fingerprint)
+
         if param_fingerprint is None:
             param_fingerprint = self._get_param_fingerprint(parameters, is_many)
         cache_key = self._make_cache_key(sql, param_fingerprint, is_many)
@@ -402,6 +405,13 @@ class SQLProcessor:
         self._last_cache_key = cache_key
         self._last_result = result
         return result
+
+    def _has_dynamic_sqlcommenter(self) -> bool:
+        """Return whether SQLCommenter resolves per-call context during compilation."""
+        return bool(
+            self._config.enable_sqlcommenter
+            and (self._config.sqlcommenter_enable_context or self._config.sqlcommenter_enable_traceparent)
+        )
 
     def _materialize_cached_result(self, cached_result: CompiledSQL, parameters: Any, is_many: bool) -> CompiledSQL:
         """Return cached compilation metadata with parameters for the current call."""

--- a/sqlspec/driver/_async.py
+++ b/sqlspec/driver/_async.py
@@ -2,6 +2,7 @@
 
 import logging
 from abc import abstractmethod
+from inspect import isawaitable
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, ClassVar, Final, cast, final, overload
 
@@ -422,9 +423,10 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin):
     ) -> "SQLResult":
         """Execute pre-compiled query via ultra-fast path (async).
 
-        Uses _stmt_cache_build_direct + dispatch_execute since async drivers can't
-        call cursor.execute directly. For DML operations, returns DMLResult
-        to bypass full SQLResult construction.
+        Uses DBAPI-style async cursor methods when available. Async adapters with
+        connection-level execution APIs fall back to dispatch_execute so they can
+        preserve adapter-specific parameter binding semantics. For DML operations,
+        returns DMLResult to bypass full SQLResult construction.
 
         Args:
             sql: Raw SQL string (original, not compiled).
@@ -434,33 +436,76 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin):
         Returns:
             SQLResult or DMLResult.
         """
-        compiled_sql = cached.compiled_sql
-        direct_statement = self._stmt_cache_build_direct(
-            sql, params, cached, params, params_are_simple=True, compiled_sql=compiled_sql
-        )
-
+        direct_statement: SQL | None = None
         exc_handler = self.handle_database_exceptions()
         result: SQLResult | None = None
         try:
             async with exc_handler, self.with_cursor(self.connection) as cursor:
-                execution_result = await self.dispatch_execute(cursor, direct_statement)
+                execute = getattr(cursor, "execute", None)
+                fetchall = getattr(cursor, "fetchall", None)
+                can_use_cursor_fast_path = execute is not None and (
+                    (cached.operation_profile.returns_rows and fetchall is not None)
+                    or (not cached.operation_profile.returns_rows and hasattr(cursor, "rowcount"))
+                )
+                if can_use_cursor_fast_path:
+                    assert execute is not None
+                    try:
+                        execute_result = execute(cached.compiled_sql, params)
+                        if isawaitable(execute_result):
+                            await execute_result
+                            if cached.operation_profile.returns_rows:
+                                assert fetchall is not None
+                                fetched_data = fetchall()
+                                if isawaitable(fetched_data):
+                                    fetched_data = await fetched_data
+                                data, column_names, row_count = self.collect_rows(cursor, fetched_data)
+                                execution_result = self.create_execution_result(
+                                    cursor,
+                                    selected_data=data,
+                                    column_names=column_names,
+                                    data_row_count=row_count,
+                                    is_select_result=True,
+                                    row_format="tuple",
+                                )
+                                direct_statement = self._stmt_cache_build_direct(
+                                    sql,
+                                    params,
+                                    cached,
+                                    params,
+                                    params_are_simple=True,
+                                    compiled_sql=cached.compiled_sql,
+                                )
+                                result = self.build_statement_result(direct_statement, execution_result)
+                            else:
+                                affected_rows = self.resolve_rowcount(cursor)
+                                result = DMLResult(cached.operation_type, affected_rows)
+                    except (AttributeError, NotImplementedError):
+                        pass
 
-                if cached.operation_profile.returns_rows:
-                    result = self.build_statement_result(direct_statement, execution_result)
-                else:
-                    # DML path: use DMLResult to bypass full SQLResult construction
-                    affected_rows = (
-                        execution_result.rowcount_override
-                        if execution_result.rowcount_override is not None and execution_result.rowcount_override >= 0
-                        else 0
+                if result is None:
+                    direct_statement = self._stmt_cache_build_direct(
+                        sql, params, cached, params, params_are_simple=True, compiled_sql=cached.compiled_sql
                     )
-                    result = DMLResult(cached.operation_type, affected_rows)
+                    execution_result = await self.dispatch_execute(cursor, direct_statement)
+
+                    if cached.operation_profile.returns_rows:
+                        result = self.build_statement_result(direct_statement, execution_result)
+                    else:
+                        # DML path: use DMLResult to bypass full SQLResult construction
+                        affected_rows = (
+                            execution_result.rowcount_override
+                            if execution_result.rowcount_override is not None
+                            and execution_result.rowcount_override >= 0
+                            else 0
+                        )
+                        result = DMLResult(cached.operation_type, affected_rows)
 
             self._check_pending_exception(exc_handler)
             assert result is not None
             return result
         finally:
-            self._release_pooled_statement(direct_statement)
+            if direct_statement is not None:
+                self._release_pooled_statement(direct_statement)
 
     async def _stmt_cache_lookup(self, statement: str, params: "tuple[Any, ...] | list[Any]") -> "SQLResult | None":
         """Attempt fast-path execution for cached query (async).

--- a/sqlspec/driver/_common.py
+++ b/sqlspec/driver/_common.py
@@ -543,7 +543,7 @@ class DataDictionaryDialectMixin:
         return bool(version >= required_version)
 
     def get_default_features(self) -> "list[str]":
-        """Get default feature flags. Overridden by DataDictionaryMixin."""
+        """Get default feature flags for this dialect."""
         return []
 
     def list_available_features(self) -> "list[str]":
@@ -710,14 +710,6 @@ class DataDictionaryMixin:
             "text": "TEXT",
             "blob": "BLOB",
         }
-
-    def get_default_features(self) -> "list[str]":
-        """Get default feature flags supported by most databases.
-
-        Returns:
-            List of commonly supported feature names
-        """
-        return ["supports_transactions", "supports_prepared_statements"]
 
     def sort_tables_topologically(self, tables: "list[str]", foreign_keys: "list[ForeignKeyMetadata]") -> "list[str]":
         """Sort tables topologically based on foreign key dependencies using Python.
@@ -1967,14 +1959,7 @@ class CommonDriverAttributesMixin:
                 expr.set("with_", None)
 
         if isinstance(expr, exp.Select):
-            from_clause = expr.args.get("from")
-            if from_clause is None:
-                from_clause = expr.args.get("froms")
-            if from_clause is None:
-                tables = list(expr.find_all(exp.Table))
-                if tables:
-                    first_table = tables[0]
-                    from_clause = exp.from_(first_table)
+            from_clause = expr.args.get("from_")
             if from_clause is None:
                 msg = (
                     "Cannot create COUNT query: SELECT statement missing FROM clause. "
@@ -1997,8 +1982,8 @@ class CommonDriverAttributesMixin:
                 count_expr = exp.select(exp.Count(this=exp.Star()))
 
                 # Copy FROM clause(s)
-                # handle both 'from' (single) and 'froms' (list) which sqlglot might use
-                from_arg = expr.args.get("from") or expr.args.get("from_")
+                # handle current sqlglot's 'from_' and keep 'from' as defensive compatibility
+                from_arg = expr.args.get("from_") or expr.args.get("from")
                 if from_arg:
                     count_expr.set("from_", from_arg.copy())
                 else:

--- a/sqlspec/migrations/commands.py
+++ b/sqlspec/migrations/commands.py
@@ -1876,10 +1876,13 @@ class AsyncMigrationCommands(BaseMigrationCommands["AsyncConfigT", Any]):
             allow_gaps: Allow gaps in version sequence.
             output_format: Output format ("sql" or "py").
         """
+        context = MigrationContext.from_config(self.config)
+        context.extension_config = self.extension_configs
+
         sync_runner = SyncMigrationRunner(
             self.migrations_path,
             self._discover_extension_migrations(),
-            None,
+            context,
             self.extension_configs,
             runtime=self._runtime,
             description_hints=self._template_settings.description_hints,

--- a/sqlspec/storage/backends/obstore.py
+++ b/sqlspec/storage/backends/obstore.py
@@ -850,8 +850,7 @@ class ObStoreBackend:
         Returns:
             AsyncIterator yielding Arrow record batches.
         """
-        resolved_pattern = resolve_storage_path(pattern, self.base_path, self.protocol, strip_file_scheme=True)
-        return AsyncArrowBatchIterator(self.stream_arrow_sync(resolved_pattern, **kwargs))
+        return AsyncArrowBatchIterator(self.stream_arrow_sync(pattern, **kwargs))
 
     @overload
     async def sign_async(self, paths: str, expires_in: int = 3600, for_upload: bool = False) -> str: ...

--- a/tests/unit/adapters/test_aiomysql/test_adk_store.py
+++ b/tests/unit/adapters/test_aiomysql/test_adk_store.py
@@ -1,5 +1,5 @@
 # pyright: reportPrivateUsage=false
-"""Unit tests for asyncmy ADK store extension configuration."""
+"""Unit tests for aiomysql ADK store extension configuration."""
 
 import asyncio
 from typing import Any, cast, get_args, get_origin
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 from typing_extensions import NotRequired
 
-from sqlspec.adapters.asyncmy.adk import AsyncmyADKConfig, AsyncmyADKMemoryStore, AsyncmyADKStore
+from sqlspec.adapters.aiomysql.adk import AiomysqlADKConfig, AiomysqlADKMemoryStore, AiomysqlADKStore
 from sqlspec.config import ADKConfig
 
 
@@ -21,16 +21,10 @@ class _MysqlMissingTableError(Exception):
     errno = 1146
 
 
-def test_asyncmy_table_missing_uses_errno_attribute() -> None:
-    from sqlspec.adapters.asyncmy.adk.store import _is_mysql_table_missing
+def test_aiomysql_adk_config_types_adapter_local_mysql_options() -> None:
+    """aiomysql ADK MySQL options are typed on the adapter-local extension config."""
 
-    assert _is_mysql_table_missing(_MysqlMissingTableError()) is True
-
-
-def test_asyncmy_adk_config_types_adapter_local_mysql_options() -> None:
-    """asyncmy ADK MySQL options are typed on the adapter-local extension config."""
-
-    assert cast("Any", ADKConfig).__optional_keys__ <= cast("Any", AsyncmyADKConfig).__optional_keys__
+    assert cast("Any", ADKConfig).__optional_keys__ <= cast("Any", AiomysqlADKConfig).__optional_keys__
 
     expected_types: dict[str, object] = {
         "enable_event_generated_columns": bool,
@@ -42,16 +36,16 @@ def test_asyncmy_adk_config_types_adapter_local_mysql_options() -> None:
         "memory_table_options": str,
     }
     for feature_name, expected_type in expected_types.items():
-        annotation = cast("Any", AsyncmyADKConfig.__annotations__[feature_name])
+        annotation = cast("Any", AiomysqlADKConfig.__annotations__[feature_name])
         assert get_origin(annotation) is NotRequired
         assert get_args(annotation) == (expected_type,)
 
 
-def test_asyncmy_adk_tables_use_plain_mysql_schema_by_default() -> None:
-    """asyncmy ADK profile DDL stays opt-in through extension_config["adk"]."""
+def test_aiomysql_adk_tables_use_plain_mysql_schema_by_default() -> None:
+    """aiomysql ADK profile DDL stays opt-in through extension_config["adk"]."""
 
-    store = AsyncmyADKStore(_mock_config())
-    memory_store = AsyncmyADKMemoryStore(_mock_config())
+    store = AiomysqlADKStore(_mock_config())
+    memory_store = AiomysqlADKMemoryStore(_mock_config())
 
     events_sql = asyncio.run(store._get_create_events_table_sql())
     memory_sql = asyncio.run(memory_store._get_create_memory_table_sql())
@@ -63,10 +57,10 @@ def test_asyncmy_adk_tables_use_plain_mysql_schema_by_default() -> None:
     assert "COMMENT='adk-memory'" not in memory_sql
 
 
-def test_asyncmy_adk_tables_apply_adapter_local_mysql_profile() -> None:
-    """asyncmy ADK MySQL options add generated columns, covering keys, and table options."""
+def test_aiomysql_adk_tables_apply_adapter_local_mysql_profile() -> None:
+    """aiomysql ADK MySQL options add generated columns, covering keys, and table options."""
 
-    store = AsyncmyADKStore(
+    store = AiomysqlADKStore(
         _mock_config({
             "enable_event_generated_columns": True,
             "enable_covering_indexes": True,
@@ -76,7 +70,7 @@ def test_asyncmy_adk_tables_apply_adapter_local_mysql_profile() -> None:
             "user_state_table_options": "COMMENT='adk-user-state'",
         })
     )
-    memory_store = AsyncmyADKMemoryStore(_mock_config({"memory_table_options": "COMMENT='adk-memory'"}))
+    memory_store = AiomysqlADKMemoryStore(_mock_config({"memory_table_options": "COMMENT='adk-memory'"}))
 
     session_sql = asyncio.run(store._get_create_sessions_table_sql())
     events_sql = asyncio.run(store._get_create_events_table_sql())
@@ -101,3 +95,9 @@ def test_asyncmy_adk_tables_apply_adapter_local_mysql_profile() -> None:
     assert "COMMENT='adk-app-state'" in app_state_sql
     assert "COMMENT='adk-user-state'" in user_state_sql
     assert "COMMENT='adk-memory'" in memory_sql
+
+
+def test_aiomysql_table_missing_uses_errno_attribute() -> None:
+    from sqlspec.adapters.aiomysql.adk.store import _is_mysql_table_missing
+
+    assert _is_mysql_table_missing(_MysqlMissingTableError()) is True

--- a/tests/unit/adapters/test_pymysql/test_adk_store.py
+++ b/tests/unit/adapters/test_pymysql/test_adk_store.py
@@ -16,6 +16,16 @@ def _mock_config(adk_config: dict[str, object] | None = None) -> MagicMock:
     return config
 
 
+class _MysqlMissingTableError(Exception):
+    errno = 1146
+
+
+def test_pymysql_table_missing_uses_errno_attribute() -> None:
+    from sqlspec.adapters.pymysql.adk.store import _is_mysql_table_missing
+
+    assert _is_mysql_table_missing(_MysqlMissingTableError()) is True
+
+
 def test_pymysql_adk_config_types_adapter_local_mysql_options() -> None:
     """PyMySQL ADK MySQL options are typed on the adapter-local extension config."""
 

--- a/tests/unit/builder/test_parsing_utils.py
+++ b/tests/unit/builder/test_parsing_utils.py
@@ -6,6 +6,7 @@ was added to fix QueryBuilder parameter handling issues.
 """
 
 import contextlib
+from typing import Any
 
 import pytest
 from sqlglot import exp
@@ -14,6 +15,7 @@ from sqlglot.errors import ParseError
 import sqlspec.builder._parsing_utils as parsing_utils
 from sqlspec import sql
 from sqlspec.builder import (
+    Select,
     parse_column_expression,
     parse_condition_expression,
     parse_order_expression,
@@ -278,6 +280,21 @@ def test_cached_static_expression_reuses_factory() -> None:
     assert first.parameters == {"p": 1}
     assert second.parameters == {"p": 2}
     assert first.sql == second.sql
+
+
+def test_build_static_expression_explicit_optimize_overrides_disabled_builder(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def fake_optimize(expression: exp.Expr, **kwargs: Any) -> exp.Expr:
+        _ = kwargs
+        nonlocal calls
+        calls += 1
+        return expression
+
+    monkeypatch.setattr("sqlspec.builder._base.optimize", fake_optimize)
+    builder = Select(enable_optimization=False, simplify_expressions=True)
+    builder.build_static_expression(expression=exp.select("1"), optimize_expression=True)
+    assert calls == 1
 
 
 def test_cached_static_expression_respects_copy_flag() -> None:

--- a/tests/unit/builder/test_sql_factory.py
+++ b/tests/unit/builder/test_sql_factory.py
@@ -48,6 +48,12 @@ def test_sql_factory_default_dialect() -> None:
     assert factory_with_dialect.dialect == "postgres"
 
 
+def test_decode_renders_trailing_default_else_clause() -> None:
+    expr = sql.decode("status", "A", 1, "B", 2, 0)
+    rendered = expr.expression.sql()
+    assert "ELSE 0" in rendered.upper()
+
+
 def test_where_eq_uses_placeholder_not_var() -> None:
     """Test that where_eq uses Placeholder instead of var for parameters."""
     query = sql.select("*").from_("users").where_eq("name", "John")
@@ -134,6 +140,13 @@ def test_where_in_uses_placeholders() -> None:
     assert ":status_2" in stmt.sql
 
 
+def test_where_in_binds_plain_string_like_where_not_in() -> None:
+    """Plain string values should bind as scalar values, not parse as SQL."""
+    stmt = sql.select("*").from_("users").where_in("status", "active").build()
+    assert stmt.parameters["status"] == "active"
+    assert ":status" in stmt.sql
+
+
 def test_where_not_in_uses_placeholders() -> None:
     """Test that where_not_in uses proper parameter binding."""
     query = sql.select("*").from_("users").where_not_in("role", ["admin", "superuser"])
@@ -142,6 +155,13 @@ def test_where_not_in_uses_placeholders() -> None:
     assert "role_2" in stmt.parameters
     assert stmt.parameters["role_1"] == "admin"
     assert stmt.parameters["role_2"] == "superuser"
+
+
+def test_where_not_in_binds_plain_string_like_where_in() -> None:
+    """Plain string values should bind consistently across IN helpers."""
+    stmt = sql.select("*").from_("users").where_not_in("status", "active").build()
+    assert stmt.parameters["status"] == "active"
+    assert ":status" in stmt.sql
 
 
 def test_where_any_with_values_uses_placeholders() -> None:

--- a/tests/unit/core/test_sqlcommenter.py
+++ b/tests/unit/core/test_sqlcommenter.py
@@ -10,7 +10,7 @@ import sqlglot
 from sqlglot import exp
 
 import sqlspec.core.sqlcommenter as sqlcommenter_module
-from sqlspec.core import StatementConfig
+from sqlspec.core import SQL, StatementConfig
 from sqlspec.core.sqlcommenter import (
     SQLCommenterContext,
     append_comment,
@@ -399,6 +399,20 @@ def test_context_scope_restores_previous() -> None:
         assert attrs["route"] == "/outer"
     finally:
         SQLCommenterContext.set(None)
+
+
+def test_dynamic_sqlcommenter_context_not_frozen_by_compiled_cache() -> None:
+    config = StatementConfig(enable_sqlcommenter=True, sqlcommenter_enable_context=True)
+
+    with SQLCommenterContext.scope({"route": "/first"}):
+        first_sql, _ = SQL("SELECT 1", statement_config=config).compile()
+
+    with SQLCommenterContext.scope({"route": "/second"}):
+        second_sql, _ = SQL("SELECT 1", statement_config=config).compile()
+
+    assert "route='%2Ffirst'" in first_sql
+    assert "route='%2Fsecond'" in second_sql
+    assert "route='%2Ffirst'" not in second_sql
 
 
 def test_statement_config_enable_sqlcommenter() -> None:

--- a/tests/unit/driver/test_count_query.py
+++ b/tests/unit/driver/test_count_query.py
@@ -173,6 +173,16 @@ def test_count_query_select_columns_no_from(mock_driver: "MockSyncDriver") -> No
         mock_driver._create_count_query(sql)
 
 
+def test_count_query_does_not_infer_nested_table_as_outer_from(mock_driver: "MockSyncDriver") -> None:
+    sql = mock_driver.prepare_statement(
+        SQL("SELECT (SELECT count(*) FROM audit_log) AS total"), statement_config=mock_driver.statement_config
+    )
+    sql.compile()
+
+    with pytest.raises(ImproperConfigurationError, match="missing FROM clause"):
+        mock_driver._create_count_query(sql)
+
+
 def test_count_query_valid_select_with_from(mock_driver: "MockSyncDriver") -> None:
     """Test COUNT query succeeds with valid SELECT...FROM."""
     sql = mock_driver.prepare_statement(

--- a/tests/unit/driver/test_data_dictionary.py
+++ b/tests/unit/driver/test_data_dictionary.py
@@ -26,6 +26,7 @@ from sqlspec.adapters.spanner.data_dictionary import SpannerDataDictionary
 from sqlspec.adapters.sqlite.data_dictionary import SqliteDataDictionary
 from sqlspec.data_dictionary import IndexMetadata, VersionInfo
 from sqlspec.driver import SyncDriverAdapterBase
+from sqlspec.driver._common import DataDictionaryDialectMixin, DataDictionaryMixin
 from tests.conftest import requires_interpreted
 
 pytestmark = requires_interpreted
@@ -100,6 +101,11 @@ def test_public_data_dictionary_classes_remain_constructible() -> None:
 
     for dictionary_type in data_dictionary_types:
         assert dictionary_type().__class__ is dictionary_type
+
+
+def test_data_dictionary_shadowed_default_features_removed() -> None:
+    assert not hasattr(DataDictionaryMixin, "get_default_features")
+    assert "Overridden by DataDictionaryMixin" not in (DataDictionaryDialectMixin.get_default_features.__doc__ or "")
 
 
 def test_postgres_data_dictionary_normalizes_identifier_binds() -> None:

--- a/tests/unit/driver/test_query_cache.py
+++ b/tests/unit/driver/test_query_cache.py
@@ -271,6 +271,35 @@ async def test_async_execute_populates_fast_path_cache_on_normal_path(aiosqlite_
 
 
 @pytest.mark.anyio
+async def test_async_stmt_cache_execute_direct_uses_cursor_fast_path(
+    aiosqlite_async_driver: Any, monkeypatch: Any
+) -> None:
+    """Async direct cache execution should bypass adapter dispatch when cursor.execute is awaitable."""
+    await aiosqlite_async_driver.execute("CREATE TABLE t (id INTEGER)")
+
+    async def _fake_dispatch_execute(cursor: Any, statement: Any) -> Any:
+        _ = (cursor, statement)
+        pytest.fail("dispatch_execute should not be called on async direct fast path")
+
+    monkeypatch.setattr(aiosqlite_async_driver, "dispatch_execute", _fake_dispatch_execute)
+
+    cached = _make_cached(
+        compiled_sql="INSERT INTO t (id) VALUES (?)",
+        param_count=1,
+        operation_type="INSERT",
+        operation_profile=OperationProfile(returns_rows=False, modifies_rows=True),
+        processed_state=ProcessedState(
+            compiled_sql="INSERT INTO t (id) VALUES (?)", execution_parameters=[1], operation_type="INSERT"
+        ),
+    )
+
+    result = await aiosqlite_async_driver._stmt_cache_execute_direct("INSERT INTO t (id) VALUES (?)", (1,), cached)
+
+    assert result.operation_type == "INSERT"
+    assert result.rows_affected == 1
+
+
+@pytest.mark.anyio
 async def test_async_stmt_cache_execute_re_raises_mapped_exception(
     aiosqlite_async_driver: Any, monkeypatch: Any
 ) -> None:
@@ -296,11 +325,19 @@ async def test_async_stmt_cache_execute_direct_re_raises_mapped_exception(
 
     await aiosqlite_async_driver.execute("CREATE TABLE t (id INTEGER)")
 
-    async def _fake_dispatch_execute(cursor: Any, statement: Any) -> Any:
-        _ = (cursor, statement)
-        raise aiosqlite.OperationalError("boom")
+    class FailingCursor:
+        async def execute(self, sql: str, params: tuple[Any, ...]) -> None:
+            _ = (sql, params)
+            raise aiosqlite.OperationalError("boom")
 
-    monkeypatch.setattr(aiosqlite_async_driver, "dispatch_execute", _fake_dispatch_execute)
+    class FailingCursorContext:
+        async def __aenter__(self) -> FailingCursor:
+            return FailingCursor()
+
+        async def __aexit__(self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: Any) -> None:
+            _ = (exc_type, exc, tb)
+
+    monkeypatch.setattr(aiosqlite_async_driver, "with_cursor", lambda _connection: FailingCursorContext())
 
     cached = _make_cached(
         compiled_sql="INSERT INTO t (id) VALUES (?)",

--- a/tests/unit/migrations/test_commands_squash.py
+++ b/tests/unit/migrations/test_commands_squash.py
@@ -85,6 +85,29 @@ def test_sync_migration_commands_squash_squash_update_database_false_skips_track
 
 
 @pytest.mark.anyio
+async def test_async_squash_builds_sync_runner_with_migration_context(tmp_path: Path) -> None:
+    """Async squash should mirror the sync path and pass a real migration context."""
+    from sqlspec.migrations.commands import AsyncMigrationCommands
+    from sqlspec.migrations.context import MigrationContext
+
+    (tmp_path / "0001_initial.py").write_text("def up(context): pass\n\ndef down(context): pass\n")
+    config = Mock()
+    config.is_async = True
+    config.migration_tracker_type = Mock(return_value=Mock())
+    config.migration_config = {"script_location": str(tmp_path)}
+    config.get_observability_runtime = Mock(return_value=None)
+    commands = AsyncMigrationCommands(config)
+
+    with patch("sqlspec.migrations.commands.SyncMigrationRunner") as runner_type:
+        runner = runner_type.return_value
+        runner.get_migration_files.return_value = [("0001", tmp_path / "0001_initial.py")]
+        await commands.squash(start_version="0001", end_version="0001", description="release", dry_run=True)
+
+    context = runner_type.call_args.args[2]
+    assert isinstance(context, MigrationContext)
+
+
+@pytest.mark.anyio
 async def test_async_migration_commands_squash_async_squash_valid_range(tmp_path: Path) -> None:
     """Test async squash succeeds with valid version range."""
     from sqlspec.migrations.commands import AsyncMigrationCommands

--- a/tests/unit/storage/test_obstore_backend.py
+++ b/tests/unit/storage/test_obstore_backend.py
@@ -1,6 +1,7 @@
 # pyright: reportPrivateUsage=false
 """Unit tests for ObStoreBackend."""
 
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, cast
 
@@ -771,6 +772,26 @@ async def test_write_arrow_async_resolves_cloud_base_path_once(monkeypatch: pyte
     await store.write_arrow_async("key", cast("Any", _FakeArrowTable()))
 
     assert fake_store.put_paths == ["mybase/key"]
+
+
+@pytest.mark.skipif(not OBSTORE_INSTALLED, reason="obstore missing")
+async def test_stream_arrow_async_resolves_cloud_base_path_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    from sqlspec.storage.backends.obstore import ObStoreBackend
+
+    store = ObStoreBackend("memory://", base_path="mybase")
+    seen_patterns: list[str] = []
+
+    def fake_stream_arrow_sync(self: ObStoreBackend, pattern: str, **kwargs: Any) -> Iterator[Any]:
+        _ = self
+        _ = kwargs
+        seen_patterns.append(pattern)
+        return iter(())
+
+    monkeypatch.setattr(ObStoreBackend, "stream_arrow_sync", fake_stream_arrow_sync)
+
+    _ = [batch async for batch in store.stream_arrow_async("*.parquet")]
+
+    assert seen_patterns == ["*.parquet"]
 
 
 @pytest.mark.skipif(not OBSTORE_INSTALLED or not PYARROW_INSTALLED, reason="obstore or PyArrow missing")


### PR DESCRIPTION
## Summary

This PR fixes a set of correctness issues across SQL compilation, query builders, migration commands, storage streaming, async driver cache execution, ADK table setup, and data dictionary capability reporting. It also restores the missing v0.52.0 changelog entry and records these patch-level fixes in the changelog.

## Changes

- Prevent dynamic SQLCommenter request context and traceparent comments from being reused from compiled statement cache hits.
- Build async migration squash runners with a real migration context so extension configuration follows the synchronous command path.
- Avoid double-applying ObStore cloud base paths in async Arrow streaming.
- Render trailing sql.decode() defaults as ELSE clauses, and bind plain strings in where_in() the same way as the related WHERE helper variants.
- Keep count-query FROM detection focused on the outer SELECT instead of nested scalar subquery tables.
- Let cursor-style async adapters use the statement-cache direct execution path while preserving adapter dispatch for connection-style async APIs.
- Apply aiomysql ADK MySQL DDL options consistently and recognize errno-based missing-table errors across MySQL-family ADK stores.
- Ensure data dictionary default feature reporting comes from the dialect-specific mixin rather than the generic compatibility layer.
- Add missing v0.52.0 changelog coverage and document the new patch fixes.


Fixes #573
Fixes #574
Fixes #575
Fixes #576
Fixes #577
Fixes #578
Fixes #579
Fixes #580
Fixes #581
Fixes #582
