### PR TITLE
refactor(#585): standardize adapter exception mappers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,12 @@ Recent Updates
 v0.53.0 - SQL processing correctness fixes
 ------------------------------------------------------------------------------
 
+**Changed:**
+
+* Standardized adapter ``create_mapped_exception()`` helper signatures to accept
+  ``(error, *, logger=None)`` across backends while preserving existing
+  exception mapping behavior.
+
 **Fixed:**
 
 * Dynamic SQLCommenter context and trace attributes are appended after stable

--- a/sqlspec/adapters/adbc/core.py
+++ b/sqlspec/adapters/adbc/core.py
@@ -503,7 +503,7 @@ def prepare_postgres_parameters(
     )
 
 
-def create_mapped_exception(error: Any) -> SQLSpecError:
+def create_mapped_exception(error: Any, *, logger: Any | None = None) -> SQLSpecError:
     """Map ADBC errors to SQLSpec exceptions.
 
     This is a factory function that returns an exception instance rather than
@@ -521,6 +521,7 @@ def create_mapped_exception(error: Any) -> SQLSpecError:
     Returns:
         A SQLSpec exception that wraps the original error
     """
+    del logger
     sqlstate_attr = error.sqlstate if has_sqlstate(error) else None
     sqlstate = sqlstate_attr if sqlstate_attr is not None else None
 

--- a/sqlspec/adapters/adbc/core.py
+++ b/sqlspec/adapters/adbc/core.py
@@ -517,6 +517,7 @@ def create_mapped_exception(error: Any, *, logger: Any | None = None) -> SQLSpec
 
     Args:
         error: The ADBC exception to map
+        logger: Optional logger accepted for adapter signature parity.
 
     Returns:
         A SQLSpec exception that wraps the original error

--- a/sqlspec/adapters/aiosqlite/core.py
+++ b/sqlspec/adapters/aiosqlite/core.py
@@ -269,7 +269,7 @@ def _create_aiosqlite_error(
     return exc
 
 
-def create_mapped_exception(error: BaseException) -> SQLSpecError:
+def create_mapped_exception(error: BaseException, *, logger: Any | None = None) -> SQLSpecError:
     """Map aiosqlite exceptions to SQLSpec exceptions.
 
     This is a factory function that returns an exception instance rather than
@@ -282,6 +282,7 @@ def create_mapped_exception(error: BaseException) -> SQLSpecError:
     Returns:
         A SQLSpec exception that wraps the original error
     """
+    del logger
     if has_sqlite_error(error):
         error_code = error.sqlite_errorcode
         error_name = error.sqlite_errorname

--- a/sqlspec/adapters/aiosqlite/core.py
+++ b/sqlspec/adapters/aiosqlite/core.py
@@ -278,6 +278,7 @@ def create_mapped_exception(error: BaseException, *, logger: Any | None = None) 
 
     Args:
         error: The aiosqlite exception to map
+        logger: Optional logger accepted for adapter signature parity.
 
     Returns:
         A SQLSpec exception that wraps the original error

--- a/sqlspec/adapters/arrow_odbc/core.py
+++ b/sqlspec/adapters/arrow_odbc/core.py
@@ -59,12 +59,13 @@ def resolve_dialect_from_dbms_name(dbms_name: str | None) -> str:
     return "sqlite"
 
 
-def create_mapped_exception(exc: Exception) -> Exception:
+def create_mapped_exception(error: Exception, *, logger: Any | None = None) -> SQLSpecError:
     """Map an arrow-odbc exception to SQLSpec's exception hierarchy."""
-    message = str(exc)
+    del logger
+    message = str(error)
     if "Native error: 102" in message or "Incorrect syntax near" in message:
-        return SQLParsingError(f"ODBC SQL parsing error. Original error: {exc}")
-    return SQLSpecError(f"ODBC database error. Original error: {exc}")
+        return SQLParsingError(f"ODBC SQL parsing error. Original error: {error}")
+    return SQLSpecError(f"ODBC database error. Original error: {error}")
 
 
 def apply_driver_features(features: "dict[str, Any] | None") -> dict[str, Any]:

--- a/sqlspec/adapters/asyncpg/core.py
+++ b/sqlspec/adapters/asyncpg/core.py
@@ -445,6 +445,7 @@ def create_mapped_exception(error: Any, *, logger: Any | None = None) -> SQLSpec
 
     Args:
         error: The asyncpg exception to map
+        logger: Optional logger accepted for adapter signature parity.
 
     Returns:
         A SQLSpec exception that wraps the original error

--- a/sqlspec/adapters/asyncpg/core.py
+++ b/sqlspec/adapters/asyncpg/core.py
@@ -431,7 +431,7 @@ _EXCEPTION_MAPPING_DISPATCHER.register(
 )
 
 
-def create_mapped_exception(error: Any) -> SQLSpecError:
+def create_mapped_exception(error: Any, *, logger: Any | None = None) -> SQLSpecError:
     """Map asyncpg exceptions to SQLSpec exceptions.
 
     This is a factory function that returns an exception instance rather than
@@ -449,6 +449,7 @@ def create_mapped_exception(error: Any) -> SQLSpecError:
     Returns:
         A SQLSpec exception that wraps the original error
     """
+    del logger
     mapped_error = _EXCEPTION_MAPPING_DISPATCHER.get(error)
     if mapped_error is not None:
         error_code, error_class, description = mapped_error

--- a/sqlspec/adapters/bigquery/core.py
+++ b/sqlspec/adapters/bigquery/core.py
@@ -1046,7 +1046,7 @@ def _create_bigquery_error(
     return exc
 
 
-def create_mapped_exception(error: Any) -> SQLSpecError:
+def create_mapped_exception(error: Any, *, logger: Any | None = None) -> SQLSpecError:
     """Map BigQuery exceptions to SQLSpec exceptions.
 
     This is a factory function that returns an exception instance rather than
@@ -1072,6 +1072,7 @@ def create_mapped_exception(error: Any) -> SQLSpecError:
     Returns:
         A SQLSpec exception that wraps the original error
     """
+    del logger
     try:
         status_code = error.code
     except AttributeError:

--- a/sqlspec/adapters/bigquery/core.py
+++ b/sqlspec/adapters/bigquery/core.py
@@ -1068,6 +1068,7 @@ def create_mapped_exception(error: Any, *, logger: Any | None = None) -> SQLSpec
 
     Args:
         error: The BigQuery exception to map
+        logger: Optional logger accepted for adapter signature parity.
 
     Returns:
         A SQLSpec exception that wraps the original error

--- a/sqlspec/adapters/duckdb/core.py
+++ b/sqlspec/adapters/duckdb/core.py
@@ -295,6 +295,7 @@ def create_mapped_exception(error: "BaseException", *, logger: Any | None = None
 
     Args:
         error: The DuckDB exception to map
+        logger: Optional logger accepted for adapter signature parity.
 
     Returns:
         A SQLSpec exception that wraps the original error

--- a/sqlspec/adapters/duckdb/core.py
+++ b/sqlspec/adapters/duckdb/core.py
@@ -279,7 +279,7 @@ def _classify_duckdb_constraint(error: "BaseException") -> SQLSpecError:
 _register_duckdb_exception_mappings()
 
 
-def create_mapped_exception(exc_type: "type[BaseException]", error: "BaseException") -> SQLSpecError:
+def create_mapped_exception(error: "BaseException", *, logger: Any | None = None) -> SQLSpecError:
     """Map DuckDB exceptions to SQLSpec exceptions.
 
     This is a factory function that returns an exception instance rather than
@@ -294,12 +294,13 @@ def create_mapped_exception(exc_type: "type[BaseException]", error: "BaseExcepti
         5. Default SQLSpecError fallback
 
     Args:
-        exc_type: The exception type (class)
         error: The DuckDB exception to map
 
     Returns:
         A SQLSpec exception that wraps the original error
     """
+    del logger
+    exc_type = type(error)
     if _CONSTRAINT_EXCEPTION_TYPE is not None and isinstance(error, _CONSTRAINT_EXCEPTION_TYPE):
         return _classify_duckdb_constraint(error)
 

--- a/sqlspec/adapters/duckdb/driver.py
+++ b/sqlspec/adapters/duckdb/driver.py
@@ -61,7 +61,7 @@ class DuckDBExceptionHandler(BaseSyncExceptionHandler):
     def _handle_exception(self, exc_type: "type[BaseException] | None", exc_val: "BaseException") -> bool:
         if exc_type is None:
             return False
-        self.pending_exception = create_mapped_exception(exc_type, exc_val)
+        self.pending_exception = create_mapped_exception(exc_val)
         return True
 
 

--- a/sqlspec/adapters/mssql_python/core.py
+++ b/sqlspec/adapters/mssql_python/core.py
@@ -89,25 +89,25 @@ _ERROR_CODE_MAPPING: Final[dict[int, tuple[type[SQLSpecError], str]]] = {
 }
 
 
-def create_mapped_exception(exc: Exception, logger: "Logger | None" = None) -> Exception:
+def create_mapped_exception(error: Exception, *, logger: "Logger | None" = None) -> SQLSpecError:
     """Map a mssql-python exception to SQLSpec's exception hierarchy."""
-    error_number = _extract_error_number(exc)
+    error_number = _extract_error_number(error)
     if error_number is not None:
         mapping = _ERROR_CODE_MAPPING.get(error_number)
         if mapping is not None:
             error_class, description = mapping
-            return error_class(f"SQL Server error {error_number}: {description}. Original error: {exc}")
+            return error_class(f"SQL Server error {error_number}: {description}. Original error: {error}")
         if logger is not None:
             logger.debug("Unmapped SQL Server error number: %s", error_number)
 
-    exc_name = type(exc).__name__
+    exc_name = type(error).__name__
     if exc_name == "IntegrityError":
-        return IntegrityError(f"SQL Server integrity error. Original error: {exc}")
+        return IntegrityError(f"SQL Server integrity error. Original error: {error}")
     if exc_name == "OperationalError":
-        return OperationalError(f"SQL Server operational error. Original error: {exc}")
+        return OperationalError(f"SQL Server operational error. Original error: {error}")
     if exc_name == "DataError":
-        return DataError(f"SQL Server data error. Original error: {exc}")
-    return SQLSpecError(f"SQL Server database error. Original error: {exc}")
+        return DataError(f"SQL Server data error. Original error: {error}")
+    return SQLSpecError(f"SQL Server database error. Original error: {error}")
 
 
 def apply_driver_features(features: "dict[str, Any] | None") -> dict[str, Any]:

--- a/sqlspec/adapters/oracledb/core.py
+++ b/sqlspec/adapters/oracledb/core.py
@@ -971,6 +971,7 @@ def create_mapped_exception(error: Any, *, logger: Any | None = None) -> SQLSpec
 
     Args:
         error: The Oracle exception to map
+        logger: Optional logger accepted for adapter signature parity.
 
     Returns:
         A SQLSpec exception that wraps the original error

--- a/sqlspec/adapters/oracledb/core.py
+++ b/sqlspec/adapters/oracledb/core.py
@@ -962,7 +962,7 @@ def _create_oracle_error(
     return exc
 
 
-def create_mapped_exception(error: Any) -> SQLSpecError:
+def create_mapped_exception(error: Any, *, logger: Any | None = None) -> SQLSpecError:
     """Map Oracle exceptions to SQLSpec exceptions.
 
     This is a factory function that returns an exception instance rather than
@@ -975,6 +975,7 @@ def create_mapped_exception(error: Any) -> SQLSpecError:
     Returns:
         A SQLSpec exception that wraps the original error
     """
+    del logger
     error_obj = error.args[0] if getattr(error, "args", None) else None
     if not error_obj:
         return _create_oracle_error(error, None, SQLSpecError, "database error")

--- a/sqlspec/adapters/psqlpy/core.py
+++ b/sqlspec/adapters/psqlpy/core.py
@@ -571,6 +571,7 @@ def create_mapped_exception(error: Any, *, logger: Any | None = None) -> SQLSpec
 
     Args:
         error: The psqlpy exception to map
+        logger: Optional logger accepted for adapter signature parity.
 
     Returns:
         A SQLSpec exception that wraps the original error

--- a/sqlspec/adapters/psqlpy/core.py
+++ b/sqlspec/adapters/psqlpy/core.py
@@ -551,7 +551,7 @@ def _create_postgres_error(error: Any, error_class: type[SQLSpecError], descript
     return exc
 
 
-def create_mapped_exception(error: Any) -> SQLSpecError:
+def create_mapped_exception(error: Any, *, logger: Any | None = None) -> SQLSpecError:
     """Map psqlpy exceptions to SQLSpec exceptions.
 
     This is a factory function that returns an exception instance rather than
@@ -575,6 +575,7 @@ def create_mapped_exception(error: Any) -> SQLSpecError:
     Returns:
         A SQLSpec exception that wraps the original error
     """
+    del logger
     error_msg = str(error).lower()
 
     if "unique" in error_msg or "duplicate key" in error_msg:

--- a/sqlspec/adapters/psycopg/core.py
+++ b/sqlspec/adapters/psycopg/core.py
@@ -623,6 +623,7 @@ def create_mapped_exception(error: Any, *, logger: Any | None = None) -> SQLSpec
 
     Args:
         error: The psycopg exception to map
+        logger: Optional logger accepted for adapter signature parity.
 
     Returns:
         A SQLSpec exception that wraps the original error

--- a/sqlspec/adapters/psycopg/core.py
+++ b/sqlspec/adapters/psycopg/core.py
@@ -609,7 +609,7 @@ def _resolve_exception_mapping(error_type: type[Any]) -> "tuple[str, type[SQLSpe
 _register_exception_mappings()
 
 
-def create_mapped_exception(error: Any) -> SQLSpecError:
+def create_mapped_exception(error: Any, *, logger: Any | None = None) -> SQLSpecError:
     """Map psycopg exceptions to SQLSpec exceptions.
 
     This is a factory function that returns an exception instance rather than
@@ -627,6 +627,7 @@ def create_mapped_exception(error: Any) -> SQLSpecError:
     Returns:
         A SQLSpec exception that wraps the original error
     """
+    del logger
     error_type = type(error)
     mapped_error = _EXCEPTION_MAPPING.get(error_type)
     if mapped_error is None:

--- a/sqlspec/adapters/pymssql/core.py
+++ b/sqlspec/adapters/pymssql/core.py
@@ -159,25 +159,25 @@ def apply_driver_features(
     return statement_config, features
 
 
-def create_mapped_exception(exc: Exception, logger: "Logger | None" = None) -> Exception:
+def create_mapped_exception(error: Exception, *, logger: "Logger | None" = None) -> SQLSpecError:
     """Map a pymssql exception to SQLSpec's exception hierarchy."""
-    error_number = _extract_error_number(exc)
+    error_number = _extract_error_number(error)
     if error_number is not None:
         mapping = _ERROR_CODE_MAPPING.get(error_number)
         if mapping is not None:
             error_class, description = mapping
-            return error_class(f"SQL Server error {error_number}: {description}. Original error: {exc}")
+            return error_class(f"SQL Server error {error_number}: {description}. Original error: {error}")
         if logger is not None:
             logger.debug("Unmapped SQL Server error number: %s", error_number)
 
-    exc_name = type(exc).__name__
+    exc_name = type(error).__name__
     if exc_name == "IntegrityError":
-        return IntegrityError(f"SQL Server integrity error. Original error: {exc}")
+        return IntegrityError(f"SQL Server integrity error. Original error: {error}")
     if exc_name == "OperationalError":
-        return OperationalError(f"SQL Server operational error. Original error: {exc}")
+        return OperationalError(f"SQL Server operational error. Original error: {error}")
     if exc_name == "DataError":
-        return DataError(f"SQL Server data error. Original error: {exc}")
-    return SQLSpecError(f"SQL Server database error. Original error: {exc}")
+        return DataError(f"SQL Server data error. Original error: {error}")
+    return SQLSpecError(f"SQL Server database error. Original error: {error}")
 
 
 def resolve_column_names(description: "Sequence[Any] | None") -> "list[str]":

--- a/sqlspec/adapters/spanner/core.py
+++ b/sqlspec/adapters/spanner/core.py
@@ -224,6 +224,7 @@ def create_mapped_exception(error: Any, *, logger: Any | None = None) -> SQLSpec
 
     Args:
         error: The Spanner exception to map
+        logger: Optional logger accepted for adapter signature parity.
 
     Returns:
         A SQLSpec exception that wraps the original error

--- a/sqlspec/adapters/spanner/core.py
+++ b/sqlspec/adapters/spanner/core.py
@@ -211,7 +211,7 @@ def _create_spanner_error(error: Any, error_class: type[SQLSpecError], descripti
     return exc
 
 
-def create_mapped_exception(error: Any) -> SQLSpecError:
+def create_mapped_exception(error: Any, *, logger: Any | None = None) -> SQLSpecError:
     """Map Spanner exceptions to SQLSpec exceptions.
 
     This is a factory function that returns an exception instance rather than
@@ -228,6 +228,7 @@ def create_mapped_exception(error: Any) -> SQLSpecError:
     Returns:
         A SQLSpec exception that wraps the original error
     """
+    del logger
     # Integrity errors
     if isinstance(error, api_exceptions.AlreadyExists):
         return _create_spanner_error(error, UniqueViolationError, "resource already exists")

--- a/sqlspec/adapters/sqlite/core.py
+++ b/sqlspec/adapters/sqlite/core.py
@@ -266,7 +266,7 @@ def _create_sqlite_error(
     return exc
 
 
-def create_mapped_exception(error: BaseException) -> SQLSpecError:
+def create_mapped_exception(error: BaseException, *, logger: Any | None = None) -> SQLSpecError:
     """Map SQLite exceptions to SQLSpec exceptions.
 
     This is a factory function that returns an exception instance rather than
@@ -285,6 +285,7 @@ def create_mapped_exception(error: BaseException) -> SQLSpecError:
     Returns:
         A SQLSpec exception that wraps the original error
     """
+    del logger
     if has_sqlite_error(error):
         error_code = error.sqlite_errorcode
         error_name = error.sqlite_errorname

--- a/sqlspec/adapters/sqlite/core.py
+++ b/sqlspec/adapters/sqlite/core.py
@@ -281,6 +281,7 @@ def create_mapped_exception(error: BaseException, *, logger: Any | None = None) 
 
     Args:
         error: The SQLite exception to map
+        logger: Optional logger accepted for adapter signature parity.
 
     Returns:
         A SQLSpec exception that wraps the original error

--- a/tests/unit/adapters/test_adapter_implementations.py
+++ b/tests/unit/adapters/test_adapter_implementations.py
@@ -1,5 +1,6 @@
 """Parameterized tests for real adapter implementations."""
 
+import inspect
 import operator
 import sqlite3
 from typing import Any
@@ -9,7 +10,7 @@ import pytest
 from sqlspec.adapters.sqlite.driver import SqliteDriver
 from sqlspec.core import SQL, ParameterStyle, ParameterStyleConfig, SQLResult, StatementConfig
 from sqlspec.driver import ExecutionResult
-from sqlspec.exceptions import SQLSpecError
+from sqlspec.exceptions import SQLParsingError, SQLSpecError
 
 __all__ = ()
 
@@ -54,6 +55,26 @@ ADAPTER_CONFIGS = [
     },
 ]
 
+CREATE_MAPPED_EXCEPTION_MODULES = (
+    "sqlspec.adapters.adbc.core",
+    "sqlspec.adapters.aiomysql.core",
+    "sqlspec.adapters.aiosqlite.core",
+    "sqlspec.adapters.arrow_odbc.core",
+    "sqlspec.adapters.asyncmy.core",
+    "sqlspec.adapters.asyncpg.core",
+    "sqlspec.adapters.bigquery.core",
+    "sqlspec.adapters.duckdb.core",
+    "sqlspec.adapters.mssql_python.core",
+    "sqlspec.adapters.mysqlconnector.core",
+    "sqlspec.adapters.oracledb.core",
+    "sqlspec.adapters.psqlpy.core",
+    "sqlspec.adapters.psycopg.core",
+    "sqlspec.adapters.pymssql.core",
+    "sqlspec.adapters.pymysql.core",
+    "sqlspec.adapters.spanner.core",
+    "sqlspec.adapters.sqlite.core",
+)
+
 
 @pytest.fixture(params=ADAPTER_CONFIGS, ids=operator.itemgetter("name"))
 def adapter_config(request: pytest.FixtureRequest) -> "dict[str, Any]":
@@ -81,6 +102,37 @@ def statement_config_for_adapter(adapter_config: "dict[str, Any]") -> StatementC
             supported_execution_parameter_styles={exec_style},
         ),
     )
+
+
+@pytest.mark.parametrize("module_name", CREATE_MAPPED_EXCEPTION_MODULES)
+def test_adapter_create_mapped_exception_signature_is_uniform(module_name: str) -> None:
+    module = pytest.importorskip(module_name)
+
+    signature = inspect.signature(module.create_mapped_exception)
+
+    assert tuple(signature.parameters) == ("error", "logger")
+    assert signature.parameters["error"].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert signature.parameters["logger"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert signature.parameters["logger"].default is None
+
+
+def test_duckdb_create_mapped_exception_accepts_standard_shape() -> None:
+    from sqlspec.adapters.duckdb.core import create_mapped_exception
+
+    class ParserException(Exception):
+        pass
+
+    mapped = create_mapped_exception(ParserException("syntax error"))
+
+    assert isinstance(mapped, SQLParsingError)
+
+
+def test_arrow_odbc_create_mapped_exception_accepts_standard_shape() -> None:
+    from sqlspec.adapters.arrow_odbc.core import create_mapped_exception
+
+    mapped = create_mapped_exception(Exception("Native error: 102 Incorrect syntax near 'FROM'"), logger=None)
+
+    assert isinstance(mapped, SQLParsingError)
 
 
 def test_adapter_parameter_style_handling(

--- a/tests/unit/adapters/test_duckdb/test_exception_mapping.py
+++ b/tests/unit/adapters/test_duckdb/test_exception_mapping.py
@@ -59,8 +59,8 @@ def test_create_mapped_exception_native_dispatch(
     native_name: str, message: str, expected_class: type[SQLSpecError]
 ) -> None:
     """Native DuckDB exception types must map to the expected SQLSpec error class."""
-    exc_type, error = _make_native(native_name, message)
-    mapped = create_mapped_exception(exc_type, error)
+    _, error = _make_native(native_name, message)
+    mapped = create_mapped_exception(error)
     assert isinstance(mapped, expected_class), (
         f"{native_name}({message!r}) should map to {expected_class.__name__}, got {type(mapped).__name__}"
     )
@@ -75,7 +75,7 @@ def test_create_mapped_exception_fallback_unknown_returns_sqlspec_error() -> Non
         pass
 
     error: BaseException = _SomeOtherError("totally unrelated")
-    mapped = create_mapped_exception(_SomeOtherError, error)
+    mapped = create_mapped_exception(error)
     assert type(mapped) is SQLSpecError
     assert mapped.__cause__ is error
 
@@ -87,7 +87,7 @@ def test_create_mapped_exception_substring_fallback_permission_message() -> None
         pass
 
     error: BaseException = _Generic("permission denied for table users")
-    mapped = create_mapped_exception(_Generic, error)
+    mapped = create_mapped_exception(error)
     assert isinstance(mapped, PermissionDeniedError)
 
 
@@ -98,7 +98,7 @@ def test_create_mapped_exception_substring_fallback_interrupt_message() -> None:
         pass
 
     error: BaseException = _Generic("statement was canceled by user")
-    mapped = create_mapped_exception(_Generic, error)
+    mapped = create_mapped_exception(error)
     assert isinstance(mapped, QueryTimeoutError)
 
 
@@ -109,7 +109,7 @@ def test_create_mapped_exception_substring_fallback_type_mismatch_message() -> N
         pass
 
     error: BaseException = _Generic("type mismatch in cast")
-    mapped = create_mapped_exception(_Generic, error)
+    mapped = create_mapped_exception(error)
     assert isinstance(mapped, DataError)
 
 
@@ -123,15 +123,15 @@ def test_create_mapped_exception_subclass_dispatch() -> None:
         pass
 
     err: Any = _CustomCatalogError("derived missing-table error")
-    mapped = create_mapped_exception(_CustomCatalogError, err)
+    mapped = create_mapped_exception(err)
     assert isinstance(mapped, NotFoundError)
 
 
 def test_create_mapped_exception_repeated_calls_consistent() -> None:
     """Repeated calls for the same type return the same mapping class (cache safety)."""
-    exc_type, error = _make_native("CatalogException", "missing table x")
-    first = create_mapped_exception(exc_type, error)
-    second = create_mapped_exception(exc_type, error)
+    _, error = _make_native("CatalogException", "missing table x")
+    first = create_mapped_exception(error)
+    second = create_mapped_exception(error)
     assert type(first) is type(second)
     assert isinstance(first, NotFoundError)
     assert isinstance(second, NotFoundError)

--- a/tests/unit/exceptions/test_exception_handler.py
+++ b/tests/unit/exceptions/test_exception_handler.py
@@ -54,9 +54,9 @@ def test_duckdb_exception_handler_maps_any_present_exception(monkeypatch: pytest
     mapped = RuntimeError("mapped")
     seen: dict[str, object] = {}
 
-    def fake_create_mapped_exception(exc_type: type[BaseException], exc_val: BaseException) -> Exception:
-        seen["exc_type"] = exc_type
+    def fake_create_mapped_exception(exc_val: BaseException, *, logger: object | None = None) -> Exception:
         seen["exc_val"] = exc_val
+        seen["logger"] = logger
         return mapped
 
     monkeypatch.setattr(duckdb_driver, "create_mapped_exception", fake_create_mapped_exception)
@@ -66,7 +66,7 @@ def test_duckdb_exception_handler_maps_any_present_exception(monkeypatch: pytest
 
     assert handler.__exit__(type(error), error, None) is True
     assert handler.pending_exception is mapped
-    assert seen == {"exc_type": ValueError, "exc_val": error}
+    assert seen == {"exc_val": error, "logger": None}
 
 
 def test_mysqlconnector_sync_exception_handler_preserves_suppression(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -245,7 +245,8 @@ def test_duckdb_handler_maps_constraint_exception(monkeypatch: pytest.MonkeyPatc
     from sqlspec.adapters.duckdb.driver import DuckDBExceptionHandler
     from sqlspec.exceptions import UniqueViolationError
 
-    def fake_create_mapped_exception(exc_type: "type[BaseException]", exc_val: "BaseException") -> Exception:
+    def fake_create_mapped_exception(exc_val: "BaseException", *, logger: object | None = None) -> Exception:
+        assert logger is None
         return UniqueViolationError(str(exc_val))
 
     monkeypatch.setattr(duckdb_core, "create_mapped_exception", fake_create_mapped_exception)


### PR DESCRIPTION
## Summary

Standardizes adapter exception mapping helpers on a single error-first signature with an optional keyword-only logger. DuckDB now derives the exception type inside the mapper, and existing adapter exception behavior is preserved.

The changelog now targets the next release section as v0.53.0.

Closes #585