### PR TITLE
refactor(sql-processing): finish cache and adapter parity cleanup

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,12 +21,38 @@ v0.53.0 - SQL processing correctness fixes
   statement config plus normalized driver-feature dictionary across backends.
 * MySQL-family adapter config, driver, and pool modules now resolve runtime
   vendor symbols through adapter-local typing modules.
+* Driver statement-object caches are now bounded by the configured statement
+  cache size, and cached named-parameter rebinding reuses driver-owned
+  processing state.
+* MySQL local-infile support now requires explicit opt-in consent before
+  enabling client-side file reads.
 
 **Fixed:**
 
 * Dynamic SQLCommenter context and trace attributes are appended after stable
   SQL compilation, so repeated compiles reuse cached uncommented SQL while still
   using the current request context.
+* Statement configs are frozen before pipeline fingerprinting so repeated
+  compiles avoid avoidable cache-key hashing.
+* Repeated statement-cache stores now skip redundant processed-state cloning
+  when the raw SQL is already cached.
+* Parameter extraction, type-dispatch misses, scalar coercion, and execute-many
+  fingerprints now avoid unnecessary hashing and allocation on hot paths.
+* No-op AST transformers no longer force full SQL finalization when they return
+  the original expression and parameter objects.
+* Simple dict and keyword-parameter executions can use the direct statement
+  cache path when the cached query profile can safely rebind them.
+* Oracle lock-target rendering for builder-generated ``FOR UPDATE OF`` clauses
+  is handled by SQLGlot generation rather than post-render SQL rewriting.
+* ``adbc`` and ``arrow-odbc`` configs now honor ``on_connection_create`` driver
+  hooks after creating raw connections.
+* CockroachDB psycopg session contexts now resolve callable statement configs
+  at session entry, matching the rest of the PostgreSQL family.
+* Bridge cursor cleanup now suppresses close failures consistently so cleanup
+  errors do not mask an in-flight database exception.
+* The ``mssql-python`` connection pool implementation now lives in its adapter
+  pool module while preserving the existing public import.
+* Spanner adapter modules no longer expose module-level proxy lookup hooks.
 * Async migration squash now builds its internal migration runner with a real
   migration context, matching the synchronous command path.
 * ObStore Arrow streaming no longer resolves cloud ``base_path`` twice for

--- a/sqlspec/adapters/adbc/config.py
+++ b/sqlspec/adapters/adbc/config.py
@@ -108,6 +108,8 @@ class AdbcDriverFeatures(TypedDict):
             Defaults to True when extension_config["events"] is configured.
             Provides pub/sub capabilities via table-backed queue (ADBC has no native pub/sub).
             Requires extension_config["events"] for migration setup.
+        on_connection_create: Callback executed when a connection is created.
+            Receives the raw ADBC connection for low-level driver configuration.
         events_backend: Event channel backend selection.
         Only option: "table_queue" (durable table-backed queue with retries and exactly-once delivery).
             ADBC does not have native pub/sub, so table_queue is the only backend.
@@ -123,6 +125,7 @@ class AdbcDriverFeatures(TypedDict):
     enable_pgvector: NotRequired[bool]
     enable_paradedb: NotRequired[bool]
     enable_events: NotRequired[bool]
+    on_connection_create: "NotRequired[Callable[[AdbcConnection], None]]"
     events_backend: NotRequired[str]
 
 
@@ -189,7 +192,13 @@ class AdbcConfig(NoPoolSyncConfig[AdbcConnection, AdbcDriver]):
     _session_factory_class: "ClassVar[type[_AdbcSessionConnectionHandler]]" = _AdbcSessionConnectionHandler
     _session_context_class: "ClassVar[type[AdbcSessionContext]]" = AdbcSessionContext
     _default_statement_config = StatementConfig()
-    __slots__ = ("_default_session_config", "_paradedb_available", "_pgvector_available", "_resolved_dialect")
+    __slots__ = (
+        "_default_session_config",
+        "_paradedb_available",
+        "_pgvector_available",
+        "_resolved_dialect",
+        "_user_connection_hook",
+    )
 
     def __init__(
         self,
@@ -227,6 +236,10 @@ class AdbcConfig(NoPoolSyncConfig[AdbcConnection, AdbcDriver]):
             statement_config = get_statement_config(self._resolved_dialect)
 
         statement_config, driver_features = apply_driver_features(statement_config, driver_features)
+        features_dict = dict(driver_features) if driver_features else {}
+        self._user_connection_hook = cast(
+            "Callable[[AdbcConnection], None] | None", features_dict.pop("on_connection_create", None)
+        )
         self._default_session_config = get_statement_config(self._resolved_dialect)
 
         super().__init__(
@@ -234,7 +247,7 @@ class AdbcConfig(NoPoolSyncConfig[AdbcConnection, AdbcDriver]):
             connection_instance=connection_instance,
             migration_config=migration_config,
             statement_config=statement_config,
-            driver_features=driver_features,
+            driver_features=features_dict,
             bind_key=bind_key,
             extension_config=extension_config,
             observability_config=observability_config,
@@ -262,6 +275,8 @@ class AdbcConfig(NoPoolSyncConfig[AdbcConnection, AdbcDriver]):
             connection = resolve_driver_connect_func(driver_name, uri)(
                 **build_connection_config(self.connection_config)
             )
+            if self._user_connection_hook is not None:
+                self._user_connection_hook(cast("AdbcConnection", connection))
             return cast("AdbcConnection", connection)
         except Exception as e:
             err_driver_name = self.connection_config.get("driver_name", "Unknown")

--- a/sqlspec/adapters/aiomysql/_typing.py
+++ b/sqlspec/adapters/aiomysql/_typing.py
@@ -4,6 +4,7 @@ This module contains type aliases and classes that are excluded from mypyc
 compilation to avoid ABI boundary issues.
 """
 
+import contextlib
 from typing import TYPE_CHECKING, Any
 
 import aiomysql as _aiomysql  # pyright: ignore
@@ -98,7 +99,8 @@ class AiomysqlCursor:
 
     async def __aexit__(self, *_: object) -> None:
         if self.cursor is not None:
-            await self.cursor.close()
+            with contextlib.suppress(Exception):
+                await self.cursor.close()
 
 
 class AiomysqlSessionContext:

--- a/sqlspec/adapters/aiomysql/config.py
+++ b/sqlspec/adapters/aiomysql/config.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 __all__ = ("AiomysqlConfig", "AiomysqlConnectionParams", "AiomysqlDriverFeatures", "AiomysqlPoolParams")
 
 _POOL_ONLY_CONFIG_KEYS = frozenset({"maxsize", "minsize", "pool_recycle"})
+_AIOMYSQL_LOCAL_INFILE_GATE = "allow_local_infile"
 aiomysql: "AiomysqlModule" = cast("AiomysqlModule", AiomysqlModule)
 
 
@@ -58,6 +59,7 @@ class AiomysqlConnectionParams(TypedDict):
     read_default_file: NotRequired[str]
     read_default_group: NotRequired[str]
     autocommit: NotRequired[bool | None]
+    allow_local_infile: NotRequired[bool]
     echo: NotRequired[bool]
     local_infile: NotRequired[bool]
     enable_local_infile: NotRequired[bool]
@@ -83,9 +85,31 @@ class AiomysqlPoolParams(AiomysqlConnectionParams):
     pool_recycle: NotRequired[int]
 
 
+def _normalize_aiomysql_local_infile_config(
+    connection_config: "Mapping[str, Any]", *, strip_consent_gate: bool
+) -> "dict[str, Any]":
+    """Normalize aiomysql local-infile aliases and SQLSpec's consent gate."""
+    config = dict(connection_config)
+
+    enable_local_infile = bool(config.get("enable_local_infile", False))
+    allow_local_infile = bool(config.get(_AIOMYSQL_LOCAL_INFILE_GATE, False))
+    local_infile = bool(config.get("local_infile", False) or enable_local_infile)
+    if local_infile and not allow_local_infile:
+        msg = (
+            "Aiomysql local_infile=True requires allow_local_infile=True because "
+            "LOAD DATA LOCAL INFILE can read client files."
+        )
+        raise ImproperConfigurationError(msg)
+    config["local_infile"] = bool(local_infile and allow_local_infile)
+    config.pop("enable_local_infile", None)
+    if strip_consent_gate:
+        config.pop(_AIOMYSQL_LOCAL_INFILE_GATE, None)
+    return config
+
+
 def _normalize_aiomysql_connection_kwargs(connection_config: "Mapping[str, Any]") -> "dict[str, Any]":
     """Build aiomysql.connect-compatible kwargs from SQLSpec connection config."""
-    config = dict(connection_config)
+    config = _normalize_aiomysql_local_infile_config(connection_config, strip_consent_gate=True)
 
     for key in _POOL_ONLY_CONFIG_KEYS:
         config.pop(key, None)
@@ -101,11 +125,6 @@ def _normalize_aiomysql_connection_kwargs(connection_config: "Mapping[str, Any]"
     if "passwd" in config and "password" not in config:
         config["password"] = config["passwd"]
     config.pop("passwd", None)
-
-    if config.pop("enable_local_infile", False):
-        config["local_infile"] = True
-    else:
-        config.setdefault("local_infile", False)
 
     return config
 
@@ -238,7 +257,9 @@ class AiomysqlConfig(AsyncDatabaseConfig[AiomysqlConnection, "AiomysqlPool", Aio
             observability_config: Adapter-level observability overrides for lifecycle hooks and observers
             **kwargs: Additional keyword arguments
         """
-        connection_config = normalize_connection_config(connection_config)
+        connection_config = _normalize_aiomysql_local_infile_config(
+            normalize_connection_config(connection_config), strip_consent_gate=False
+        )
 
         connection_config.setdefault("host", "localhost")
         connection_config.setdefault("port", 3306)
@@ -254,10 +275,11 @@ class AiomysqlConfig(AsyncDatabaseConfig[AiomysqlConnection, "AiomysqlPool", Aio
         # Track initialized connections to ensure callback runs exactly once per physical connection
         self._initialized_connections: WeakSet[Any] = WeakSet()
 
-        if features_dict.get("enable_local_infile_bulk_load") and not (
-            connection_config.get("enable_local_infile") or connection_config.get("local_infile")
-        ):
-            msg = "enable_local_infile_bulk_load requires enable_local_infile=True (or local_infile=True) in connection_config."
+        if features_dict.get("enable_local_infile_bulk_load") and not connection_config.get("local_infile"):
+            msg = (
+                "enable_local_infile_bulk_load requires local_infile=True and "
+                "allow_local_infile=True in connection_config."
+            )
             raise ImproperConfigurationError(msg)
 
         super().__init__(

--- a/sqlspec/adapters/aiosqlite/driver.py
+++ b/sqlspec/adapters/aiosqlite/driver.py
@@ -51,6 +51,8 @@ class AiosqliteExceptionHandler(BaseAsyncExceptionHandler):
     to avoid ABI boundary violations with compiled code.
     """
 
+    __slots__ = ()
+
     def _handle_exception(self, exc_type: "type[BaseException] | None", exc_val: "BaseException") -> bool:
         _ = exc_type
         if isinstance(exc_val, (aiosqlite.Error, sqlite3.Error)):

--- a/sqlspec/adapters/arrow_odbc/config.py
+++ b/sqlspec/adapters/arrow_odbc/config.py
@@ -67,6 +67,7 @@ class ArrowOdbcDriverFeatures(TypedDict):
     json_serializer: "NotRequired[Callable[[Any], str]]"
     json_deserializer: "NotRequired[Callable[[str], Any]]"
     enable_events: NotRequired[bool]
+    on_connection_create: "NotRequired[Callable[[ArrowOdbcConnection], None]]"
 
 
 class ArrowOdbcConnectionContext(SyncPoolConnectionContext):
@@ -126,6 +127,7 @@ class ArrowOdbcConfig(NoPoolSyncConfig[ArrowOdbcConnection, ArrowOdbcDriver]):
     _session_factory_class: "ClassVar[type[_ArrowOdbcSessionConnectionHandler]]" = _ArrowOdbcSessionConnectionHandler
     _session_context_class: "ClassVar[type[ArrowOdbcSessionContext]]" = ArrowOdbcSessionContext
     _default_statement_config = default_statement_config
+    __slots__ = ("_user_connection_hook",)
 
     def __init__(
         self,
@@ -153,6 +155,9 @@ class ArrowOdbcConfig(NoPoolSyncConfig[ArrowOdbcConnection, ArrowOdbcDriver]):
             features.setdefault("dbms_name", str(normalized["driver"]))
         if provided_statement_config is None:
             statement_config = _resolve_statement_config(features)
+        self._user_connection_hook = cast(
+            "Callable[[ArrowOdbcConnection], None] | None", features.pop("on_connection_create", None)
+        )
 
         super().__init__(
             connection_config=normalized,
@@ -173,6 +178,8 @@ class ArrowOdbcConfig(NoPoolSyncConfig[ArrowOdbcConnection, ArrowOdbcDriver]):
         connection_string, connect_kwargs = build_connection_config(self.connection_config)
         try:
             connection = cast("ArrowOdbcConnection", arrow_odbc_connect(connection_string, **connect_kwargs))
+            if self._user_connection_hook is not None:
+                self._user_connection_hook(connection)
             return cast("ArrowOdbcConnection", connection)
         except Exception as exc:
             msg = f"Could not configure arrow-odbc connection. Error: {exc}"

--- a/sqlspec/adapters/asyncmy/_typing.py
+++ b/sqlspec/adapters/asyncmy/_typing.py
@@ -4,6 +4,7 @@ This module contains type aliases and classes that are excluded from mypyc
 compilation to avoid ABI boundary issues.
 """
 
+import contextlib
 from typing import TYPE_CHECKING, Any
 
 import asyncmy as _asyncmy  # pyright: ignore
@@ -90,7 +91,8 @@ class AsyncmyCursor:
 
     async def __aexit__(self, *_: object) -> None:
         if self.cursor is not None:
-            await self.cursor.close()
+            with contextlib.suppress(Exception):
+                await self.cursor.close()
 
 
 class AsyncmySessionContext:

--- a/sqlspec/adapters/cockroach_psycopg/_typing.py
+++ b/sqlspec/adapters/cockroach_psycopg/_typing.py
@@ -59,7 +59,7 @@ class CockroachPsycopgSyncSessionContext:
         self,
         acquire_connection: "Callable[[], Any]",
         release_connection: "Callable[[Any], Any]",
-        statement_config: "StatementConfig",
+        statement_config: "StatementConfig | Callable[[], StatementConfig]",
         driver_features: "dict[str, Any]",
         prepare_driver: "Callable[[CockroachPsycopgSyncDriver], CockroachPsycopgSyncDriver]",
     ) -> None:
@@ -75,8 +75,9 @@ class CockroachPsycopgSyncSessionContext:
         from sqlspec.adapters.cockroach_psycopg.driver import CockroachPsycopgSyncDriver
 
         self._connection = self._acquire_connection()
+        statement_config = self._statement_config() if callable(self._statement_config) else self._statement_config
         self._driver = CockroachPsycopgSyncDriver(
-            connection=self._connection, statement_config=self._statement_config, driver_features=self._driver_features
+            connection=self._connection, statement_config=statement_config, driver_features=self._driver_features
         )
         return self._prepare_driver(self._driver)
 
@@ -106,7 +107,7 @@ class CockroachPsycopgAsyncSessionContext:
         self,
         acquire_connection: "Callable[[], Any]",
         release_connection: "Callable[[Any], Any]",
-        statement_config: "StatementConfig",
+        statement_config: "StatementConfig | Callable[[], StatementConfig]",
         driver_features: "dict[str, Any]",
         prepare_driver: "Callable[[CockroachPsycopgAsyncDriver], CockroachPsycopgAsyncDriver]",
     ) -> None:
@@ -122,8 +123,9 @@ class CockroachPsycopgAsyncSessionContext:
         from sqlspec.adapters.cockroach_psycopg.driver import CockroachPsycopgAsyncDriver
 
         self._connection = await self._acquire_connection()
+        statement_config = self._statement_config() if callable(self._statement_config) else self._statement_config
         self._driver = CockroachPsycopgAsyncDriver(
-            connection=self._connection, statement_config=self._statement_config, driver_features=self._driver_features
+            connection=self._connection, statement_config=statement_config, driver_features=self._driver_features
         )
         return self._prepare_driver(self._driver)
 

--- a/sqlspec/adapters/cockroach_psycopg/config.py
+++ b/sqlspec/adapters/cockroach_psycopg/config.py
@@ -19,6 +19,7 @@ from sqlspec.adapters.cockroach_psycopg.driver import (
     CockroachPsycopgSyncDriver,
     CockroachPsycopgSyncExceptionHandler,
 )
+from sqlspec.adapters.psycopg.core import resolve_runtime_statement_config
 from sqlspec.config import AsyncDatabaseConfig, ExtensionConfigs, SyncDatabaseConfig
 from sqlspec.driver._async import AsyncPoolConnectionContext, AsyncPoolSessionFactory
 from sqlspec.driver._sync import SyncPoolConnectionContext, SyncPoolSessionFactory
@@ -302,7 +303,8 @@ class CockroachPsycopgSyncConfig(
         return CockroachPsycopgSyncSessionContext(
             acquire_connection=handler.acquire_connection,
             release_connection=handler.release_connection,
-            statement_config=statement_config or self.statement_config or default_statement_config,
+            statement_config=statement_config
+            or (lambda: resolve_runtime_statement_config(None, self.statement_config, default_statement_config)),
             driver_features=driver_features,
             prepare_driver=self._prepare_driver,
         )
@@ -517,7 +519,8 @@ class CockroachPsycopgAsyncConfig(
         return CockroachPsycopgAsyncSessionContext(
             acquire_connection=handler.acquire_connection,
             release_connection=handler.release_connection,
-            statement_config=statement_config or self.statement_config or default_statement_config,
+            statement_config=statement_config
+            or (lambda: resolve_runtime_statement_config(None, self.statement_config, default_statement_config)),
             driver_features=driver_features,
             prepare_driver=self._prepare_driver,
         )

--- a/sqlspec/adapters/mssql_python/__init__.py
+++ b/sqlspec/adapters/mssql_python/__init__.py
@@ -11,7 +11,6 @@ from sqlspec.adapters.mssql_python.config import (
     MssqlPythonAsyncConfig,
     MssqlPythonConfig,
     MssqlPythonConnectionParams,
-    MssqlPythonConnectionPool,
     MssqlPythonDriverFeatures,
     MssqlPythonPoolParams,
 )
@@ -29,6 +28,7 @@ from sqlspec.adapters.mssql_python.driver import (
     MssqlPythonExceptionHandler,
 )
 from sqlspec.adapters.mssql_python.migrations import MssqlPythonAsyncMigrationTracker, MssqlPythonSyncMigrationTracker
+from sqlspec.adapters.mssql_python.pool import MssqlPythonConnectionPool
 from sqlspec.adapters.mssql_python.type_converter import MssqlPythonTypeConverter, mssql_type_to_arrow
 
 __all__ = (

--- a/sqlspec/adapters/mssql_python/_typing.py
+++ b/sqlspec/adapters/mssql_python/_typing.py
@@ -1,6 +1,7 @@
 """mssql-python adapter type definitions and mypyc-excluded context managers."""
 
 import asyncio
+import contextlib
 from typing import TYPE_CHECKING, Any
 
 import mssql_python as _mssql_python  # pyright: ignore[reportMissingImports]
@@ -50,7 +51,8 @@ class MssqlPythonCursor:
 
     def __exit__(self, *_: object) -> None:
         if self.cursor is not None:
-            self.cursor.close()
+            with contextlib.suppress(Exception):
+                self.cursor.close()
 
 
 class MssqlPythonAsyncCursor:
@@ -68,7 +70,8 @@ class MssqlPythonAsyncCursor:
 
     async def __aexit__(self, *_: object) -> None:
         if self.cursor is not None:
-            await asyncio.to_thread(self.cursor.close)
+            with contextlib.suppress(Exception):
+                await asyncio.to_thread(self.cursor.close)
 
 
 class MssqlPythonSessionContext:

--- a/sqlspec/adapters/mssql_python/config.py
+++ b/sqlspec/adapters/mssql_python/config.py
@@ -1,13 +1,11 @@
 """mssql-python database configuration."""
 
 import asyncio
-import warnings
 from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 
 from typing_extensions import NotRequired
 
 from sqlspec.adapters.mssql_python._typing import (
-    MSSQL_PYTHON_MODULE,
     MssqlPythonAsyncSessionContext,
     MssqlPythonConnection,
     MssqlPythonSessionContext,
@@ -15,6 +13,7 @@ from sqlspec.adapters.mssql_python._typing import (
 from sqlspec.adapters.mssql_python.core import apply_driver_features, build_connection_config, default_statement_config
 from sqlspec.adapters.mssql_python.driver import MssqlPythonAsyncDriver, MssqlPythonDriver
 from sqlspec.adapters.mssql_python.migrations import MssqlPythonAsyncMigrationTracker, MssqlPythonSyncMigrationTracker
+from sqlspec.adapters.mssql_python.pool import MssqlPythonConnectionPool
 from sqlspec.config import AsyncDatabaseConfig, ExtensionConfigs, SyncDatabaseConfig
 from sqlspec.driver._async import AsyncPoolConnectionContext, AsyncPoolSessionFactory
 from sqlspec.driver._sync import SyncPoolConnectionContext, SyncPoolSessionFactory
@@ -35,8 +34,6 @@ __all__ = (
     "MssqlPythonDriverFeatures",
     "MssqlPythonPoolParams",
 )
-
-_POOLING_PARAMS: "tuple[int, int, bool] | None" = None
 
 
 class MssqlPythonConnectionParams(TypedDict):
@@ -107,65 +104,6 @@ class MssqlPythonDriverFeatures(TypedDict):
     json_deserializer: "NotRequired[Callable[[str], Any]]"
     on_connection_create: "NotRequired[Callable[[MssqlPythonConnection], None]]"
     enable_events: NotRequired[bool]
-
-
-class MssqlPythonConnectionPool:
-    """Small SQLSpec pool facade over mssql-python's driver-level pooling."""
-
-    __slots__ = (
-        "_closed",
-        "connect_kwargs",
-        "connection_string",
-        "enabled",
-        "idle_timeout",
-        "max_size",
-        "on_connection_create",
-    )
-
-    def __init__(
-        self,
-        *,
-        connection_string: str,
-        connect_kwargs: "dict[str, Any] | None" = None,
-        max_size: int = 100,
-        idle_timeout: int = 600,
-        enabled: bool = True,
-        on_connection_create: "Callable[[MssqlPythonConnection], None] | None" = None,
-    ) -> None:
-        self.connection_string = connection_string
-        self.connect_kwargs = connect_kwargs or {}
-        self.max_size = max_size
-        self.idle_timeout = idle_timeout
-        self.enabled = enabled
-        self.on_connection_create = on_connection_create
-        self._closed = False
-        global _POOLING_PARAMS
-        new_params = (max_size, idle_timeout, enabled)
-        if _POOLING_PARAMS is not None and new_params != _POOLING_PARAMS:
-            warnings.warn(
-                f"mssql-python pooling config already set to {_POOLING_PARAMS}; "
-                f"overwriting with {new_params}. Only one pool config per process is supported.",
-                stacklevel=2,
-            )
-        MSSQL_PYTHON_MODULE.pooling(max_size=max_size, idle_timeout=idle_timeout, enabled=enabled)
-        _POOLING_PARAMS = new_params
-
-    def acquire(self) -> "MssqlPythonConnection":
-        if self._closed:
-            msg = "Cannot acquire a connection from a closed mssql-python pool."
-            raise RuntimeError(msg)
-        connection = cast(
-            "MssqlPythonConnection", MSSQL_PYTHON_MODULE.connect(self.connection_string, **self.connect_kwargs)
-        )
-        if self.on_connection_create is not None:
-            self.on_connection_create(connection)
-        return connection
-
-    def release(self, connection: "MssqlPythonConnection") -> None:
-        connection.close()
-
-    def close(self) -> None:
-        self._closed = True
 
 
 class MssqlPythonConnectionContext(SyncPoolConnectionContext):

--- a/sqlspec/adapters/mssql_python/pool.py
+++ b/sqlspec/adapters/mssql_python/pool.py
@@ -1,0 +1,72 @@
+"""mssql-python pool facade."""
+
+import warnings
+from typing import TYPE_CHECKING, Any, cast
+
+from sqlspec.adapters.mssql_python._typing import MSSQL_PYTHON_MODULE, MssqlPythonConnection
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+__all__ = ("MssqlPythonConnectionPool",)
+
+_POOLING_PARAMS: "tuple[int, int, bool] | None" = None
+
+
+class MssqlPythonConnectionPool:
+    """Small SQLSpec pool facade over mssql-python's driver-level pooling."""
+
+    __slots__ = (
+        "_closed",
+        "connect_kwargs",
+        "connection_string",
+        "enabled",
+        "idle_timeout",
+        "max_size",
+        "on_connection_create",
+    )
+
+    def __init__(
+        self,
+        *,
+        connection_string: str,
+        connect_kwargs: "dict[str, Any] | None" = None,
+        max_size: int = 100,
+        idle_timeout: int = 600,
+        enabled: bool = True,
+        on_connection_create: "Callable[[MssqlPythonConnection], None] | None" = None,
+    ) -> None:
+        self.connection_string = connection_string
+        self.connect_kwargs = connect_kwargs or {}
+        self.max_size = max_size
+        self.idle_timeout = idle_timeout
+        self.enabled = enabled
+        self.on_connection_create = on_connection_create
+        self._closed = False
+        global _POOLING_PARAMS
+        new_params = (max_size, idle_timeout, enabled)
+        if _POOLING_PARAMS is not None and new_params != _POOLING_PARAMS:
+            warnings.warn(
+                f"mssql-python pooling config already set to {_POOLING_PARAMS}; "
+                f"overwriting with {new_params}. Only one pool config per process is supported.",
+                stacklevel=2,
+            )
+        MSSQL_PYTHON_MODULE.pooling(max_size=max_size, idle_timeout=idle_timeout, enabled=enabled)
+        _POOLING_PARAMS = new_params
+
+    def acquire(self) -> "MssqlPythonConnection":
+        if self._closed:
+            msg = "Cannot acquire a connection from a closed mssql-python pool."
+            raise RuntimeError(msg)
+        connection = cast(
+            "MssqlPythonConnection", MSSQL_PYTHON_MODULE.connect(self.connection_string, **self.connect_kwargs)
+        )
+        if self.on_connection_create is not None:
+            self.on_connection_create(connection)
+        return connection
+
+    def release(self, connection: "MssqlPythonConnection") -> None:
+        connection.close()
+
+    def close(self) -> None:
+        self._closed = True

--- a/sqlspec/adapters/mysqlconnector/_typing.py
+++ b/sqlspec/adapters/mysqlconnector/_typing.py
@@ -4,6 +4,7 @@ This module contains type aliases and classes that are excluded from mypyc
 compilation to avoid ABI boundary issues.
 """
 
+import contextlib
 from typing import TYPE_CHECKING, Any
 
 import mysql as _mysql
@@ -107,7 +108,8 @@ class MysqlConnectorSyncCursor:
 
     def __exit__(self, *_: object) -> None:
         if self.cursor is not None:
-            self.cursor.close()
+            with contextlib.suppress(Exception):
+                self.cursor.close()
 
 
 class MysqlConnectorAsyncCursor:
@@ -128,7 +130,8 @@ class MysqlConnectorAsyncCursor:
 
     async def __aexit__(self, *_: object) -> None:
         if self.cursor is not None:
-            await self.cursor.close()
+            with contextlib.suppress(Exception):
+                await self.cursor.close()
 
 
 class MysqlConnectorSyncSessionContext:

--- a/sqlspec/adapters/oracledb/_typing.py
+++ b/sqlspec/adapters/oracledb/_typing.py
@@ -111,7 +111,8 @@ class OracleSyncCursor:
 
     def __exit__(self, *_: object) -> None:
         if self.cursor is not None:
-            self.cursor.close()
+            with contextlib.suppress(Exception):
+                self.cursor.close()
 
 
 class OracleAsyncCursor:

--- a/sqlspec/adapters/psycopg/_typing.py
+++ b/sqlspec/adapters/psycopg/_typing.py
@@ -4,6 +4,7 @@ This module contains type aliases and classes that are excluded from mypyc
 compilation to avoid ABI boundary issues.
 """
 
+import contextlib
 from typing import TYPE_CHECKING, Any, Protocol
 
 from psycopg import AsyncConnection, AsyncCursor, Connection, Cursor
@@ -64,7 +65,8 @@ class PsycopgSyncCursor:
 
     def __exit__(self, *_: Any) -> None:
         if self.cursor is not None:
-            self.cursor.close()
+            with contextlib.suppress(Exception):
+                self.cursor.close()
 
 
 class PsycopgAsyncCursor:
@@ -85,7 +87,8 @@ class PsycopgAsyncCursor:
     ) -> None:
         _ = (exc_type, exc_val, exc_tb)
         if self.cursor is not None:
-            await self.cursor.close()
+            with contextlib.suppress(Exception):
+                await self.cursor.close()
 
 
 class PsycopgPipelineDriver(Protocol):

--- a/sqlspec/adapters/pymysql/_typing.py
+++ b/sqlspec/adapters/pymysql/_typing.py
@@ -4,6 +4,7 @@ This module contains type aliases and classes that are excluded from mypyc
 compilation to avoid ABI boundary issues.
 """
 
+import contextlib
 from typing import TYPE_CHECKING, Any
 
 import pymysql
@@ -66,7 +67,8 @@ class PyMysqlCursor:
 
     def __exit__(self, *_: object) -> None:
         if self.cursor is not None:
-            self.cursor.close()
+            with contextlib.suppress(Exception):
+                self.cursor.close()
 
 
 class PyMysqlSessionContext:

--- a/sqlspec/adapters/pymysql/config.py
+++ b/sqlspec/adapters/pymysql/config.py
@@ -80,6 +80,7 @@ class PyMysqlConnectionParams(TypedDict):
     read_timeout: NotRequired[PyMysqlTimeout]
     write_timeout: NotRequired[PyMysqlTimeout]
     autocommit: NotRequired[bool]
+    allow_local_infile: NotRequired[bool]
     local_infile: NotRequired[bool]
     max_allowed_packet: NotRequired[int]
     defer_connect: NotRequired[bool]
@@ -155,6 +156,21 @@ _CLOUD_SQL_DIRECT_CONNECTION_KEYS = frozenset((
     "unix_socket",
     "user",
 ))
+
+
+def _normalize_pymysql_local_infile_config(connection_config: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalize PyMySQL local-infile configuration and SQLSpec's consent gate."""
+    config = dict(connection_config)
+    allow_local_infile = bool(config.pop("allow_local_infile", False))
+    local_infile = bool(config.get("local_infile", False))
+    if local_infile and not allow_local_infile:
+        msg = (
+            "PyMySQL local_infile=True requires allow_local_infile=True because "
+            "LOAD DATA LOCAL INFILE can read client files."
+        )
+        raise ImproperConfigurationError(msg)
+    config["local_infile"] = bool(local_infile and allow_local_infile)
+    return config
 
 
 class _PyMysqlCloudSqlConnector:
@@ -236,7 +252,7 @@ class PyMysqlConfig(SyncDatabaseConfig[PyMysqlConnection, PyMysqlConnectionPool,
         observability_config: "ObservabilityConfig | None" = None,
         **kwargs: Any,
     ) -> None:
-        connection_config = normalize_connection_config(connection_config)
+        connection_config = _normalize_pymysql_local_infile_config(normalize_connection_config(connection_config))
         connection_config.setdefault("host", "localhost")
         connection_config.setdefault("port", 3306)
         connection_config.setdefault("local_infile", False)

--- a/sqlspec/adapters/spanner/config.py
+++ b/sqlspec/adapters/spanner/config.py
@@ -549,12 +549,3 @@ class SpannerSyncConfig(SyncDatabaseConfig["SpannerConnection", "AbstractSession
         """Return queue defaults for Spanner JSON handling."""
 
         return EventRuntimeHints(json_passthrough=True)
-
-
-def __getattr__(name: str) -> Any:
-    if name == "Client":
-        from google.cloud.spanner_v1 import Client
-
-        return Client
-    msg = f"module {__name__} has no attribute {name}"
-    raise AttributeError(msg)

--- a/sqlspec/adapters/spanner/driver.py
+++ b/sqlspec/adapters/spanner/driver.py
@@ -584,11 +584,4 @@ class SpannerSyncDriver(SyncDriverAdapterBase):
         return resolve_column_names(fields, self._column_name_cache)
 
 
-def __getattr__(name: str) -> Any:
-    if name == "Transaction":
-        return Transaction
-    msg = f"module {__name__} has no attribute {name}"
-    raise AttributeError(msg)
-
-
 register_driver_profile("spanner", driver_profile)

--- a/sqlspec/adapters/spanner/type_converter.py
+++ b/sqlspec/adapters/spanner/type_converter.py
@@ -23,6 +23,7 @@ from uuid import UUID
 
 from typing_extensions import final
 
+from sqlspec.core import TypedParameter
 from sqlspec.core.type_converter import CachedOutputConverter, convert_uuid
 from sqlspec.utils.module_loader import import_optional_attr
 from sqlspec.utils.serializers import from_json
@@ -268,6 +269,8 @@ def coerce_params_for_spanner(
     json_object_type = _get_json_object_type()
     coerced: dict[str, Any] = {}
     for key, value in params.items():
+        if type(value) is TypedParameter:
+            value = value.value
         if isinstance(value, _UUID_TYPES):
             std_uuid = value if isinstance(value, UUID) else UUID(bytes=value.bytes)
             coerced[key] = bytes_to_spanner(uuid_to_spanner(std_uuid))

--- a/sqlspec/adapters/sqlite/driver.py
+++ b/sqlspec/adapters/sqlite/driver.py
@@ -48,6 +48,8 @@ class SqliteExceptionHandler(BaseSyncExceptionHandler):
     to avoid ABI boundary violations with compiled code.
     """
 
+    __slots__ = ()
+
     def _handle_exception(self, exc_type: "type[BaseException] | None", exc_val: "BaseException") -> bool:
         if exc_type is None:
             return False
@@ -191,7 +193,7 @@ class SqliteDriver(SyncDriverAdapterBase):
         return super().execute_many(statement, parameters, *filters, statement_config=statement_config, **kwargs)
 
     def _stmt_cache_execute_direct(
-        self, sql: str, params: "tuple[Any, ...] | list[Any]", cached: "CachedQuery"
+        self, sql: str, params: "tuple[Any, ...] | list[Any] | dict[str, Any]", cached: "CachedQuery"
     ) -> "SQLResult":
         """Execute cached query through SQLite connection.execute fast path.
 

--- a/sqlspec/builder/_base.py
+++ b/sqlspec/builder/_base.py
@@ -20,6 +20,7 @@ from sqlglot.optimizer.pushdown_predicates import pushdown_predicates as _pushdo
 from sqlglot.optimizer.simplify import simplify as _simplify_rule
 from typing_extensions import Self
 
+from sqlspec.builder._locking import register_lock_generator
 from sqlspec.builder._vector_distance import has_vector_distance_ancestor
 from sqlspec.core import (
     SQL,
@@ -123,7 +124,6 @@ class QueryBuilder(ABC):
 
     __slots__ = (
         "_expression",
-        "_lock_targets_quoted",
         "_merge_target_quoted",
         "_parameter_counter",
         "_parameter_name_counters",
@@ -158,7 +158,6 @@ class QueryBuilder(ABC):
         self._parameters: dict[str, Any] = {}
         self._parameter_counter: int = 0
         self._with_ctes: dict[str, exp.CTE] = {}
-        self._lock_targets_quoted = False
         self._merge_target_quoted = False
 
     @classmethod
@@ -625,8 +624,10 @@ class QueryBuilder(ABC):
                     else final_expression
                 )
                 identify = self._should_identify(target_dialect)
+                if normalized_expression.find(exp.Lock):
+                    register_lock_generator(target_dialect)
                 sql_string = normalized_expression.sql(dialect=target_dialect, pretty=True, identify=identify)
-                sql_string = self._strip_lock_identifier_quotes(sql_string)
+                sql_string = self._strip_merge_target_identifier_quotes(sql_string)
             else:
                 sql_string = str(final_expression)
         except Exception as e:
@@ -886,12 +887,7 @@ class QueryBuilder(ABC):
         # SQLGlot transform(copy=True) deep-copies internally. Copy once here, then mutate that copy.
         return expression.copy().transform(_unquote_identifier, copy=False)
 
-    def _strip_lock_identifier_quotes(self, sql_string: str) -> str:
-        for keyword in ("FOR UPDATE OF ", "FOR SHARE OF "):
-            if keyword in sql_string and not self._lock_targets_quoted:
-                head, tail = sql_string.split(keyword, 1)
-                tail = tail.replace('"', "")
-                return f"{head}{keyword}{tail}"
+    def _strip_merge_target_identifier_quotes(self, sql_string: str) -> str:
         if sql_string.startswith('MERGE INTO "') and not self._merge_target_quoted:
             # Remove quotes around target table only, leave alias/rest intact
             end_quote = sql_string.find('"', len('MERGE INTO "'))

--- a/sqlspec/builder/_locking.py
+++ b/sqlspec/builder/_locking.py
@@ -1,0 +1,90 @@
+"""SQLGlot lock-clause generator registration."""
+
+from collections.abc import Callable, MutableMapping
+from typing import TYPE_CHECKING, ClassVar, Protocol, cast
+
+from sqlglot import exp
+from sqlglot.generator import Generator
+
+from sqlspec.builder._generation import invalidate_generator_dispatch
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from sqlglot.dialects.dialect import DialectType
+
+__all__ = ("register_lock_generator",)
+
+
+class _GeneratorClass(Protocol):
+    TRANSFORMS: ClassVar[MutableMapping[type[exp.Lock], Callable[[Generator, exp.Lock], str]]]
+
+
+class _DialectClass(Protocol):
+    Generator: ClassVar[type[_GeneratorClass]]
+
+
+_REGISTERED_LOCK_GENERATORS: set[type[_GeneratorClass]] = set()
+
+
+def _render_lock_target(generator: "Generator", expression: exp.Expr) -> str:
+    if isinstance(expression, exp.Identifier) and not expression.args.get("quoted"):
+        return expression.name
+    return str(generator.sql(expression))
+
+
+def _render_lock_targets(generator: "Generator", expressions: "Iterable[exp.Expr]") -> str:
+    return ", ".join(_render_lock_target(generator, expression) for expression in expressions)
+
+
+def _lock_sql(generator: "Generator", expression: exp.Lock) -> str:
+    if not generator.LOCKING_READS_SUPPORTED:
+        generator.unsupported("Locking reads using 'FOR UPDATE/SHARE' are not supported")
+        return ""
+
+    update = expression.args["update"]
+    key = expression.args.get("key")
+    lock_type = ("FOR NO KEY UPDATE" if key else "FOR UPDATE") if update else "FOR KEY SHARE" if key else "FOR SHARE"
+
+    targets = _render_lock_targets(generator, expression.expressions)
+    target_sql = f" OF {targets}" if targets else ""
+    wait = expression.args.get("wait")
+
+    if wait is not None:
+        if isinstance(wait, exp.Literal):
+            wait = f" WAIT {generator.sql(wait)}"
+        else:
+            wait = " NOWAIT" if wait else " SKIP LOCKED"
+
+    return f"{lock_type}{target_sql}{wait or ''}"
+
+
+def _generator_class_for_dialect(dialect: "DialectType | str | None") -> "type[_GeneratorClass]":
+    if dialect is None:
+        return cast("type[_GeneratorClass]", Generator)
+
+    from sqlglot import Dialect
+
+    dialect_class: type[Dialect]
+    if isinstance(dialect, str):
+        dialect_class = type(Dialect.get_or_raise(dialect))
+    elif isinstance(dialect, type) and issubclass(dialect, Dialect):
+        dialect_class = dialect
+    elif isinstance(dialect, Dialect):
+        dialect_class = type(dialect)
+    else:
+        dialect_class = type(Dialect.get_or_raise(str(dialect)))
+
+    return cast("_DialectClass", dialect_class).Generator
+
+
+def register_lock_generator(dialect: "DialectType | str | None") -> None:
+    """Register lock-clause rendering for the dialect being rendered."""
+    generator_class = _generator_class_for_dialect(dialect)
+    if generator_class in _REGISTERED_LOCK_GENERATORS:
+        return
+
+    generator_class.TRANSFORMS[exp.Lock] = _lock_sql
+    invalidate_generator_dispatch(generator_class)
+
+    _REGISTERED_LOCK_GENERATORS.add(generator_class)

--- a/sqlspec/builder/_merge.py
+++ b/sqlspec/builder/_merge.py
@@ -684,7 +684,6 @@ class Merge(
     __slots__ = ()
     _expression: exp.Expr | None
     _merge_target_quoted: bool
-    _lock_targets_quoted: bool
 
     def __init__(self, target_table: str | None = None, **kwargs: Any) -> None:
         """Initialize MERGE with optional target table.
@@ -707,7 +706,6 @@ class Merge(
             simplify_expressions=simplify_expressions,
         )
         self._merge_target_quoted = False
-        self._lock_targets_quoted = False
         self._initialize_expression()
 
         if target_table:

--- a/sqlspec/builder/_select.py
+++ b/sqlspec/builder/_select.py
@@ -1490,9 +1490,6 @@ class Select(
         if of:
             tables = [of] if isinstance(of, str) else of
             lock_args["expressions"] = [exp.to_identifier(str(t), quoted=is_explicitly_quoted(t)) for t in tables]
-            self._lock_targets_quoted = any(is_explicitly_quoted(t) for t in tables)
-        else:
-            self._lock_targets_quoted = False
 
         lock = exp.Lock(**lock_args)
 

--- a/sqlspec/core/compiler.py
+++ b/sqlspec/core/compiler.py
@@ -683,11 +683,17 @@ class SQLProcessor:
         ast_was_transformed = False
         if statement_transformers:
             for transformer in statement_transformers:
+                current_expression = expression
+                current_parameters = parameters
                 expression, parameters = transformer(expression, parameters)
-            ast_was_transformed = True
+                if expression is not current_expression or parameters is not current_parameters:
+                    ast_was_transformed = True
         if ast_transformer:
+            current_expression = expression
+            current_parameters = parameters
             expression, parameters = ast_transformer(expression, parameters, parameter_profile, is_many)
-            ast_was_transformed = True
+            if expression is not current_expression or parameters is not current_parameters:
+                ast_was_transformed = True
         if ast_was_transformed:
             if expression is None:
                 return expression, parameters, ast_was_transformed, operation_type, operation_profile

--- a/sqlspec/core/parameters/_processor.py
+++ b/sqlspec/core/parameters/_processor.py
@@ -941,10 +941,6 @@ def _fingerprint_execute_many(parameters: "Sequence[Any]") -> Any:
 
     Extracted to reduce code duplication and allow inlining of the common single-execution path.
     """
-    param_count = len(parameters)
-    sample_size = (
-        min(_EXECUTE_MANY_SAMPLE_SIZE, param_count) if param_count > _EXECUTE_MANY_SAMPLE_THRESHOLD else param_count
-    )
     first = parameters[0]
     first_type = type(first)
 
@@ -952,31 +948,22 @@ def _fingerprint_execute_many(parameters: "Sequence[Any]") -> Any:
     if first_type is dict:
         keys = tuple(first.keys())
         type_sig = tuple(type(v) for v in first.values())
-        return ("many_dict", keys, type_sig, param_count)
+        return ("many_dict", keys, type_sig)
 
     if first_type is list or first_type is tuple:
-        type_sigs: list[tuple[type, ...]] = []
-        for i in range(sample_size):
-            param_item: Any = parameters[i]
-            type_sigs.append(tuple(type(v) for v in param_item))
-        return ("many_seq", tuple(type_sigs), param_count)
+        return ("many_seq", tuple(type(v) for v in first))
 
     # Fallback to ABC checks
     if isinstance(first, Mapping):
         keys = tuple(first.keys())
         type_sig = tuple(type(v) for v in first.values())
-        return ("many_dict", keys, type_sig, param_count)
+        return ("many_dict", keys, type_sig)
 
     if isinstance(first, Sequence) and not isinstance(first, (str, bytes)):
-        type_sigs = []
-        for i in range(sample_size):
-            param_item = parameters[i]
-            type_sigs.append(tuple(type(v) for v in param_item))
-        return ("many_seq", tuple(type_sigs), param_count)
+        return ("many_seq", tuple(type(v) for v in first))
 
     # Scalar values in sequence for execute_many
-    type_sig = tuple(type(parameters[i]) for i in range(sample_size))
-    return ("many_scalar", type_sig, param_count)
+    return ("many_scalar", first_type)
 
 
 def _type_coercion_fallbacks(

--- a/sqlspec/core/parameters/_validator.py
+++ b/sqlspec/core/parameters/_validator.py
@@ -1,6 +1,5 @@
 """Parameter extraction utilities."""
 
-import hashlib
 import re
 from collections import OrderedDict
 from typing import Final
@@ -106,7 +105,7 @@ class ParameterValidator:
         if self._cache_max_size <= 0:
             return self._extract_parameters_uncached(sql)
 
-        cache_key = hashlib.blake2b(sql.encode(), digest_size=8).hexdigest()
+        cache_key = sql
         cached_result = self._parameter_cache.get(cache_key)
         if cached_result is not None:
             self._parameter_cache.move_to_end(cache_key)

--- a/sqlspec/core/pipeline.py
+++ b/sqlspec/core/pipeline.py
@@ -154,6 +154,8 @@ class StatementPipelineRegistry:
         expression: "exp.Expr | None" = None,
         param_fingerprint: "Any | None" = None,
     ) -> "CompiledSQL":
+        if not getattr(config, "_is_frozen", False):
+            config.freeze()
         key = self._fingerprint_config(config)
         pipeline = self._pipelines.get(key)
         record_metrics = _RECORD_PIPELINE_METRICS

--- a/sqlspec/driver/_async.py
+++ b/sqlspec/driver/_async.py
@@ -419,7 +419,7 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin):
         raise NotImplementedError(msg)
 
     async def _stmt_cache_execute_direct(
-        self, sql: str, params: "tuple[Any, ...] | list[Any]", cached: CachedQuery
+        self, sql: str, params: "tuple[Any, ...] | list[Any] | dict[str, Any]", cached: CachedQuery
     ) -> "SQLResult":
         """Execute pre-compiled query via ultra-fast path (async).
 
@@ -507,7 +507,9 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin):
             if direct_statement is not None:
                 self._release_pooled_statement(direct_statement)
 
-    async def _stmt_cache_lookup(self, statement: str, params: "tuple[Any, ...] | list[Any]") -> "SQLResult | None":
+    async def _stmt_cache_lookup(
+        self, statement: str, params: "tuple[Any, ...] | list[Any] | dict[str, Any]"
+    ) -> "SQLResult | None":
         """Attempt fast-path execution for cached query (async).
 
         Args:
@@ -591,15 +593,18 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin):
         exc_handler = self.handle_database_exceptions()
         result: SQLResult | None = None
         async with exc_handler:
+            fast_params: tuple[Any, ...] | list[Any] | dict[str, Any] | None = None
+            if not kwargs and len(parameters) == 1 and isinstance(parameters[0], (tuple, list, dict)):
+                fast_params = cast("tuple[Any, ...] | list[Any] | dict[str, Any]", parameters[0])
+            elif not parameters and kwargs:
+                fast_params = kwargs
             if (
                 self._stmt_cache_enabled
                 and (statement_config is None or statement_config is self.statement_config)
                 and isinstance(statement, str)
-                and len(parameters) == 1
-                and isinstance(parameters[0], (tuple, list))
-                and not kwargs
+                and fast_params is not None
             ):
-                fast_result = await self._stmt_cache_lookup(statement, parameters[0])
+                fast_result = await self._stmt_cache_lookup(statement, fast_params)
                 if fast_result is not None:
                     result = fast_result
             if result is None:

--- a/sqlspec/driver/_common.py
+++ b/sqlspec/driver/_common.py
@@ -4,6 +4,7 @@ import graphlib
 import hashlib
 import logging
 import re
+from collections import OrderedDict
 from contextlib import suppress
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, ClassVar, Final, Literal, NamedTuple, NoReturn, Protocol, cast, overload
@@ -785,6 +786,7 @@ class CommonDriverAttributesMixin:
         "_stmt_cache",
         "_stmt_cache_enabled",
         "_stmt_cache_max_size",
+        "_stmt_cache_rebind_processor",
         "connection",
         "driver_features",
         "statement_config",
@@ -809,12 +811,19 @@ class CommonDriverAttributesMixin:
             observability: Optional runtime handling lifecycle hooks, observers, and spans
         """
         self.connection = connection
+        statement_config.freeze()
         self.statement_config = statement_config
         self.driver_features = driver_features or {}
         self._observability = observability
-        self._statement_cache: dict[str, SQL] = {}
+        self._statement_cache: OrderedDict[str, SQL] = OrderedDict()
         self._stmt_cache_max_size = self._resolve_stmt_cache_max_size()
         self._stmt_cache = QueryCache(self._stmt_cache_max_size)
+        self._stmt_cache_rebind_processor = ParameterProcessor(
+            converter=self.statement_config.parameter_converter,
+            validator=self.statement_config.parameter_validator,
+            cache_max_size=0,
+            validator_cache_max_size=0,
+        )
         self._stmt_cache_enabled = False
         self._statement_pool = get_sql_pool()
         self._processed_state_pool = get_processed_state_pool()
@@ -863,7 +872,9 @@ class CommonDriverAttributesMixin:
             raise StorageCapabilityError(msg, capability="storage_capabilities")
         return cast("StorageCapabilities", dict(capabilities))
 
-    def stmt_cache_rebind(self, params: "tuple[Any, ...] | list[Any]", cached: "CachedQuery") -> "ConvertedParameters":
+    def stmt_cache_rebind(
+        self, params: "tuple[Any, ...] | list[Any] | dict[str, Any]", cached: "CachedQuery"
+    ) -> "ConvertedParameters":
         """Rebind parameters for a cached query."""
         config = self.statement_config.parameter_config
         needs_style_remap = bool(_CACHED_NAMED_STYLES.intersection(cached.parameter_profile.styles))
@@ -874,13 +885,7 @@ class CommonDriverAttributesMixin:
             and not needs_style_remap
         ):
             return params
-        processor = ParameterProcessor(
-            converter=self.statement_config.parameter_converter,
-            validator=self.statement_config.parameter_validator,
-            cache_max_size=0,
-            validator_cache_max_size=0,
-        )
-        return processor._transform_cached_parameters(
+        return self._stmt_cache_rebind_processor._transform_cached_parameters(
             params,
             cached.parameter_profile,
             config,
@@ -1062,6 +1067,7 @@ class CommonDriverAttributesMixin:
         if isinstance(statement, str):
             cached_sql = self._statement_cache.get(statement)
             if cached_sql is not None and not kwargs:
+                self._statement_cache.move_to_end(statement)
                 # Check if parameters contain filters
                 has_filters = any(is_statement_filter(p) for p in parameters)
                 if not has_filters:
@@ -1079,7 +1085,9 @@ class CommonDriverAttributesMixin:
         else:
             sql_statement = self._prepare_from_string(statement, data_parameters, statement_config, kwargs)
             # Cache the newly created SQL object for future use
-            if not filters and not kwargs and isinstance(statement, str):
+            if not filters and not kwargs and isinstance(statement, str) and self._stmt_cache_max_size > 0:
+                if len(self._statement_cache) >= self._stmt_cache_max_size:
+                    self._statement_cache.popitem(last=False)
                 self._statement_cache[statement] = sql_statement
 
         _validate_declared_parameters(sql_statement)
@@ -1232,7 +1240,7 @@ class CommonDriverAttributesMixin:
     def _stmt_cache_build_direct(
         self,
         sql: str,
-        _params: "tuple[Any, ...] | list[Any]",
+        _params: "tuple[Any, ...] | list[Any] | dict[str, Any]",
         cached: "CachedQuery",
         execution_parameters: "ConvertedParameters",
         *,
@@ -1274,7 +1282,9 @@ class CommonDriverAttributesMixin:
         ProcessedState.__init__(direct_state, compiled_sql=sql, execution_parameters=execution_parameters)
         return SQL._create_cached_direct(sql, self.statement_config, direct_state)
 
-    def _stmt_cache_prepare_direct(self, statement: str, params: "tuple[Any, ...] | list[Any]") -> "SQL | None":
+    def _stmt_cache_prepare_direct(
+        self, statement: str, params: "tuple[Any, ...] | list[Any] | dict[str, Any]"
+    ) -> "SQL | None":
         """Prepare direct execution if cache hit.
 
         Only essential checks in the hot lookup path. All detailed eligibility
@@ -1282,7 +1292,7 @@ class CommonDriverAttributesMixin:
 
         Args:
             statement: Raw SQL string.
-            params: Query parameters (tuple or list).
+            params: Query parameters.
 
         Returns:
             Prepared SQL object with processed state if cache hit, None otherwise.
@@ -1292,8 +1302,10 @@ class CommonDriverAttributesMixin:
         cached = self._stmt_cache.get(statement)
         if cached is None or cached.param_count != len(params):
             return None
+        param_values = _cache_param_values(params)
+
         # AST transformer fallback
-        if self.statement_config.parameter_config.ast_transformer is not None and any(p is None for p in params):
+        if self.statement_config.parameter_config.ast_transformer is not None and any(p is None for p in param_values):
             return None
 
         # Fast-path: skip stmt_cache_rebind entirely when no transformations are needed.
@@ -1301,10 +1313,10 @@ class CommonDriverAttributesMixin:
         needs_rebind = bool(cached.input_named_parameters or cached.applied_wrap_types)
         if not needs_rebind and config.type_coercion_map:
             coercion_types = config.type_coercion_map
-            if len(params) == 1:
-                needs_rebind = type(params[0]) in coercion_types
+            if len(param_values) == 1:
+                needs_rebind = type(param_values[0]) in coercion_types
             else:
-                needs_rebind = any(type(p) in coercion_types for p in params)
+                needs_rebind = any(type(p) in coercion_types for p in param_values)
         if not needs_rebind and _CACHED_NAMED_STYLES.intersection(cached.parameter_profile.styles):
             needs_rebind = True
         if needs_rebind:
@@ -1325,7 +1337,7 @@ class CommonDriverAttributesMixin:
         )
 
     def _stmt_cache_lookup(
-        self, statement: str, params: "tuple[Any, ...] | list[Any]"
+        self, statement: str, params: "tuple[Any, ...] | list[Any] | dict[str, Any]"
     ) -> "SQLResult | None | Awaitable[SQLResult | None]":
         """Attempt cached execution for query.
 
@@ -1343,10 +1355,12 @@ class CommonDriverAttributesMixin:
         if cached is None or cached.param_count != len(params):
             return None
 
+        param_values = _cache_param_values(params)
+
         # AST transformer fallback
         config = self.statement_config
         param_config = config.parameter_config
-        if param_config.ast_transformer is not None and any(p is None for p in params):
+        if param_config.ast_transformer is not None and any(p is None for p in param_values):
             return None
 
         # Check if we can use the pre-compiled direct execute path
@@ -1354,10 +1368,10 @@ class CommonDriverAttributesMixin:
         needs_rebind = bool(cached.input_named_parameters or cached.applied_wrap_types)
         if not needs_rebind and param_config.type_coercion_map:
             coercion_types = param_config.type_coercion_map
-            if len(params) == 1:
-                needs_rebind = type(params[0]) in coercion_types
+            if len(param_values) == 1:
+                needs_rebind = type(param_values[0]) in coercion_types
             else:
-                needs_rebind = any(type(p) in coercion_types for p in params)
+                needs_rebind = any(type(p) in coercion_types for p in param_values)
 
         if not needs_rebind and _CACHED_NAMED_STYLES.intersection(cached.parameter_profile.styles):
             needs_rebind = True
@@ -1388,7 +1402,7 @@ class CommonDriverAttributesMixin:
         raise NotImplementedError
 
     def _stmt_cache_execute_direct(
-        self, sql: str, params: "tuple[Any, ...] | list[Any]", cached: "CachedQuery"
+        self, sql: str, params: "tuple[Any, ...] | list[Any] | dict[str, Any]", cached: "CachedQuery"
     ) -> "SQLResult | Awaitable[SQLResult]":
         """Execute pre-compiled query via ultra-fast path (no rebind needed).
 
@@ -1438,6 +1452,8 @@ class CommonDriverAttributesMixin:
             params = statement.positional_parameters
             if any(p is None for p in params):
                 return
+        if self._stmt_cache.get(statement.raw_sql) is not None:
+            return
 
         processed = cast("ProcessedState", statement.get_processed_state())
         param_profile = processed.parameter_profile
@@ -1707,30 +1723,31 @@ class CommonDriverAttributesMixin:
             return []
 
         type_coercion_map = statement_config.parameter_config.type_coercion_map
-        coerce_value = self._apply_coercion
+        fallback_items = _type_coercion_fallbacks(type_coercion_map)
+        coerce_value = self._apply_coercion_with_fallback
 
         if not isinstance(parameters, (dict, list, tuple)):
-            return [coerce_value(parameters, type_coercion_map)]
+            return [coerce_value(parameters, type_coercion_map, fallback_items)]
 
         if isinstance(parameters, dict):
             if statement_config.parameter_config.supported_execution_parameter_styles and (
                 ParameterStyle.NAMED_PYFORMAT in statement_config.parameter_config.supported_execution_parameter_styles
                 or ParameterStyle.NAMED_COLON in statement_config.parameter_config.supported_execution_parameter_styles
             ):
-                return _lazy_copy_coerce_dict(parameters, coerce_value, type_coercion_map)
+                return _lazy_copy_coerce_dict(parameters, coerce_value, type_coercion_map, fallback_items)
             if statement_config.parameter_config.default_parameter_style in {
                 ParameterStyle.NUMERIC,
                 ParameterStyle.QMARK,
                 ParameterStyle.POSITIONAL_PYFORMAT,
             }:
                 sorted_items = sorted(parameters.items(), key=_parameter_sort_key)
-                return [coerce_value(value, type_coercion_map) for _, value in sorted_items]
+                return [coerce_value(value, type_coercion_map, fallback_items) for _, value in sorted_items]
 
-            return _lazy_copy_coerce_dict(parameters, coerce_value, type_coercion_map)
+            return _lazy_copy_coerce_dict(parameters, coerce_value, type_coercion_map, fallback_items)
 
         updated_params: list[Any] | None = None
         for idx, value in enumerate(parameters):
-            coerced_value = coerce_value(value, type_coercion_map)
+            coerced_value = coerce_value(value, type_coercion_map, fallback_items)
             if updated_params is None:
                 if coerced_value is value:
                     continue
@@ -2184,10 +2201,15 @@ def _parameter_sort_key(item: "tuple[str, object]") -> float:
     return float("inf")
 
 
-def _lazy_copy_coerce_dict(parameters: "dict[str, Any]", coerce_value: Any, type_coercion_map: Any) -> "dict[str, Any]":
+def _lazy_copy_coerce_dict(
+    parameters: "dict[str, Any]",
+    coerce_value: Any,
+    type_coercion_map: Any,
+    fallback_items: "tuple[tuple[type, Any], ...]",
+) -> "dict[str, Any]":
     result: dict[str, Any] | None = None
     for key, value in parameters.items():
-        coerced_value = coerce_value(value, type_coercion_map)
+        coerced_value = coerce_value(value, type_coercion_map, fallback_items)
         if result is None:
             if coerced_value is value:
                 continue
@@ -2196,6 +2218,12 @@ def _lazy_copy_coerce_dict(parameters: "dict[str, Any]", coerce_value: Any, type
     if result is None:
         return parameters
     return result
+
+
+def _cache_param_values(params: "tuple[Any, ...] | list[Any] | dict[str, Any]") -> "tuple[Any, ...] | list[Any]":
+    if isinstance(params, dict):
+        return tuple(params.values())
+    return params
 
 
 def _clone_processed_state(processed: "ProcessedState") -> "ProcessedState":

--- a/sqlspec/driver/_sync.py
+++ b/sqlspec/driver/_sync.py
@@ -401,7 +401,7 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin):
         raise NotImplementedError(msg)
 
     def _stmt_cache_execute_direct(
-        self, sql: str, params: "tuple[Any, ...] | list[Any]", cached: CachedQuery
+        self, sql: str, params: "tuple[Any, ...] | list[Any] | dict[str, Any]", cached: CachedQuery
     ) -> "SQLResult":
         """Execute pre-compiled query via ultra-fast path (sync).
 
@@ -539,15 +539,18 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin):
         exc_handler = self.handle_database_exceptions()
         result: SQLResult | None = None
         with exc_handler:
+            fast_params: tuple[Any, ...] | list[Any] | dict[str, Any] | None = None
+            if not kwargs and len(parameters) == 1 and isinstance(parameters[0], (tuple, list, dict)):
+                fast_params = cast("tuple[Any, ...] | list[Any] | dict[str, Any]", parameters[0])
+            elif not parameters and kwargs:
+                fast_params = kwargs
             if (
                 self._stmt_cache_enabled
                 and (statement_config is None or statement_config is self.statement_config)
                 and isinstance(statement, str)
-                and len(parameters) == 1
-                and isinstance(parameters[0], (tuple, list))
-                and not kwargs
+                and fast_params is not None
             ):
-                fast_result = self._stmt_cache_lookup(statement, parameters[0])
+                fast_result = self._stmt_cache_lookup(statement, fast_params)
                 if fast_result is not None:
                     result = cast("SQLResult", fast_result)
             if result is None:

--- a/sqlspec/utils/dispatch.py
+++ b/sqlspec/utils/dispatch.py
@@ -1,4 +1,4 @@
-from typing import Any, Final, Generic, TypeVar
+from typing import Any, Final, Generic, TypeVar, cast
 
 from mypy_extensions import mypyc_attr
 
@@ -6,7 +6,8 @@ __all__ = ("TypeDispatcher",)
 
 
 T = TypeVar("T")
-_MISSING: Final[object] = object()
+_CACHE_MISS: Final[object] = object()
+_NO_MATCH: Final[object] = object()
 
 
 @mypyc_attr(allow_interpreted_subclasses=False)
@@ -20,7 +21,7 @@ class TypeDispatcher(Generic[T]):
     __slots__ = ("_cache", "_registry")
 
     def __init__(self) -> None:
-        self._cache: dict[type, T] = {}
+        self._cache: dict[type, T | object] = {}
         self._registry: dict[type, T] = {}
 
     def register(self, type_: type, value: T) -> None:
@@ -54,9 +55,11 @@ class TypeDispatcher(Generic[T]):
 
     def resolve_type(self, obj_type: type) -> T | None:
         """Resolve a value directly from a concrete runtime type."""
-        cached_value = self._cache.get(obj_type, _MISSING)
-        if cached_value is not _MISSING:
-            return cached_value  # type: ignore[return-value]
+        cached_value = self._cache.get(obj_type, _CACHE_MISS)
+        if cached_value is _NO_MATCH:
+            return None
+        if cached_value is not _CACHE_MISS:
+            return cast("T", cached_value)
 
         return self._resolve(obj_type)
 
@@ -70,17 +73,17 @@ class TypeDispatcher(Generic[T]):
             The resolved value or None.
         """
         # Fast path: check registry directly
-        direct_value = self._registry.get(obj_type, _MISSING)
-        if direct_value is not _MISSING:
-            self._cache[obj_type] = direct_value  # type: ignore[assignment]
-            return direct_value  # type: ignore[return-value]
+        direct_value = self._registry.get(obj_type, _CACHE_MISS)
+        if direct_value is not _CACHE_MISS:
+            self._cache[obj_type] = direct_value
+            return cast("T", direct_value)
 
         # Slow path: walk MRO
         for base in obj_type.__mro__[1:]:
-            value = self._registry.get(base, _MISSING)
-            if value is not _MISSING:
-                self._cache[obj_type] = value  # type: ignore[assignment]
-                return value  # type: ignore[return-value]
+            value = self._registry.get(base, _CACHE_MISS)
+            if value is not _CACHE_MISS:
+                self._cache[obj_type] = value
+                return cast("T", value)
 
         # ABC/protocol fallback: issubclass() resolves virtual hierarchies not present in __mro__.
         for registered_type, value in self._registry.items():
@@ -94,6 +97,7 @@ class TypeDispatcher(Generic[T]):
             self._cache[obj_type] = value
             return value
 
+        self._cache[obj_type] = _NO_MATCH
         return None
 
     def clear_cache(self) -> None:

--- a/tests/integration/adapters/aiomysql/test_local_infile_bulk_load.py
+++ b/tests/integration/adapters/aiomysql/test_local_infile_bulk_load.py
@@ -21,6 +21,7 @@ async def aiomysql_infile_config(mysql_service: "MySQLService") -> "AsyncGenerat
             "password": mysql_service.password,
             "db": mysql_service.db,
             "autocommit": True,
+            "allow_local_infile": True,
             "enable_local_infile": True,
         },
         driver_features={"enable_local_infile_bulk_load": True},

--- a/tests/integration/adapters/pymysql/test_storage_bridge.py
+++ b/tests/integration/adapters/pymysql/test_storage_bridge.py
@@ -21,6 +21,7 @@ def pymysql_infile_config(mysql_service: "MySQLService") -> "Generator[PyMysqlCo
             "password": mysql_service.password,
             "database": mysql_service.db,
             "autocommit": True,
+            "allow_local_infile": True,
             "local_infile": True,
         },
         driver_features={"enable_local_infile_bulk_load": True},

--- a/tests/unit/adapters/test_adapter_implementations.py
+++ b/tests/unit/adapters/test_adapter_implementations.py
@@ -1,6 +1,7 @@
 """Parameterized tests for real adapter implementations."""
 
 import ast
+import importlib
 import inspect
 import operator
 import sqlite3
@@ -93,6 +94,28 @@ MYSQL_FAMILY_UNCOMPILED_MODULES = (
     "sqlspec/adapters/pymysql/pool.py",
 )
 MYSQL_VENDOR_IMPORT_ROOTS = ("aiomysql", "asyncmy", "mysql", "pymysql")
+SPANNER_MODULE_PROXY_PATHS = ("sqlspec/adapters/spanner/config.py", "sqlspec/adapters/spanner/driver.py")
+SQLITE_EXCEPTION_HANDLER_CLASSES = (
+    ("sqlspec.adapters.aiosqlite.driver", "AiosqliteExceptionHandler"),
+    ("sqlspec.adapters.sqlite.driver", "SqliteExceptionHandler"),
+)
+BRIDGE_CURSOR_CLOSE_METHODS = (
+    ("sqlspec/adapters/adbc/_typing.py", "AdbcCursor", "__exit__"),
+    ("sqlspec/adapters/aiomysql/_typing.py", "AiomysqlCursor", "__aexit__"),
+    ("sqlspec/adapters/aiosqlite/_typing.py", "AiosqliteCursor", "__aexit__"),
+    ("sqlspec/adapters/asyncmy/_typing.py", "AsyncmyCursor", "__aexit__"),
+    ("sqlspec/adapters/mssql_python/_typing.py", "MssqlPythonCursor", "__exit__"),
+    ("sqlspec/adapters/mssql_python/_typing.py", "MssqlPythonAsyncCursor", "__aexit__"),
+    ("sqlspec/adapters/mysqlconnector/_typing.py", "MysqlConnectorSyncCursor", "__exit__"),
+    ("sqlspec/adapters/mysqlconnector/_typing.py", "MysqlConnectorAsyncCursor", "__aexit__"),
+    ("sqlspec/adapters/oracledb/_typing.py", "OracleSyncCursor", "__exit__"),
+    ("sqlspec/adapters/oracledb/_typing.py", "OracleAsyncCursor", "__aexit__"),
+    ("sqlspec/adapters/psycopg/_typing.py", "PsycopgSyncCursor", "__exit__"),
+    ("sqlspec/adapters/psycopg/_typing.py", "PsycopgAsyncCursor", "__aexit__"),
+    ("sqlspec/adapters/pymssql/_typing.py", "PymssqlCursor", "__exit__"),
+    ("sqlspec/adapters/pymysql/_typing.py", "PyMysqlCursor", "__exit__"),
+    ("sqlspec/adapters/sqlite/_typing.py", "SqliteCursor", "__exit__"),
+)
 
 
 @pytest.fixture(params=ADAPTER_CONFIGS, ids=operator.itemgetter("name"))
@@ -154,6 +177,14 @@ def test_arrow_odbc_create_mapped_exception_accepts_standard_shape() -> None:
     assert isinstance(mapped, SQLParsingError)
 
 
+@pytest.mark.parametrize(("module_name", "class_name"), SQLITE_EXCEPTION_HANDLER_CLASSES)
+def test_sqlite_exception_handlers_declare_empty_slots(module_name: str, class_name: str) -> None:
+    module = importlib.import_module(module_name)
+    exception_handler = getattr(module, class_name)
+
+    assert exception_handler.__slots__ == ()
+
+
 @pytest.mark.parametrize("module_name", APPLY_DRIVER_FEATURES_MODULES)
 def test_adapter_apply_driver_features_signature_and_return_shape(module_name: str) -> None:
     module = pytest.importorskip(module_name)
@@ -208,6 +239,54 @@ def test_mysql_family_uncompiled_modules_use_adapter_typing_boundary(module_path
     ]
 
     assert direct_vendor_imports == []
+
+
+@pytest.mark.parametrize("module_path", SPANNER_MODULE_PROXY_PATHS)
+def test_spanner_modules_do_not_define_module_proxy_getattr(module_path: str) -> None:
+    tree = ast.parse(Path(module_path).read_text())
+
+    module_getattrs = [node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "__getattr__"]
+
+    assert module_getattrs == []
+
+
+def test_mssql_python_pool_is_implemented_in_pool_module() -> None:
+    from sqlspec.adapters.mssql_python import MssqlPythonConnectionPool
+
+    assert MssqlPythonConnectionPool.__module__ == "sqlspec.adapters.mssql_python.pool"
+
+
+@pytest.mark.parametrize(("module_path", "class_name", "method_name"), BRIDGE_CURSOR_CLOSE_METHODS)
+def test_bridge_cursor_close_cleanup_suppresses_close_errors(
+    module_path: str, class_name: str, method_name: str
+) -> None:
+    tree = ast.parse(Path(module_path).read_text())
+    class_node = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == class_name)
+    method_node = next(
+        node
+        for node in class_node.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == method_name
+    )
+
+    suppress_calls = [
+        item.context_expr
+        for node in ast.walk(method_node)
+        if isinstance(node, ast.With)
+        for item in node.items
+        if isinstance(item.context_expr, ast.Call)
+    ]
+    suppresses_close_errors = any(
+        isinstance(call.func, ast.Attribute)
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id == "contextlib"
+        and call.func.attr == "suppress"
+        and len(call.args) == 1
+        and isinstance(call.args[0], ast.Name)
+        and call.args[0].id == "Exception"
+        for call in suppress_calls
+    )
+
+    assert suppresses_close_errors
 
 
 def test_adapter_parameter_style_handling(

--- a/tests/unit/adapters/test_adbc/test_adbc_config_normalization.py
+++ b/tests/unit/adapters/test_adbc/test_adbc_config_normalization.py
@@ -1,6 +1,7 @@
 """Unit tests for ADBC config normalization helpers."""
 
 from typing import Any, get_type_hints
+from unittest.mock import MagicMock
 
 from sqlspec.adapters.adbc import AdbcConfig
 from sqlspec.adapters.adbc.config import AdbcConnectionParams
@@ -15,6 +16,25 @@ def _resolve_driver_name(config: AdbcConfig) -> str:
 def _get_connection_config_dict(config: AdbcConfig) -> dict[str, Any]:
     """Build the normalized connection configuration."""
     return build_connection_config(config.connection_config)
+
+
+def test_adbc_config_runs_connection_create_callback(monkeypatch: Any) -> None:
+    """ADBC should run the connection hook when it creates a physical connection."""
+    connection = MagicMock()
+    seen: list[Any] = []
+
+    def fake_connect(**_kwargs: Any) -> Any:
+        return connection
+
+    monkeypatch.setattr("sqlspec.adapters.adbc.config.resolve_driver_connect_func", lambda *_args: fake_connect)
+
+    config = AdbcConfig(
+        connection_config={"driver_name": "sqlite"}, driver_features={"on_connection_create": seen.append}
+    )
+
+    assert config.create_connection() is connection
+    assert seen == [connection]
+    assert "on_connection_create" not in config.driver_features
 
 
 def test_resolve_driver_name_alias_to_connect_path() -> None:

--- a/tests/unit/adapters/test_adbc/test_driver.py
+++ b/tests/unit/adapters/test_adbc/test_driver.py
@@ -181,6 +181,6 @@ def test_dispatch_execute_many_postgres_with_casts_calls_batch_helper_once(monke
 
     assert calls == [prepared_rows]
     cursor.executemany.assert_called_once_with(
-        "INSERT INTO events (id, payload) VALUES ($1, CAST($2 AS JSONB))", [(1, "prepared"), (2, "prepared")]
+        "INSERT INTO events (id, payload) VALUES ($1, $2::jsonb)", [(1, "prepared"), (2, "prepared")]
     )
     assert result.rowcount_override == 2

--- a/tests/unit/adapters/test_aiomysql/test_config.py
+++ b/tests/unit/adapters/test_aiomysql/test_config.py
@@ -9,6 +9,7 @@ import pytest
 from sqlspec.adapters.aiomysql._typing import AiomysqlCursor, AiomysqlDictCursor, AiomysqlRawCursor
 from sqlspec.adapters.aiomysql.config import AiomysqlConfig
 from sqlspec.adapters.aiomysql.core import build_statement_config
+from sqlspec.exceptions import ImproperConfigurationError
 
 
 def test_build_default_statement_config_custom_serializers() -> None:
@@ -62,6 +63,7 @@ def test_aiomysql_connection_kwargs_normalize_cursor_alias_and_omit_pool_only_ke
             "maxsize": 8,
             "pool_recycle": 30,
             "enable_local_infile": True,
+            "allow_local_infile": True,
         }
     )
 
@@ -74,6 +76,19 @@ def test_aiomysql_connection_kwargs_normalize_cursor_alias_and_omit_pool_only_ke
     assert "pool_recycle" not in connect_kwargs
     assert connect_kwargs["local_infile"] is True
     assert "enable_local_infile" not in connect_kwargs
+    assert "allow_local_infile" not in connect_kwargs
+
+
+def test_aiomysql_local_infile_requires_explicit_security_gate() -> None:
+    """LOAD DATA LOCAL INFILE should require a separate consent gate."""
+    with pytest.raises(ImproperConfigurationError, match="allow_local_infile=True"):
+        AiomysqlConfig(connection_config={"local_infile": True})
+
+    config = AiomysqlConfig(connection_config={"allow_local_infile": True, "local_infile": True})
+    connect_kwargs = config._get_connection_kwargs()  # pyright: ignore[reportPrivateUsage]
+
+    assert connect_kwargs["local_infile"] is True
+    assert "allow_local_infile" not in connect_kwargs
 
 
 def test_aiomysql_connection_kwargs_default_local_infile_disabled() -> None:
@@ -154,6 +169,7 @@ async def test_aiomysql_create_pool_forwards_sanitized_pool_kwargs(monkeypatch: 
         connection_config={
             "cursor_class": AiomysqlDictCursor,
             "enable_local_infile": True,
+            "allow_local_infile": True,
             "minsize": 2,
             "maxsize": 8,
             "pool_recycle": 30,

--- a/tests/unit/adapters/test_aiomysql/test_local_infile_bulk_load.py
+++ b/tests/unit/adapters/test_aiomysql/test_local_infile_bulk_load.py
@@ -33,6 +33,7 @@ def test_config_gate_raises_when_local_infile_disabled() -> None:
 
 def test_config_gate_allows_when_enable_local_infile_set() -> None:
     config = AiomysqlConfig(
-        connection_config={"enable_local_infile": True}, driver_features={"enable_local_infile_bulk_load": True}
+        connection_config={"enable_local_infile": True, "allow_local_infile": True},
+        driver_features={"enable_local_infile_bulk_load": True},
     )
     assert config.driver_features["enable_local_infile_bulk_load"] is True

--- a/tests/unit/adapters/test_arrow_odbc/test_driver.py
+++ b/tests/unit/adapters/test_arrow_odbc/test_driver.py
@@ -299,6 +299,26 @@ def test_arrow_odbc_config_connects_with_verified_keyword_names(monkeypatch: Any
     assert connection.closed is True
 
 
+def test_arrow_odbc_config_runs_connection_create_callback(monkeypatch: Any) -> None:
+    """arrow-odbc should run the connection hook when it creates a physical connection."""
+    connection = FakeConnection()
+    seen: list[Any] = []
+
+    def fake_connect(_connection_string: str, **_kwargs: Any) -> FakeConnection:
+        return connection
+
+    monkeypatch.setattr("sqlspec.adapters.arrow_odbc.config.arrow_odbc_connect", fake_connect)
+
+    config = ArrowOdbcConfig(
+        connection_config={"connection_string": "Driver={ODBC Driver 18 for SQL Server};"},
+        driver_features={"on_connection_create": seen.append},
+    )
+
+    assert config.create_connection() is connection
+    assert seen == [connection]
+    assert "on_connection_create" not in config.driver_features
+
+
 def test_arrow_odbc_connection_params_declares_routed_security_keys() -> None:
     """Connection params should type the ODBC security keys routed by core."""
     expected_keys = {"trusted_connection", "trust_server_certificate", "encrypt"}

--- a/tests/unit/adapters/test_cockroach_psycopg/test_config.py
+++ b/tests/unit/adapters/test_cockroach_psycopg/test_config.py
@@ -15,9 +15,11 @@ import pytest
 
 from sqlspec.adapters.cockroach_psycopg import (
     CockroachPsycopgAsyncConfig,
+    CockroachPsycopgAsyncSessionContext,
     CockroachPsycopgDriverFeatures,
     CockroachPsycopgRetryConfig,
     CockroachPsycopgSyncConfig,
+    CockroachPsycopgSyncSessionContext,
 )
 from sqlspec.adapters.cockroach_psycopg.config import default_statement_config
 from sqlspec.exceptions import ImproperConfigurationError
@@ -194,6 +196,32 @@ def test_cockroach_psycopg_sync_config_class_attributes() -> None:
     assert CockroachPsycopgSyncConfig.supports_native_arrow_import is True
 
 
+def test_cockroach_psycopg_sync_session_context_resolves_callable_statement_config() -> None:
+    """Sync session context should match psycopg callable statement_config behavior."""
+    connection = object()
+    statement_config = default_statement_config.replace(dialect="cockroach")
+    calls: list[str] = []
+
+    def statement_config_factory() -> Any:
+        calls.append("factory")
+        return statement_config
+
+    ctx = CockroachPsycopgSyncSessionContext(
+        acquire_connection=lambda: connection,
+        release_connection=lambda _connection: None,
+        statement_config=statement_config_factory,
+        driver_features={},
+        prepare_driver=lambda driver: driver,
+    )
+
+    with patch("sqlspec.adapters.cockroach_psycopg.driver.CockroachPsycopgSyncDriver") as driver_type:
+        with ctx:
+            pass
+
+    assert calls == ["factory"]
+    driver_type.assert_called_once_with(connection=connection, statement_config=statement_config, driver_features={})
+
+
 def test_cockroach_psycopg_async_config_default_initialization() -> None:
     """Config should initialize with sensible defaults."""
     config = CockroachPsycopgAsyncConfig()
@@ -257,6 +285,38 @@ def test_cockroach_psycopg_async_config_bind_key_configuration() -> None:
     """Bind key should be stored for multi-database setups."""
     config = CockroachPsycopgAsyncConfig(bind_key="cockroach_async")
     assert config.bind_key == "cockroach_async"
+
+
+async def test_cockroach_psycopg_async_session_context_resolves_callable_statement_config() -> None:
+    """Async session context should match psycopg callable statement_config behavior."""
+    connection = object()
+    statement_config = default_statement_config.replace(dialect="cockroach")
+    calls: list[str] = []
+
+    def statement_config_factory() -> Any:
+        calls.append("factory")
+        return statement_config
+
+    async def acquire_connection() -> object:
+        return connection
+
+    async def release_connection(_connection: object) -> None:
+        return None
+
+    ctx = CockroachPsycopgAsyncSessionContext(
+        acquire_connection=acquire_connection,
+        release_connection=release_connection,
+        statement_config=statement_config_factory,
+        driver_features={},
+        prepare_driver=lambda driver: driver,
+    )
+
+    with patch("sqlspec.adapters.cockroach_psycopg.driver.CockroachPsycopgAsyncDriver") as driver_type:
+        async with ctx:
+            pass
+
+    assert calls == ["factory"]
+    driver_type.assert_called_once_with(connection=connection, statement_config=statement_config, driver_features={})
 
 
 @pytest.mark.anyio
@@ -337,6 +397,8 @@ def test_cockroach_psycopg_async_config_provide_session_uses_default_statement_c
     config = CockroachPsycopgAsyncConfig()
     config.statement_config = None
     session_config = config.provide_session()._statement_config
+    if callable(session_config):
+        session_config = session_config()
     assert session_config is default_statement_config
 
 

--- a/tests/unit/adapters/test_mssql_python/test_async.py
+++ b/tests/unit/adapters/test_mssql_python/test_async.py
@@ -52,9 +52,9 @@ async def test_async_config_provide_session_yields_async_driver(monkeypatch: pyt
     """MssqlPythonAsyncConfig should provide an async driver and release connections."""
     connection = DummyConnection()
 
-    monkeypatch.setattr("sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.pooling", lambda **_: None)
+    monkeypatch.setattr("sqlspec.adapters.mssql_python.pool.MSSQL_PYTHON_MODULE.pooling", lambda **_: None)
     monkeypatch.setattr(
-        "sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.connect", lambda *_args, **_kwargs: connection
+        "sqlspec.adapters.mssql_python.pool.MSSQL_PYTHON_MODULE.connect", lambda *_args, **_kwargs: connection
     )
 
     config = MssqlPythonAsyncConfig(connection_config={"server": "localhost"})
@@ -71,9 +71,9 @@ async def test_async_config_connection_hook_runs_for_session_connections(monkeyp
     connection = DummyConnection()
     seen: list[DummyConnection] = []
 
-    monkeypatch.setattr("sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.pooling", lambda **_: None)
+    monkeypatch.setattr("sqlspec.adapters.mssql_python.pool.MSSQL_PYTHON_MODULE.pooling", lambda **_: None)
     monkeypatch.setattr(
-        "sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.connect", lambda *_args, **_kwargs: connection
+        "sqlspec.adapters.mssql_python.pool.MSSQL_PYTHON_MODULE.connect", lambda *_args, **_kwargs: connection
     )
 
     config = MssqlPythonAsyncConfig(

--- a/tests/unit/adapters/test_mssql_python/test_config.py
+++ b/tests/unit/adapters/test_mssql_python/test_config.py
@@ -5,14 +5,14 @@ from typing import Any, cast, get_type_hints
 
 import pytest
 
-import sqlspec.adapters.mssql_python.config as _mssql_config
+import sqlspec.adapters.mssql_python.pool as _mssql_pool
 from sqlspec.adapters.mssql_python.config import (
     MssqlPythonAsyncConfig,
     MssqlPythonConfig,
     MssqlPythonConnectionParams,
-    MssqlPythonConnectionPool,
     _normalize_mssql_python_init,
 )
+from sqlspec.adapters.mssql_python.pool import MssqlPythonConnectionPool
 
 
 class DummyConnection:
@@ -29,7 +29,7 @@ def test_connection_pool_configures_mssql_python_pooling(monkeypatch: pytest.Mon
     """The SQLSpec pool wrapper should configure driver-level pooling before connect."""
     calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
     connection = DummyConnection()
-    monkeypatch.setattr(_mssql_config, "_POOLING_PARAMS", None)
+    monkeypatch.setattr(_mssql_pool, "_POOLING_PARAMS", None)
 
     def fake_pooling(*args: Any, **kwargs: Any) -> None:
         calls.append(("pooling", args, kwargs))
@@ -38,8 +38,8 @@ def test_connection_pool_configures_mssql_python_pooling(monkeypatch: pytest.Mon
         calls.append(("connect", (connection_string,), kwargs))
         return connection
 
-    monkeypatch.setattr("sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.pooling", fake_pooling)
-    monkeypatch.setattr("sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.connect", fake_connect)
+    monkeypatch.setattr("sqlspec.adapters.mssql_python.pool.MSSQL_PYTHON_MODULE.pooling", fake_pooling)
+    monkeypatch.setattr("sqlspec.adapters.mssql_python.pool.MSSQL_PYTHON_MODULE.connect", fake_connect)
 
     pool = MssqlPythonConnectionPool(
         connection_string="Server=localhost;", connect_kwargs={"timeout": 5}, max_size=7, idle_timeout=30, enabled=True
@@ -57,12 +57,12 @@ def test_connection_pool_configures_mssql_python_pooling(monkeypatch: pytest.Mon
 def test_config_create_pool_splits_connection_and_pool_options(monkeypatch: pytest.MonkeyPatch) -> None:
     """MssqlPythonConfig should pass connection options and pool options to the right APIs."""
     pooling_calls: list[dict[str, Any]] = []
-    monkeypatch.setattr(_mssql_config, "_POOLING_PARAMS", None)
+    monkeypatch.setattr(_mssql_pool, "_POOLING_PARAMS", None)
 
     def fake_pooling(**kwargs: Any) -> None:
         pooling_calls.append(kwargs)
 
-    monkeypatch.setattr("sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.pooling", fake_pooling)
+    monkeypatch.setattr("sqlspec.adapters.mssql_python.pool.MSSQL_PYTHON_MODULE.pooling", fake_pooling)
 
     config = MssqlPythonConfig(
         connection_config={
@@ -122,12 +122,12 @@ def test_connection_params_include_current_mssql_python_odbc_keywords() -> None:
 def test_config_create_pool_normalizes_current_odbc_aliases(monkeypatch: pytest.MonkeyPatch) -> None:
     """Current mssql-python ODBC aliases should become canonical connection fields."""
     pooling_calls: list[dict[str, Any]] = []
-    monkeypatch.setattr(_mssql_config, "_POOLING_PARAMS", None)
+    monkeypatch.setattr(_mssql_pool, "_POOLING_PARAMS", None)
 
     def fake_pooling(**kwargs: Any) -> None:
         pooling_calls.append(kwargs)
 
-    monkeypatch.setattr("sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.pooling", fake_pooling)
+    monkeypatch.setattr("sqlspec.adapters.mssql_python.pool.MSSQL_PYTHON_MODULE.pooling", fake_pooling)
 
     config = MssqlPythonConfig(
         connection_config={
@@ -176,7 +176,7 @@ def test_config_create_pool_normalizes_current_odbc_aliases(monkeypatch: pytest.
 
 def test_config_create_pool_rejects_conflicting_server_aliases(monkeypatch: pytest.MonkeyPatch) -> None:
     """Conflicting canonical ODBC aliases should fail instead of silently choosing one."""
-    monkeypatch.setattr(_mssql_config, "_POOLING_PARAMS", None)
+    monkeypatch.setattr(_mssql_pool, "_POOLING_PARAMS", None)
 
     config = MssqlPythonConfig(connection_config={"server": "srv1", "addr": "srv2"})
 
@@ -188,11 +188,11 @@ def test_config_connection_hook_runs_for_session_connections(monkeypatch: pytest
     """on_connection_create should run for connections acquired by provide_session()."""
     connection = DummyConnection()
     seen: list[DummyConnection] = []
-    monkeypatch.setattr(_mssql_config, "_POOLING_PARAMS", None)
+    monkeypatch.setattr(_mssql_pool, "_POOLING_PARAMS", None)
 
-    monkeypatch.setattr("sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.pooling", lambda **_: None)
+    monkeypatch.setattr("sqlspec.adapters.mssql_python.pool.MSSQL_PYTHON_MODULE.pooling", lambda **_: None)
     monkeypatch.setattr(
-        "sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.connect", lambda *_args, **_kwargs: connection
+        "sqlspec.adapters.mssql_python.pool.MSSQL_PYTHON_MODULE.connect", lambda *_args, **_kwargs: connection
     )
 
     config = MssqlPythonConfig(
@@ -207,10 +207,10 @@ def test_config_connection_hook_runs_for_session_connections(monkeypatch: pytest
 
 def test_second_pool_warns_on_different_params(monkeypatch: pytest.MonkeyPatch) -> None:
     """A second pool with different process-wide pooling params emits one warning."""
-    monkeypatch.setattr(_mssql_config, "_POOLING_PARAMS", None)
-    monkeypatch.setattr("sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.pooling", lambda **_: None)
+    monkeypatch.setattr(_mssql_pool, "_POOLING_PARAMS", None)
+    monkeypatch.setattr("sqlspec.adapters.mssql_python.pool.MSSQL_PYTHON_MODULE.pooling", lambda **_: None)
     monkeypatch.setattr(
-        "sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.connect", lambda *_args, **_kwargs: DummyConnection()
+        "sqlspec.adapters.mssql_python.pool.MSSQL_PYTHON_MODULE.connect", lambda *_args, **_kwargs: DummyConnection()
     )
 
     MssqlPythonConnectionPool(connection_string="Server=srv1;", max_size=10, idle_timeout=60, enabled=True)
@@ -228,10 +228,10 @@ def test_second_pool_warns_on_different_params(monkeypatch: pytest.MonkeyPatch) 
 
 def test_second_pool_same_params_no_warn(monkeypatch: pytest.MonkeyPatch) -> None:
     """A second pool with identical process-wide pooling params emits no warning."""
-    monkeypatch.setattr(_mssql_config, "_POOLING_PARAMS", None)
-    monkeypatch.setattr("sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.pooling", lambda **_: None)
+    monkeypatch.setattr(_mssql_pool, "_POOLING_PARAMS", None)
+    monkeypatch.setattr("sqlspec.adapters.mssql_python.pool.MSSQL_PYTHON_MODULE.pooling", lambda **_: None)
     monkeypatch.setattr(
-        "sqlspec.adapters.mssql_python.config.MSSQL_PYTHON_MODULE.connect", lambda *_args, **_kwargs: DummyConnection()
+        "sqlspec.adapters.mssql_python.pool.MSSQL_PYTHON_MODULE.connect", lambda *_args, **_kwargs: DummyConnection()
     )
 
     MssqlPythonConnectionPool(connection_string="Server=srv1;", max_size=10, idle_timeout=60, enabled=True)

--- a/tests/unit/adapters/test_pymysql/test_config.py
+++ b/tests/unit/adapters/test_pymysql/test_config.py
@@ -4,9 +4,11 @@ import ssl
 from collections.abc import Mapping
 from typing import get_args, get_origin, get_type_hints
 
+import pytest
 from typing_extensions import NotRequired
 
 from sqlspec.adapters.pymysql.config import PyMysqlConfig, PyMysqlConnectionParams
+from sqlspec.exceptions import ImproperConfigurationError
 
 
 def _unwrap_not_required(annotation: object) -> object:
@@ -38,6 +40,7 @@ def test_connection_params_type_current_pymysql_options() -> None:
         "read_timeout",
         "write_timeout",
         "autocommit",
+        "allow_local_infile",
         "local_infile",
         "max_allowed_packet",
         "defer_connect",
@@ -77,12 +80,28 @@ def test_create_pool_defaults_local_infile_off() -> None:
     assert pool._connection_parameters["local_infile"] is False
 
 
-def test_create_pool_preserves_local_infile_opt_in() -> None:
-    """Explicit local infile opt-in should still pass through to PyMySQL."""
-    config = PyMysqlConfig(connection_config={"local_infile": True})
+def test_create_pool_preserves_local_infile_opt_in_with_security_gate() -> None:
+    """Explicit local infile opt-in should still pass through to PyMySQL after consent."""
+    config = PyMysqlConfig(connection_config={"allow_local_infile": True, "local_infile": True})
     pool = config._create_pool()
 
     assert pool._connection_parameters["local_infile"] is True
+    assert "allow_local_infile" not in pool._connection_parameters
+
+
+def test_create_pool_rejects_local_infile_without_security_gate() -> None:
+    """PyMySQL should match asyncmy's separate local-infile consent gate."""
+    with pytest.raises(ImproperConfigurationError, match="allow_local_infile=True"):
+        PyMysqlConfig(connection_config={"local_infile": True})
+
+
+def test_create_pool_does_not_enable_local_infile_for_gate_only() -> None:
+    """The consent gate alone should not enable client-file reads."""
+    config = PyMysqlConfig(connection_config={"allow_local_infile": True})
+    pool = config._create_pool()
+
+    assert pool._connection_parameters["local_infile"] is False
+    assert "allow_local_infile" not in pool._connection_parameters
 
 
 def test_create_pool_preserves_ssl_context_and_flat_tls_options() -> None:

--- a/tests/unit/adapters/test_pymysql/test_local_infile_bulk_load.py
+++ b/tests/unit/adapters/test_pymysql/test_local_infile_bulk_load.py
@@ -42,6 +42,7 @@ def test_config_gate_raises_when_local_infile_disabled() -> None:
 
 def test_config_gate_allows_when_local_infile_enabled() -> None:
     config = PyMysqlConfig(
-        connection_config={"local_infile": True}, driver_features={"enable_local_infile_bulk_load": True}
+        connection_config={"allow_local_infile": True, "local_infile": True},
+        driver_features={"enable_local_infile_bulk_load": True},
     )
     assert config.driver_features["enable_local_infile_bulk_load"] is True

--- a/tests/unit/adapters/test_spanner/test_type_converter.py
+++ b/tests/unit/adapters/test_spanner/test_type_converter.py
@@ -1,6 +1,8 @@
+from datetime import datetime, timezone
 from uuid import UUID
 
-from sqlspec.adapters.spanner.type_converter import SpannerOutputConverter
+from sqlspec.adapters.spanner.type_converter import SpannerOutputConverter, coerce_params_for_spanner
+from sqlspec.core import TypedParameter
 
 
 def test_uuid_conversion() -> None:
@@ -37,3 +39,12 @@ def test_spanner_output_converter_is_final() -> None:
 def test_spanner_output_converter_instantiates() -> None:
     converter = SpannerOutputConverter()
     assert isinstance(converter, SpannerOutputConverter)
+
+
+def test_coerce_params_unwraps_typed_datetime_parameter() -> None:
+    timestamp = datetime(2026, 7, 4, 22, 9, 0, tzinfo=timezone.utc)
+    params = {"available_at": TypedParameter(timestamp, datetime)}
+
+    coerced = coerce_params_for_spanner(params)
+
+    assert coerced == {"available_at": timestamp}

--- a/tests/unit/builder/test_dialect_override.py
+++ b/tests/unit/builder/test_dialect_override.py
@@ -1,5 +1,7 @@
 """Unit tests for build() and to_sql() dialect override parameter."""
 
+from pathlib import Path
+
 from sqlspec import sql
 from sqlspec.builder import Column
 from sqlspec.core import StatementConfig
@@ -151,6 +153,13 @@ def test_oracle_to_statement_compile_uses_unquoted_identifiers() -> None:
     assert "FROM vector_docs_oracledb_async vector_docs_oracledb_async" in compiled_sql
     assert '"vector_docs_oracledb_async"' not in compiled_sql
     assert "VECTOR_DISTANCE(vector_docs_oracledb_async.embedding" in compiled_sql
+
+
+def test_oracle_lock_target_rendering_does_not_use_builder_string_cleanup() -> None:
+    query = sql.select("id", dialect="oracle").from_("job", alias="j").for_update(of="j")
+
+    assert "FOR UPDATE OF j" in query.build().sql
+    assert "_strip_lock_identifier_quotes" not in Path("sqlspec/builder/_base.py").read_text()
 
 
 def test_to_sql_dialect_override_with_complex_query() -> None:

--- a/tests/unit/core/test_cache_keys.py
+++ b/tests/unit/core/test_cache_keys.py
@@ -61,3 +61,10 @@ def test_structural_fingerprint_list_vs_tuple() -> None:
 
     # They produce same fingerprint for same structure
     assert key_list == key_tuple
+
+
+def test_execute_many_structural_fingerprint_ignores_batch_length() -> None:
+    short_batch = [(1,), (2,)]
+    long_batch = [(1,), (2,), (3,)]
+
+    assert structural_fingerprint(short_batch, is_many=True) == structural_fingerprint(long_batch, is_many=True)

--- a/tests/unit/core/test_compiler.py
+++ b/tests/unit/core/test_compiler.py
@@ -599,6 +599,25 @@ def test_ast_transformer_single_parse(basic_statement_config: "StatementConfig")
     assert mock_parse.call_count == 1
 
 
+def test_noop_ast_transformer_skips_finalization_pass(basic_statement_config: "StatementConfig") -> None:
+    def pass_through(
+        expression: exp.Expr, parameters: Any, _parameter_profile: "ParameterProfile", _is_many: bool = False
+    ) -> "tuple[exp.Expr, Any]":
+        return expression, parameters
+
+    parameter_config = basic_statement_config.parameter_config.replace(ast_transformer=pass_through)
+    config = basic_statement_config.replace(parameter_config=parameter_config)
+    processor = SQLProcessor(config)
+
+    with patch(
+        "sqlspec.core.parameters._processor.ParameterProcessor.process_for_execution"
+    ) as mock_process_for_execution:
+        result = processor.compile("SELECT * FROM users WHERE id = ?", [123])
+
+    mock_process_for_execution.assert_not_called()
+    assert result.operation_type == "SELECT"
+
+
 def test_ast_transformer_receives_parameter_profile(basic_statement_config: "StatementConfig") -> None:
     """AST transformers should receive the detected parameter profile."""
     captured: dict[str, int] = {}

--- a/tests/unit/core/test_parameters.py
+++ b/tests/unit/core/test_parameters.py
@@ -905,6 +905,18 @@ def test_extract_parameters_caching(validator: ParameterValidator) -> None:
     assert parameters1 is parameters2
 
 
+def test_extract_parameters_cache_uses_sql_string_without_hashing(validator: ParameterValidator) -> None:
+    """Parameter extraction cache should avoid hashing SQL text on the hot path."""
+    sql = "SELECT * FROM users WHERE id = ? AND name = :name"
+
+    with patch("hashlib.blake2b") as mock_blake2b:
+        validator.extract_parameters(sql)
+        validator.extract_parameters(sql)
+
+    mock_blake2b.assert_not_called()
+    assert sql in validator._parameter_cache
+
+
 def test_extract_parameters_complex_sql(validator: ParameterValidator) -> None:
     """Test parameter extraction from complex SQL with multiple styles."""
     sql = "\n    SELECT u.*, o.*\n    FROM users u\n    JOIN orders o ON u.id = o.user_id\n    WHERE u.name = :name\n      AND u.email = %(email)s\n      AND o.created_at > ?\n      AND o.status = @status\n      AND o.total > $1\n    "

--- a/tests/unit/core/test_pipeline.py
+++ b/tests/unit/core/test_pipeline.py
@@ -73,6 +73,16 @@ def test_fingerprint_cache_uses_cached_slot_value() -> None:
     assert second_fingerprint == first_fingerprint
 
 
+def test_pipeline_compile_freezes_config_before_fingerprinting() -> None:
+    registry = StatementPipelineRegistry()
+    config = StatementConfig()
+
+    registry.compile(config, "SELECT 1", {})
+
+    assert config._is_frozen is True
+    assert config._fingerprint_cache is not None
+
+
 def test_fingerprint_cache_does_not_mutate_unfrozen_config() -> None:
     registry = StatementPipelineRegistry()
     config = StatementConfig()

--- a/tests/unit/driver/test_query_cache.py
+++ b/tests/unit/driver/test_query_cache.py
@@ -18,6 +18,7 @@ from sqlspec.core import (
     clear_all_caches,
     get_cache,
 )
+from sqlspec.core.parameters._processor import ParameterProcessor
 from sqlspec.driver._query_cache import CachedQuery, QueryCache
 from sqlspec.exceptions import SQLSpecError
 
@@ -30,6 +31,7 @@ def _make_cached(
     operation_profile: OperationProfile | None = None,
     parameter_profile: ParameterProfile | None = None,
     processed_state: ProcessedState | None = None,
+    input_named_parameters: tuple[str, ...] = (),
 ) -> CachedQuery:
     if operation_profile is None:
         operation_profile = OperationProfile(returns_rows=True, modifies_rows=False)
@@ -40,7 +42,7 @@ def _make_cached(
     return CachedQuery(
         compiled_sql=compiled_sql,
         parameter_profile=parameter_profile or ParameterProfile(),
-        input_named_parameters=(),
+        input_named_parameters=input_named_parameters,
         applied_wrap_types=False,
         parameter_casts={},
         operation_type=operation_type,
@@ -93,6 +95,40 @@ def test_execute_uses_fast_path_when_eligible(sqlite_sync_driver, monkeypatch) -
     assert called["args"] == ("SELECT ?", (1,))
 
 
+def test_execute_uses_fast_path_with_dict_payload(sqlite_sync_driver, monkeypatch) -> None:
+    sentinel = object()
+    called: dict[str, object] = {}
+
+    def _fake_try(statement: str, params: tuple[Any, ...] | list[Any] | dict[str, Any]) -> object:
+        called["args"] = (statement, params)
+        return sentinel
+
+    monkeypatch.setattr(sqlite_sync_driver, "_stmt_cache_lookup", _fake_try)
+    sqlite_sync_driver._stmt_cache_enabled = True
+
+    result = sqlite_sync_driver.execute("SELECT :id", {"id": 1})
+
+    assert result is sentinel
+    assert called["args"] == ("SELECT :id", {"id": 1})
+
+
+def test_execute_uses_fast_path_with_kwargs_payload(sqlite_sync_driver, monkeypatch) -> None:
+    sentinel = object()
+    called: dict[str, object] = {}
+
+    def _fake_try(statement: str, params: tuple[Any, ...] | list[Any] | dict[str, Any]) -> object:
+        called["args"] = (statement, params)
+        return sentinel
+
+    monkeypatch.setattr(sqlite_sync_driver, "_stmt_cache_lookup", _fake_try)
+    sqlite_sync_driver._stmt_cache_enabled = True
+
+    result = sqlite_sync_driver.execute("SELECT :id", id=1)
+
+    assert result is sentinel
+    assert called["args"] == ("SELECT :id", {"id": 1})
+
+
 def test_execute_skips_fast_path_with_statement_config_override(sqlite_sync_driver, monkeypatch) -> None:
     called = False
 
@@ -123,6 +159,60 @@ def test_execute_populates_fast_path_cache_on_normal_path(sqlite_sync_driver) ->
     assert cached.param_count == 1
     assert cached.operation_type == "SELECT"
     assert result.operation_type == "SELECT"
+
+
+def test_prepare_statement_sql_object_cache_is_bounded(sqlite_sync_driver: Any) -> None:
+    sqlite_sync_driver._stmt_cache_max_size = 2
+
+    first = sqlite_sync_driver.prepare_statement("SELECT 1")
+    second = sqlite_sync_driver.prepare_statement("SELECT 2")
+    third = sqlite_sync_driver.prepare_statement("SELECT 3")
+
+    assert first.raw_sql == "SELECT 1"
+    assert second.raw_sql == "SELECT 2"
+    assert third.raw_sql == "SELECT 3"
+    assert list(sqlite_sync_driver._statement_cache) == ["SELECT 2", "SELECT 3"]
+
+
+def test_stmt_cache_store_skips_clone_when_raw_sql_already_cached(sqlite_sync_driver: Any, monkeypatch: Any) -> None:
+    statement = SQL("SELECT ?", 1, statement_config=sqlite_sync_driver.statement_config)
+    sqlite_sync_driver._get_compiled_statement(statement, sqlite_sync_driver.statement_config)
+
+    assert sqlite_sync_driver._stmt_cache.get("SELECT ?") is not None
+
+    monkeypatch.setattr(
+        "sqlspec.driver._common._clone_processed_state",
+        lambda *_args, **_kwargs: pytest.fail("duplicate store should not clone processed state"),
+    )
+
+    sqlite_sync_driver._stmt_cache_store(statement)
+
+
+def test_stmt_cache_rebind_reuses_driver_owned_processor(sqlite_sync_driver: Any, monkeypatch: Any) -> None:
+    parameter_profile = ParameterProfile([
+        ParameterInfo("id", ParameterStyle.NAMED_COLON, position=31, ordinal=0, placeholder_text=":id")
+    ])
+    cached = _make_cached(
+        compiled_sql="SELECT * FROM users WHERE id = ?",
+        param_count=1,
+        parameter_profile=parameter_profile,
+        input_named_parameters=("id",),
+    )
+    processor = sqlite_sync_driver._stmt_cache_rebind_processor
+    calls: list[object] = []
+    original_transform = ParameterProcessor._transform_cached_parameters
+
+    def wrapped_transform(self: ParameterProcessor, *args: Any, **kwargs: Any) -> Any:
+        calls.append(self)
+        return original_transform(self, *args, **kwargs)
+
+    monkeypatch.setattr(ParameterProcessor, "_transform_cached_parameters", wrapped_transform)
+
+    sqlite_sync_driver.stmt_cache_rebind({"id": 1}, cached)
+    sqlite_sync_driver.stmt_cache_rebind({"id": 2}, cached)
+
+    assert calls == [processor, processor]
+    assert sqlite_sync_driver._stmt_cache_rebind_processor is processor
 
 
 def test_compilation_cache_hit_skips_compile_and_stmt_cache_store(sqlite_sync_driver: Any, monkeypatch: Any) -> None:
@@ -232,6 +322,24 @@ async def test_async_execute_uses_fast_path_when_eligible(aiosqlite_async_driver
 
     assert result is sentinel
     assert called["args"] == ("SELECT ?", (1,))
+
+
+@pytest.mark.anyio
+async def test_async_execute_uses_fast_path_with_kwargs_payload(aiosqlite_async_driver: Any, monkeypatch: Any) -> None:
+    sentinel = object()
+    called: dict[str, object] = {}
+
+    async def _fake_try(statement: str, params: tuple[Any, ...] | list[Any] | dict[str, Any]) -> object:
+        called["args"] = (statement, params)
+        return sentinel
+
+    monkeypatch.setattr(aiosqlite_async_driver, "_stmt_cache_lookup", _fake_try)
+    aiosqlite_async_driver._stmt_cache_enabled = True
+
+    result = await aiosqlite_async_driver.execute("SELECT :id", id=1)
+
+    assert result is sentinel
+    assert called["args"] == ("SELECT :id", {"id": 1})
 
 
 @pytest.mark.anyio

--- a/tests/unit/utils/test_dispatch.py
+++ b/tests/unit/utils/test_dispatch.py
@@ -48,6 +48,15 @@ def test_dispatcher_no_match() -> None:
     assert dispatcher.get(Unrelated()) is None
 
 
+def test_dispatcher_caches_no_match() -> None:
+    dispatcher = TypeDispatcher[str]()
+    dispatcher.register(Base, "base")
+
+    assert dispatcher.get(Unrelated()) is None
+    assert Unrelated in dispatcher._cache
+    assert dispatcher.get(Unrelated()) is None
+
+
 def test_dispatcher_caching() -> None:
     dispatcher = TypeDispatcher[str]()
     dispatcher.register(Base, "base")


### PR DESCRIPTION
## Summary

This PR completes the remaining statement-processing cache and adapter parity cleanup for the next release.

- Bounds driver statement-object caches, reuses the driver-owned cached-parameter rebind processor, and avoids redundant cached-state cloning.
- Reduces hot-path parameter overhead by avoiding unnecessary SQL hashing, caching type-dispatch misses, and sampling execute-many shapes more accurately.
- Keeps stable compiled SQL cacheable while applying dynamic SQLCommenter attributes at materialization time.
- Expands the direct statement-cache path to simple dict and keyword-parameter executions when the cached query profile can safely rebind them.
- Normalizes adapter parity around connection-create hooks, local-infile consent gates, CockroachDB psycopg statement config resolution, bridge cursor cleanup, mssql-python pool placement, and Spanner module exports.
- Moves builder lock-target rendering into SQLGlot generation and updates the 0.53.0 changelog.

Follows the MySQL adapter typing cleanup merged in #592.

Closes #593.