### PR TITLE
fix(#584): cache stable SQLCommenter output

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,14 +9,14 @@ important operational fixes.
 Recent Updates
 ==============
 
-v0.52.1 - SQL processing correctness fixes
+v0.53.0 - SQL processing correctness fixes
 ------------------------------------------------------------------------------
 
 **Fixed:**
 
-* Dynamic SQLCommenter context and trace attributes are no longer frozen by the
-  compiled statement cache; repeated compiles now use the current request
-  context.
+* Dynamic SQLCommenter context and trace attributes are appended after stable
+  SQL compilation, so repeated compiles reuse cached uncommented SQL while still
+  using the current request context.
 * Async migration squash now builds its internal migration runner with a real
   migration context, matching the synchronous command path.
 * ObStore Arrow streaming no longer resolves cloud ``base_path`` twice for

--- a/sqlspec/core/compiler.py
+++ b/sqlspec/core/compiler.py
@@ -25,6 +25,7 @@ from sqlspec.core.parameters import (
     value_fingerprint,
 )
 from sqlspec.core.parameters._processor import _make_cache_key_tuple
+from sqlspec.core.sqlcommenter import _append_sqlcommenter_comment_to_sql, _resolve_sqlcommenter_attributes
 from sqlspec.utils.logging import get_logger, log_with_context
 from sqlspec.utils.type_guards import get_value_attribute
 
@@ -371,10 +372,9 @@ class SQLProcessor:
             CompiledSQL with execution information
         """
         if not self._cache_enabled:
-            return self._compile_uncached(sql, parameters, is_many, expression, param_fingerprint=None)
-
-        if self._has_dynamic_sqlcommenter():
-            return self._compile_uncached(sql, parameters, is_many, expression, param_fingerprint=param_fingerprint)
+            return self._apply_dynamic_sqlcommenter(
+                self._compile_uncached(sql, parameters, is_many, expression, param_fingerprint=None)
+            )
 
         if param_fingerprint is None:
             param_fingerprint = self._get_param_fingerprint(parameters, is_many)
@@ -383,7 +383,9 @@ class SQLProcessor:
         # MICRO-CACHE: Fast path for repeating statements
         if cache_key == self._last_cache_key and self._last_result is not None:
             self._cache_hits += 1
-            return self._materialize_cached_result(self._last_result, parameters, is_many)
+            return self._apply_dynamic_sqlcommenter(
+                self._materialize_cached_result(self._last_result, parameters, is_many)
+            )
 
         cached_result = self._cache.get(cache_key)
         if cached_result is not None:
@@ -393,7 +395,7 @@ class SQLProcessor:
             # Update micro-cache
             self._last_cache_key = cache_key
             self._last_result = cached_result
-            return self._materialize_cached_result(cached_result, parameters, is_many)
+            return self._apply_dynamic_sqlcommenter(self._materialize_cached_result(cached_result, parameters, is_many))
 
         self._cache_misses += 1
         result = self._compile_uncached(sql, parameters, is_many, expression, param_fingerprint=param_fingerprint)
@@ -404,13 +406,41 @@ class SQLProcessor:
         self._cache[cache_key] = result
         self._last_cache_key = cache_key
         self._last_result = result
-        return result
+        return self._apply_dynamic_sqlcommenter(result)
 
     def _has_dynamic_sqlcommenter(self) -> bool:
         """Return whether SQLCommenter resolves per-call context during compilation."""
         return bool(
             self._config.enable_sqlcommenter
             and (self._config.sqlcommenter_enable_context or self._config.sqlcommenter_enable_traceparent)
+        )
+
+    def _apply_dynamic_sqlcommenter(self, result: CompiledSQL) -> CompiledSQL:
+        """Append current dynamic SQLCommenter attributes to a compiled result."""
+        if not self._has_dynamic_sqlcommenter():
+            return result
+
+        attrs = _resolve_sqlcommenter_attributes(
+            self._config.sqlcommenter_attributes or {},
+            enable_traceparent=self._config.sqlcommenter_enable_traceparent,
+            enable_context=self._config.sqlcommenter_enable_context,
+        )
+        compiled_sql = _append_sqlcommenter_comment_to_sql(result.compiled_sql, attrs)
+        if compiled_sql == result.compiled_sql:
+            return result
+
+        return CompiledSQL(
+            compiled_sql=compiled_sql,
+            execution_parameters=result.execution_parameters,
+            operation_type=result.operation_type,
+            expression=result.expression,
+            parameter_style=result.parameter_style,
+            supports_many=result.supports_many,
+            parameter_casts=result.parameter_casts,
+            parameter_profile=result.parameter_profile,
+            operation_profile=result.operation_profile,
+            input_named_parameters=result.input_named_parameters,
+            applied_wrap_types=result.applied_wrap_types,
         )
 
     def _materialize_cached_result(self, cached_result: CompiledSQL, parameters: Any, is_many: bool) -> CompiledSQL:
@@ -632,6 +662,8 @@ class SQLProcessor:
             Updated expression metadata and transformation state.
         """
         statement_transformers = self._config.statement_transformers
+        if statement_transformers and self._has_dynamic_sqlcommenter():
+            statement_transformers = statement_transformers[:-1]
         ast_transformer = self._parameter_config.ast_transformer
         if expression is None or (not statement_transformers and not ast_transformer):
             return expression, parameters, False, operation_type, operation_profile

--- a/sqlspec/core/sqlcommenter.py
+++ b/sqlspec/core/sqlcommenter.py
@@ -258,9 +258,7 @@ class _DynamicSQLCommenterTransformer:
 
     def __call__(self, expression: exp.Expr, params: Any) -> tuple[exp.Expr, Any]:
         merged = _resolve_sqlcommenter_attributes(
-            self._static_attrs,
-            enable_traceparent=self._enable_traceparent,
-            enable_context=self._enable_context,
+            self._static_attrs, enable_traceparent=self._enable_traceparent, enable_context=self._enable_context
         )
         return append_comment(expression, merged), params
 

--- a/sqlspec/core/sqlcommenter.py
+++ b/sqlspec/core/sqlcommenter.py
@@ -134,6 +134,47 @@ def append_comment(expression: exp.Expr, attrs: Mapping[str, str | None]) -> exp
     return expression
 
 
+def _append_sqlcommenter_comment_to_sql(sql: str, attrs: Mapping[str, str | None]) -> str:
+    """Append a sqlcommenter block to rendered SQL text."""
+    comment_body = generate_comment(attrs)
+    if not comment_body:
+        return sql
+
+    stripped_sql = sql.rstrip()
+    if not stripped_sql:
+        return sql
+    trailing_whitespace = sql[len(stripped_sql) :]
+    comment = f"/* {comment_body} */"
+
+    if stripped_sql.endswith(";"):
+        before_semicolon = stripped_sql[:-1]
+        statement = before_semicolon.rstrip()
+        semicolon_padding = before_semicolon[len(statement) :]
+        return f"{statement} {comment}{semicolon_padding};{trailing_whitespace}"
+
+    return f"{stripped_sql} {comment}{trailing_whitespace}"
+
+
+def _resolve_sqlcommenter_attributes(
+    static_attrs: Mapping[str, str | None], *, enable_traceparent: bool, enable_context: bool
+) -> dict[str, str | None]:
+    """Resolve static and dynamic sqlcommenter attributes for the current call."""
+    merged: dict[str, str | None] = {}
+    if enable_context:
+        ctx_attrs = SQLCommenterContext.get()
+        if ctx_attrs:
+            merged.update(ctx_attrs)
+        correlation_id = CorrelationContext.get()
+        if correlation_id and "correlation_id" not in merged:
+            merged["correlation_id"] = correlation_id
+    merged.update(static_attrs)
+    if enable_traceparent:
+        trace_id, span_id = get_trace_context()
+        if trace_id and span_id:
+            merged["traceparent"] = _build_traceparent(trace_id, span_id)
+    return merged
+
+
 def parse_comment(expression: exp.Expr) -> tuple[exp.Expr, dict[str, str]]:
     """Extract sqlcommenter attributes from a parsed expression's comments.
 
@@ -216,19 +257,11 @@ class _DynamicSQLCommenterTransformer:
         self._enable_context = enable_context
 
     def __call__(self, expression: exp.Expr, params: Any) -> tuple[exp.Expr, Any]:
-        merged: dict[str, str | None] = {}
-        if self._enable_context:
-            ctx_attrs = SQLCommenterContext.get()
-            if ctx_attrs:
-                merged.update(ctx_attrs)
-            correlation_id = CorrelationContext.get()
-            if correlation_id and "correlation_id" not in merged:
-                merged["correlation_id"] = correlation_id
-        merged.update(self._static_attrs)
-        if self._enable_traceparent:
-            trace_id, span_id = get_trace_context()
-            if trace_id and span_id:
-                merged["traceparent"] = _build_traceparent(trace_id, span_id)
+        merged = _resolve_sqlcommenter_attributes(
+            self._static_attrs,
+            enable_traceparent=self._enable_traceparent,
+            enable_context=self._enable_context,
+        )
         return append_comment(expression, merged), params
 
 

--- a/tests/unit/core/test_sqlcommenter.py
+++ b/tests/unit/core/test_sqlcommenter.py
@@ -11,6 +11,7 @@ from sqlglot import exp
 
 import sqlspec.core.sqlcommenter as sqlcommenter_module
 from sqlspec.core import SQL, StatementConfig
+from sqlspec.core.compiler import SQLProcessor
 from sqlspec.core.sqlcommenter import (
     SQLCommenterContext,
     append_comment,
@@ -30,6 +31,12 @@ def test_generate_comment_basic() -> None:
 def test_generate_comment_empty_attrs() -> None:
     result = generate_comment({})
     assert result == ""
+
+
+def test_append_sqlcommenter_comment_to_sql_preserves_trailing_semicolon() -> None:
+    result = sqlcommenter_module._append_sqlcommenter_comment_to_sql("SELECT 1;", {"route": "/users"})
+
+    assert result == "SELECT 1 /* route='%2Fusers' */;"
 
 
 def test_sqlcommenter_prefix_constant_removed() -> None:
@@ -413,6 +420,25 @@ def test_dynamic_sqlcommenter_context_not_frozen_by_compiled_cache() -> None:
     assert "route='%2Ffirst'" in first_sql
     assert "route='%2Fsecond'" in second_sql
     assert "route='%2Ffirst'" not in second_sql
+
+
+def test_dynamic_sqlcommenter_uses_compiled_cache_without_caching_comment() -> None:
+    config = StatementConfig(enable_sqlcommenter=True, sqlcommenter_enable_context=True)
+    processor = SQLProcessor(config)
+
+    with SQLCommenterContext.scope({"route": "/first"}):
+        first_result = processor.compile("SELECT 1")
+
+    with SQLCommenterContext.scope({"route": "/second"}):
+        second_result = processor.compile("SELECT 1")
+
+    assert "route='%2Ffirst'" in first_result.compiled_sql
+    assert "route='%2Fsecond'" in second_result.compiled_sql
+    assert "route='%2Ffirst'" not in second_result.compiled_sql
+    assert processor.cache_stats["hits"] == 1
+    assert processor.cache_stats["misses"] == 1
+    assert processor._last_result is not None
+    assert "route=" not in processor._last_result.compiled_sql
 
 
 def test_statement_config_enable_sqlcommenter() -> None:


### PR DESCRIPTION
## Summary

Caches the stable SQL generated for dynamic SQLCommenter statements and appends the current request or trace comment only when returning a compiled result. This keeps request-scoped SQLCommenter values current without disabling compiled statement cache reuse.

The changelog now targets the next release section as v0.53.0.

Closes #584