### PR TITLE
refactor(#588): standardize adapter driver feature helpers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,8 @@ v0.53.0 - SQL processing correctness fixes
 * Standardized adapter ``create_mapped_exception()`` helper signatures to accept
   ``(error, *, logger=None)`` across backends while preserving existing
   exception mapping behavior.
+* Standardized adapter ``apply_driver_features()`` helpers to return an updated
+  statement config plus normalized driver-feature dictionary across backends.
 
 **Fixed:**
 

--- a/sqlspec/adapters/arrow_odbc/config.py
+++ b/sqlspec/adapters/arrow_odbc/config.py
@@ -142,18 +142,23 @@ class ArrowOdbcConfig(NoPoolSyncConfig[ArrowOdbcConnection, ArrowOdbcDriver]):
     ) -> None:
         """Initialize arrow-odbc configuration."""
         normalized = normalize_connection_config(connection_config)
-        features = apply_driver_features(dict(driver_features or {}))
+        provided_statement_config = statement_config
+        statement_config, features = apply_driver_features(
+            statement_config or default_statement_config, driver_features
+        )
         connection_string = normalized.get("connection_string")
         if connection_string is not None:
             features.setdefault("connection_string", str(connection_string))
         elif normalized.get("driver") is not None:
             features.setdefault("dbms_name", str(normalized["driver"]))
+        if provided_statement_config is None:
+            statement_config = _resolve_statement_config(features)
 
         super().__init__(
             connection_config=normalized,
             connection_instance=connection_instance,
             migration_config=migration_config,
-            statement_config=statement_config or _resolve_statement_config(features),
+            statement_config=statement_config,
             driver_features=features,
             bind_key=bind_key,
             extension_config=extension_config,

--- a/sqlspec/adapters/arrow_odbc/core.py
+++ b/sqlspec/adapters/arrow_odbc/core.py
@@ -8,7 +8,7 @@ from sqlspec.utils.serializers import from_json, to_json
 from sqlspec.utils.type_converters import build_uuid_coercions
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
 
     from sqlspec.core import StatementConfig
 
@@ -68,7 +68,9 @@ def create_mapped_exception(error: Exception, *, logger: Any | None = None) -> S
     return SQLSpecError(f"ODBC database error. Original error: {error}")
 
 
-def apply_driver_features(features: "dict[str, Any] | None") -> dict[str, Any]:
+def apply_driver_features(
+    statement_config: "StatementConfig", driver_features: "Mapping[str, Any] | None"
+) -> "tuple[StatementConfig, dict[str, Any]]":
     """Merge arrow-odbc driver feature defaults with caller overrides."""
     defaults: dict[str, Any] = {
         "chunk_size": 65_536,
@@ -80,8 +82,8 @@ def apply_driver_features(features: "dict[str, Any] | None") -> dict[str, Any]:
         "json_serializer": to_json,
         "json_deserializer": from_json,
     }
-    defaults.update(features or {})
-    return defaults
+    defaults.update(driver_features or {})
+    return statement_config, defaults
 
 
 def build_connection_config(params: dict[str, Any]) -> tuple[str, dict[str, Any]]:

--- a/sqlspec/adapters/bigquery/config.py
+++ b/sqlspec/adapters/bigquery/config.py
@@ -6,7 +6,7 @@ from google.cloud.bigquery import LoadJobConfig, QueryJobConfig
 from typing_extensions import NotRequired
 
 from sqlspec.adapters.bigquery._typing import BigQueryConnection, BigQueryCursor, BigQuerySessionContext
-from sqlspec.adapters.bigquery.core import apply_driver_features, build_statement_config, default_statement_config
+from sqlspec.adapters.bigquery.core import apply_driver_features, default_statement_config
 from sqlspec.adapters.bigquery.driver import BigQueryDriver, BigQueryExceptionHandler
 from sqlspec.config import ExtensionConfigs, NoPoolSyncConfig
 from sqlspec.driver._sync import SyncPoolConnectionContext, SyncPoolSessionFactory
@@ -206,17 +206,18 @@ class BigQueryConfig(NoPoolSyncConfig[BigQueryConnection, BigQueryDriver]):
 
         self.connection_config = normalize_connection_config(connection_config)
 
-        (driver_features, serializer, user_connection_hook, features_connection_instance) = apply_driver_features(
-            driver_features
+        statement_config = statement_config or default_statement_config
+        statement_config, driver_features = apply_driver_features(statement_config, driver_features)
+        user_connection_hook = cast(
+            "Callable[[BigQueryConnection], None] | None", driver_features.pop("on_connection_create", None)
         )
+        features_connection_instance = driver_features.pop("connection_instance", None)
 
         resolved_connection_instance = connection_instance or features_connection_instance
         self._connection_instance = resolved_connection_instance
 
         if "default_query_job_config" not in self.connection_config:
             self._setup_default_job_config()
-
-        statement_config = statement_config or build_statement_config(json_serializer=serializer)
 
         # Fired directly in create_connection (the client-construction path) like every other adapter,
         # rather than bridged through the observability lifecycle dispatcher (which only runs under the

--- a/sqlspec/adapters/bigquery/core.py
+++ b/sqlspec/adapters/bigquery/core.py
@@ -1006,23 +1006,13 @@ default_statement_config = build_statement_config()
 
 
 def apply_driver_features(
-    driver_features: "Mapping[str, Any] | None",
-) -> "tuple[dict[str, Any], Callable[[Any], str] | None, Callable[[Any], None] | None, Any | None]":
+    statement_config: StatementConfig, driver_features: "Mapping[str, Any] | None"
+) -> "tuple[StatementConfig, dict[str, Any]]":
     """Apply BigQuery driver feature defaults and extract core options."""
     features: dict[str, Any] = dict(driver_features) if driver_features else {}
-    user_connection_hook = features.pop("on_connection_create", None)
     features.setdefault("enable_uuid_conversion", True)
-    serializer = features.setdefault("json_serializer", to_json)
-    connection_instance = features.get("connection_instance")
-    if connection_instance is not None:
-        features.pop("connection_instance", None)
-
-    return (
-        features,
-        cast("Callable[[Any], str] | None", serializer),
-        cast("Callable[[Any], None] | None", user_connection_hook),
-        connection_instance,
-    )
+    features.setdefault("json_serializer", to_json)
+    return statement_config, features
 
 
 def _create_bigquery_error(

--- a/sqlspec/adapters/cockroach_psycopg/driver.py
+++ b/sqlspec/adapters/cockroach_psycopg/driver.py
@@ -15,7 +15,6 @@ from sqlspec.adapters.cockroach_psycopg._typing import (
 )
 from sqlspec.adapters.cockroach_psycopg.core import (
     CockroachPsycopgRetryConfig,
-    apply_driver_features,
     build_statement_config,
     calculate_backoff_seconds,
     driver_profile,
@@ -100,9 +99,8 @@ class CockroachPsycopgSyncDriver(PsycopgSyncDriver):
             statement_config = build_statement_config().replace(
                 enable_caching=get_cache_config().compiled_cache_enabled
             )
-
-        statement_config, normalized_features = apply_driver_features(statement_config, driver_features)
-        super().__init__(connection=connection, statement_config=statement_config, driver_features=normalized_features)
+        driver_features = dict(driver_features) if driver_features else {}
+        super().__init__(connection=connection, statement_config=statement_config, driver_features=driver_features)
 
         self._retry_config = CockroachPsycopgRetryConfig.from_features(self.driver_features)
         self._enable_retry = bool(self.driver_features.get("enable_auto_retry", True))
@@ -187,9 +185,8 @@ class CockroachPsycopgAsyncDriver(PsycopgAsyncDriver):
             statement_config = build_statement_config().replace(
                 enable_caching=get_cache_config().compiled_cache_enabled
             )
-
-        statement_config, normalized_features = apply_driver_features(statement_config, driver_features)
-        super().__init__(connection=connection, statement_config=statement_config, driver_features=normalized_features)
+        driver_features = dict(driver_features) if driver_features else {}
+        super().__init__(connection=connection, statement_config=statement_config, driver_features=driver_features)
 
         self._retry_config = CockroachPsycopgRetryConfig.from_features(self.driver_features)
         self._enable_retry = bool(self.driver_features.get("enable_auto_retry", True))

--- a/sqlspec/adapters/duckdb/config.py
+++ b/sqlspec/adapters/duckdb/config.py
@@ -284,7 +284,7 @@ class DuckDBConfig(SyncDatabaseConfig[DuckDBConnection, DuckDBConnectionPool, Du
         statement_config = statement_config or build_statement_config(
             json_serializer=cast("Callable[[Any], str]", serializer)
         )
-        statement_config = apply_driver_features(statement_config, features)
+        statement_config, features = apply_driver_features(statement_config, features)
 
         super().__init__(
             bind_key=bind_key,

--- a/sqlspec/adapters/duckdb/core.py
+++ b/sqlspec/adapters/duckdb/core.py
@@ -170,19 +170,20 @@ driver_profile = build_profile()
 
 def apply_driver_features(
     statement_config: "StatementConfig", driver_features: "Mapping[str, Any] | None"
-) -> "StatementConfig":
+) -> "tuple[StatementConfig, dict[str, Any]]":
     """Apply DuckDB-specific driver features to statement configuration."""
-    if not driver_features:
-        return statement_config
+    features: dict[str, Any] = dict(driver_features) if driver_features else {}
+    if not features:
+        return statement_config, features
 
     param_config = statement_config.parameter_config
-    json_serializer = driver_features.get("json_serializer")
+    json_serializer = features.get("json_serializer")
     if json_serializer:
         param_config = param_config.with_json_serializers(
             cast("Callable[[Any], str]", json_serializer), tuple_strategy="tuple"
         )
 
-    enable_uuid_conversion = driver_features.get("enable_uuid_conversion", True)
+    enable_uuid_conversion = features.get("enable_uuid_conversion", True)
     if not enable_uuid_conversion:
         type_converter = DuckDBOutputConverter(enable_uuid_conversion=enable_uuid_conversion)
         type_coercion_map = dict(param_config.type_coercion_map)
@@ -190,8 +191,8 @@ def apply_driver_features(
         param_config = param_config.replace(type_coercion_map=type_coercion_map)
 
     if param_config is statement_config.parameter_config:
-        return statement_config
-    return statement_config.replace(parameter_config=param_config)
+        return statement_config, features
+    return statement_config.replace(parameter_config=param_config), features
 
 
 def _create_duckdb_error(error: Any, error_class: type[SQLSpecError], description: str) -> SQLSpecError:

--- a/sqlspec/adapters/duckdb/driver.py
+++ b/sqlspec/adapters/duckdb/driver.py
@@ -8,7 +8,6 @@ import duckdb
 
 from sqlspec.adapters.duckdb._typing import DuckDBCursor, DuckDBSessionContext
 from sqlspec.adapters.duckdb.core import (
-    apply_driver_features,
     collect_rows,
     create_mapped_exception,
     default_statement_config,
@@ -89,7 +88,7 @@ class DuckDBDriver(SyncDriverAdapterBase):
             statement_config = default_statement_config.replace(
                 enable_caching=get_cache_config().compiled_cache_enabled
             )
-            statement_config = apply_driver_features(statement_config, driver_features)
+        driver_features = dict(driver_features) if driver_features else {}
 
         super().__init__(connection=connection, statement_config=statement_config, driver_features=driver_features)
         self._data_dictionary: DuckDBDataDictionary | None = None

--- a/sqlspec/adapters/mssql_python/config.py
+++ b/sqlspec/adapters/mssql_python/config.py
@@ -443,6 +443,6 @@ def _normalize_mssql_python_init(
     driver_features: "MssqlPythonDriverFeatures | dict[str, Any] | None",
 ) -> "tuple[dict[str, Any], dict[str, Any], Callable[[MssqlPythonConnection], None] | None]":
     normalized = normalize_connection_config(connection_config)
-    features_dict = apply_driver_features(dict(driver_features or {}))
+    _, features_dict = apply_driver_features(default_statement_config, driver_features)
     hook = cast("Callable[[MssqlPythonConnection], None] | None", features_dict.pop("on_connection_create", None))
     return normalized, features_dict, hook

--- a/sqlspec/adapters/mssql_python/core.py
+++ b/sqlspec/adapters/mssql_python/core.py
@@ -24,7 +24,7 @@ from sqlspec.utils.serializers import from_json, to_json
 from sqlspec.utils.type_converters import build_uuid_coercions
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
     from logging import Logger
 
     from sqlspec.core import StatementConfig
@@ -110,11 +110,13 @@ def create_mapped_exception(error: Exception, *, logger: "Logger | None" = None)
     return SQLSpecError(f"SQL Server database error. Original error: {error}")
 
 
-def apply_driver_features(features: "dict[str, Any] | None") -> dict[str, Any]:
+def apply_driver_features(
+    statement_config: "StatementConfig", driver_features: "Mapping[str, Any] | None"
+) -> "tuple[StatementConfig, dict[str, Any]]":
     """Merge mssql-python driver-feature defaults with caller overrides."""
     defaults: dict[str, Any] = {"use_pool": True, "json_serializer": to_json, "json_deserializer": from_json}
-    defaults.update(features or {})
-    return defaults
+    defaults.update(driver_features or {})
+    return statement_config, defaults
 
 
 def build_connection_config(params: dict[str, Any]) -> tuple[str, dict[str, Any]]:

--- a/sqlspec/adapters/oracledb/config.py
+++ b/sqlspec/adapters/oracledb/config.py
@@ -320,8 +320,7 @@ class OracleSyncConfig(SyncDatabaseConfig[OracleSyncConnection, "OracleSyncConne
             "Callable[[OracleSyncConnection, str], None] | None", connection_config.pop("session_callback", None)
         )
         statement_config = statement_config or default_statement_config
-
-        driver_features = apply_driver_features(driver_features)
+        statement_config, driver_features = apply_driver_features(statement_config, driver_features)
 
         # Extract user connection hook before storing driver_features
         features_dict = dict(driver_features) if driver_features else {}
@@ -534,7 +533,8 @@ class OracleAsyncConfig(AsyncDatabaseConfig[OracleAsyncConnection, "OracleAsyncC
             "Callable[[OracleAsyncConnection, str], Any] | None", connection_config.pop("session_callback", None)
         )
 
-        driver_features = apply_driver_features(driver_features)
+        statement_config = statement_config or default_statement_config
+        statement_config, driver_features = apply_driver_features(statement_config, driver_features)
 
         # Extract user connection hook before storing driver_features
         features_dict = dict(driver_features) if driver_features else {}
@@ -546,7 +546,7 @@ class OracleAsyncConfig(AsyncDatabaseConfig[OracleAsyncConnection, "OracleAsyncC
             connection_config=connection_config,
             connection_instance=connection_instance,
             migration_config=migration_config,
-            statement_config=statement_config or default_statement_config,
+            statement_config=statement_config,
             driver_features=features_dict,
             bind_key=bind_key,
             extension_config=extension_config,

--- a/sqlspec/adapters/oracledb/core.py
+++ b/sqlspec/adapters/oracledb/core.py
@@ -534,7 +534,9 @@ def resolve_rowcount(cursor: Any) -> int:
     return 0
 
 
-def apply_driver_features(driver_features: "Mapping[str, Any] | None") -> "dict[str, Any]":
+def apply_driver_features(
+    statement_config: "StatementConfig", driver_features: "Mapping[str, Any] | None"
+) -> "tuple[StatementConfig, dict[str, Any]]":
     """Apply OracleDB driver feature defaults."""
     features: dict[str, Any] = dict(driver_features) if driver_features else {}
     features.setdefault("enable_numpy_vectors", NUMPY_INSTALLED)
@@ -549,7 +551,7 @@ def apply_driver_features(driver_features: "Mapping[str, Any] | None") -> "dict[
             features["vector_return_format"] = "array"
     features.setdefault("oracle_varchar2_byte_limit", 4000)
     features.setdefault("oracle_raw_byte_limit", 2000)
-    return features
+    return statement_config, features
 
 
 def _description_requires_lob_coercion(description: "list[Any]") -> bool:

--- a/sqlspec/adapters/spanner/config.py
+++ b/sqlspec/adapters/spanner/config.py
@@ -293,9 +293,8 @@ class SpannerSyncConfig(SyncDatabaseConfig["SpannerConnection", "AbstractSession
         self.connection_config.setdefault("size", self.connection_config.pop("max_sessions", 10))
         self.connection_config.setdefault("pool_type", FixedSizePool)
 
-        driver_features = apply_driver_features(raw_driver_features)
-
         statement_config = statement_config or default_statement_config
+        statement_config, driver_features = apply_driver_features(statement_config, raw_driver_features)
 
         super().__init__(
             connection_config=self.connection_config,

--- a/sqlspec/adapters/spanner/core.py
+++ b/sqlspec/adapters/spanner/core.py
@@ -77,13 +77,15 @@ def build_statement_config() -> StatementConfig:
 default_statement_config = build_statement_config()
 
 
-def apply_driver_features(driver_features: "Mapping[str, Any] | None") -> "dict[str, Any]":
+def apply_driver_features(
+    statement_config: "StatementConfig", driver_features: "Mapping[str, Any] | None"
+) -> "tuple[StatementConfig, dict[str, Any]]":
     """Apply Spanner driver feature defaults."""
     processed_features: dict[str, Any] = dict(driver_features) if driver_features else {}
     processed_features.setdefault("enable_uuid_conversion", True)
     processed_features.setdefault("json_serializer", to_json)
     processed_features.setdefault("json_deserializer", from_json)
-    return processed_features
+    return statement_config, processed_features
 
 
 def supports_write(cursor: Any) -> bool:

--- a/tests/unit/adapters/test_adapter_implementations.py
+++ b/tests/unit/adapters/test_adapter_implementations.py
@@ -1,8 +1,10 @@
 """Parameterized tests for real adapter implementations."""
 
+import ast
 import inspect
 import operator
 import sqlite3
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -55,7 +57,7 @@ ADAPTER_CONFIGS = [
     },
 ]
 
-CREATE_MAPPED_EXCEPTION_MODULES = (
+ADAPTER_CORE_MODULES = (
     "sqlspec.adapters.adbc.core",
     "sqlspec.adapters.aiomysql.core",
     "sqlspec.adapters.aiosqlite.core",
@@ -73,6 +75,12 @@ CREATE_MAPPED_EXCEPTION_MODULES = (
     "sqlspec.adapters.pymysql.core",
     "sqlspec.adapters.spanner.core",
     "sqlspec.adapters.sqlite.core",
+)
+CREATE_MAPPED_EXCEPTION_MODULES = ADAPTER_CORE_MODULES
+APPLY_DRIVER_FEATURES_MODULES = ADAPTER_CORE_MODULES
+ADAPTER_DRIVER_MODULES_WITH_FEATURE_HELPERS = (
+    "sqlspec/adapters/cockroach_psycopg/driver.py",
+    "sqlspec/adapters/duckdb/driver.py",
 )
 
 
@@ -133,6 +141,41 @@ def test_arrow_odbc_create_mapped_exception_accepts_standard_shape() -> None:
     mapped = create_mapped_exception(Exception("Native error: 102 Incorrect syntax near 'FROM'"), logger=None)
 
     assert isinstance(mapped, SQLParsingError)
+
+
+@pytest.mark.parametrize("module_name", APPLY_DRIVER_FEATURES_MODULES)
+def test_adapter_apply_driver_features_signature_and_return_shape(module_name: str) -> None:
+    module = pytest.importorskip(module_name)
+    statement_config = StatementConfig()
+
+    signature = inspect.signature(module.apply_driver_features)
+    assert tuple(signature.parameters) == ("statement_config", "driver_features")
+
+    resolved_statement_config, features = module.apply_driver_features(statement_config, {"custom": "value"})
+
+    assert isinstance(resolved_statement_config, StatementConfig)
+    assert isinstance(features, dict)
+    assert features["custom"] == "value"
+
+
+@pytest.mark.parametrize("module_path", ADAPTER_DRIVER_MODULES_WITH_FEATURE_HELPERS)
+def test_adapter_drivers_do_not_apply_driver_features(module_path: str) -> None:
+    tree = ast.parse(Path(module_path).read_text())
+
+    imports_helper = any(
+        isinstance(node, ast.ImportFrom)
+        and node.module is not None
+        and node.module.endswith(".core")
+        and any(alias.name == "apply_driver_features" for alias in node.names)
+        for node in ast.walk(tree)
+    )
+    calls_helper = any(
+        isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "apply_driver_features"
+        for node in ast.walk(tree)
+    )
+
+    assert imports_helper is False
+    assert calls_helper is False
 
 
 def test_adapter_parameter_style_handling(

--- a/tests/unit/adapters/test_bigquery/test_config.py
+++ b/tests/unit/adapters/test_bigquery/test_config.py
@@ -30,15 +30,14 @@ def test_build_statement_config_custom_serializer() -> None:
 
 
 def test_bigquery_config_applies_driver_feature_serializer() -> None:
-    """Driver features should mutate the BigQuery statement configuration."""
+    """Driver features should preserve the serializer for BigQuery parameter construction."""
 
     def serializer(_: object) -> str:
         return "feature"
 
     config = BigQueryConfig(driver_features={"json_serializer": serializer})
 
-    parameter_config = config.statement_config.parameter_config
-    assert parameter_config.json_serializer is serializer
+    assert config.driver_features["json_serializer"] is serializer
 
 
 def test_bigquery_config_wires_query_timeout_ms_to_default_job_config() -> None:

--- a/tests/unit/adapters/test_bigquery/test_parameters.py
+++ b/tests/unit/adapters/test_bigquery/test_parameters.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 
 import pytest
 
+from sqlspec.adapters.bigquery import BigQueryConfig
 from sqlspec.adapters.bigquery.core import create_parameters, default_statement_config
 from sqlspec.core import SQL
 from sqlspec.exceptions import SQLSpecError
@@ -25,6 +26,17 @@ def test_create_parameters_builds_array_query_parameter() -> None:
     assert api_repr["name"] == "values"
     assert api_repr["parameterType"] == {"type": "ARRAY", "arrayType": {"type": "INT64"}}
     assert api_repr["parameterValue"] == {"arrayValues": [{"value": "1"}, {"value": "2"}, {"value": "3"}]}
+
+
+def test_create_parameters_rejects_compiled_empty_array_parameter() -> None:
+    """Compiled empty arrays should fail locally before BigQuery sees a JSON string."""
+    config = BigQueryConfig()
+    _sql, parameters = SQL(
+        "SELECT ARRAY_LENGTH(@values)", {"values": []}, statement_config=config.statement_config
+    ).compile()
+
+    with pytest.raises(SQLSpecError, match="Cannot determine BigQuery ARRAY type"):
+        create_parameters(parameters, json_serializer=str)
 
 
 def test_sql_compile_accepts_native_at_parameter_keys() -> None:

--- a/tests/unit/adapters/test_duckdb/test_config.py
+++ b/tests/unit/adapters/test_duckdb/test_config.py
@@ -112,20 +112,25 @@ def test_build_connection_config_preserves_nested_config_and_extra() -> None:
     }
 
 
-def test_driver_init_apply_driver_features_called_once_when_statement_config_is_none() -> None:
+def test_driver_init_does_not_apply_driver_features_when_statement_config_is_none() -> None:
     connection = duckdb.connect(database=":memory:")
     driver_features: dict[str, Any] = {"json_serializer": lambda value: "[]"}
-    with patch("sqlspec.adapters.duckdb.driver.apply_driver_features", wraps=apply_driver_features) as mock_apply:
-        DuckDBDriver(connection=connection, statement_config=None, driver_features=driver_features)
-    assert mock_apply.call_count == 1
+    driver = DuckDBDriver(connection=connection, statement_config=None, driver_features=driver_features)
+
+    assert driver.driver_features is not driver_features
+    assert driver.driver_features == driver_features
 
 
 def test_driver_init_apply_driver_features_not_called_when_statement_config_provided() -> None:
     connection = duckdb.connect(database=":memory:")
     driver_features: dict[str, Any] = {"json_serializer": lambda value: "[]"}
-    with patch("sqlspec.adapters.duckdb.driver.apply_driver_features", wraps=apply_driver_features) as mock_apply:
-        DuckDBDriver(connection=connection, statement_config=default_statement_config, driver_features=driver_features)
-    assert mock_apply.call_count == 0
+    driver = DuckDBDriver(
+        connection=connection, statement_config=default_statement_config, driver_features=driver_features
+    )
+
+    assert driver.statement_config is default_statement_config
+    assert driver.driver_features is not driver_features
+    assert driver.driver_features == driver_features
 
 
 def test_driver_init_custom_json_serializer_identity_preserved_through_session() -> None:
@@ -146,10 +151,10 @@ def test_driver_init_apply_driver_features_not_called_per_session_via_config() -
     def custom_serializer(_: object) -> str:
         return "custom"
 
-    with patch("sqlspec.adapters.duckdb.driver.apply_driver_features", wraps=apply_driver_features) as mock_apply:
+    with patch("sqlspec.adapters.duckdb.config.apply_driver_features", wraps=apply_driver_features) as mock_apply:
         config = DuckDBConfig(
             connection_config={"database": ":memory:"}, driver_features={"json_serializer": custom_serializer}
         )
         with config.provide_session():
             pass
-    assert mock_apply.call_count == 0
+    assert mock_apply.call_count == 1

--- a/tests/unit/adapters/test_oracledb/test_core_driver_features.py
+++ b/tests/unit/adapters/test_oracledb/test_core_driver_features.py
@@ -11,15 +11,21 @@ from sqlspec.adapters.oracledb import config
 from sqlspec.adapters.oracledb._typing import OracleAsyncCursor
 from sqlspec.adapters.oracledb.config import OracleAsyncConfig, OracleSyncConfig
 from sqlspec.adapters.oracledb.core import apply_driver_features
+from sqlspec.core import StatementConfig
 from sqlspec.typing import NUMPY_INSTALLED
 
 if TYPE_CHECKING:
     from sqlspec.adapters.oracledb._typing import OracleAsyncConnection
 
 
+def _apply_features(features: dict[str, object] | None = None) -> dict[str, object]:
+    _, resolved_features = apply_driver_features(StatementConfig(), features)
+    return resolved_features
+
+
 def test_apply_driver_features_returns_dict_when_input_none() -> None:
     """``apply_driver_features(None)`` returns a populated defaults dict."""
-    features = apply_driver_features(None)
+    features = _apply_features()
     assert isinstance(features, dict)
     assert "enable_numpy_vectors" in features
     assert "enable_lowercase_column_names" in features
@@ -33,26 +39,26 @@ def test_apply_driver_features_sets_vector_return_format_default() -> None:
     Mirrors the policy in chapter-3/spec.md §3 T5: NumPy users keep zero-copy
     ndarray reads as the default; pure-Python users get list[float|int].
     """
-    features = apply_driver_features({})
+    features = _apply_features({})
     expected = "numpy" if NUMPY_INSTALLED else "list"
     assert features["vector_return_format"] == expected
 
 
 def test_apply_driver_features_preserves_user_vector_return_format() -> None:
     """User-supplied ``vector_return_format`` is not overwritten by the default."""
-    features = apply_driver_features({"vector_return_format": "list"})
+    features = _apply_features({"vector_return_format": "list"})
     assert features["vector_return_format"] == "list"
 
 
 def test_apply_driver_features_preserves_user_array_return_format() -> None:
     """User-supplied ``"array"`` return format survives the defaults pass."""
-    features = apply_driver_features({"vector_return_format": "array"})
+    features = _apply_features({"vector_return_format": "array"})
     assert features["vector_return_format"] == "array"
 
 
 def test_apply_driver_features_honors_numpy_vectors_opt_out() -> None:
     """``enable_numpy_vectors=False`` keeps the driver-native VECTOR return type."""
-    features = apply_driver_features({"enable_numpy_vectors": False})
+    features = _apply_features({"enable_numpy_vectors": False})
     assert features["vector_return_format"] == "array"
 
 
@@ -66,13 +72,13 @@ def test_oracle_driver_features_typeddict_advertises_vector_return_format() -> N
 
 def test_apply_driver_features_sets_varchar2_byte_limit_default() -> None:
     """``oracle_varchar2_byte_limit`` defaults to 4000 (Oracle SQL VARCHAR2 limit)."""
-    features = apply_driver_features({})
+    features = _apply_features({})
     assert features["oracle_varchar2_byte_limit"] == 4000
 
 
 def test_apply_driver_features_sets_raw_byte_limit_default() -> None:
     """``oracle_raw_byte_limit`` defaults to 2000 (Oracle SQL RAW limit)."""
-    features = apply_driver_features({})
+    features = _apply_features({})
     assert features["oracle_raw_byte_limit"] == 2000
 
 
@@ -82,19 +88,19 @@ def test_apply_driver_features_preserves_user_varchar2_byte_limit() -> None:
     MAX_STRING_SIZE=EXTENDED databases may set this to 32767 to keep larger
     strings as VARCHAR2 instead of auto-coercing to CLOB.
     """
-    features = apply_driver_features({"oracle_varchar2_byte_limit": 32767})
+    features = _apply_features({"oracle_varchar2_byte_limit": 32767})
     assert features["oracle_varchar2_byte_limit"] == 32767
 
 
 def test_apply_driver_features_preserves_user_raw_byte_limit() -> None:
     """User-supplied ``oracle_raw_byte_limit`` is not overwritten by the default."""
-    features = apply_driver_features({"oracle_raw_byte_limit": 100})
+    features = _apply_features({"oracle_raw_byte_limit": 100})
     assert features["oracle_raw_byte_limit"] == 100
 
 
 def test_apply_driver_features_does_not_default_fetch_tuning_options() -> None:
     """Absent fetch tuning keys should leave python-oracledb defaults untouched."""
-    features = apply_driver_features({})
+    features = _apply_features({})
     assert "arraysize" not in features
     assert "prefetchrows" not in features
     assert "fetch_lobs" not in features
@@ -103,7 +109,7 @@ def test_apply_driver_features_does_not_default_fetch_tuning_options() -> None:
 
 def test_apply_driver_features_preserves_user_fetch_tuning_options() -> None:
     """User-supplied fetch tuning options survive the defaults pass."""
-    features = apply_driver_features({"arraysize": 5000, "fetch_decimals": True})
+    features = _apply_features({"arraysize": 5000, "fetch_decimals": True})
     assert features["arraysize"] == 5000
     assert features["fetch_decimals"] is True
 


### PR DESCRIPTION
## Summary

- Standardizes adapter `apply_driver_features` helpers so configs receive both updated statement config and normalized driver features.
- Keeps feature normalization in config/session construction, avoiding driver-time reapplication in DuckDB and Cockroach psycopg fallback constructors.
- Preserves BigQuery array bind values until BigQuery parameter construction so empty arrays fail locally instead of reaching the API as strings.
- Adds regression coverage for the helper contract and the BigQuery empty-array path.

Closes #588.