### PR TITLE
refactor(mysql): route vendor symbols through typing modules

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,8 @@ v0.53.0 - SQL processing correctness fixes
   exception mapping behavior.
 * Standardized adapter ``apply_driver_features()`` helpers to return an updated
   statement config plus normalized driver-feature dictionary across backends.
+* MySQL-family adapter config, driver, and pool modules now resolve runtime
+  vendor symbols through adapter-local typing modules.
 
 **Fixed:**
 

--- a/sqlspec/adapters/aiomysql/_typing.py
+++ b/sqlspec/adapters/aiomysql/_typing.py
@@ -6,13 +6,16 @@ compilation to avoid ABI boundary issues.
 
 from typing import TYPE_CHECKING, Any
 
+import aiomysql as _aiomysql  # pyright: ignore
 from aiomysql import Connection  # pyright: ignore
 from aiomysql import Pool as _AiomysqlPool  # pyright: ignore
 from aiomysql.cursors import Cursor as _AiomysqlCursor  # pyright: ignore
 from aiomysql.cursors import DictCursor as _AiomysqlDictCursor  # pyright: ignore
+from pymysql import err as _pymysql_err  # pyright: ignore
+from pymysql.constants import FIELD_TYPE as _PYMYSQL_FIELD_TYPE  # pyright: ignore
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Awaitable, Callable
     from types import TracebackType
     from typing import Protocol, TypeAlias
 
@@ -20,30 +23,48 @@ if TYPE_CHECKING:
     from sqlspec.core import StatementConfig
 
     class AiomysqlConnectionProtocol(Protocol):
-        async def cursor(self, cursor: "type[Any] | None" = None) -> "AiomysqlRawCursor": ...
+        async def cursor(self, cursor: "type[AiomysqlRawCursor] | None" = None) -> "AiomysqlRawCursor": ...
 
-        async def commit(self) -> Any: ...
+        async def commit(self) -> object: ...
 
-        async def rollback(self) -> Any: ...
+        async def rollback(self) -> object: ...
 
-        def close(self) -> Any: ...
+        def close(self) -> object: ...
+
+    class AiomysqlModuleProtocol(Protocol):
+        async def create_pool(self, **kwargs: Any) -> "AiomysqlPool": ...
+
+    class AiomysqlFieldTypeProtocol(Protocol):
+        JSON: int
 
     AiomysqlConnection: TypeAlias = AiomysqlConnectionProtocol
+    AiomysqlModule: TypeAlias = AiomysqlModuleProtocol
     AiomysqlRawCursor: TypeAlias = _AiomysqlCursor
     AiomysqlDictCursor: TypeAlias = _AiomysqlDictCursor
+    AiomysqlFieldType: TypeAlias = AiomysqlFieldTypeProtocol
     AiomysqlPool: TypeAlias = _AiomysqlPool
+    AiomysqlPymysqlError: TypeAlias = _pymysql_err.Error
+    AiomysqlPymysqlMySQLError: TypeAlias = _pymysql_err.MySQLError
 
 if not TYPE_CHECKING:
     AiomysqlConnection = Connection
+    AiomysqlModule = _aiomysql
     AiomysqlRawCursor = _AiomysqlCursor
     AiomysqlDictCursor = _AiomysqlDictCursor
+    AiomysqlFieldType = _PYMYSQL_FIELD_TYPE
     AiomysqlPool = _AiomysqlPool
+    AiomysqlPymysqlError = _pymysql_err.Error
+    AiomysqlPymysqlMySQLError = _pymysql_err.MySQLError
 
 __all__ = (
     "AiomysqlConnection",
     "AiomysqlCursor",
     "AiomysqlDictCursor",
+    "AiomysqlFieldType",
+    "AiomysqlModule",
     "AiomysqlPool",
+    "AiomysqlPymysqlError",
+    "AiomysqlPymysqlMySQLError",
     "AiomysqlRawCursor",
     "AiomysqlSessionContext",
 )
@@ -63,7 +84,7 @@ class AiomysqlCursor:
 
     __slots__ = ("connection", "cursor", "cursor_class")
 
-    def __init__(self, connection: "AiomysqlConnection", cursor_class: "type[Any] | None" = None) -> None:
+    def __init__(self, connection: "AiomysqlConnection", cursor_class: "type[AiomysqlRawCursor] | None" = None) -> None:
         self.connection = connection
         self.cursor_class = cursor_class
         self.cursor: AiomysqlRawCursor | None = None
@@ -75,7 +96,7 @@ class AiomysqlCursor:
             self.cursor = await self.connection.cursor(self.cursor_class)
         return self.cursor
 
-    async def __aexit__(self, *_: Any) -> None:
+    async def __aexit__(self, *_: object) -> None:
         if self.cursor is not None:
             await self.cursor.close()
 
@@ -103,8 +124,8 @@ class AiomysqlSessionContext:
 
     def __init__(
         self,
-        acquire_connection: "Callable[[], Any]",
-        release_connection: "Callable[[Any], Any]",
+        acquire_connection: "Callable[[], Awaitable[AiomysqlConnection]]",
+        release_connection: "Callable[[AiomysqlConnection], Awaitable[None]]",
         statement_config: "StatementConfig",
         driver_features: "dict[str, Any]",
         prepare_driver: "Callable[[AiomysqlDriver], AiomysqlDriver]",
@@ -114,7 +135,7 @@ class AiomysqlSessionContext:
         self._statement_config = statement_config
         self._driver_features = driver_features
         self._prepare_driver = prepare_driver
-        self._connection: Any = None
+        self._connection: AiomysqlConnection | None = None
         self._driver: AiomysqlDriver | None = None
 
     async def __aenter__(self) -> "AiomysqlDriver":

--- a/sqlspec/adapters/aiomysql/config.py
+++ b/sqlspec/adapters/aiomysql/config.py
@@ -3,7 +3,6 @@
 from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 from weakref import WeakSet
 
-import aiomysql  # pyright: ignore
 from mypy_extensions import mypyc_attr
 from typing_extensions import NotRequired
 
@@ -11,6 +10,7 @@ from sqlspec.adapters.aiomysql._typing import (
     AiomysqlConnection,
     AiomysqlCursor,
     AiomysqlDictCursor,
+    AiomysqlModule,
     AiomysqlPool,
     AiomysqlRawCursor,
     AiomysqlSessionContext,
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 __all__ = ("AiomysqlConfig", "AiomysqlConnectionParams", "AiomysqlDriverFeatures", "AiomysqlPoolParams")
 
 _POOL_ONLY_CONFIG_KEYS = frozenset({"maxsize", "minsize", "pool_recycle"})
+aiomysql: "AiomysqlModule" = cast("AiomysqlModule", AiomysqlModule)
 
 
 class AiomysqlConnectionParams(TypedDict):

--- a/sqlspec/adapters/aiomysql/driver.py
+++ b/sqlspec/adapters/aiomysql/driver.py
@@ -12,10 +12,13 @@ from collections.abc import Sized
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final, cast
 
-import pymysql.err  # pyright: ignore
-from pymysql.constants import FIELD_TYPE as PYMYSQL_FIELD_TYPE  # pyright: ignore
-
-from sqlspec.adapters.aiomysql._typing import AiomysqlCursor, AiomysqlSessionContext
+from sqlspec.adapters.aiomysql._typing import (
+    AiomysqlCursor,
+    AiomysqlFieldType,
+    AiomysqlPymysqlError,
+    AiomysqlPymysqlMySQLError,
+    AiomysqlSessionContext,
+)
 from sqlspec.adapters.aiomysql.core import (
     AiomysqlStreamSource,
     build_insert_statement,
@@ -55,7 +58,7 @@ __all__ = ("AiomysqlCursor", "AiomysqlDriver", "AiomysqlExceptionHandler", "Aiom
 logger = get_logger(__name__)
 
 json_type_value = (
-    PYMYSQL_FIELD_TYPE.JSON if PYMYSQL_FIELD_TYPE is not None and supports_json_type(PYMYSQL_FIELD_TYPE) else None
+    AiomysqlFieldType.JSON if AiomysqlFieldType is not None and supports_json_type(AiomysqlFieldType) else None
 )
 AIOMYSQL_JSON_TYPE_CODES: Final[set[int]] = {json_type_value} if json_type_value is not None else set()
 
@@ -79,7 +82,7 @@ class AiomysqlExceptionHandler(BaseAsyncExceptionHandler):
     def _handle_exception(self, exc_type: "type[BaseException] | None", exc_val: "BaseException") -> bool:
         if exc_type is None:
             return False
-        if issubclass(exc_type, pymysql.err.Error):
+        if issubclass(exc_type, AiomysqlPymysqlError):
             result = create_mapped_exception(exc_val, logger=logger)
             if result is True:
                 return True
@@ -214,7 +217,7 @@ class AiomysqlDriver(AsyncDriverAdapterBase):
         try:
             async with AiomysqlCursor(self.connection) as cursor:
                 await cursor.execute("BEGIN")
-        except pymysql.err.MySQLError as e:
+        except AiomysqlPymysqlMySQLError as e:
             msg = f"Failed to begin MySQL transaction: {e}"
             raise SQLSpecError(msg) from e
 
@@ -226,7 +229,7 @@ class AiomysqlDriver(AsyncDriverAdapterBase):
         """
         try:
             await self.connection.commit()
-        except pymysql.err.MySQLError as e:
+        except AiomysqlPymysqlMySQLError as e:
             msg = f"Failed to commit MySQL transaction: {e}"
             raise SQLSpecError(msg) from e
 
@@ -238,7 +241,7 @@ class AiomysqlDriver(AsyncDriverAdapterBase):
         """
         try:
             await self.connection.rollback()
-        except pymysql.err.MySQLError as e:
+        except AiomysqlPymysqlMySQLError as e:
             msg = f"Failed to rollback MySQL transaction: {e}"
             raise SQLSpecError(msg) from e
 

--- a/sqlspec/adapters/asyncmy/_typing.py
+++ b/sqlspec/adapters/asyncmy/_typing.py
@@ -6,13 +6,16 @@ compilation to avoid ABI boundary issues.
 
 from typing import TYPE_CHECKING, Any
 
+import asyncmy as _asyncmy  # pyright: ignore
 from asyncmy import Connection  # pyright: ignore
+from asyncmy import errors as _asyncmy_errors  # pyright: ignore
+from asyncmy.constants import FIELD_TYPE as _ASYNCMY_FIELD_TYPE  # pyright: ignore
 from asyncmy.cursors import Cursor as _AsyncmyCursor  # pyright: ignore
 from asyncmy.cursors import DictCursor as _AsyncmyDictCursor  # pyright: ignore
 from asyncmy.pool import Pool as _AsyncmyPool  # pyright: ignore
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Awaitable, Callable
     from types import TracebackType
     from typing import Protocol, TypeAlias
 
@@ -22,20 +25,36 @@ if TYPE_CHECKING:
     class AsyncmyConnectionProtocol(Protocol):
         def cursor(self) -> "AsyncmyRawCursor": ...
 
-        async def commit(self) -> Any: ...
+        async def commit(self) -> object: ...
 
-        async def rollback(self) -> Any: ...
+        async def rollback(self) -> object: ...
 
-        async def close(self) -> Any: ...
+        async def close(self) -> object: ...
+
+    class AsyncmyModuleProtocol(Protocol):
+        def connect(self, *args: Any, **kwargs: Any) -> "AsyncmyConnection": ...
+
+        async def create_pool(self, **kwargs: Any) -> "AsyncmyPool": ...
+
+    class AsyncmyFieldTypeProtocol(Protocol):
+        JSON: int
 
     AsyncmyConnection: TypeAlias = AsyncmyConnectionProtocol
     AsyncmyDictCursor: TypeAlias = _AsyncmyDictCursor
+    AsyncmyError: TypeAlias = _asyncmy_errors.Error
+    AsyncmyFieldType: TypeAlias = AsyncmyFieldTypeProtocol
+    AsyncmyMySQLError: TypeAlias = _asyncmy_errors.MySQLError
+    AsyncmyModule: TypeAlias = AsyncmyModuleProtocol
     AsyncmyPool: TypeAlias = _AsyncmyPool
     AsyncmyRawCursor: TypeAlias = _AsyncmyCursor
 
 if not TYPE_CHECKING:
     AsyncmyConnection = Connection
     AsyncmyDictCursor = _AsyncmyDictCursor
+    AsyncmyError = _asyncmy_errors.Error
+    AsyncmyFieldType = _ASYNCMY_FIELD_TYPE
+    AsyncmyMySQLError = _asyncmy_errors.MySQLError
+    AsyncmyModule = _asyncmy
     AsyncmyPool = _AsyncmyPool
     AsyncmyRawCursor = _AsyncmyCursor
 
@@ -43,6 +62,10 @@ __all__ = (
     "AsyncmyConnection",
     "AsyncmyCursor",
     "AsyncmyDictCursor",
+    "AsyncmyError",
+    "AsyncmyFieldType",
+    "AsyncmyModule",
+    "AsyncmyMySQLError",
     "AsyncmyPool",
     "AsyncmyRawCursor",
     "AsyncmySessionContext",
@@ -65,7 +88,7 @@ class AsyncmyCursor:
         self.cursor = self.connection.cursor()
         return self.cursor
 
-    async def __aexit__(self, *_: Any) -> None:
+    async def __aexit__(self, *_: object) -> None:
         if self.cursor is not None:
             await self.cursor.close()
 
@@ -93,8 +116,8 @@ class AsyncmySessionContext:
 
     def __init__(
         self,
-        acquire_connection: "Callable[[], Any]",
-        release_connection: "Callable[[Any], Any]",
+        acquire_connection: "Callable[[], Awaitable[AsyncmyConnection]]",
+        release_connection: "Callable[[AsyncmyConnection], Awaitable[None]]",
         statement_config: "StatementConfig",
         driver_features: "dict[str, Any]",
         prepare_driver: "Callable[[AsyncmyDriver], AsyncmyDriver]",
@@ -104,7 +127,7 @@ class AsyncmySessionContext:
         self._statement_config = statement_config
         self._driver_features = driver_features
         self._prepare_driver = prepare_driver
-        self._connection: Any = None
+        self._connection: AsyncmyConnection | None = None
         self._driver: AsyncmyDriver | None = None
 
     async def __aenter__(self) -> "AsyncmyDriver":

--- a/sqlspec/adapters/asyncmy/config.py
+++ b/sqlspec/adapters/asyncmy/config.py
@@ -4,7 +4,6 @@ import inspect
 from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 from weakref import WeakSet
 
-import asyncmy
 from mypy_extensions import mypyc_attr
 from typing_extensions import NotRequired
 
@@ -12,6 +11,7 @@ from sqlspec.adapters.asyncmy._typing import (
     AsyncmyConnection,
     AsyncmyCursor,
     AsyncmyDictCursor,
+    AsyncmyModule,
     AsyncmyPool,
     AsyncmyRawCursor,
     AsyncmySessionContext,
@@ -39,6 +39,7 @@ __all__ = ("AsyncmyConfig", "AsyncmyConnectionParams", "AsyncmyDriverFeatures", 
 _ASYNCMY_POOL_ONLY_KEYS = frozenset(("minsize", "maxsize", "pool_recycle"))
 _ASYNCMY_POOL_KEYS = _ASYNCMY_POOL_ONLY_KEYS | {"echo"}
 _ASYNCMY_LOCAL_INFILE_GATE = "allow_local_infile"
+asyncmy: "AsyncmyModule" = cast("AsyncmyModule", AsyncmyModule)
 
 
 def _get_asyncmy_connect_parameter_names() -> "frozenset[str]":

--- a/sqlspec/adapters/asyncmy/driver.py
+++ b/sqlspec/adapters/asyncmy/driver.py
@@ -7,10 +7,13 @@ type coercion, error handling, and transaction management.
 from collections.abc import Sized
 from typing import TYPE_CHECKING, Any, Final, cast
 
-import asyncmy.errors  # pyright: ignore
-from asyncmy.constants import FIELD_TYPE as ASYNC_MY_FIELD_TYPE  # pyright: ignore
-
-from sqlspec.adapters.asyncmy._typing import AsyncmyCursor, AsyncmySessionContext
+from sqlspec.adapters.asyncmy._typing import (
+    AsyncmyCursor,
+    AsyncmyError,
+    AsyncmyFieldType,
+    AsyncmyMySQLError,
+    AsyncmySessionContext,
+)
 from sqlspec.adapters.asyncmy.core import (
     AsyncmyStreamSource,
     build_insert_statement,
@@ -48,7 +51,7 @@ __all__ = ("AsyncmyCursor", "AsyncmyDriver", "AsyncmyExceptionHandler", "Asyncmy
 logger = get_logger(__name__)
 
 json_type_value = (
-    ASYNC_MY_FIELD_TYPE.JSON if ASYNC_MY_FIELD_TYPE is not None and supports_json_type(ASYNC_MY_FIELD_TYPE) else None
+    AsyncmyFieldType.JSON if AsyncmyFieldType is not None and supports_json_type(AsyncmyFieldType) else None
 )
 ASYNCMY_JSON_TYPE_CODES: Final[set[int]] = {json_type_value} if json_type_value is not None else set()
 
@@ -69,7 +72,7 @@ class AsyncmyExceptionHandler(BaseAsyncExceptionHandler):
     def _handle_exception(self, exc_type: "type[BaseException] | None", exc_val: "BaseException") -> bool:
         if exc_type is None:
             return False
-        if issubclass(exc_type, asyncmy.errors.Error):
+        if issubclass(exc_type, cast("type[BaseException]", AsyncmyError)):
             result = create_mapped_exception(exc_val, logger=logger)
             if result is True:
                 return True
@@ -215,7 +218,7 @@ class AsyncmyDriver(AsyncDriverAdapterBase):
         try:
             async with AsyncmyCursor(self.connection) as cursor:
                 await cursor.execute("BEGIN")
-        except asyncmy.errors.MySQLError as e:
+        except AsyncmyMySQLError as e:
             msg = f"Failed to begin MySQL transaction: {e}"
             raise SQLSpecError(msg) from e
 
@@ -227,7 +230,7 @@ class AsyncmyDriver(AsyncDriverAdapterBase):
         """
         try:
             await self.connection.commit()
-        except asyncmy.errors.MySQLError as e:
+        except AsyncmyMySQLError as e:
             msg = f"Failed to commit MySQL transaction: {e}"
             raise SQLSpecError(msg) from e
 
@@ -239,7 +242,7 @@ class AsyncmyDriver(AsyncDriverAdapterBase):
         """
         try:
             await self.connection.rollback()
-        except asyncmy.errors.MySQLError as e:
+        except AsyncmyMySQLError as e:
             msg = f"Failed to rollback MySQL transaction: {e}"
             raise SQLSpecError(msg) from e
 

--- a/sqlspec/adapters/mysqlconnector/_typing.py
+++ b/sqlspec/adapters/mysqlconnector/_typing.py
@@ -6,19 +6,24 @@ compilation to avoid ABI boundary issues.
 
 from typing import TYPE_CHECKING, Any
 
+import mysql as _mysql
+import mysql.connector as _mysql_connector
 from mysql.connector import MySQLConnection as _MysqlConnectorSyncConnection
+from mysql.connector import aio as _mysql_connector_aio
+from mysql.connector import pooling as _mysql_connector_pooling
 from mysql.connector.aio import (
     MySQLConnection as _MysqlConnectorAsyncConnection,  # pyright: ignore[reportMissingImports]
 )
 from mysql.connector.aio.cursor import (
     MySQLCursor as _MysqlConnectorAsyncRawCursor,  # pyright: ignore[reportMissingImports]
 )
+from mysql.connector.constants import FieldType as _MysqlConnectorFieldType
 from mysql.connector.cursor import MySQLCursor as _MysqlConnectorSyncRawCursor
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
     from types import TracebackType
-    from typing import Protocol, TypeAlias
+    from typing import ClassVar, Protocol, TypeAlias
 
     from sqlspec.adapters.mysqlconnector.driver import MysqlConnectorAsyncDriver, MysqlConnectorSyncDriver
     from sqlspec.core import StatementConfig
@@ -26,28 +31,57 @@ if TYPE_CHECKING:
     class MysqlConnectorAsyncConnectionProtocol(Protocol):
         def cursor(self, **kwargs: Any) -> "Awaitable[MysqlConnectorAsyncRawCursor]": ...
 
-        async def commit(self) -> Any: ...
+        async def commit(self) -> object: ...
 
-        async def rollback(self) -> Any: ...
+        async def rollback(self) -> object: ...
 
-        async def close(self) -> Any: ...
+        async def close(self) -> object: ...
+
+        async def set_autocommit(self, value: bool) -> object: ...
+
+    class MysqlConnectorAioModuleProtocol(Protocol):
+        def connect(self, *args: Any, **kwargs: Any) -> "Awaitable[MysqlConnectorAsyncConnection]": ...
+
+    class MysqlConnectorFieldTypeProtocol(Protocol):
+        JSON: int
+
+    class MysqlConnectorConnectorModuleProtocol(Protocol):
+        def connect(self, *args: Any, **kwargs: Any) -> "MysqlConnectorSyncConnection": ...
+
+    class MysqlConnectorMysqlModuleProtocol(Protocol):
+        connector: "ClassVar[MysqlConnectorConnectorModuleProtocol]"
 
     MysqlConnectorSyncConnection: TypeAlias = _MysqlConnectorSyncConnection
+    MysqlConnectorAio: TypeAlias = MysqlConnectorAioModuleProtocol
     MysqlConnectorAsyncConnection: TypeAlias = MysqlConnectorAsyncConnectionProtocol
     MysqlConnectorSyncRawCursor: TypeAlias = _MysqlConnectorSyncRawCursor
+    MysqlConnectorConnectionPool: TypeAlias = _mysql_connector_pooling.MySQLConnectionPool
+    MysqlConnectorError: TypeAlias = _mysql_connector.Error
+    MysqlConnectorFieldType: TypeAlias = MysqlConnectorFieldTypeProtocol
+    MysqlConnectorMysqlModule: TypeAlias = MysqlConnectorMysqlModuleProtocol
     MysqlConnectorAsyncRawCursor: TypeAlias = _MysqlConnectorAsyncRawCursor
 
 if not TYPE_CHECKING:
+    MysqlConnectorAio = _mysql_connector_aio
     MysqlConnectorSyncConnection = _MysqlConnectorSyncConnection
     MysqlConnectorAsyncConnection = _MysqlConnectorAsyncConnection
+    MysqlConnectorConnectionPool = _mysql_connector_pooling.MySQLConnectionPool
+    MysqlConnectorError = _mysql_connector.Error
+    MysqlConnectorFieldType = _MysqlConnectorFieldType
+    MysqlConnectorMysqlModule = _mysql
     MysqlConnectorSyncRawCursor = _MysqlConnectorSyncRawCursor
     MysqlConnectorAsyncRawCursor = _MysqlConnectorAsyncRawCursor
 
 __all__ = (
+    "MysqlConnectorAio",
     "MysqlConnectorAsyncConnection",
     "MysqlConnectorAsyncCursor",
     "MysqlConnectorAsyncRawCursor",
     "MysqlConnectorAsyncSessionContext",
+    "MysqlConnectorConnectionPool",
+    "MysqlConnectorError",
+    "MysqlConnectorFieldType",
+    "MysqlConnectorMysqlModule",
     "MysqlConnectorSyncConnection",
     "MysqlConnectorSyncCursor",
     "MysqlConnectorSyncRawCursor",
@@ -71,7 +105,7 @@ class MysqlConnectorSyncCursor:
         self.cursor = self.connection.cursor(**self.cursor_options)
         return self.cursor
 
-    def __exit__(self, *_: Any) -> None:
+    def __exit__(self, *_: object) -> None:
         if self.cursor is not None:
             self.cursor.close()
 
@@ -92,7 +126,7 @@ class MysqlConnectorAsyncCursor:
         self.cursor = await self.connection.cursor(**self.cursor_options)
         return self.cursor
 
-    async def __aexit__(self, *_: Any) -> None:
+    async def __aexit__(self, *_: object) -> None:
         if self.cursor is not None:
             await self.cursor.close()
 
@@ -112,8 +146,8 @@ class MysqlConnectorSyncSessionContext:
 
     def __init__(
         self,
-        acquire_connection: "Callable[[], Any]",
-        release_connection: "Callable[[Any], Any]",
+        acquire_connection: "Callable[[], MysqlConnectorSyncConnection]",
+        release_connection: "Callable[[MysqlConnectorSyncConnection], None]",
         statement_config: "StatementConfig",
         driver_features: "dict[str, Any]",
         prepare_driver: "Callable[[MysqlConnectorSyncDriver], MysqlConnectorSyncDriver]",
@@ -123,7 +157,7 @@ class MysqlConnectorSyncSessionContext:
         self._statement_config = statement_config
         self._driver_features = driver_features
         self._prepare_driver = prepare_driver
-        self._connection: Any = None
+        self._connection: MysqlConnectorSyncConnection | None = None
         self._driver: MysqlConnectorSyncDriver | None = None
 
     def __enter__(self) -> "MysqlConnectorSyncDriver":
@@ -159,8 +193,8 @@ class MysqlConnectorAsyncSessionContext:
 
     def __init__(
         self,
-        acquire_connection: "Callable[[], Any]",
-        release_connection: "Callable[[Any], Any]",
+        acquire_connection: "Callable[[], Awaitable[MysqlConnectorAsyncConnection]]",
+        release_connection: "Callable[[MysqlConnectorAsyncConnection], Awaitable[None]]",
         statement_config: "StatementConfig",
         driver_features: "dict[str, Any]",
         prepare_driver: "Callable[[MysqlConnectorAsyncDriver], MysqlConnectorAsyncDriver]",
@@ -170,7 +204,7 @@ class MysqlConnectorAsyncSessionContext:
         self._statement_config = statement_config
         self._driver_features = driver_features
         self._prepare_driver = prepare_driver
-        self._connection: Any = None
+        self._connection: MysqlConnectorAsyncConnection | None = None
         self._driver: MysqlConnectorAsyncDriver | None = None
 
     async def __aenter__(self) -> "MysqlConnectorAsyncDriver":

--- a/sqlspec/adapters/mysqlconnector/config.py
+++ b/sqlspec/adapters/mysqlconnector/config.py
@@ -5,14 +5,15 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
 from weakref import WeakSet
 
-import mysql.connector
-from mysql.connector import pooling
 from typing_extensions import NotRequired
 
 from sqlspec.adapters.mysqlconnector._typing import (
+    MysqlConnectorAio,
     MysqlConnectorAsyncConnection,
     MysqlConnectorAsyncCursor,
     MysqlConnectorAsyncSessionContext,
+    MysqlConnectorConnectionPool,
+    MysqlConnectorMysqlModule,
     MysqlConnectorSyncConnection,
     MysqlConnectorSyncCursor,
     MysqlConnectorSyncSessionContext,
@@ -35,8 +36,6 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable
     from types import TracebackType
 
-    from mysql.connector.pooling import MySQLConnectionPool
-
     from sqlspec.core import StatementConfig
     from sqlspec.observability import ObservabilityConfig
 
@@ -51,6 +50,8 @@ __all__ = (
     "MysqlConnectorSyncConfig",
     "MysqlConnectorSyncConnectionParams",
 )
+mysql: "MysqlConnectorMysqlModule" = cast("MysqlConnectorMysqlModule", MysqlConnectorMysqlModule)
+mysqlconnector_aio: "MysqlConnectorAio" = cast("MysqlConnectorAio", MysqlConnectorAio)
 
 
 MysqlConnectorClientFlags = int | list[int] | tuple[int, ...]
@@ -266,7 +267,7 @@ class _MysqlConnectorAsyncSessionConnectionHandler(AsyncPoolSessionFactory):
 
 
 class MysqlConnectorSyncConfig(
-    SyncDatabaseConfig[MysqlConnectorSyncConnection, "MySQLConnectionPool", MysqlConnectorSyncDriver]
+    SyncDatabaseConfig[MysqlConnectorSyncConnection, "MysqlConnectorConnectionPool", MysqlConnectorSyncDriver]
 ):
     """Configuration for mysql-connector synchronous MySQL connections."""
 
@@ -291,7 +292,7 @@ class MysqlConnectorSyncConfig(
         self,
         *,
         connection_config: "MysqlConnectorPoolParams | dict[str, Any] | None" = None,
-        connection_instance: "MySQLConnectionPool | None" = None,
+        connection_instance: "MysqlConnectorConnectionPool | None" = None,
         migration_config: "dict[str, Any] | None" = None,
         statement_config: "StatementConfig | None" = None,
         driver_features: "MysqlConnectorDriverFeatures | dict[str, Any] | None" = None,
@@ -349,12 +350,12 @@ class MysqlConnectorSyncConfig(
         self._ensure_connection_initialized(connection)
         return connection
 
-    def _create_pool(self) -> "MySQLConnectionPool":
+    def _create_pool(self) -> "MysqlConnectorConnectionPool":
         config = dict(self.connection_config)
         pool_name = config.pop("pool_name", None)
         pool_size = config.pop("pool_size", None)
         pool_reset = config.pop("pool_reset_session", True)
-        return pooling.MySQLConnectionPool(
+        return MysqlConnectorConnectionPool(
             pool_name=pool_name, pool_size=pool_size or 5, pool_reset_session=pool_reset, **config
         )
 
@@ -364,7 +365,7 @@ class MysqlConnectorSyncConfig(
             self.connection_instance = None
 
     def create_connection(self) -> MysqlConnectorSyncConnection:
-        connection = cast("MysqlConnectorSyncConnection", mysql.connector.connect(**self.connection_config))
+        connection = mysql.connector.connect(**self.connection_config)
         autocommit = self.connection_config.get("autocommit")
         if autocommit is not None and hasattr(connection, "autocommit"):
             with contextlib.suppress(Exception):
@@ -452,9 +453,7 @@ class MysqlConnectorAsyncConfig(NoPoolAsyncConfig[MysqlConnectorAsyncConnection,
         )
 
     async def create_connection(self) -> MysqlConnectorAsyncConnection:
-        from mysql.connector import aio
-
-        connection = await aio.connect(**self.connection_config)
+        connection = await mysqlconnector_aio.connect(**self.connection_config)
         autocommit = self.connection_config.get("autocommit")
         if autocommit is not None and hasattr(connection, "set_autocommit"):
             with contextlib.suppress(Exception):
@@ -462,9 +461,9 @@ class MysqlConnectorAsyncConfig(NoPoolAsyncConfig[MysqlConnectorAsyncConnection,
 
         # Call user-provided callback after connection setup
         if self._user_connection_hook is not None:
-            await self._user_connection_hook(cast("MysqlConnectorAsyncConnection", connection))
+            await self._user_connection_hook(connection)
 
-        return cast("MysqlConnectorAsyncConnection", connection)
+        return connection
 
     def provide_connection(self, *args: Any, **kwargs: Any) -> "MysqlConnectorAsyncConnectionContext":
         return MysqlConnectorAsyncConnectionContext(self)

--- a/sqlspec/adapters/mysqlconnector/driver.py
+++ b/sqlspec/adapters/mysqlconnector/driver.py
@@ -9,12 +9,11 @@ from collections.abc import Sized
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final, cast
 
-import mysql.connector
-from mysql.connector.constants import FieldType
-
 from sqlspec.adapters.mysqlconnector._typing import (
     MysqlConnectorAsyncCursor,
     MysqlConnectorAsyncSessionContext,
+    MysqlConnectorError,
+    MysqlConnectorFieldType,
     MysqlConnectorSyncCursor,
     MysqlConnectorSyncSessionContext,
 )
@@ -76,7 +75,7 @@ __all__ = (
 
 logger = get_logger("sqlspec.adapters.mysqlconnector")
 
-json_type_value = FieldType.JSON if supports_json_type(FieldType) else None
+json_type_value = MysqlConnectorFieldType.JSON if supports_json_type(MysqlConnectorFieldType) else None
 MYSQLCONNECTOR_JSON_TYPE_CODES: Final[set[int]] = {json_type_value} if json_type_value is not None else set()
 
 
@@ -88,7 +87,7 @@ class MysqlConnectorSyncExceptionHandler(BaseSyncExceptionHandler):
     def _handle_exception(self, exc_type: "type[BaseException] | None", exc_val: "BaseException") -> bool:
         if exc_type is None:
             return False
-        if issubclass(exc_type, mysql.connector.Error):
+        if issubclass(exc_type, MysqlConnectorError):
             result = create_mapped_exception(exc_val, logger=logger)
             if result is True:
                 return True
@@ -177,21 +176,21 @@ class MysqlConnectorSyncDriver(SyncDriverAdapterBase):
         try:
             with MysqlConnectorSyncCursor(self.connection) as cursor:
                 cursor.execute("BEGIN")
-        except mysql.connector.Error as e:
+        except MysqlConnectorError as e:
             msg = f"Failed to begin MySQL transaction: {e}"
             raise SQLSpecError(msg) from e
 
     def commit(self) -> None:
         try:
             self.connection.commit()
-        except mysql.connector.Error as e:
+        except MysqlConnectorError as e:
             msg = f"Failed to commit MySQL transaction: {e}"
             raise SQLSpecError(msg) from e
 
     def rollback(self) -> None:
         try:
             self.connection.rollback()
-        except mysql.connector.Error as e:
+        except MysqlConnectorError as e:
             msg = f"Failed to rollback MySQL transaction: {e}"
             raise SQLSpecError(msg) from e
 
@@ -342,7 +341,7 @@ class MysqlConnectorAsyncExceptionHandler(BaseAsyncExceptionHandler):
     def _handle_exception(self, exc_type: "type[BaseException] | None", exc_val: "BaseException") -> bool:
         if exc_type is None:
             return False
-        if issubclass(exc_type, mysql.connector.Error):
+        if issubclass(exc_type, MysqlConnectorError):
             result = create_mapped_exception(exc_val, logger=logger)
             if result is True:
                 return True
@@ -431,21 +430,21 @@ class MysqlConnectorAsyncDriver(AsyncDriverAdapterBase):
         try:
             async with MysqlConnectorAsyncCursor(self.connection) as cursor:
                 await cursor.execute("BEGIN")
-        except mysql.connector.Error as e:
+        except MysqlConnectorError as e:
             msg = f"Failed to begin MySQL transaction: {e}"
             raise SQLSpecError(msg) from e
 
     async def commit(self) -> None:
         try:
             await self.connection.commit()
-        except mysql.connector.Error as e:
+        except MysqlConnectorError as e:
             msg = f"Failed to commit MySQL transaction: {e}"
             raise SQLSpecError(msg) from e
 
     async def rollback(self) -> None:
         try:
             await self.connection.rollback()
-        except mysql.connector.Error as e:
+        except MysqlConnectorError as e:
             msg = f"Failed to rollback MySQL transaction: {e}"
             raise SQLSpecError(msg) from e
 

--- a/sqlspec/adapters/pymysql/_typing.py
+++ b/sqlspec/adapters/pymysql/_typing.py
@@ -7,23 +7,48 @@ compilation to avoid ABI boundary issues.
 from typing import TYPE_CHECKING, Any
 
 import pymysql
+from pymysql.constants import FIELD_TYPE as _PYMYSQL_FIELD_TYPE
+from pymysql.constants import SERVER_STATUS as _PYMYSQL_SERVER_STATUS
 
 if TYPE_CHECKING:
     from collections.abc import Callable
     from types import TracebackType
-    from typing import TypeAlias
+    from typing import Protocol, TypeAlias
 
     from sqlspec.adapters.pymysql.driver import PyMysqlDriver
     from sqlspec.core import StatementConfig
 
+    class PyMysqlFieldTypeProtocol(Protocol):
+        JSON: int
+
+    class PyMysqlServerStatusProtocol(Protocol):
+        SERVER_STATUS_IN_TRANS: int
+
+    PyMysqlConnect: TypeAlias = type["PyMysqlConnection"]
     PyMysqlConnection: TypeAlias = pymysql.connections.Connection
+    PyMysqlFieldType: TypeAlias = PyMysqlFieldTypeProtocol
+    PyMysqlMySQLError: TypeAlias = pymysql.MySQLError
     PyMysqlRawCursor: TypeAlias = pymysql.cursors.Cursor
+    PyMysqlServerStatus: TypeAlias = PyMysqlServerStatusProtocol
 
 if not TYPE_CHECKING:
+    PyMysqlConnect = pymysql.connect
     PyMysqlConnection = pymysql.connections.Connection
+    PyMysqlFieldType = _PYMYSQL_FIELD_TYPE
+    PyMysqlMySQLError = pymysql.MySQLError
     PyMysqlRawCursor = pymysql.cursors.Cursor
+    PyMysqlServerStatus = _PYMYSQL_SERVER_STATUS
 
-__all__ = ("PyMysqlConnection", "PyMysqlCursor", "PyMysqlRawCursor", "PyMysqlSessionContext")
+__all__ = (
+    "PyMysqlConnect",
+    "PyMysqlConnection",
+    "PyMysqlCursor",
+    "PyMysqlFieldType",
+    "PyMysqlMySQLError",
+    "PyMysqlRawCursor",
+    "PyMysqlServerStatus",
+    "PyMysqlSessionContext",
+)
 
 
 class PyMysqlCursor:
@@ -39,7 +64,7 @@ class PyMysqlCursor:
         self.cursor = self.connection.cursor()
         return self.cursor
 
-    def __exit__(self, *_: Any) -> None:
+    def __exit__(self, *_: object) -> None:
         if self.cursor is not None:
             self.cursor.close()
 
@@ -59,8 +84,8 @@ class PyMysqlSessionContext:
 
     def __init__(
         self,
-        acquire_connection: "Callable[[], Any]",
-        release_connection: "Callable[[Any], Any]",
+        acquire_connection: "Callable[[], PyMysqlConnection]",
+        release_connection: "Callable[[PyMysqlConnection], None]",
         statement_config: "StatementConfig",
         driver_features: "dict[str, Any]",
         prepare_driver: "Callable[[PyMysqlDriver], PyMysqlDriver]",
@@ -70,7 +95,7 @@ class PyMysqlSessionContext:
         self._statement_config = statement_config
         self._driver_features = driver_features
         self._prepare_driver = prepare_driver
-        self._connection: Any = None
+        self._connection: PyMysqlConnection | None = None
         self._driver: PyMysqlDriver | None = None
 
     def __enter__(self) -> "PyMysqlDriver":

--- a/sqlspec/adapters/pymysql/driver.py
+++ b/sqlspec/adapters/pymysql/driver.py
@@ -5,10 +5,13 @@ from collections.abc import Sized
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Final, cast
 
-import pymysql
-from pymysql.constants import FIELD_TYPE, SERVER_STATUS
-
-from sqlspec.adapters.pymysql._typing import PyMysqlCursor, PyMysqlSessionContext
+from sqlspec.adapters.pymysql._typing import (
+    PyMysqlCursor,
+    PyMysqlFieldType,
+    PyMysqlMySQLError,
+    PyMysqlServerStatus,
+    PyMysqlSessionContext,
+)
 from sqlspec.adapters.pymysql.core import (
     PymysqlStreamSource,
     build_insert_statement,
@@ -47,7 +50,7 @@ __all__ = ("PyMysqlCursor", "PyMysqlDriver", "PyMysqlExceptionHandler", "PyMysql
 
 logger = get_logger("sqlspec.adapters.pymysql")
 
-json_type_value = FIELD_TYPE.JSON if supports_json_type(FIELD_TYPE) else None
+json_type_value = PyMysqlFieldType.JSON if supports_json_type(PyMysqlFieldType) else None
 PYMYSQL_JSON_TYPE_CODES: Final[set[int]] = {json_type_value} if json_type_value is not None else set()
 
 
@@ -59,7 +62,7 @@ class PyMysqlExceptionHandler(BaseSyncExceptionHandler):
     def _handle_exception(self, exc_type: "type[BaseException] | None", exc_val: "BaseException") -> bool:
         if exc_type is None:
             return False
-        if issubclass(exc_type, pymysql.MySQLError):
+        if issubclass(exc_type, PyMysqlMySQLError):
             result = create_mapped_exception(exc_val, logger=logger)
             if result is True:
                 return True
@@ -148,21 +151,21 @@ class PyMysqlDriver(SyncDriverAdapterBase):
         try:
             with PyMysqlCursor(self.connection) as cursor:
                 cursor.execute("BEGIN")
-        except pymysql.MySQLError as exc:
+        except PyMysqlMySQLError as exc:
             msg = f"Failed to begin MySQL transaction: {exc}"
             raise SQLSpecError(msg) from exc
 
     def commit(self) -> None:
         try:
             self.connection.commit()
-        except pymysql.MySQLError as exc:
+        except PyMysqlMySQLError as exc:
             msg = f"Failed to commit MySQL transaction: {exc}"
             raise SQLSpecError(msg) from exc
 
     def rollback(self) -> None:
         try:
             self.connection.rollback()
-        except pymysql.MySQLError as exc:
+        except PyMysqlMySQLError as exc:
             msg = f"Failed to rollback MySQL transaction: {exc}"
             raise SQLSpecError(msg) from exc
 
@@ -290,7 +293,7 @@ class PyMysqlDriver(SyncDriverAdapterBase):
 
     def _connection_in_transaction(self) -> bool:
         try:
-            return bool(self.connection.server_status & SERVER_STATUS.SERVER_STATUS_IN_TRANS)
+            return bool(self.connection.server_status & PyMysqlServerStatus.SERVER_STATUS_IN_TRANS)
         except Exception:
             return False
 

--- a/sqlspec/adapters/pymysql/pool.py
+++ b/sqlspec/adapters/pymysql/pool.py
@@ -8,9 +8,7 @@ import uuid
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, cast
 
-import pymysql
-
-from sqlspec.adapters.pymysql._typing import PyMysqlConnection
+from sqlspec.adapters.pymysql._typing import PyMysqlConnect, PyMysqlConnection
 from sqlspec.utils.logging import POOL_LOGGER_NAME, get_logger, log_with_context
 
 if TYPE_CHECKING:
@@ -21,6 +19,7 @@ __all__ = ("PyMysqlConnectionPool",)
 
 logger = get_logger(POOL_LOGGER_NAME)
 _ADAPTER_NAME = "pymysql"
+_pymysql_connect: "PyMysqlConnect" = cast("PyMysqlConnect", PyMysqlConnect)
 
 
 class PyMysqlConnectionPool:
@@ -70,7 +69,7 @@ class PyMysqlConnectionPool:
         if self._connection_factory is not None:
             connection = self._connection_factory()
         else:
-            connection = pymysql.connect(**self._connection_parameters)
+            connection = _pymysql_connect(**self._connection_parameters)
 
         # Call user-provided callback after connection creation
         if self._on_connection_create is not None:

--- a/tests/unit/adapters/test_adapter_implementations.py
+++ b/tests/unit/adapters/test_adapter_implementations.py
@@ -82,6 +82,17 @@ ADAPTER_DRIVER_MODULES_WITH_FEATURE_HELPERS = (
     "sqlspec/adapters/cockroach_psycopg/driver.py",
     "sqlspec/adapters/duckdb/driver.py",
 )
+MYSQL_FAMILY_UNCOMPILED_MODULES = (
+    "sqlspec/adapters/aiomysql/config.py",
+    "sqlspec/adapters/aiomysql/driver.py",
+    "sqlspec/adapters/asyncmy/config.py",
+    "sqlspec/adapters/asyncmy/driver.py",
+    "sqlspec/adapters/mysqlconnector/config.py",
+    "sqlspec/adapters/mysqlconnector/driver.py",
+    "sqlspec/adapters/pymysql/driver.py",
+    "sqlspec/adapters/pymysql/pool.py",
+)
+MYSQL_VENDOR_IMPORT_ROOTS = ("aiomysql", "asyncmy", "mysql", "pymysql")
 
 
 @pytest.fixture(params=ADAPTER_CONFIGS, ids=operator.itemgetter("name"))
@@ -176,6 +187,27 @@ def test_adapter_drivers_do_not_apply_driver_features(module_path: str) -> None:
 
     assert imports_helper is False
     assert calls_helper is False
+
+
+@pytest.mark.parametrize("module_path", MYSQL_FAMILY_UNCOMPILED_MODULES)
+def test_mysql_family_uncompiled_modules_use_adapter_typing_boundary(module_path: str) -> None:
+    tree = ast.parse(Path(module_path).read_text())
+    direct_imports: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            direct_imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            direct_imports.append(node.module)
+
+    direct_vendor_imports = [
+        import_name
+        for import_name in direct_imports
+        if import_name in MYSQL_VENDOR_IMPORT_ROOTS
+        or import_name.startswith(tuple(f"{root}." for root in MYSQL_VENDOR_IMPORT_ROOTS))
+    ]
+
+    assert direct_vendor_imports == []
 
 
 def test_adapter_parameter_style_handling(

--- a/tests/unit/adapters/test_pymysql/test_cloud_sql_connector.py
+++ b/tests/unit/adapters/test_pymysql/test_cloud_sql_connector.py
@@ -138,7 +138,7 @@ def test_cloud_sql_connection_factory_calls_connector(mock_cloud_sql_module: Mag
         )
         pool = config._create_pool()
 
-    with patch("sqlspec.adapters.pymysql.pool.pymysql.connect") as mock_pymysql_connect:
+    with patch("sqlspec.adapters.pymysql.pool._pymysql_connect") as mock_pymysql_connect:
         connection = pool._create_connection()
 
     assert connection is cloud_connection
@@ -166,7 +166,7 @@ def test_pool_runs_connection_create_callback_after_direct_or_factory_paths() ->
         seen_connections.append(connection)
 
     direct_pool = PyMysqlConnectionPool({"host": "localhost"}, on_connection_create=on_connection_create)
-    with patch("sqlspec.adapters.pymysql.pool.pymysql.connect", return_value=direct_connection):
+    with patch("sqlspec.adapters.pymysql.pool._pymysql_connect", return_value=direct_connection):
         assert direct_pool._create_connection() is direct_connection
 
     factory_pool = PyMysqlConnectionPool(


### PR DESCRIPTION
## Summary

- Routes MySQL-family adapter runtime vendor symbols through adapter-local typing modules for aiomysql, asyncmy, mysql-connector, and PyMySQL.
- Keeps config, driver, and pool modules from importing vendor packages directly where the local typing boundary already exposes the runtime object.
- Adds source-shape coverage for the MySQL-family uncompiled modules and records the v0.53.0 changelog note.

Stacked on #589.

Closes #591.