### PR TITLE
refactor(cleanup): rename private SQL helper functions

### DIFF
--- a/sqlspec/adapters/adbc/adk/store.py
+++ b/sqlspec/adapters/adbc/adk/store.py
@@ -255,23 +255,23 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
             return None
         return from_json(str(data))  # type: ignore[no-any-return]
 
-    def _get_create_sessions_table_sql(self) -> str:
+    def _sessions_table_ddl(self) -> str:
         """Get CREATE TABLE SQL for sessions with dialect dispatch.
 
         Returns:
             SQL statement to create adk_sessions table.
         """
         if self._dialect == DIALECT_POSTGRESQL:
-            return self._get_sessions_ddl_postgresql()
+            return self._sessions_ddl_postgresql()
         if self._dialect == DIALECT_SQLITE:
-            return self._get_sessions_ddl_sqlite()
+            return self._sessions_ddl_sqlite()
         if self._dialect == DIALECT_DUCKDB:
-            return self._get_sessions_ddl_duckdb()
+            return self._sessions_ddl_duckdb()
         if self._dialect == DIALECT_SNOWFLAKE:
-            return self._get_sessions_ddl_snowflake()
-        return self._get_sessions_ddl_generic()
+            return self._sessions_ddl_snowflake()
+        return self._sessions_ddl_generic()
 
-    def _get_sessions_ddl_postgresql(self) -> str:
+    def _sessions_ddl_postgresql(self) -> str:
         """PostgreSQL DDL with JSONB and TIMESTAMPTZ.
 
         Returns:
@@ -289,7 +289,7 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         )
         """
 
-    def _get_sessions_ddl_sqlite(self) -> str:
+    def _sessions_ddl_sqlite(self) -> str:
         """SQLite DDL with TEXT and REAL timestamps.
 
         Returns:
@@ -307,7 +307,7 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         )
         """
 
-    def _get_sessions_ddl_duckdb(self) -> str:
+    def _sessions_ddl_duckdb(self) -> str:
         """DuckDB DDL with native JSON type.
 
         Returns:
@@ -325,7 +325,7 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         )
         """
 
-    def _get_sessions_ddl_snowflake(self) -> str:
+    def _sessions_ddl_snowflake(self) -> str:
         """Snowflake DDL with VARIANT type.
 
         Returns:
@@ -343,7 +343,7 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         )
         """
 
-    def _get_sessions_ddl_generic(self) -> str:
+    def _sessions_ddl_generic(self) -> str:
         """Generic SQL-92 compatible DDL fallback.
 
         Returns:
@@ -361,23 +361,23 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         )
         """
 
-    def _get_create_events_table_sql(self) -> str:
+    def _events_table_ddl(self) -> str:
         """Get CREATE TABLE SQL for events with dialect dispatch.
 
         Returns:
             SQL statement to create adk_events table.
         """
         if self._dialect == DIALECT_POSTGRESQL:
-            return self._get_events_ddl_postgresql()
+            return self._events_ddl_postgresql()
         if self._dialect == DIALECT_SQLITE:
-            return self._get_events_ddl_sqlite()
+            return self._events_ddl_sqlite()
         if self._dialect == DIALECT_DUCKDB:
-            return self._get_events_ddl_duckdb()
+            return self._events_ddl_duckdb()
         if self._dialect == DIALECT_SNOWFLAKE:
-            return self._get_events_ddl_snowflake()
-        return self._get_events_ddl_generic()
+            return self._events_ddl_snowflake()
+        return self._events_ddl_generic()
 
-    def _get_events_ddl_postgresql(self) -> str:
+    def _events_ddl_postgresql(self) -> str:
         """PostgreSQL DDL for events table.
 
         Returns:
@@ -394,7 +394,7 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         )
         """
 
-    def _get_events_ddl_sqlite(self) -> str:
+    def _events_ddl_sqlite(self) -> str:
         """SQLite DDL for events table.
 
         Returns:
@@ -411,7 +411,7 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         )
         """
 
-    def _get_events_ddl_duckdb(self) -> str:
+    def _events_ddl_duckdb(self) -> str:
         """DuckDB DDL for events table.
 
         Returns:
@@ -428,7 +428,7 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         )
         """
 
-    def _get_events_ddl_snowflake(self) -> str:
+    def _events_ddl_snowflake(self) -> str:
         """Snowflake DDL for events table.
 
         Returns:
@@ -445,7 +445,7 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         )
         """
 
-    def _get_events_ddl_generic(self) -> str:
+    def _events_ddl_generic(self) -> str:
         """Generic SQL-92 compatible DDL for events table.
 
         Returns:
@@ -462,7 +462,7 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         )
         """
 
-    def _get_create_app_states_table_sql(self) -> str:
+    def _app_states_table_ddl(self) -> str:
         json_type = self._json_storage_type()
         timestamp_type = self._timestamp_storage_type()
         default = "DEFAULT CURRENT_TIMESTAMP()" if self._dialect == DIALECT_SNOWFLAKE else "DEFAULT CURRENT_TIMESTAMP"
@@ -474,7 +474,7 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         )
         """
 
-    def _get_create_user_states_table_sql(self) -> str:
+    def _user_states_table_ddl(self) -> str:
         json_type = self._json_storage_type()
         timestamp_type = self._timestamp_storage_type()
         default = "DEFAULT CURRENT_TIMESTAMP()" if self._dialect == DIALECT_SNOWFLAKE else "DEFAULT CURRENT_TIMESTAMP"
@@ -488,7 +488,7 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         )
         """
 
-    def _get_create_metadata_table_sql(self) -> str:
+    def _metadata_table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._metadata_table} (
             key VARCHAR(128) PRIMARY KEY,
@@ -496,7 +496,7 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         )
         """
 
-    def _get_seed_metadata_sql(self) -> str:
+    def _metadata_seed_sql(self) -> str:
         if self._dialect in {DIALECT_POSTGRESQL, DIALECT_SQLITE, DIALECT_DUCKDB}:
             return f"""
             INSERT INTO {self._metadata_table} (key, value)
@@ -509,25 +509,25 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         WHERE NOT EXISTS (SELECT 1 FROM {self._metadata_table} WHERE key = 'schema_version')
         """
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._app_state_table}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._user_state_table}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         """Get DROP TABLE SQL statements.
 
         Returns:
             List of SQL statements to drop tables and indexes.
         """
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {self._events_table}",
             f"DROP TABLE IF EXISTS {self._session_table}",
         ]
@@ -539,7 +539,7 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
             try:
                 self._enable_foreign_keys(cursor, conn)
 
-                cursor.execute(self._get_create_sessions_table_sql())
+                cursor.execute(self._sessions_table_ddl())
                 conn.commit()
 
                 sessions_idx_app_user = (
@@ -556,7 +556,7 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
                 cursor.execute(sessions_idx_update)
                 conn.commit()
 
-                cursor.execute(self._get_create_events_table_sql())
+                cursor.execute(self._events_table_ddl())
                 conn.commit()
 
                 events_idx = (
@@ -566,16 +566,16 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
                 cursor.execute(events_idx)
                 conn.commit()
 
-                cursor.execute(self._get_create_app_states_table_sql())
+                cursor.execute(self._app_states_table_ddl())
                 conn.commit()
 
-                cursor.execute(self._get_create_user_states_table_sql())
+                cursor.execute(self._user_states_table_ddl())
                 conn.commit()
 
-                cursor.execute(self._get_create_metadata_table_sql())
+                cursor.execute(self._metadata_table_ddl())
                 conn.commit()
 
-                cursor.execute(self._get_seed_metadata_sql())
+                cursor.execute(self._metadata_seed_sql())
                 conn.commit()
             finally:
                 cursor.close()
@@ -1256,18 +1256,18 @@ class AdbcADKMemoryStore(BaseSyncADKMemoryStore["AdbcConfig"]):
             return datetime.fromisoformat(value)
         return datetime.fromisoformat(str(value))
 
-    def _get_create_memory_table_sql(self) -> str:
+    def _memory_table_ddl(self) -> str:
         if self._dialect == DIALECT_POSTGRESQL:
-            return self._get_memory_ddl_postgresql()
+            return self._memory_ddl_postgresql()
         if self._dialect == DIALECT_SQLITE:
-            return self._get_memory_ddl_sqlite()
+            return self._memory_ddl_sqlite()
         if self._dialect == DIALECT_DUCKDB:
-            return self._get_memory_ddl_duckdb()
+            return self._memory_ddl_duckdb()
         if self._dialect == DIALECT_SNOWFLAKE:
-            return self._get_memory_ddl_snowflake()
-        return self._get_memory_ddl_generic()
+            return self._memory_ddl_snowflake()
+        return self._memory_ddl_generic()
 
-    def _get_memory_ddl_postgresql(self) -> str:
+    def _memory_ddl_postgresql(self) -> str:
         owner_id_ddl = f", {self._owner_id_column_ddl}" if self._owner_id_column_ddl else ""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._memory_table} (
@@ -1285,7 +1285,7 @@ class AdbcADKMemoryStore(BaseSyncADKMemoryStore["AdbcConfig"]):
         )
         """
 
-    def _get_memory_ddl_sqlite(self) -> str:
+    def _memory_ddl_sqlite(self) -> str:
         owner_id_ddl = f", {self._owner_id_column_ddl}" if self._owner_id_column_ddl else ""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._memory_table} (
@@ -1303,7 +1303,7 @@ class AdbcADKMemoryStore(BaseSyncADKMemoryStore["AdbcConfig"]):
         )
         """
 
-    def _get_memory_ddl_duckdb(self) -> str:
+    def _memory_ddl_duckdb(self) -> str:
         owner_id_ddl = f", {self._owner_id_column_ddl}" if self._owner_id_column_ddl else ""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._memory_table} (
@@ -1321,7 +1321,7 @@ class AdbcADKMemoryStore(BaseSyncADKMemoryStore["AdbcConfig"]):
         )
         """
 
-    def _get_memory_ddl_snowflake(self) -> str:
+    def _memory_ddl_snowflake(self) -> str:
         owner_id_ddl = f", {self._owner_id_column_ddl}" if self._owner_id_column_ddl else ""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._memory_table} (
@@ -1339,7 +1339,7 @@ class AdbcADKMemoryStore(BaseSyncADKMemoryStore["AdbcConfig"]):
         )
         """
 
-    def _get_memory_ddl_generic(self) -> str:
+    def _memory_ddl_generic(self) -> str:
         owner_id_ddl = f", {self._owner_id_column_ddl}" if self._owner_id_column_ddl else ""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._memory_table} (
@@ -1357,7 +1357,7 @@ class AdbcADKMemoryStore(BaseSyncADKMemoryStore["AdbcConfig"]):
         )
         """
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         return [f"DROP TABLE IF EXISTS {self._memory_table}"]
 
     def _create_tables(self) -> None:
@@ -1367,7 +1367,7 @@ class AdbcADKMemoryStore(BaseSyncADKMemoryStore["AdbcConfig"]):
         with self._config.provide_connection() as conn:
             cursor = conn.cursor()
             try:
-                cursor.execute(self._get_create_memory_table_sql())
+                cursor.execute(self._memory_table_ddl())
                 conn.commit()
 
                 idx_app_user = (

--- a/sqlspec/adapters/adbc/events/store.py
+++ b/sqlspec/adapters/adbc/events/store.py
@@ -136,7 +136,7 @@ class AdbcEventQueueStore(BaseEventQueueStore["AdbcConfig"]):
 
         return "TEXT", "TEXT", "TIMESTAMP"
 
-    def _build_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Build dialect-specific CREATE TABLE SQL."""
         dialect = self.dialect
 
@@ -204,9 +204,9 @@ class AdbcEventQueueStore(BaseEventQueueStore["AdbcConfig"]):
                 ")"
             )
 
-        return super()._build_create_table_sql()
+        return super()._table_ddl()
 
-    def _build_index_sql(self) -> str | None:
+    def _index_ddl(self) -> str | None:
         """Build dialect-specific index SQL."""
         dialect = self.dialect
 
@@ -222,7 +222,7 @@ class AdbcEventQueueStore(BaseEventQueueStore["AdbcConfig"]):
                 "WHERE status = 'pending'"
             )
 
-        return super()._build_index_sql()
+        return super()._index_ddl()
 
     def _wrap_create_statement(self, statement: str, object_type: str) -> str:
         """Return statement unchanged since ADBC dialects support IF NOT EXISTS.
@@ -247,8 +247,8 @@ class AdbcEventQueueStore(BaseEventQueueStore["AdbcConfig"]):
         Returns separate statements for table and index to support
         databases that require separate execution.
         """
-        statements = [self._build_create_table_sql()]
-        index_sql = self._build_index_sql()
+        statements = [self._table_ddl()]
+        index_sql = self._index_ddl()
         if index_sql:
             statements.append(index_sql)
         return statements

--- a/sqlspec/adapters/adbc/litestar/store.py
+++ b/sqlspec/adapters/adbc/litestar/store.py
@@ -75,7 +75,7 @@ class ADBCStore(BaseSQLSpecStore["AdbcConfig"]):
         assert self._dialect is not None
         return self._dialect
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get dialect-specific CREATE TABLE SQL for ADBC.
 
         Returns:
@@ -198,13 +198,13 @@ class ADBCStore(BaseSQLSpecStore["AdbcConfig"]):
 
     def _create_table(self) -> None:
         """Synchronous implementation of create_table using ADBC driver."""
-        sql_text = self._get_create_table_sql()
+        sql_text = self._table_ddl()
         with self._config.provide_session() as driver:
             driver.execute_script(sql_text)
             driver.commit()
         self._log_table_created()
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         """Get dialect-specific DROP TABLE SQL statements for ADBC.
 
         Returns:

--- a/sqlspec/adapters/aiomysql/adk/store.py
+++ b/sqlspec/adapters/aiomysql/adk/store.py
@@ -65,12 +65,12 @@ class AiomysqlADKStore(BaseAsyncADKStore["AiomysqlConfig"]):
     async def create_tables(self) -> None:
         """Create all ADK session tables if they don't exist."""
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_sessions_table_sql())
-            await driver.execute_script(await self._get_create_events_table_sql())
-            await driver.execute_script(await self._get_create_app_states_table_sql())
-            await driver.execute_script(await self._get_create_user_states_table_sql())
-            await driver.execute_script(await self._get_create_metadata_table_sql())
-            await driver.execute_script(await self._get_seed_metadata_sql())
+            await driver.execute_script(await self._sessions_table_ddl())
+            await driver.execute_script(await self._events_table_ddl())
+            await driver.execute_script(await self._app_states_table_ddl())
+            await driver.execute_script(await self._user_states_table_ddl())
+            await driver.execute_script(await self._metadata_table_ddl())
+            await driver.execute_script(await self._metadata_seed_sql())
 
     async def create_session(
         self, session_id: str, app_name: str, user_id: str, state: "dict[str, Any]", owner_id: "Any | None" = None
@@ -439,54 +439,54 @@ class AiomysqlADKStore(BaseAsyncADKStore["AiomysqlConfig"]):
             await cursor.execute(_mysql_upsert_metadata_sql(self._metadata_table), (key, value))
             await conn.commit()
 
-    async def _get_create_sessions_table_sql(self) -> str:
+    async def _sessions_table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL for sessions."""
         adk_config = _adk_config(self._config)
         table_options = _mysql_table_options(adk_config, "session_table_options")
         return _mysql_sessions_ddl(self._session_table, self._owner_id_column_ddl, table_options)
 
-    async def _get_create_events_table_sql(self) -> str:
+    async def _events_table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL for events."""
         return _mysql_events_ddl(self._events_table, self._session_table, _adk_config(self._config))
 
-    async def _get_create_app_states_table_sql(self) -> str:
+    async def _app_states_table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL for app-scoped state."""
         adk_config = _adk_config(self._config)
         table_options = _mysql_table_options(adk_config, "app_state_table_options")
         return _mysql_app_state_ddl(self._app_state_table, table_options)
 
-    async def _get_create_user_states_table_sql(self) -> str:
+    async def _user_states_table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL for user-scoped state."""
         adk_config = _adk_config(self._config)
         table_options = _mysql_table_options(adk_config, "user_state_table_options")
         return _mysql_user_state_ddl(self._user_state_table, table_options)
 
-    async def _get_create_metadata_table_sql(self) -> str:
+    async def _metadata_table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL for ADK metadata."""
         return _mysql_metadata_ddl(self._metadata_table)
 
-    async def _get_seed_metadata_sql(self) -> str:
+    async def _metadata_seed_sql(self) -> str:
         """Get MySQL metadata seed SQL."""
         return f"INSERT IGNORE INTO {self._metadata_table} (`key`, value) VALUES ('schema_version', '1')"
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         """Get MySQL DROP TABLE SQL for app-scoped state."""
         return f"DROP TABLE IF EXISTS {self._app_state_table}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         """Get MySQL DROP TABLE SQL for user-scoped state."""
         return f"DROP TABLE IF EXISTS {self._user_state_table}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         """Get MySQL DROP TABLE SQL for ADK metadata."""
         return f"DROP TABLE IF EXISTS {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         """Get MySQL DROP TABLE SQL statements."""
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {self._events_table}",
             f"DROP TABLE IF EXISTS {self._session_table}",
         ]
@@ -507,7 +507,7 @@ class AiomysqlADKMemoryStore(BaseAsyncADKMemoryStore["AiomysqlConfig"]):
             return
 
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_memory_table_sql())
+            await driver.execute_script(await self._memory_table_ddl())
 
     async def insert_memory_entries(self, entries: "list[MemoryRecord]", owner_id: "object | None" = None) -> int:
         """Bulk insert memory entries with deduplication."""
@@ -646,7 +646,7 @@ class AiomysqlADKMemoryStore(BaseAsyncADKMemoryStore["AiomysqlConfig"]):
             await conn.commit()
             return cursor.rowcount if cursor.rowcount and cursor.rowcount > 0 else 0
 
-    async def _get_create_memory_table_sql(self) -> str:
+    async def _memory_table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL for memory entries."""
         adk_config = _adk_config(self._config)
         table_options = _mysql_table_options(adk_config, "memory_table_options")
@@ -680,7 +680,7 @@ class AiomysqlADKMemoryStore(BaseAsyncADKMemoryStore["AiomysqlConfig"]):
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci{table_options}
         """
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         """Get MySQL DROP TABLE SQL statements."""
         return [f"DROP TABLE IF EXISTS {self._memory_table}"]
 

--- a/sqlspec/adapters/aiomysql/events/store.py
+++ b/sqlspec/adapters/aiomysql/events/store.py
@@ -50,7 +50,7 @@ class AiomysqlEventQueueStore(BaseEventQueueStore[AiomysqlConfig]):
         """
         return "CURRENT_TIMESTAMP(6)"
 
-    def _build_index_sql(self) -> str | None:
+    def _index_ddl(self) -> str | None:
         """Build MySQL conditional index creation SQL.
 
         MySQL does not support IF NOT EXISTS for CREATE INDEX, so this method

--- a/sqlspec/adapters/aiomysql/litestar/store.py
+++ b/sqlspec/adapters/aiomysql/litestar/store.py
@@ -45,7 +45,7 @@ class AiomysqlStore(BaseSQLSpecStore["AiomysqlConfig"]):
         """
         super().__init__(config)
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL with optimized schema.
 
         Returns:
@@ -62,7 +62,7 @@ class AiomysqlStore(BaseSQLSpecStore["AiomysqlConfig"]):
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         """Get MySQL/MariaDB DROP TABLE SQL statements.
 
         Returns:
@@ -75,7 +75,7 @@ class AiomysqlStore(BaseSQLSpecStore["AiomysqlConfig"]):
 
     async def create_table(self) -> None:
         """Create the session table if it doesn't exist."""
-        sql = self._get_create_table_sql()
+        sql = self._table_ddl()
         async with self._config.provide_session() as driver:
             await driver.execute_script(sql)
         self._log_table_created()

--- a/sqlspec/adapters/aiosqlite/adk/store.py
+++ b/sqlspec/adapters/aiosqlite/adk/store.py
@@ -132,12 +132,12 @@ class AiosqliteADKStore(BaseAsyncADKStore["AiosqliteConfig"]):
         """Create both sessions and events tables if they don't exist."""
         async with self._config.provide_session() as driver:
             await self._apply_pragmas(driver.connection)
-            await driver.execute_script(await self._get_create_sessions_table_sql())
-            await driver.execute_script(await self._get_create_events_table_sql())
-            await driver.execute_script(await self._get_create_app_states_table_sql())
-            await driver.execute_script(await self._get_create_user_states_table_sql())
-            await driver.execute_script(await self._get_create_metadata_table_sql())
-            await driver.execute_script(await self._get_seed_metadata_sql())
+            await driver.execute_script(await self._sessions_table_ddl())
+            await driver.execute_script(await self._events_table_ddl())
+            await driver.execute_script(await self._app_states_table_ddl())
+            await driver.execute_script(await self._user_states_table_ddl())
+            await driver.execute_script(await self._metadata_table_ddl())
+            await driver.execute_script(await self._metadata_seed_sql())
             await driver.commit()
 
     async def create_session(
@@ -659,7 +659,7 @@ class AiosqliteADKStore(BaseAsyncADKStore["AiosqliteConfig"]):
         for pragma_name, pragma_value in self._pragma_overrides:
             await connection.execute(f"PRAGMA {pragma_name} = {pragma_value}")
 
-    async def _get_create_sessions_table_sql(self) -> str:
+    async def _sessions_table_ddl(self) -> str:
         """Get SQLite CREATE TABLE SQL for sessions.
 
         Returns:
@@ -684,7 +684,7 @@ class AiosqliteADKStore(BaseAsyncADKStore["AiosqliteConfig"]):
             ON {self._session_table}(update_time DESC);
         """
 
-    async def _get_create_events_table_sql(self) -> str:
+    async def _events_table_ddl(self) -> str:
         """Get SQLite CREATE TABLE SQL for events."""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._events_table} (
@@ -705,7 +705,7 @@ class AiosqliteADKStore(BaseAsyncADKStore["AiosqliteConfig"]):
             ON {self._events_table}(timestamp ASC);
         """
 
-    async def _get_create_app_states_table_sql(self) -> str:
+    async def _app_states_table_ddl(self) -> str:
         """Get SQLite CREATE TABLE SQL for app-scoped state."""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._app_state_table} (
@@ -715,7 +715,7 @@ class AiosqliteADKStore(BaseAsyncADKStore["AiosqliteConfig"]):
         );
         """
 
-    async def _get_create_user_states_table_sql(self) -> str:
+    async def _user_states_table_ddl(self) -> str:
         """Get SQLite CREATE TABLE SQL for user-scoped state."""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._user_state_table} (
@@ -727,7 +727,7 @@ class AiosqliteADKStore(BaseAsyncADKStore["AiosqliteConfig"]):
         );
         """
 
-    async def _get_create_metadata_table_sql(self) -> str:
+    async def _metadata_table_ddl(self) -> str:
         """Get SQLite CREATE TABLE SQL for ADK internal metadata."""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._metadata_table} (
@@ -736,7 +736,7 @@ class AiosqliteADKStore(BaseAsyncADKStore["AiosqliteConfig"]):
         );
         """
 
-    async def _get_seed_metadata_sql(self) -> str:
+    async def _metadata_seed_sql(self) -> str:
         """Get SQLite SQL to seed the ADK schema-version metadata row."""
         return f"""
         INSERT INTO {self._metadata_table} (key, value)
@@ -744,24 +744,24 @@ class AiosqliteADKStore(BaseAsyncADKStore["AiosqliteConfig"]):
         ON CONFLICT(key) DO NOTHING;
         """
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         """Get SQLite DROP TABLE SQL for app-scoped state."""
         return f"DROP TABLE IF EXISTS {self._app_state_table}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         """Get SQLite DROP TABLE SQL for user-scoped state."""
         return f"DROP TABLE IF EXISTS {self._user_state_table}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         """Get SQLite DROP TABLE SQL for ADK internal metadata."""
         return f"DROP TABLE IF EXISTS {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         """Get SQLite DROP TABLE SQL statements."""
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {self._events_table}",
             f"DROP TABLE IF EXISTS {self._session_table}",
         ]
@@ -803,7 +803,7 @@ class AiosqliteADKMemoryStore(BaseAsyncADKMemoryStore["AiosqliteConfig"]):
             return
 
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_memory_table_sql())
+            await driver.execute_script(await self._memory_table_ddl())
             await driver.commit()
 
     async def insert_memory_entries(self, entries: "list[MemoryRecord]", owner_id: "object | None" = None) -> int:
@@ -940,7 +940,7 @@ class AiosqliteADKMemoryStore(BaseAsyncADKMemoryStore["AiosqliteConfig"]):
             await conn.commit()
             return cursor.rowcount
 
-    async def _get_create_memory_table_sql(self) -> str:
+    async def _memory_table_ddl(self) -> str:
         """Get SQLite CREATE TABLE SQL for memory entries.
 
         Returns:
@@ -999,7 +999,7 @@ class AiosqliteADKMemoryStore(BaseAsyncADKMemoryStore["AiosqliteConfig"]):
         {fts_table}
         """
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         """Get SQLite DROP TABLE SQL statements."""
         statements = [f"DROP TABLE IF EXISTS {self._memory_table}"]
         if self._use_fts:

--- a/sqlspec/adapters/aiosqlite/litestar/store.py
+++ b/sqlspec/adapters/aiosqlite/litestar/store.py
@@ -39,7 +39,7 @@ class AiosqliteStore(BaseSQLSpecStore["AiosqliteConfig"]):
         """
         super().__init__(config)
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get SQLite CREATE TABLE SQL.
 
         Returns:
@@ -55,7 +55,7 @@ class AiosqliteStore(BaseSQLSpecStore["AiosqliteConfig"]):
         ON {self._table_name}(expires_at) WHERE expires_at IS NOT NULL;
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         """Get SQLite DROP TABLE SQL statements.
 
         Returns:
@@ -97,7 +97,7 @@ class AiosqliteStore(BaseSQLSpecStore["AiosqliteConfig"]):
 
     async def create_table(self) -> None:
         """Create the session table if it doesn't exist."""
-        sql = self._get_create_table_sql()
+        sql = self._table_ddl()
         async with self._config.provide_session() as driver:
             await driver.execute_script(sql)
         self._log_table_created()

--- a/sqlspec/adapters/arrow_odbc/adk/store.py
+++ b/sqlspec/adapters/arrow_odbc/adk/store.py
@@ -41,12 +41,12 @@ class ArrowOdbcADKStore(BaseSyncADKStore["ArrowOdbcConfig"]):
     def create_tables(self) -> None:
         """Create all ADK session tables if they do not exist."""
         with self._config.provide_session() as driver:
-            driver.execute(self._get_create_sessions_table_sql())
-            driver.execute(self._get_create_events_table_sql())
-            driver.execute(self._get_create_app_states_table_sql())
-            driver.execute(self._get_create_user_states_table_sql())
-            driver.execute(self._get_create_metadata_table_sql())
-            driver.execute(self._get_seed_metadata_sql())
+            driver.execute(self._sessions_table_ddl())
+            driver.execute(self._events_table_ddl())
+            driver.execute(self._app_states_table_ddl())
+            driver.execute(self._user_states_table_ddl())
+            driver.execute(self._metadata_table_ddl())
+            driver.execute(self._metadata_seed_sql())
             driver.commit()
 
     def create_session(
@@ -70,9 +70,7 @@ class ArrowOdbcADKStore(BaseSyncADKStore["ArrowOdbcConfig"]):
                 """,
                 params,
             )
-            row = driver.select_one_or_none(
-                _get_session_select_sql(self._session_table), (app_name, user_id, session_id)
-            )
+            row = driver.select_one_or_none(_session_select_sql(self._session_table), (app_name, user_id, session_id))
             driver.commit()
         if row is None:
             msg = "Failed to fetch created session"
@@ -95,7 +93,7 @@ class ArrowOdbcADKStore(BaseSyncADKStore["ArrowOdbcConfig"]):
                         (app_name, user_id, session_id),
                     )
                 row = driver.select_one_or_none(
-                    _get_session_select_sql(self._session_table), (app_name, user_id, session_id)
+                    _session_select_sql(self._session_table), (app_name, user_id, session_id)
                 )
                 if renew_for is not None:
                     driver.commit()
@@ -153,7 +151,7 @@ class ArrowOdbcADKStore(BaseSyncADKStore["ArrowOdbcConfig"]):
 
     def append_event(self, event_record: EventRecord) -> None:
         """Append an event to a session."""
-        self._execute(_get_insert_event_sql(self._events_table), _event_insert_params(event_record), commit=True)
+        self._execute(_insert_event_sql(self._events_table), _event_insert_params(event_record), commit=True)
 
     def append_event_and_update_state(
         self,
@@ -176,16 +174,14 @@ class ArrowOdbcADKStore(BaseSyncADKStore["ArrowOdbcConfig"]):
                 """,
                 (to_json(state), app_name, user_id, session_id),
             )
-            row = driver.select_one_or_none(
-                _get_session_select_sql(self._session_table), (app_name, user_id, session_id)
-            )
+            row = driver.select_one_or_none(_session_select_sql(self._session_table), (app_name, user_id, session_id))
             if row is None:
                 _raise_session_not_found(session_id)
-            driver.execute(_get_insert_event_sql(self._events_table), _event_insert_params(event_record))
+            driver.execute(_insert_event_sql(self._events_table), _event_insert_params(event_record))
             if app_state is not None:
-                driver.execute(self._get_upsert_app_state_sql(), (app_name, to_json(app_state)))
+                driver.execute(self._upsert_app_state_sql(), (app_name, to_json(app_state)))
             if user_state is not None:
-                driver.execute(self._get_upsert_user_state_sql(), (app_name, user_id, to_json(user_state)))
+                driver.execute(self._upsert_user_state_sql(), (app_name, user_id, to_json(user_state)))
             driver.commit()
         return _session_record_from_row(row)
 
@@ -200,7 +196,7 @@ class ArrowOdbcADKStore(BaseSyncADKStore["ArrowOdbcConfig"]):
         """Return events for a scoped session ordered by event timestamp."""
         if limit is not None and limit <= 0:
             return []
-        sql, params = self._get_events_query(app_name, user_id, session_id, after_timestamp, limit)
+        sql, params = self._events_query(app_name, user_id, session_id, after_timestamp, limit)
         try:
             rows = self._execute_fetchall(sql, params)
         except SQLSpecError as exc:
@@ -278,11 +274,11 @@ class ArrowOdbcADKStore(BaseSyncADKStore["ArrowOdbcConfig"]):
 
     def upsert_app_state(self, app_name: str, state: "dict[str, Any]") -> None:
         """Insert or replace app-scoped state."""
-        self._execute(self._get_upsert_app_state_sql(), (app_name, to_json(state)), commit=True)
+        self._execute(self._upsert_app_state_sql(), (app_name, to_json(state)), commit=True)
 
     def upsert_user_state(self, app_name: str, user_id: str, state: "dict[str, Any]") -> None:
         """Insert or replace user-scoped state."""
-        self._execute(self._get_upsert_user_state_sql(), (app_name, user_id, to_json(state)), commit=True)
+        self._execute(self._upsert_user_state_sql(), (app_name, user_id, to_json(state)), commit=True)
 
     def get_metadata(self, key: str) -> "str | None":
         """Return an ADK metadata value."""
@@ -299,57 +295,57 @@ class ArrowOdbcADKStore(BaseSyncADKStore["ArrowOdbcConfig"]):
 
     def set_metadata(self, key: str, value: str) -> None:
         """Set an ADK metadata value."""
-        self._execute(_get_upsert_metadata_sql(self._metadata_table), (key, value), commit=True)
+        self._execute(_upsert_metadata_sql(self._metadata_table), (key, value), commit=True)
 
-    def _get_create_sessions_table_sql(self) -> str:
+    def _sessions_table_ddl(self) -> str:
         """Return T-SQL DDL for the ADK session table."""
-        return _get_create_sessions_table_sql(self._session_table, self._owner_id_column_ddl)
+        return _sessions_table_ddl(self._session_table, self._owner_id_column_ddl)
 
-    def _get_create_events_table_sql(self) -> str:
+    def _events_table_ddl(self) -> str:
         """Return T-SQL DDL for the ADK event table."""
-        return _get_create_events_table_sql(self._events_table, self._session_table)
+        return _events_table_ddl(self._events_table, self._session_table)
 
-    def _get_create_app_states_table_sql(self) -> str:
+    def _app_states_table_ddl(self) -> str:
         """Return T-SQL DDL for the app-scoped state table."""
-        return _get_create_app_states_table_sql(self._app_state_table)
+        return _app_states_table_ddl(self._app_state_table)
 
-    def _get_create_user_states_table_sql(self) -> str:
+    def _user_states_table_ddl(self) -> str:
         """Return T-SQL DDL for the user-scoped state table."""
-        return _get_create_user_states_table_sql(self._user_state_table)
+        return _user_states_table_ddl(self._user_state_table)
 
-    def _get_create_metadata_table_sql(self) -> str:
+    def _metadata_table_ddl(self) -> str:
         """Return T-SQL DDL for the ADK metadata table."""
-        return _get_create_metadata_table_sql(self._metadata_table)
+        return _metadata_table_ddl(self._metadata_table)
 
-    def _get_seed_metadata_sql(self) -> str:
+    def _metadata_seed_sql(self) -> str:
         """Return T-SQL to seed schema-version metadata."""
-        return _get_seed_metadata_sql(self._metadata_table)
+        return _metadata_seed_sql(self._metadata_table)
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {_table_ref(self._app_state_table)}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {_table_ref(self._user_state_table)}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {_table_ref(self._metadata_table)}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {_table_ref(self._events_table)}",
             f"DROP TABLE IF EXISTS {_table_ref(self._session_table)}",
         ]
 
-    def _get_upsert_app_state_sql(self) -> str:
-        return _get_upsert_state_sql(self._app_state_table, ("app_name",), ("?",))
+    def _upsert_app_state_sql(self) -> str:
+        return _upsert_state_sql(self._app_state_table, ("app_name",), ("?",))
 
-    def _get_upsert_user_state_sql(self) -> str:
-        return _get_upsert_state_sql(self._user_state_table, ("app_name", "user_id"), ("?", "?"))
+    def _upsert_user_state_sql(self) -> str:
+        return _upsert_state_sql(self._user_state_table, ("app_name", "user_id"), ("?", "?"))
 
-    def _get_events_query(
+    def _events_query(
         self,
         app_name: str,
         user_id: str,
@@ -357,7 +353,7 @@ class ArrowOdbcADKStore(BaseSyncADKStore["ArrowOdbcConfig"]):
         after_timestamp: "datetime | None" = None,
         limit: "int | None" = None,
     ) -> "tuple[str, tuple[Any, ...]]":
-        return _get_events_query(self._events_table, app_name, user_id, session_id, after_timestamp, limit)
+        return _events_query(self._events_table, app_name, user_id, session_id, after_timestamp, limit)
 
     def _execute_fetchone(self, sql: str, params: "tuple[Any, ...]" = ()) -> "dict[str, Any] | None":
         with self._config.provide_session() as driver:
@@ -390,7 +386,7 @@ class ArrowOdbcADKMemoryStore(BaseSyncADKMemoryStore["ArrowOdbcConfig"]):
         if not self._enabled:
             return
         with self._config.provide_session() as driver:
-            for statement in self._get_create_memory_table_sql():
+            for statement in self._memory_table_ddl():
                 driver.execute(statement)
             driver.commit()
 
@@ -481,7 +477,7 @@ class ArrowOdbcADKMemoryStore(BaseSyncADKMemoryStore["ArrowOdbcConfig"]):
         )
         return count
 
-    def _get_create_memory_table_sql(self) -> "list[str]":
+    def _memory_table_ddl(self) -> "list[str]":
         owner_line = f",\n        {self._owner_id_column_ddl}" if self._owner_id_column_ddl else ""
         return [
             f"""
@@ -508,13 +504,13 @@ BEGIN
     );
 END;
 """,
-            _get_create_index_sql(
+            _create_index_sql(
                 self._memory_table, f"idx_{self._memory_table}_app_user_time", "app_name, user_id, timestamp DESC"
             ),
-            _get_create_index_sql(self._memory_table, f"idx_{self._memory_table}_session", "session_id"),
+            _create_index_sql(self._memory_table, f"idx_{self._memory_table}_session", "session_id"),
         ]
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         return [f"DROP TABLE IF EXISTS {_table_ref(self._memory_table)}"]
 
     def _execute_fetchall(self, sql: str, params: "tuple[Any, ...]" = ()) -> "list[dict[str, Any]]":
@@ -534,7 +530,7 @@ END;
         return int(value or 0)
 
 
-def _get_session_select_sql(table: str) -> str:
+def _session_select_sql(table: str) -> str:
     return f"""
     SELECT TOP 1 id, app_name, user_id, state, create_time, update_time
     FROM {_table_ref(table)}
@@ -542,7 +538,7 @@ def _get_session_select_sql(table: str) -> str:
     """
 
 
-def _get_create_sessions_table_sql(table: str, owner_id_column_ddl: "str | None") -> str:
+def _sessions_table_ddl(table: str, owner_id_column_ddl: "str | None") -> str:
     owner_line = f",\n        {owner_id_column_ddl}" if owner_id_column_ddl else ""
     return f"""
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = N'{_escape_sql_literal(table)}' AND schema_id = SCHEMA_ID(N'dbo'))
@@ -559,12 +555,12 @@ BEGIN
         CONSTRAINT {_constraint_ref("uq", table, "id")} UNIQUE (id)
     );
 END;
-{_get_create_index_sql(table, f"idx_{table}_app_user", "app_name, user_id")}
-{_get_create_index_sql(table, f"idx_{table}_update_time", "update_time DESC")}
+{_create_index_sql(table, f"idx_{table}_app_user", "app_name, user_id")}
+{_create_index_sql(table, f"idx_{table}_update_time", "update_time DESC")}
 """
 
 
-def _get_create_events_table_sql(table: str, session_table: str) -> str:
+def _events_table_ddl(table: str, session_table: str) -> str:
     return f"""
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = N'{_escape_sql_literal(table)}' AND schema_id = SCHEMA_ID(N'dbo'))
 BEGIN
@@ -583,14 +579,14 @@ BEGIN
             REFERENCES {_table_ref(session_table)}(id) ON DELETE CASCADE
     );
 END;
-{_get_create_index_sql(table, f"idx_{table}_scope", "app_name, user_id, session_id, timestamp ASC")}
-{_get_create_index_sql(table, f"idx_{table}_session", "session_id, timestamp ASC")}
-{_get_create_index_sql(table, f"idx_{table}_invocation", "invocation_id")}
-{_get_create_index_sql(table, f"idx_{table}_timestamp", "timestamp ASC")}
+{_create_index_sql(table, f"idx_{table}_scope", "app_name, user_id, session_id, timestamp ASC")}
+{_create_index_sql(table, f"idx_{table}_session", "session_id, timestamp ASC")}
+{_create_index_sql(table, f"idx_{table}_invocation", "invocation_id")}
+{_create_index_sql(table, f"idx_{table}_timestamp", "timestamp ASC")}
 """
 
 
-def _get_create_app_states_table_sql(table: str) -> str:
+def _app_states_table_ddl(table: str) -> str:
     return f"""
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = N'{_escape_sql_literal(table)}' AND schema_id = SCHEMA_ID(N'dbo'))
 BEGIN
@@ -604,7 +600,7 @@ END;
 """
 
 
-def _get_create_user_states_table_sql(table: str) -> str:
+def _user_states_table_ddl(table: str) -> str:
     return f"""
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = N'{_escape_sql_literal(table)}' AND schema_id = SCHEMA_ID(N'dbo'))
 BEGIN
@@ -619,7 +615,7 @@ END;
 """
 
 
-def _get_create_metadata_table_sql(table: str) -> str:
+def _metadata_table_ddl(table: str) -> str:
     return f"""
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = N'{_escape_sql_literal(table)}' AND schema_id = SCHEMA_ID(N'dbo'))
 BEGIN
@@ -632,7 +628,7 @@ END;
 """
 
 
-def _get_create_index_sql(table: str, index_name: str, columns: str) -> str:
+def _create_index_sql(table: str, index_name: str, columns: str) -> str:
     return f"""
 IF NOT EXISTS (
     SELECT 1 FROM sys.indexes
@@ -645,7 +641,7 @@ END;
 """
 
 
-def _get_insert_event_sql(table: str) -> str:
+def _insert_event_sql(table: str) -> str:
     return f"""
     INSERT INTO {_table_ref(table)} (
         id, app_name, user_id, session_id, invocation_id, timestamp, event_data
@@ -654,7 +650,7 @@ def _get_insert_event_sql(table: str) -> str:
     """
 
 
-def _get_upsert_state_sql(table: str, key_columns: "tuple[str, ...]", key_params: "tuple[str, ...]") -> str:
+def _upsert_state_sql(table: str, key_columns: "tuple[str, ...]", key_params: "tuple[str, ...]") -> str:
     source_columns = ", ".join(
         f"{param} AS {_quote_identifier(column)}" for column, param in zip(key_columns, key_params, strict=False)
     )
@@ -676,7 +672,7 @@ def _get_upsert_state_sql(table: str, key_columns: "tuple[str, ...]", key_params
     """
 
 
-def _get_upsert_metadata_sql(table: str) -> str:
+def _upsert_metadata_sql(table: str) -> str:
     return f"""
     MERGE INTO {_table_ref(table)} WITH (HOLDLOCK) AS target
     USING (SELECT ? AS [key], ? AS value) AS source
@@ -689,7 +685,7 @@ def _get_upsert_metadata_sql(table: str) -> str:
     """
 
 
-def _get_seed_metadata_sql(table: str) -> str:
+def _metadata_seed_sql(table: str) -> str:
     return f"""
     MERGE INTO {_table_ref(table)} WITH (HOLDLOCK) AS target
     USING (SELECT N'schema_version' AS [key], N'1' AS value) AS source
@@ -702,7 +698,7 @@ def _get_seed_metadata_sql(table: str) -> str:
     """
 
 
-def _get_events_query(
+def _events_query(
     table: str, app_name: str, user_id: str, session_id: str, after_timestamp: "datetime | None", limit: "int | None"
 ) -> "tuple[str, tuple[Any, ...]]":
     top_clause = f"TOP {int(limit)} " if limit is not None else ""

--- a/sqlspec/adapters/arrow_odbc/litestar/store.py
+++ b/sqlspec/adapters/arrow_odbc/litestar/store.py
@@ -57,7 +57,7 @@ class ArrowOdbcStore(BaseSQLSpecStore["ArrowOdbcConfig"]):
 
     def _create_table(self) -> None:
         with self._config.provide_session() as driver:
-            driver.execute_script(self._get_create_table_sql())
+            driver.execute_script(self._table_ddl())
             driver.commit()
         self._log_table_created()
 
@@ -205,7 +205,7 @@ class ArrowOdbcStore(BaseSQLSpecStore["ArrowOdbcConfig"]):
         )
         return "".join(str(_row_value(row, "data", 0) or "") for row in rows)
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get SQL Server CREATE TABLE SQL with idempotent guards."""
         return f"""
         IF NOT EXISTS (
@@ -246,7 +246,7 @@ class ArrowOdbcStore(BaseSQLSpecStore["ArrowOdbcConfig"]):
         END;
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         """Get SQL Server DROP TABLE statements."""
         return [
             f"IF OBJECT_ID(N'dbo.{self._chunk_table_name}', N'U') IS NOT NULL DROP TABLE dbo.{self._chunk_table_name};",

--- a/sqlspec/adapters/asyncmy/adk/store.py
+++ b/sqlspec/adapters/asyncmy/adk/store.py
@@ -64,12 +64,12 @@ class AsyncmyADKStore(BaseAsyncADKStore["AsyncmyConfig"]):
     async def create_tables(self) -> None:
         """Create all ADK session tables if they don't exist."""
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_sessions_table_sql())
-            await driver.execute_script(await self._get_create_events_table_sql())
-            await driver.execute_script(await self._get_create_app_states_table_sql())
-            await driver.execute_script(await self._get_create_user_states_table_sql())
-            await driver.execute_script(await self._get_create_metadata_table_sql())
-            await driver.execute_script(await self._get_seed_metadata_sql())
+            await driver.execute_script(await self._sessions_table_ddl())
+            await driver.execute_script(await self._events_table_ddl())
+            await driver.execute_script(await self._app_states_table_ddl())
+            await driver.execute_script(await self._user_states_table_ddl())
+            await driver.execute_script(await self._metadata_table_ddl())
+            await driver.execute_script(await self._metadata_seed_sql())
 
     async def create_session(
         self, session_id: str, app_name: str, user_id: str, state: "dict[str, Any]", owner_id: "Any | None" = None
@@ -383,54 +383,54 @@ class AsyncmyADKStore(BaseAsyncADKStore["AsyncmyConfig"]):
             await cursor.execute(_mysql_upsert_metadata_sql(self._metadata_table), (key, value))
             await conn.commit()
 
-    async def _get_create_sessions_table_sql(self) -> str:
+    async def _sessions_table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL for sessions."""
         adk_config = _adk_config(self._config)
         table_options = _mysql_table_options(adk_config, "session_table_options")
         return _mysql_sessions_ddl(self._session_table, self._owner_id_column_ddl, table_options)
 
-    async def _get_create_events_table_sql(self) -> str:
+    async def _events_table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL for events."""
         return _mysql_events_ddl(self._events_table, self._session_table, _adk_config(self._config))
 
-    async def _get_create_app_states_table_sql(self) -> str:
+    async def _app_states_table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL for app-scoped state."""
         adk_config = _adk_config(self._config)
         table_options = _mysql_table_options(adk_config, "app_state_table_options")
         return _mysql_app_state_ddl(self._app_state_table, table_options)
 
-    async def _get_create_user_states_table_sql(self) -> str:
+    async def _user_states_table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL for user-scoped state."""
         adk_config = _adk_config(self._config)
         table_options = _mysql_table_options(adk_config, "user_state_table_options")
         return _mysql_user_state_ddl(self._user_state_table, table_options)
 
-    async def _get_create_metadata_table_sql(self) -> str:
+    async def _metadata_table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL for ADK metadata."""
         return _mysql_metadata_ddl(self._metadata_table)
 
-    async def _get_seed_metadata_sql(self) -> str:
+    async def _metadata_seed_sql(self) -> str:
         """Get MySQL metadata seed SQL."""
         return f"INSERT IGNORE INTO {self._metadata_table} (`key`, value) VALUES ('schema_version', '1')"
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         """Get MySQL DROP TABLE SQL for app-scoped state."""
         return f"DROP TABLE IF EXISTS {self._app_state_table}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         """Get MySQL DROP TABLE SQL for user-scoped state."""
         return f"DROP TABLE IF EXISTS {self._user_state_table}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         """Get MySQL DROP TABLE SQL for ADK metadata."""
         return f"DROP TABLE IF EXISTS {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         """Get MySQL DROP TABLE SQL statements."""
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {self._events_table}",
             f"DROP TABLE IF EXISTS {self._session_table}",
         ]
@@ -451,7 +451,7 @@ class AsyncmyADKMemoryStore(BaseAsyncADKMemoryStore["AsyncmyConfig"]):
             return
 
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_memory_table_sql())
+            await driver.execute_script(await self._memory_table_ddl())
 
     async def insert_memory_entries(self, entries: "list[MemoryRecord]", owner_id: "object | None" = None) -> int:
         """Bulk insert memory entries with deduplication."""
@@ -581,7 +581,7 @@ class AsyncmyADKMemoryStore(BaseAsyncADKMemoryStore["AsyncmyConfig"]):
             await conn.commit()
             return cursor.rowcount if cursor.rowcount and cursor.rowcount > 0 else 0
 
-    async def _get_create_memory_table_sql(self) -> str:
+    async def _memory_table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL for memory entries."""
         adk_config = _adk_config(self._config)
         owner_id_line = ""
@@ -615,7 +615,7 @@ class AsyncmyADKMemoryStore(BaseAsyncADKMemoryStore["AsyncmyConfig"]):
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci{table_options}
         """
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         """Get MySQL DROP TABLE SQL statements."""
         return [f"DROP TABLE IF EXISTS {self._memory_table}"]
 

--- a/sqlspec/adapters/asyncmy/events/store.py
+++ b/sqlspec/adapters/asyncmy/events/store.py
@@ -50,7 +50,7 @@ class AsyncmyEventQueueStore(BaseEventQueueStore[AsyncmyConfig]):
         """
         return "CURRENT_TIMESTAMP(6)"
 
-    def _build_index_sql(self) -> str | None:
+    def _index_ddl(self) -> str | None:
         """Build MySQL conditional index creation SQL.
 
         MySQL does not support IF NOT EXISTS for CREATE INDEX, so this method

--- a/sqlspec/adapters/asyncmy/litestar/store.py
+++ b/sqlspec/adapters/asyncmy/litestar/store.py
@@ -42,7 +42,7 @@ class AsyncmyStore(BaseSQLSpecStore["AsyncmyConfig"]):
         """
         super().__init__(config)
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL with optimized schema.
 
         Returns:
@@ -59,7 +59,7 @@ class AsyncmyStore(BaseSQLSpecStore["AsyncmyConfig"]):
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         """Get MySQL/MariaDB DROP TABLE SQL statements.
 
         Returns:
@@ -72,7 +72,7 @@ class AsyncmyStore(BaseSQLSpecStore["AsyncmyConfig"]):
 
     async def create_table(self) -> None:
         """Create the session table if it doesn't exist."""
-        sql = self._get_create_table_sql()
+        sql = self._table_ddl()
         async with self._config.provide_session() as driver:
             await driver.execute_script(sql)
         self._log_table_created()

--- a/sqlspec/adapters/asyncpg/adk/store.py
+++ b/sqlspec/adapters/asyncpg/adk/store.py
@@ -62,12 +62,12 @@ class AsyncpgADKStore(BaseAsyncADKStore[AsyncConfigT]):
 
     async def create_tables(self) -> None:
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_sessions_table_sql())
-            await driver.execute_script(await self._get_create_events_table_sql())
-            await driver.execute_script(await self._get_create_app_states_table_sql())
-            await driver.execute_script(await self._get_create_user_states_table_sql())
-            await driver.execute_script(await self._get_create_metadata_table_sql())
-            await driver.execute_script(await self._get_seed_metadata_sql())
+            await driver.execute_script(await self._sessions_table_ddl())
+            await driver.execute_script(await self._events_table_ddl())
+            await driver.execute_script(await self._app_states_table_ddl())
+            await driver.execute_script(await self._user_states_table_ddl())
+            await driver.execute_script(await self._metadata_table_ddl())
+            await driver.execute_script(await self._metadata_seed_sql())
 
     async def create_session(
         self, session_id: str, app_name: str, user_id: str, state: "dict[str, Any]", owner_id: "Any | None" = None
@@ -397,7 +397,7 @@ class AsyncpgADKStore(BaseAsyncADKStore[AsyncConfigT]):
         async with self._config.provide_connection() as conn:
             await conn.execute(sql, key, value)
 
-    async def _get_create_sessions_table_sql(self) -> str:
+    async def _sessions_table_ddl(self) -> str:
         owner_id_line = ""
         if self._owner_id_column_ddl:
             owner_id_line = f",\n            {self._owner_id_column_ddl}"
@@ -423,7 +423,7 @@ class AsyncpgADKStore(BaseAsyncADKStore[AsyncConfigT]):
             WHERE state != '{{}}'::jsonb;
         """
 
-    async def _get_create_events_table_sql(self) -> str:
+    async def _events_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         generated_columns = ""
         generated_indexes = ""
@@ -459,7 +459,7 @@ class AsyncpgADKStore(BaseAsyncADKStore[AsyncConfigT]):
         {generated_indexes}
         """
 
-    async def _get_create_app_states_table_sql(self) -> str:
+    async def _app_states_table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._app_state_table} (
             app_name VARCHAR(128) PRIMARY KEY,
@@ -468,7 +468,7 @@ class AsyncpgADKStore(BaseAsyncADKStore[AsyncConfigT]):
         ) WITH (fillfactor = 80);
         """
 
-    async def _get_create_user_states_table_sql(self) -> str:
+    async def _user_states_table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._user_state_table} (
             app_name VARCHAR(128) NOT NULL,
@@ -479,7 +479,7 @@ class AsyncpgADKStore(BaseAsyncADKStore[AsyncConfigT]):
         ) WITH (fillfactor = 80);
         """
 
-    async def _get_create_metadata_table_sql(self) -> str:
+    async def _metadata_table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._metadata_table} (
             key VARCHAR(128) PRIMARY KEY,
@@ -487,27 +487,27 @@ class AsyncpgADKStore(BaseAsyncADKStore[AsyncConfigT]):
         );
         """
 
-    async def _get_seed_metadata_sql(self) -> str:
+    async def _metadata_seed_sql(self) -> str:
         return f"""
         INSERT INTO {self._metadata_table} (key, value)
         VALUES ('schema_version', '1')
         ON CONFLICT (key) DO NOTHING
         """
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._app_state_table}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._user_state_table}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {self._events_table}",
             f"DROP TABLE IF EXISTS {self._session_table}",
         ]
@@ -534,7 +534,7 @@ class AsyncpgADKMemoryStore(BaseAsyncADKMemoryStore["AsyncpgConfig"]):
     def __init__(self, config: "AsyncpgConfig") -> None:
         super().__init__(config)
 
-    async def _get_create_memory_table_sql(self) -> str:
+    async def _memory_table_ddl(self) -> str:
         owner_id_line = ""
         if self._owner_id_column_ddl:
             owner_id_line = f",\n            {self._owner_id_column_ddl}"
@@ -569,7 +569,7 @@ class AsyncpgADKMemoryStore(BaseAsyncADKMemoryStore["AsyncpgConfig"]):
         {fts_index}
         """
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         return [f"DROP TABLE IF EXISTS {self._memory_table}"]
 
     async def create_tables(self) -> None:
@@ -577,7 +577,7 @@ class AsyncpgADKMemoryStore(BaseAsyncADKMemoryStore["AsyncpgConfig"]):
             return
 
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_memory_table_sql())
+            await driver.execute_script(await self._memory_table_ddl())
 
     async def insert_memory_entries(self, entries: "list[MemoryRecord]", owner_id: "object | None" = None) -> int:
         if not self._enabled:

--- a/sqlspec/adapters/asyncpg/events/backend.py
+++ b/sqlspec/adapters/asyncpg/events/backend.py
@@ -98,7 +98,7 @@ class AsyncpgHybridEventsBackend:
         async with self._config.provide_session() as driver:
             await driver.execute(
                 SQL(
-                    self._queue._upsert_sql,
+                    self._queue._insert_statement,
                     {
                         "event_id": event_id,
                         "channel": channel,

--- a/sqlspec/adapters/asyncpg/litestar/store.py
+++ b/sqlspec/adapters/asyncpg/litestar/store.py
@@ -36,7 +36,7 @@ class AsyncpgStore(BaseSQLSpecStore["AsyncpgConfig"]):
         """
         super().__init__(config)
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get PostgreSQL CREATE TABLE SQL with optimized schema.
 
         Returns:
@@ -60,7 +60,7 @@ class AsyncpgStore(BaseSQLSpecStore["AsyncpgConfig"]):
         );
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         """Get PostgreSQL DROP TABLE SQL statements.
 
         Returns:
@@ -70,7 +70,7 @@ class AsyncpgStore(BaseSQLSpecStore["AsyncpgConfig"]):
 
     async def create_table(self) -> None:
         """Create the session table if it doesn't exist."""
-        sql = self._get_create_table_sql()
+        sql = self._table_ddl()
         async with self._config.provide_session() as driver:
             await driver.execute_script(sql)
         self._log_table_created()

--- a/sqlspec/adapters/bigquery/adk/store.py
+++ b/sqlspec/adapters/bigquery/adk/store.py
@@ -505,7 +505,7 @@ class BigQueryADKStore(BaseSyncADKStore[BigQueryConfig]):
             parts.append(f"partition_expiration_days = {self._partition_expiration_days}")
         return f"\nOPTIONS({', '.join(parts)})" if parts else ""
 
-    def _get_create_sessions_table_sql(self) -> str:
+    def _sessions_table_ddl(self) -> str:
         owner_column = f",\n            {self._owner_id_column_ddl}" if self._owner_id_column_ddl else ""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._qualified(self._session_table)} (
@@ -520,7 +520,7 @@ class BigQueryADKStore(BaseSyncADKStore[BigQueryConfig]):
         CLUSTER BY app_name, user_id, id{self._partition_options()}
         """
 
-    def _get_create_events_table_sql(self) -> str:
+    def _events_table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._qualified(self._events_table)} (
             id STRING NOT NULL,
@@ -535,7 +535,7 @@ class BigQueryADKStore(BaseSyncADKStore[BigQueryConfig]):
         CLUSTER BY app_name, user_id, session_id{self._partition_options(include_expiration=True)}
         """
 
-    def _get_create_app_states_table_sql(self) -> str:
+    def _app_states_table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._qualified(self._app_state_table)} (
             app_name STRING NOT NULL,
@@ -545,7 +545,7 @@ class BigQueryADKStore(BaseSyncADKStore[BigQueryConfig]):
         CLUSTER BY app_name
         """
 
-    def _get_create_user_states_table_sql(self) -> str:
+    def _user_states_table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._qualified(self._user_state_table)} (
             app_name STRING NOT NULL,
@@ -556,7 +556,7 @@ class BigQueryADKStore(BaseSyncADKStore[BigQueryConfig]):
         CLUSTER BY app_name, user_id
         """
 
-    def _get_create_metadata_table_sql(self) -> str:
+    def _metadata_table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._qualified(self._metadata_table)} (
             key STRING NOT NULL,
@@ -565,7 +565,7 @@ class BigQueryADKStore(BaseSyncADKStore[BigQueryConfig]):
         CLUSTER BY key
         """
 
-    def _get_seed_metadata_sql(self) -> str:
+    def _metadata_seed_sql(self) -> str:
         return f"""
         MERGE {self._qualified(self._metadata_table)} target
         USING (SELECT 'schema_version' AS key, '1' AS value) source
@@ -573,16 +573,16 @@ class BigQueryADKStore(BaseSyncADKStore[BigQueryConfig]):
         WHEN NOT MATCHED THEN INSERT (key, value) VALUES (source.key, source.value)
         """
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._qualified(self._app_state_table)}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._qualified(self._user_state_table)}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._qualified(self._metadata_table)}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         return [
             f"DROP TABLE IF EXISTS {self._qualified(self._events_table)}",
             f"DROP TABLE IF EXISTS {self._qualified(self._user_state_table)}",
@@ -593,12 +593,12 @@ class BigQueryADKStore(BaseSyncADKStore[BigQueryConfig]):
 
     def _create_tables(self) -> None:
         for statement in (
-            self._get_create_sessions_table_sql(),
-            self._get_create_events_table_sql(),
-            self._get_create_app_states_table_sql(),
-            self._get_create_user_states_table_sql(),
-            self._get_create_metadata_table_sql(),
-            self._get_seed_metadata_sql(),
+            self._sessions_table_ddl(),
+            self._events_table_ddl(),
+            self._app_states_table_ddl(),
+            self._user_states_table_ddl(),
+            self._metadata_table_ddl(),
+            self._metadata_seed_sql(),
         ):
             self._run_query(statement)
 

--- a/sqlspec/adapters/bigquery/events/store.py
+++ b/sqlspec/adapters/bigquery/events/store.py
@@ -55,7 +55,7 @@ class BigQueryEventQueueStore(BaseEventQueueStore[BigQueryConfig]):
         """Return BigQuery CLUSTER BY clause for query optimization."""
         return " CLUSTER BY channel, status, available_at"
 
-    def _build_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Build BigQuery CREATE TABLE with CLUSTER BY optimization.
 
         BigQuery uses CLUSTER BY for query optimization instead of indexes.
@@ -85,7 +85,7 @@ class BigQueryEventQueueStore(BaseEventQueueStore[BigQueryConfig]):
             f"){table_clause}"
         )
 
-    def _build_index_sql(self) -> str | None:
+    def _index_ddl(self) -> str | None:
         """Return None since BigQuery uses CLUSTER BY instead of indexes.
 
         Returns:
@@ -99,7 +99,7 @@ class BigQueryEventQueueStore(BaseEventQueueStore[BigQueryConfig]):
         Returns:
             List containing single CREATE TABLE statement.
         """
-        return [self._build_create_table_sql()]
+        return [self._table_ddl()]
 
     def drop_statements(self) -> "list[str]":
         """Return DDL statement for table deletion.

--- a/sqlspec/adapters/bigquery/litestar/store.py
+++ b/sqlspec/adapters/bigquery/litestar/store.py
@@ -42,7 +42,7 @@ class BigQueryStore(BaseSQLSpecStore["BigQueryConfig"]):
         """
         super().__init__(config)
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get BigQuery CREATE TABLE SQL with optimized schema.
 
         Returns:
@@ -58,7 +58,7 @@ class BigQueryStore(BaseSQLSpecStore["BigQueryConfig"]):
         CLUSTER BY session_id
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         """Get BigQuery DROP TABLE SQL statements.
 
         Returns:
@@ -98,7 +98,7 @@ class BigQueryStore(BaseSQLSpecStore["BigQueryConfig"]):
 
     def _create_table(self) -> None:
         """Synchronous implementation of create_table."""
-        sql = self._get_create_table_sql()
+        sql = self._table_ddl()
         with self._config.provide_session() as driver:
             driver.execute_script(sql)
         self._log_table_created()

--- a/sqlspec/adapters/cockroach_asyncpg/adk/store.py
+++ b/sqlspec/adapters/cockroach_asyncpg/adk/store.py
@@ -72,12 +72,12 @@ class CockroachAsyncpgADKStore(BaseAsyncADKStore["CockroachAsyncpgConfig"]):
 
     async def create_tables(self) -> None:
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_sessions_table_sql())
-            await driver.execute_script(await self._get_create_events_table_sql())
-            await driver.execute_script(await self._get_create_app_states_table_sql())
-            await driver.execute_script(await self._get_create_user_states_table_sql())
-            await driver.execute_script(await self._get_create_metadata_table_sql())
-            await driver.execute_script(await self._get_seed_metadata_sql())
+            await driver.execute_script(await self._sessions_table_ddl())
+            await driver.execute_script(await self._events_table_ddl())
+            await driver.execute_script(await self._app_states_table_ddl())
+            await driver.execute_script(await self._user_states_table_ddl())
+            await driver.execute_script(await self._metadata_table_ddl())
+            await driver.execute_script(await self._metadata_seed_sql())
 
     async def create_session(
         self, session_id: str, app_name: str, user_id: str, state: "dict[str, Any]", owner_id: "Any | None" = None
@@ -403,7 +403,7 @@ class CockroachAsyncpgADKStore(BaseAsyncADKStore["CockroachAsyncpgConfig"]):
         async with self._config.provide_connection() as conn:
             await conn.execute(sql, key, value)
 
-    async def _get_create_sessions_table_sql(self) -> str:
+    async def _sessions_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         owner_id_line = ""
         if self._owner_id_column_ddl:
@@ -433,7 +433,7 @@ class CockroachAsyncpgADKStore(BaseAsyncADKStore["CockroachAsyncpgConfig"]):
             WHERE state != '{{}}'::jsonb;
         """
 
-    async def _get_create_events_table_sql(self) -> str:
+    async def _events_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         events_locality = _cockroach_table_locality_clause(adk_config, "events_table_locality")
         hash_shard_clause = _cockroach_hash_shard_clause(adk_config)
@@ -456,7 +456,7 @@ class CockroachAsyncpgADKStore(BaseAsyncADKStore["CockroachAsyncpgConfig"]):
             ON {self._events_table} USING GIN (event_data);
         """
 
-    async def _get_create_app_states_table_sql(self) -> str:
+    async def _app_states_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         app_state_locality = _cockroach_table_locality_clause(adk_config, "app_state_table_locality")
 
@@ -468,7 +468,7 @@ class CockroachAsyncpgADKStore(BaseAsyncADKStore["CockroachAsyncpgConfig"]):
         ){app_state_locality};
         """
 
-    async def _get_create_user_states_table_sql(self) -> str:
+    async def _user_states_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         user_state_locality = _cockroach_table_locality_clause(adk_config, "user_state_table_locality")
 
@@ -482,7 +482,7 @@ class CockroachAsyncpgADKStore(BaseAsyncADKStore["CockroachAsyncpgConfig"]):
         ){user_state_locality};
         """
 
-    async def _get_create_metadata_table_sql(self) -> str:
+    async def _metadata_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         metadata_locality = _cockroach_table_locality_clause(adk_config, "metadata_table_locality")
 
@@ -493,27 +493,27 @@ class CockroachAsyncpgADKStore(BaseAsyncADKStore["CockroachAsyncpgConfig"]):
         ){metadata_locality};
         """
 
-    async def _get_seed_metadata_sql(self) -> str:
+    async def _metadata_seed_sql(self) -> str:
         return f"""
         INSERT INTO {self._metadata_table} (key, value)
         VALUES ('schema_version', '1')
         ON CONFLICT (key) DO NOTHING
         """
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._app_state_table}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._user_state_table}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {self._events_table}",
             f"DROP TABLE IF EXISTS {self._session_table}",
         ]
@@ -532,7 +532,7 @@ class CockroachAsyncpgADKMemoryStore(BaseAsyncADKMemoryStore["CockroachAsyncpgCo
             return
 
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_memory_table_sql())
+            await driver.execute_script(await self._memory_table_ddl())
 
     async def insert_memory_entries(self, entries: "list[MemoryRecord]", owner_id: "object | None" = None) -> int:
         if not self._enabled:
@@ -655,7 +655,7 @@ class CockroachAsyncpgADKMemoryStore(BaseAsyncADKMemoryStore["CockroachAsyncpgCo
             result = await conn.execute(sql)
             return int(result.split()[-1]) if result else 0
 
-    async def _get_create_memory_table_sql(self) -> str:
+    async def _memory_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         owner_id_line = ""
         if self._owner_id_column_ddl:
@@ -700,7 +700,7 @@ class CockroachAsyncpgADKMemoryStore(BaseAsyncADKMemoryStore["CockroachAsyncpgCo
         {trigram_index}
         """
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         return [f"DROP TABLE IF EXISTS {self._memory_table}"]
 
 

--- a/sqlspec/adapters/cockroach_asyncpg/litestar/store.py
+++ b/sqlspec/adapters/cockroach_asyncpg/litestar/store.py
@@ -20,7 +20,7 @@ class CockroachAsyncpgStore(BaseSQLSpecStore["CockroachAsyncpgConfig"]):
     def __init__(self, config: "CockroachAsyncpgConfig") -> None:
         super().__init__(config)
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get CockroachDB CREATE TABLE SQL with optimized schema."""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._table_name} (
@@ -35,11 +35,11 @@ class CockroachAsyncpgStore(BaseSQLSpecStore["CockroachAsyncpgConfig"]):
         ON {self._table_name}(expires_at) WHERE expires_at IS NOT NULL;
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         return [f"DROP INDEX IF EXISTS idx_{self._table_name}_expires_at", f"DROP TABLE IF EXISTS {self._table_name}"]
 
     async def create_table(self) -> None:
-        sql = self._get_create_table_sql()
+        sql = self._table_ddl()
         async with self._config.provide_session() as driver:
             await driver.execute_script(sql)
         self._log_table_created()

--- a/sqlspec/adapters/cockroach_psycopg/adk/store.py
+++ b/sqlspec/adapters/cockroach_psycopg/adk/store.py
@@ -81,12 +81,12 @@ class CockroachPsycopgAsyncADKStore(BaseAsyncADKStore["CockroachPsycopgAsyncConf
 
     async def create_tables(self) -> None:
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_sessions_table_sql())
-            await driver.execute_script(await self._get_create_events_table_sql())
-            await driver.execute_script(await self._get_create_app_states_table_sql())
-            await driver.execute_script(await self._get_create_user_states_table_sql())
-            await driver.execute_script(await self._get_create_metadata_table_sql())
-            await driver.execute_script(await self._get_seed_metadata_sql())
+            await driver.execute_script(await self._sessions_table_ddl())
+            await driver.execute_script(await self._events_table_ddl())
+            await driver.execute_script(await self._app_states_table_ddl())
+            await driver.execute_script(await self._user_states_table_ddl())
+            await driver.execute_script(await self._metadata_table_ddl())
+            await driver.execute_script(await self._metadata_seed_sql())
 
     async def create_session(
         self, session_id: str, app_name: str, user_id: str, state: "dict[str, Any]", owner_id: "Any | None" = None
@@ -432,7 +432,7 @@ class CockroachPsycopgAsyncADKStore(BaseAsyncADKStore["CockroachPsycopgAsyncConf
             await cur.execute(sql.encode(), (key, value))
             await conn.commit()
 
-    async def _get_create_sessions_table_sql(self) -> str:
+    async def _sessions_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         owner_id_line = ""
         if self._owner_id_column_ddl:
@@ -462,7 +462,7 @@ class CockroachPsycopgAsyncADKStore(BaseAsyncADKStore["CockroachPsycopgAsyncConf
             WHERE state != '{{}}'::jsonb;
         """
 
-    async def _get_create_events_table_sql(self) -> str:
+    async def _events_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         events_locality = _cockroach_table_locality_clause(adk_config, "events_table_locality")
         hash_shard_clause = _cockroach_hash_shard_clause(adk_config)
@@ -485,7 +485,7 @@ class CockroachPsycopgAsyncADKStore(BaseAsyncADKStore["CockroachPsycopgAsyncConf
             ON {self._events_table} USING GIN (event_data);
         """
 
-    async def _get_create_app_states_table_sql(self) -> str:
+    async def _app_states_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         app_state_locality = _cockroach_table_locality_clause(adk_config, "app_state_table_locality")
 
@@ -497,7 +497,7 @@ class CockroachPsycopgAsyncADKStore(BaseAsyncADKStore["CockroachPsycopgAsyncConf
         ){app_state_locality};
         """
 
-    async def _get_create_user_states_table_sql(self) -> str:
+    async def _user_states_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         user_state_locality = _cockroach_table_locality_clause(adk_config, "user_state_table_locality")
 
@@ -511,7 +511,7 @@ class CockroachPsycopgAsyncADKStore(BaseAsyncADKStore["CockroachPsycopgAsyncConf
         ){user_state_locality};
         """
 
-    async def _get_create_metadata_table_sql(self) -> str:
+    async def _metadata_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         metadata_locality = _cockroach_table_locality_clause(adk_config, "metadata_table_locality")
 
@@ -522,27 +522,27 @@ class CockroachPsycopgAsyncADKStore(BaseAsyncADKStore["CockroachPsycopgAsyncConf
         ){metadata_locality};
         """
 
-    async def _get_seed_metadata_sql(self) -> str:
+    async def _metadata_seed_sql(self) -> str:
         return f"""
         INSERT INTO {self._metadata_table} (key, value)
         VALUES ('schema_version', '1')
         ON CONFLICT (key) DO NOTHING
         """
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._app_state_table}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._user_state_table}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {self._events_table}",
             f"DROP TABLE IF EXISTS {self._session_table}",
         ]
@@ -647,7 +647,7 @@ class CockroachPsycopgSyncADKStore(BaseSyncADKStore["CockroachPsycopgSyncConfig"
         """Set a value in the ADK internal metadata table."""
         self._set_metadata(key, value)
 
-    def _get_create_sessions_table_sql(self) -> str:
+    def _sessions_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         owner_id_line = ""
         if self._owner_id_column_ddl:
@@ -677,7 +677,7 @@ class CockroachPsycopgSyncADKStore(BaseSyncADKStore["CockroachPsycopgSyncConfig"
             WHERE state != '{{}}'::jsonb;
         """
 
-    def _get_create_events_table_sql(self) -> str:
+    def _events_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         events_locality = _cockroach_table_locality_clause(adk_config, "events_table_locality")
         hash_shard_clause = _cockroach_hash_shard_clause(adk_config)
@@ -700,7 +700,7 @@ class CockroachPsycopgSyncADKStore(BaseSyncADKStore["CockroachPsycopgSyncConfig"
             ON {self._events_table} USING GIN (event_data);
         """
 
-    def _get_create_app_states_table_sql(self) -> str:
+    def _app_states_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         app_state_locality = _cockroach_table_locality_clause(adk_config, "app_state_table_locality")
 
@@ -712,7 +712,7 @@ class CockroachPsycopgSyncADKStore(BaseSyncADKStore["CockroachPsycopgSyncConfig"
         ){app_state_locality};
         """
 
-    def _get_create_user_states_table_sql(self) -> str:
+    def _user_states_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         user_state_locality = _cockroach_table_locality_clause(adk_config, "user_state_table_locality")
 
@@ -726,7 +726,7 @@ class CockroachPsycopgSyncADKStore(BaseSyncADKStore["CockroachPsycopgSyncConfig"
         ){user_state_locality};
         """
 
-    def _get_create_metadata_table_sql(self) -> str:
+    def _metadata_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         metadata_locality = _cockroach_table_locality_clause(adk_config, "metadata_table_locality")
 
@@ -737,39 +737,39 @@ class CockroachPsycopgSyncADKStore(BaseSyncADKStore["CockroachPsycopgSyncConfig"
         ){metadata_locality};
         """
 
-    def _get_seed_metadata_sql(self) -> str:
+    def _metadata_seed_sql(self) -> str:
         return f"""
         INSERT INTO {self._metadata_table} (key, value)
         VALUES ('schema_version', '1')
         ON CONFLICT (key) DO NOTHING
         """
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._app_state_table}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._user_state_table}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {self._events_table}",
             f"DROP TABLE IF EXISTS {self._session_table}",
         ]
 
     def _create_tables(self) -> None:
         with self._config.provide_session() as driver:
-            driver.execute_script(self._get_create_sessions_table_sql())
-            driver.execute_script(self._get_create_events_table_sql())
-            driver.execute_script(self._get_create_app_states_table_sql())
-            driver.execute_script(self._get_create_user_states_table_sql())
-            driver.execute_script(self._get_create_metadata_table_sql())
-            driver.execute_script(self._get_seed_metadata_sql())
+            driver.execute_script(self._sessions_table_ddl())
+            driver.execute_script(self._events_table_ddl())
+            driver.execute_script(self._app_states_table_ddl())
+            driver.execute_script(self._user_states_table_ddl())
+            driver.execute_script(self._metadata_table_ddl())
+            driver.execute_script(self._metadata_seed_sql())
 
     def _create_session(
         self, session_id: str, app_name: str, user_id: str, state: "dict[str, Any]", owner_id: "Any | None" = None
@@ -1133,7 +1133,7 @@ class CockroachPsycopgAsyncADKMemoryStore(BaseAsyncADKMemoryStore["CockroachPsyc
             return
 
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_memory_table_sql())
+            await driver.execute_script(await self._memory_table_ddl())
 
     async def insert_memory_entries(self, entries: "list[MemoryRecord]", owner_id: "object | None" = None) -> int:
         if not self._enabled:
@@ -1246,7 +1246,7 @@ class CockroachPsycopgAsyncADKMemoryStore(BaseAsyncADKMemoryStore["CockroachPsyc
             await conn.commit()
             return cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
 
-    async def _get_create_memory_table_sql(self) -> str:
+    async def _memory_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         owner_id_line = ""
         if self._owner_id_column_ddl:
@@ -1291,7 +1291,7 @@ class CockroachPsycopgAsyncADKMemoryStore(BaseAsyncADKMemoryStore["CockroachPsyc
         {trigram_index}
         """
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         return [f"DROP TABLE IF EXISTS {self._memory_table}"]
 
 
@@ -1325,7 +1325,7 @@ class CockroachPsycopgSyncADKMemoryStore(BaseSyncADKMemoryStore["CockroachPsycop
         """Delete memory entries older than specified days."""
         return self._delete_entries_older_than(days)
 
-    def _get_create_memory_table_sql(self) -> str:
+    def _memory_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         owner_id_line = ""
         if self._owner_id_column_ddl:
@@ -1370,7 +1370,7 @@ class CockroachPsycopgSyncADKMemoryStore(BaseSyncADKMemoryStore["CockroachPsycop
         {trigram_index}
         """
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         return [f"DROP TABLE IF EXISTS {self._memory_table}"]
 
     def _create_tables(self) -> None:
@@ -1378,7 +1378,7 @@ class CockroachPsycopgSyncADKMemoryStore(BaseSyncADKMemoryStore["CockroachPsycop
             return
 
         with self._config.provide_session() as driver:
-            driver.execute_script(self._get_create_memory_table_sql())
+            driver.execute_script(self._memory_table_ddl())
 
     def _insert_memory_entries(self, entries: "list[MemoryRecord]", owner_id: "object | None" = None) -> int:
         if not self._enabled:

--- a/sqlspec/adapters/cockroach_psycopg/litestar/store.py
+++ b/sqlspec/adapters/cockroach_psycopg/litestar/store.py
@@ -23,7 +23,7 @@ class CockroachPsycopgAsyncStore(BaseSQLSpecStore["CockroachPsycopgAsyncConfig"]
     def __init__(self, config: "CockroachPsycopgAsyncConfig") -> None:
         super().__init__(config)
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get CockroachDB CREATE TABLE SQL with optimized schema."""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._table_name} (
@@ -38,11 +38,11 @@ class CockroachPsycopgAsyncStore(BaseSQLSpecStore["CockroachPsycopgAsyncConfig"]
         ON {self._table_name}(expires_at) WHERE expires_at IS NOT NULL;
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         return [f"DROP INDEX IF EXISTS idx_{self._table_name}_expires_at", f"DROP TABLE IF EXISTS {self._table_name}"]
 
     async def create_table(self) -> None:
-        sql = self._get_create_table_sql()
+        sql = self._table_ddl()
         async with self._config.provide_session() as driver:
             await driver.execute_script(sql)
             await driver.commit()
@@ -171,7 +171,7 @@ class CockroachPsycopgSyncStore(BaseSQLSpecStore["CockroachPsycopgSyncConfig"]):
     def __init__(self, config: "CockroachPsycopgSyncConfig") -> None:
         super().__init__(config)
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._table_name} (
             session_id TEXT PRIMARY KEY,
@@ -185,11 +185,11 @@ class CockroachPsycopgSyncStore(BaseSQLSpecStore["CockroachPsycopgSyncConfig"]):
         ON {self._table_name}(expires_at) WHERE expires_at IS NOT NULL;
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         return [f"DROP INDEX IF EXISTS idx_{self._table_name}_expires_at", f"DROP TABLE IF EXISTS {self._table_name}"]
 
     def _create_table(self) -> None:
-        sql = self._get_create_table_sql()
+        sql = self._table_ddl()
         with self._config.provide_session() as driver:
             driver.execute_script(sql)
             driver.commit()

--- a/sqlspec/adapters/duckdb/adk/store.py
+++ b/sqlspec/adapters/duckdb/adk/store.py
@@ -270,7 +270,7 @@ class DuckdbADKStore(BaseSyncADKStore["DuckDBConfig"]):
         """Set a metadata value."""
         self._set_metadata(key, value)
 
-    def _get_create_sessions_table_sql(self) -> str:
+    def _sessions_table_ddl(self) -> str:
         """Get DuckDB CREATE TABLE SQL for sessions.
 
         Returns:
@@ -293,14 +293,14 @@ class DuckdbADKStore(BaseSyncADKStore["DuckDBConfig"]):
         CREATE INDEX IF NOT EXISTS idx_{self._session_table}_update_time ON {self._session_table}(update_time DESC);
         """
 
-    def _get_create_events_table_sql(self) -> str:
+    def _events_table_ddl(self) -> str:
         """Get DuckDB CREATE TABLE SQL for events.
 
         Returns:
             SQL statement to create adk_event table with indexes.
         """
-        generated_columns = self._get_event_generated_columns_sql()
-        generated_indexes = self._get_event_generated_column_indexes_sql()
+        generated_columns = self._event_generated_columns_sql()
+        generated_indexes = self._event_generated_column_indexes_sql()
         return f"""
         CREATE TABLE IF NOT EXISTS {self._events_table} (
             id VARCHAR PRIMARY KEY,
@@ -314,7 +314,7 @@ class DuckdbADKStore(BaseSyncADKStore["DuckDBConfig"]):
         {generated_indexes}
         """
 
-    def _get_event_generated_columns_sql(self) -> str:
+    def _event_generated_columns_sql(self) -> str:
         """Return DuckDB ADK generated event projection columns."""
         adk_config = _adk_config(self._config)
         if not adk_config.get("enable_event_generated_columns", False):
@@ -324,7 +324,7 @@ class DuckdbADKStore(BaseSyncADKStore["DuckDBConfig"]):
             author_gc VARCHAR GENERATED ALWAYS AS ((event_data::{DUCKDB_EVENT_PROJECTION_STRUCT}).author) VIRTUAL,
             node_path_gc VARCHAR GENERATED ALWAYS AS ((event_data::{DUCKDB_EVENT_PROJECTION_STRUCT}).node_info.path) VIRTUAL"""
 
-    def _get_event_generated_column_indexes_sql(self) -> str:
+    def _event_generated_column_indexes_sql(self) -> str:
         """Return optional indexes for generated event projection columns."""
         adk_config = _adk_config(self._config)
         if not (
@@ -341,7 +341,7 @@ class DuckdbADKStore(BaseSyncADKStore["DuckDBConfig"]):
             ON {self._events_table}(session_id, node_path_gc, timestamp ASC);
         """
 
-    def _get_create_app_states_table_sql(self) -> str:
+    def _app_states_table_ddl(self) -> str:
         """Get DuckDB CREATE TABLE SQL for app-scoped state."""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._app_state_table} (
@@ -351,7 +351,7 @@ class DuckdbADKStore(BaseSyncADKStore["DuckDBConfig"]):
         )
         """
 
-    def _get_create_user_states_table_sql(self) -> str:
+    def _user_states_table_ddl(self) -> str:
         """Get DuckDB CREATE TABLE SQL for user-scoped state."""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._user_state_table} (
@@ -363,7 +363,7 @@ class DuckdbADKStore(BaseSyncADKStore["DuckDBConfig"]):
         )
         """
 
-    def _get_create_metadata_table_sql(self) -> str:
+    def _metadata_table_ddl(self) -> str:
         """Get DuckDB CREATE TABLE SQL for internal ADK metadata."""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._metadata_table} (
@@ -372,7 +372,7 @@ class DuckdbADKStore(BaseSyncADKStore["DuckDBConfig"]):
         )
         """
 
-    def _get_seed_metadata_sql(self) -> str:
+    def _metadata_seed_sql(self) -> str:
         """Get DuckDB SQL for seeding the schema metadata row."""
         return f"""
         INSERT INTO {self._metadata_table} (key, value)
@@ -380,28 +380,28 @@ class DuckdbADKStore(BaseSyncADKStore["DuckDBConfig"]):
         ON CONFLICT(key) DO NOTHING
         """
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         """Get DuckDB DROP TABLE SQL for app-scoped state."""
         return f"DROP TABLE IF EXISTS {self._app_state_table}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         """Get DuckDB DROP TABLE SQL for user-scoped state."""
         return f"DROP TABLE IF EXISTS {self._user_state_table}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         """Get DuckDB DROP TABLE SQL for internal ADK metadata."""
         return f"DROP TABLE IF EXISTS {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         """Get DuckDB DROP TABLE SQL statements.
 
         Returns:
             List of SQL statements to drop tables and indexes.
         """
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {self._events_table}",
             f"DROP TABLE IF EXISTS {self._session_table}",
         ]
@@ -409,15 +409,15 @@ class DuckdbADKStore(BaseSyncADKStore["DuckDBConfig"]):
     def _create_tables(self) -> None:
         """Synchronous implementation of create_tables."""
         with self._config.provide_connection() as conn:
-            conn.execute(self.__get_create_sessions_table_sql_sync())
-            conn.execute(self.__get_create_events_table_sql_sync())
-            conn.execute(self._get_create_app_states_table_sql())
-            conn.execute(self._get_create_user_states_table_sql())
-            conn.execute(self._get_create_metadata_table_sql())
-            conn.execute(self._get_seed_metadata_sql())
+            conn.execute(self._sync_sessions_table_ddl())
+            conn.execute(self._sync_events_table_ddl())
+            conn.execute(self._app_states_table_ddl())
+            conn.execute(self._user_states_table_ddl())
+            conn.execute(self._metadata_table_ddl())
+            conn.execute(self._metadata_seed_sql())
             conn.commit()
 
-    def __get_create_sessions_table_sql_sync(self) -> str:
+    def _sync_sessions_table_ddl(self) -> str:
         """Synchronous version of DDL generation for use in _create_tables."""
         owner_id_line = ""
         if self._owner_id_column_ddl:
@@ -436,10 +436,10 @@ class DuckdbADKStore(BaseSyncADKStore["DuckDBConfig"]):
         CREATE INDEX IF NOT EXISTS idx_{self._session_table}_update_time ON {self._session_table}(update_time DESC);
         """
 
-    def __get_create_events_table_sql_sync(self) -> str:
+    def _sync_events_table_ddl(self) -> str:
         """Synchronous version of DDL generation for use in _create_tables."""
-        generated_columns = self._get_event_generated_columns_sql()
-        generated_indexes = self._get_event_generated_column_indexes_sql()
+        generated_columns = self._event_generated_columns_sql()
+        generated_indexes = self._event_generated_column_indexes_sql()
         return f"""
         CREATE TABLE IF NOT EXISTS {self._events_table} (
             id VARCHAR PRIMARY KEY,
@@ -935,7 +935,7 @@ class DuckdbADKMemoryStore(BaseSyncADKMemoryStore["DuckDBConfig"]):
             return
 
         try:
-            conn.execute(self._get_create_fts_index_sql(overwrite=False))
+            conn.execute(self._fts_index_ddl(overwrite=False))
             conn.commit()
         except Exception as exc:
             logger.debug("Failed to create DuckDB FTS index: %s", exc)
@@ -950,12 +950,12 @@ class DuckdbADKMemoryStore(BaseSyncADKMemoryStore["DuckDBConfig"]):
             return
 
         try:
-            conn.execute(self._get_create_fts_index_sql(overwrite=True))
+            conn.execute(self._fts_index_ddl(overwrite=True))
             conn.commit()
         except Exception as exc:
             logger.debug("Failed to refresh DuckDB FTS index: %s", exc)
 
-    def _get_create_fts_index_sql(self, *, overwrite: bool) -> str:
+    def _fts_index_ddl(self, *, overwrite: bool) -> str:
         """Return DuckDB FTS index PRAGMA SQL for the memory table."""
         return (
             f"PRAGMA create_fts_index('{self._memory_table}', 'id', 'content_text', "
@@ -980,7 +980,7 @@ class DuckdbADKMemoryStore(BaseSyncADKMemoryStore["DuckDBConfig"]):
             if option_name in options
         )
 
-    def _get_create_memory_table_sql(self) -> str:
+    def _memory_table_ddl(self) -> str:
         """Get DuckDB CREATE TABLE SQL for memory entries.
 
         Returns:
@@ -1012,7 +1012,7 @@ class DuckdbADKMemoryStore(BaseSyncADKMemoryStore["DuckDBConfig"]):
             ON {self._memory_table}(session_id);
         """
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         """Get DuckDB DROP TABLE SQL statements."""
         return [f"DROP TABLE IF EXISTS {self._memory_table}"]
 
@@ -1021,13 +1021,13 @@ class DuckdbADKMemoryStore(BaseSyncADKMemoryStore["DuckDBConfig"]):
         if not self._enabled:
             return
 
-        ddl = self.__get_create_memory_table_sql_sync()
+        ddl = self._sync_memory_table_ddl()
         with self._config.provide_connection() as conn:
             conn.execute(ddl)
             if self._use_fts:
                 self._create_fts_index(conn)
 
-    def __get_create_memory_table_sql_sync(self) -> str:
+    def _sync_memory_table_ddl(self) -> str:
         """Synchronous version of DDL generation for use in _create_tables."""
         owner_id_line = ""
         if self._owner_id_column_ddl:

--- a/sqlspec/adapters/duckdb/litestar/store.py
+++ b/sqlspec/adapters/duckdb/litestar/store.py
@@ -42,7 +42,7 @@ class DuckdbStore(BaseSQLSpecStore["DuckDBConfig"]):
         """
         super().__init__(config)
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get DuckDB CREATE TABLE SQL.
 
         Returns:
@@ -60,7 +60,7 @@ class DuckdbStore(BaseSQLSpecStore["DuckDBConfig"]):
         ON {self._table_name}(expires_at);
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         """Get DuckDB DROP TABLE SQL statements.
 
         Returns:
@@ -103,7 +103,7 @@ class DuckdbStore(BaseSQLSpecStore["DuckDBConfig"]):
 
     def _create_table(self) -> None:
         """Synchronous implementation of create_table."""
-        sql = self._get_create_table_sql()
+        sql = self._table_ddl()
         with self._config.provide_session() as driver:
             driver.execute_script(sql)
         self._log_table_created()

--- a/sqlspec/adapters/duckdb/pool.py
+++ b/sqlspec/adapters/duckdb/pool.py
@@ -385,7 +385,7 @@ def _create_secret(connection: DuckDBConnection, secret_config: dict[str, Any]) 
     try:
         _validate_sql_identifier(secret_name, "secret_name")
         _validate_sql_identifier(secret_type, "secret_type")
-        sql = _build_secret_sql(secret_config, secret_name, secret_type)
+        sql = _secret_sql(secret_config, secret_name, secret_type)
         connection.execute(sql)
         if required:
             _verify_secret(connection, secret_config, secret_name, secret_type)
@@ -395,7 +395,7 @@ def _create_secret(connection: DuckDBConnection, secret_config: dict[str, Any]) 
         logger.warning("DuckDB secret %r creation failed (best-effort)", secret_name)
 
 
-def _build_secret_sql(secret_config: dict[str, Any], secret_name: str, secret_type: str) -> str:
+def _secret_sql(secret_config: dict[str, Any], secret_name: str, secret_type: str) -> str:
     parts = [f"TYPE {secret_type}"]
 
     provider = secret_config.get("provider")

--- a/sqlspec/adapters/mssql_python/adk/store.py
+++ b/sqlspec/adapters/mssql_python/adk/store.py
@@ -54,12 +54,12 @@ class MssqlPythonSyncADKStore(BaseSyncADKStore["MssqlPythonConfig"]):
     def create_tables(self) -> None:
         """Create all ADK session tables if they do not exist."""
         with self._config.provide_session() as driver:
-            driver.execute_script(self._get_create_sessions_table_sql())
-            driver.execute_script(self._get_create_events_table_sql())
-            driver.execute_script(self._get_create_app_states_table_sql())
-            driver.execute_script(self._get_create_user_states_table_sql())
-            driver.execute_script(self._get_create_metadata_table_sql())
-            driver.execute_script(self._get_seed_metadata_sql())
+            driver.execute_script(self._sessions_table_ddl())
+            driver.execute_script(self._events_table_ddl())
+            driver.execute_script(self._app_states_table_ddl())
+            driver.execute_script(self._user_states_table_ddl())
+            driver.execute_script(self._metadata_table_ddl())
+            driver.execute_script(self._metadata_seed_sql())
             driver.commit()
 
     def create_session(
@@ -163,7 +163,7 @@ class MssqlPythonSyncADKStore(BaseSyncADKStore["MssqlPythonConfig"]):
 
     def append_event(self, event_record: EventRecord) -> None:
         """Append an event to a session."""
-        self._execute(_get_insert_event_sql(self._events_table), _event_insert_params(event_record), commit=True)
+        self._execute(_insert_event_sql(self._events_table), _event_insert_params(event_record), commit=True)
 
     def append_event_and_update_state(
         self,
@@ -189,11 +189,11 @@ class MssqlPythonSyncADKStore(BaseSyncADKStore["MssqlPythonConfig"]):
                 row = cursor.fetchone()
                 if row is None:
                     _raise_session_not_found(session_id)
-                cursor.execute(_get_insert_event_sql(self._events_table), _event_insert_params(event_record))
+                cursor.execute(_insert_event_sql(self._events_table), _event_insert_params(event_record))
                 if app_state is not None:
-                    cursor.execute(self._get_upsert_app_state_sql(), (app_name, to_json(app_state)))
+                    cursor.execute(self._upsert_app_state_sql(), (app_name, to_json(app_state)))
                 if user_state is not None:
-                    cursor.execute(self._get_upsert_user_state_sql(), (app_name, user_id, to_json(user_state)))
+                    cursor.execute(self._upsert_user_state_sql(), (app_name, user_id, to_json(user_state)))
             except Exception:
                 conn.rollback()
                 raise
@@ -211,7 +211,7 @@ class MssqlPythonSyncADKStore(BaseSyncADKStore["MssqlPythonConfig"]):
         """Return events for a scoped session ordered by event timestamp."""
         if limit == 0:
             return []
-        sql, params = self._get_events_query(app_name, user_id, session_id, after_timestamp, limit)
+        sql, params = self._events_query(app_name, user_id, session_id, after_timestamp, limit)
         try:
             rows = self._execute_fetchall(sql, params)
         except MSSQL_ERROR as exc:
@@ -273,11 +273,11 @@ class MssqlPythonSyncADKStore(BaseSyncADKStore["MssqlPythonConfig"]):
 
     def upsert_app_state(self, app_name: str, state: "dict[str, Any]") -> None:
         """Insert or replace app-scoped state."""
-        self._execute(self._get_upsert_app_state_sql(), (app_name, to_json(state)), commit=True)
+        self._execute(self._upsert_app_state_sql(), (app_name, to_json(state)), commit=True)
 
     def upsert_user_state(self, app_name: str, user_id: str, state: "dict[str, Any]") -> None:
         """Insert or replace user-scoped state."""
-        self._execute(self._get_upsert_user_state_sql(), (app_name, user_id, to_json(state)), commit=True)
+        self._execute(self._upsert_user_state_sql(), (app_name, user_id, to_json(state)), commit=True)
 
     def get_metadata(self, key: str) -> "str | None":
         """Return an ADK metadata value."""
@@ -293,59 +293,57 @@ class MssqlPythonSyncADKStore(BaseSyncADKStore["MssqlPythonConfig"]):
 
     def set_metadata(self, key: str, value: str) -> None:
         """Set an ADK metadata value."""
-        self._execute(_get_upsert_metadata_sql(self._metadata_table), (key, value), commit=True)
+        self._execute(_upsert_metadata_sql(self._metadata_table), (key, value), commit=True)
 
-    def _get_create_sessions_table_sql(self) -> str:
+    def _sessions_table_ddl(self) -> str:
         """Return T-SQL DDL for the ADK session table."""
-        return _get_create_sessions_table_sql(
-            self._session_table, self._json_column_type_sync(), self._owner_id_column_ddl
-        )
+        return _sessions_table_ddl(self._session_table, self._json_column_type_sync(), self._owner_id_column_ddl)
 
-    def _get_create_events_table_sql(self) -> str:
+    def _events_table_ddl(self) -> str:
         """Return T-SQL DDL for the ADK event table."""
-        return _get_create_events_table_sql(self._events_table, self._session_table, self._json_column_type_sync())
+        return _events_table_ddl(self._events_table, self._session_table, self._json_column_type_sync())
 
-    def _get_create_app_states_table_sql(self) -> str:
+    def _app_states_table_ddl(self) -> str:
         """Return T-SQL DDL for the app-scoped state table."""
-        return _get_create_app_states_table_sql(self._app_state_table, self._json_column_type_sync())
+        return _app_states_table_ddl(self._app_state_table, self._json_column_type_sync())
 
-    def _get_create_user_states_table_sql(self) -> str:
+    def _user_states_table_ddl(self) -> str:
         """Return T-SQL DDL for the user-scoped state table."""
-        return _get_create_user_states_table_sql(self._user_state_table, self._json_column_type_sync())
+        return _user_states_table_ddl(self._user_state_table, self._json_column_type_sync())
 
-    def _get_create_metadata_table_sql(self) -> str:
+    def _metadata_table_ddl(self) -> str:
         """Return T-SQL DDL for the ADK metadata table."""
-        return _get_create_metadata_table_sql(self._metadata_table)
+        return _metadata_table_ddl(self._metadata_table)
 
-    def _get_seed_metadata_sql(self) -> str:
+    def _metadata_seed_sql(self) -> str:
         """Return T-SQL to seed schema-version metadata."""
-        return _get_seed_metadata_sql(self._metadata_table)
+        return _metadata_seed_sql(self._metadata_table)
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {_table_ref(self._app_state_table)}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {_table_ref(self._user_state_table)}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {_table_ref(self._metadata_table)}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {_table_ref(self._events_table)}",
             f"DROP TABLE IF EXISTS {_table_ref(self._session_table)}",
         ]
 
-    def _get_upsert_app_state_sql(self) -> str:
-        return _get_upsert_state_sql(self._app_state_table, ("app_name",), ("?",))
+    def _upsert_app_state_sql(self) -> str:
+        return _upsert_state_sql(self._app_state_table, ("app_name",), ("?",))
 
-    def _get_upsert_user_state_sql(self) -> str:
-        return _get_upsert_state_sql(self._user_state_table, ("app_name", "user_id"), ("?", "?"))
+    def _upsert_user_state_sql(self) -> str:
+        return _upsert_state_sql(self._user_state_table, ("app_name", "user_id"), ("?", "?"))
 
-    def _get_events_query(
+    def _events_query(
         self,
         app_name: str,
         user_id: str,
@@ -353,7 +351,7 @@ class MssqlPythonSyncADKStore(BaseSyncADKStore["MssqlPythonConfig"]):
         after_timestamp: "datetime | None" = None,
         limit: "int | None" = None,
     ) -> "tuple[str, tuple[Any, ...]]":
-        return _get_events_query(self._events_table, app_name, user_id, session_id, after_timestamp, limit)
+        return _events_query(self._events_table, app_name, user_id, session_id, after_timestamp, limit)
 
     def _json_column_type_sync(self) -> str:
         if self._json_column_type is not None:
@@ -404,12 +402,12 @@ class MssqlPythonAsyncADKStore(BaseAsyncADKStore["MssqlPythonAsyncConfig"]):
     async def create_tables(self) -> None:
         """Create all ADK session tables if they do not exist."""
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_sessions_table_sql())
-            await driver.execute_script(await self._get_create_events_table_sql())
-            await driver.execute_script(await self._get_create_app_states_table_sql())
-            await driver.execute_script(await self._get_create_user_states_table_sql())
-            await driver.execute_script(await self._get_create_metadata_table_sql())
-            await driver.execute_script(await self._get_seed_metadata_sql())
+            await driver.execute_script(await self._sessions_table_ddl())
+            await driver.execute_script(await self._events_table_ddl())
+            await driver.execute_script(await self._app_states_table_ddl())
+            await driver.execute_script(await self._user_states_table_ddl())
+            await driver.execute_script(await self._metadata_table_ddl())
+            await driver.execute_script(await self._metadata_seed_sql())
             await driver.commit()
 
     async def create_session(
@@ -513,7 +511,7 @@ class MssqlPythonAsyncADKStore(BaseAsyncADKStore["MssqlPythonAsyncConfig"]):
 
     async def append_event(self, event_record: EventRecord) -> None:
         """Append an event to a session."""
-        await self._execute(_get_insert_event_sql(self._events_table), _event_insert_params(event_record), commit=True)
+        await self._execute(_insert_event_sql(self._events_table), _event_insert_params(event_record), commit=True)
 
     async def append_event_and_update_state(
         self,
@@ -540,15 +538,15 @@ class MssqlPythonAsyncADKStore(BaseAsyncADKStore["MssqlPythonAsyncConfig"]):
                 if row is None:
                     _raise_session_not_found(session_id)
                 await asyncio.to_thread(
-                    cursor.execute, _get_insert_event_sql(self._events_table), _event_insert_params(event_record)
+                    cursor.execute, _insert_event_sql(self._events_table), _event_insert_params(event_record)
                 )
                 if app_state is not None:
                     await asyncio.to_thread(
-                        cursor.execute, self._get_upsert_app_state_sql(), (app_name, to_json(app_state))
+                        cursor.execute, self._upsert_app_state_sql(), (app_name, to_json(app_state))
                     )
                 if user_state is not None:
                     await asyncio.to_thread(
-                        cursor.execute, self._get_upsert_user_state_sql(), (app_name, user_id, to_json(user_state))
+                        cursor.execute, self._upsert_user_state_sql(), (app_name, user_id, to_json(user_state))
                     )
             except Exception:
                 await asyncio.to_thread(conn.rollback)
@@ -567,7 +565,7 @@ class MssqlPythonAsyncADKStore(BaseAsyncADKStore["MssqlPythonAsyncConfig"]):
         """Return events for a scoped session ordered by event timestamp."""
         if limit == 0:
             return []
-        sql, params = self._get_events_query(app_name, user_id, session_id, after_timestamp, limit)
+        sql, params = self._events_query(app_name, user_id, session_id, after_timestamp, limit)
         try:
             rows = await self._execute_fetchall(sql, params)
         except MSSQL_ERROR as exc:
@@ -629,11 +627,11 @@ class MssqlPythonAsyncADKStore(BaseAsyncADKStore["MssqlPythonAsyncConfig"]):
 
     async def upsert_app_state(self, app_name: str, state: "dict[str, Any]") -> None:
         """Insert or replace app-scoped state."""
-        await self._execute(self._get_upsert_app_state_sql(), (app_name, to_json(state)), commit=True)
+        await self._execute(self._upsert_app_state_sql(), (app_name, to_json(state)), commit=True)
 
     async def upsert_user_state(self, app_name: str, user_id: str, state: "dict[str, Any]") -> None:
         """Insert or replace user-scoped state."""
-        await self._execute(self._get_upsert_user_state_sql(), (app_name, user_id, to_json(state)), commit=True)
+        await self._execute(self._upsert_user_state_sql(), (app_name, user_id, to_json(state)), commit=True)
 
     async def get_metadata(self, key: str) -> "str | None":
         """Return an ADK metadata value."""
@@ -649,61 +647,57 @@ class MssqlPythonAsyncADKStore(BaseAsyncADKStore["MssqlPythonAsyncConfig"]):
 
     async def set_metadata(self, key: str, value: str) -> None:
         """Set an ADK metadata value."""
-        await self._execute(_get_upsert_metadata_sql(self._metadata_table), (key, value), commit=True)
+        await self._execute(_upsert_metadata_sql(self._metadata_table), (key, value), commit=True)
 
-    async def _get_create_sessions_table_sql(self) -> str:
+    async def _sessions_table_ddl(self) -> str:
         """Return T-SQL DDL for the ADK session table."""
-        return _get_create_sessions_table_sql(
-            self._session_table, await self._json_column_type_async(), self._owner_id_column_ddl
-        )
+        return _sessions_table_ddl(self._session_table, await self._json_column_type_async(), self._owner_id_column_ddl)
 
-    async def _get_create_events_table_sql(self) -> str:
+    async def _events_table_ddl(self) -> str:
         """Return T-SQL DDL for the ADK event table."""
-        return _get_create_events_table_sql(
-            self._events_table, self._session_table, await self._json_column_type_async()
-        )
+        return _events_table_ddl(self._events_table, self._session_table, await self._json_column_type_async())
 
-    async def _get_create_app_states_table_sql(self) -> str:
+    async def _app_states_table_ddl(self) -> str:
         """Return T-SQL DDL for the app-scoped state table."""
-        return _get_create_app_states_table_sql(self._app_state_table, await self._json_column_type_async())
+        return _app_states_table_ddl(self._app_state_table, await self._json_column_type_async())
 
-    async def _get_create_user_states_table_sql(self) -> str:
+    async def _user_states_table_ddl(self) -> str:
         """Return T-SQL DDL for the user-scoped state table."""
-        return _get_create_user_states_table_sql(self._user_state_table, await self._json_column_type_async())
+        return _user_states_table_ddl(self._user_state_table, await self._json_column_type_async())
 
-    async def _get_create_metadata_table_sql(self) -> str:
+    async def _metadata_table_ddl(self) -> str:
         """Return T-SQL DDL for the ADK metadata table."""
-        return _get_create_metadata_table_sql(self._metadata_table)
+        return _metadata_table_ddl(self._metadata_table)
 
-    async def _get_seed_metadata_sql(self) -> str:
+    async def _metadata_seed_sql(self) -> str:
         """Return T-SQL to seed schema-version metadata."""
-        return _get_seed_metadata_sql(self._metadata_table)
+        return _metadata_seed_sql(self._metadata_table)
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {_table_ref(self._app_state_table)}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {_table_ref(self._user_state_table)}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {_table_ref(self._metadata_table)}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {_table_ref(self._events_table)}",
             f"DROP TABLE IF EXISTS {_table_ref(self._session_table)}",
         ]
 
-    def _get_upsert_app_state_sql(self) -> str:
-        return _get_upsert_state_sql(self._app_state_table, ("app_name",), ("?",))
+    def _upsert_app_state_sql(self) -> str:
+        return _upsert_state_sql(self._app_state_table, ("app_name",), ("?",))
 
-    def _get_upsert_user_state_sql(self) -> str:
-        return _get_upsert_state_sql(self._user_state_table, ("app_name", "user_id"), ("?", "?"))
+    def _upsert_user_state_sql(self) -> str:
+        return _upsert_state_sql(self._user_state_table, ("app_name", "user_id"), ("?", "?"))
 
-    def _get_events_query(
+    def _events_query(
         self,
         app_name: str,
         user_id: str,
@@ -711,7 +705,7 @@ class MssqlPythonAsyncADKStore(BaseAsyncADKStore["MssqlPythonAsyncConfig"]):
         after_timestamp: "datetime | None" = None,
         limit: "int | None" = None,
     ) -> "tuple[str, tuple[Any, ...]]":
-        return _get_events_query(self._events_table, app_name, user_id, session_id, after_timestamp, limit)
+        return _events_query(self._events_table, app_name, user_id, session_id, after_timestamp, limit)
 
     async def _json_column_type_async(self) -> str:
         if self._json_column_type is not None:
@@ -781,7 +775,7 @@ async def _json_column_type_from_async_driver(driver: "MssqlPythonAsyncDriver") 
     return JSON_FALLBACK_COLUMN_TYPE
 
 
-def _get_create_sessions_table_sql(table: str, json_column_type: str, owner_id_column_ddl: "str | None") -> str:
+def _sessions_table_ddl(table: str, json_column_type: str, owner_id_column_ddl: "str | None") -> str:
     owner_line = f",\n        {owner_id_column_ddl}" if owner_id_column_ddl else ""
     return f"""
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = N'{_escape_sql_literal(table)}' AND schema_id = SCHEMA_ID(N'dbo'))
@@ -798,12 +792,12 @@ BEGIN
         CONSTRAINT {_constraint_ref("uq", table, "id")} UNIQUE (id)
     );
 END;
-{_get_create_index_sql(table, f"idx_{table}_app_user", "app_name, user_id")}
-{_get_create_index_sql(table, f"idx_{table}_update_time", "update_time DESC")}
+{_create_index_sql(table, f"idx_{table}_app_user", "app_name, user_id")}
+{_create_index_sql(table, f"idx_{table}_update_time", "update_time DESC")}
 """
 
 
-def _get_create_events_table_sql(table: str, session_table: str, json_column_type: str) -> str:
+def _events_table_ddl(table: str, session_table: str, json_column_type: str) -> str:
     return f"""
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = N'{_escape_sql_literal(table)}' AND schema_id = SCHEMA_ID(N'dbo'))
 BEGIN
@@ -822,14 +816,14 @@ BEGIN
             REFERENCES {_table_ref(session_table)}(id) ON DELETE CASCADE
     );
 END;
-{_get_create_index_sql(table, f"idx_{table}_scope", "app_name, user_id, session_id, timestamp ASC")}
-{_get_create_index_sql(table, f"idx_{table}_session", "session_id, timestamp ASC")}
-{_get_create_index_sql(table, f"idx_{table}_invocation", "invocation_id")}
-{_get_create_index_sql(table, f"idx_{table}_timestamp", "timestamp ASC")}
+{_create_index_sql(table, f"idx_{table}_scope", "app_name, user_id, session_id, timestamp ASC")}
+{_create_index_sql(table, f"idx_{table}_session", "session_id, timestamp ASC")}
+{_create_index_sql(table, f"idx_{table}_invocation", "invocation_id")}
+{_create_index_sql(table, f"idx_{table}_timestamp", "timestamp ASC")}
 """
 
 
-def _get_create_app_states_table_sql(table: str, json_column_type: str) -> str:
+def _app_states_table_ddl(table: str, json_column_type: str) -> str:
     return f"""
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = N'{_escape_sql_literal(table)}' AND schema_id = SCHEMA_ID(N'dbo'))
 BEGIN
@@ -843,7 +837,7 @@ END;
 """
 
 
-def _get_create_user_states_table_sql(table: str, json_column_type: str) -> str:
+def _user_states_table_ddl(table: str, json_column_type: str) -> str:
     return f"""
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = N'{_escape_sql_literal(table)}' AND schema_id = SCHEMA_ID(N'dbo'))
 BEGIN
@@ -858,7 +852,7 @@ END;
 """
 
 
-def _get_create_metadata_table_sql(table: str) -> str:
+def _metadata_table_ddl(table: str) -> str:
     return f"""
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = N'{_escape_sql_literal(table)}' AND schema_id = SCHEMA_ID(N'dbo'))
 BEGIN
@@ -871,7 +865,7 @@ END;
 """
 
 
-def _get_create_index_sql(table: str, index_name: str, columns: str) -> str:
+def _create_index_sql(table: str, index_name: str, columns: str) -> str:
     return f"""
 IF NOT EXISTS (
     SELECT 1 FROM sys.indexes
@@ -884,7 +878,7 @@ END;
 """
 
 
-def _get_insert_event_sql(table: str) -> str:
+def _insert_event_sql(table: str) -> str:
     return f"""
     INSERT INTO {_table_ref(table)} (
         id, app_name, user_id, session_id, invocation_id, timestamp, event_data
@@ -893,7 +887,7 @@ def _get_insert_event_sql(table: str) -> str:
     """
 
 
-def _get_upsert_state_sql(table: str, key_columns: "tuple[str, ...]", key_params: "tuple[str, ...]") -> str:
+def _upsert_state_sql(table: str, key_columns: "tuple[str, ...]", key_params: "tuple[str, ...]") -> str:
     source_columns = ", ".join(
         f"{param} AS {_quote_identifier(column)}" for column, param in zip(key_columns, key_params, strict=False)
     )
@@ -915,7 +909,7 @@ def _get_upsert_state_sql(table: str, key_columns: "tuple[str, ...]", key_params
     """
 
 
-def _get_upsert_metadata_sql(table: str) -> str:
+def _upsert_metadata_sql(table: str) -> str:
     return f"""
     MERGE INTO {_table_ref(table)} WITH (HOLDLOCK) AS target
     USING (SELECT ? AS [key], ? AS value) AS source
@@ -928,7 +922,7 @@ def _get_upsert_metadata_sql(table: str) -> str:
     """
 
 
-def _get_seed_metadata_sql(table: str) -> str:
+def _metadata_seed_sql(table: str) -> str:
     return f"""
     MERGE INTO {_table_ref(table)} WITH (HOLDLOCK) AS target
     USING (SELECT N'schema_version' AS [key], N'1' AS value) AS source
@@ -941,7 +935,7 @@ def _get_seed_metadata_sql(table: str) -> str:
     """
 
 
-def _get_events_query(
+def _events_query(
     table: str, app_name: str, user_id: str, session_id: str, after_timestamp: "datetime | None", limit: "int | None"
 ) -> "tuple[str, tuple[Any, ...]]":
     top_clause = "TOP (?) " if limit is not None else ""

--- a/sqlspec/adapters/mssql_python/litestar/store.py
+++ b/sqlspec/adapters/mssql_python/litestar/store.py
@@ -22,7 +22,7 @@ class MssqlPythonStore(BaseSQLSpecStore["MssqlPythonAsyncConfig"]):
     async def create_table(self) -> None:
         """Create the session table if it doesn't exist."""
         async with self._config.provide_session() as session:
-            await session.execute_script(self._get_create_table_sql())
+            await session.execute_script(self._table_ddl())
         self._log_table_created()
 
     async def get(self, key: str, renew_for: "int | timedelta | None" = None) -> "bytes | None":
@@ -135,7 +135,7 @@ class MssqlPythonStore(BaseSQLSpecStore["MssqlPythonAsyncConfig"]):
             self._log_delete_expired(count)
         return count
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get SQL Server CREATE TABLE SQL with idempotent guards."""
         return f"""
         IF NOT EXISTS (
@@ -159,7 +159,7 @@ class MssqlPythonStore(BaseSQLSpecStore["MssqlPythonAsyncConfig"]):
         END;
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         """Get SQL Server DROP TABLE statements."""
         return [f"IF OBJECT_ID(N'dbo.{self._table_name}', N'U') IS NOT NULL DROP TABLE dbo.{self._table_name};"]
 

--- a/sqlspec/adapters/mssql_python/migrations.py
+++ b/sqlspec/adapters/mssql_python/migrations.py
@@ -28,7 +28,7 @@ class MssqlPythonMigrationTrackerMixin:
 
     version_table: str
 
-    def _get_create_table_sql(self) -> CreateTable:
+    def _tracking_table_ddl(self) -> CreateTable:
         """Return T-SQL-compatible migration tracking table DDL."""
         return (
             sql
@@ -44,10 +44,10 @@ class MssqlPythonMigrationTrackerMixin:
             .column("replaces", "NVARCHAR(MAX)")
         )
 
-    def _get_idempotent_create_table_sql_text(self) -> str:
+    def _idempotent_tracking_table_ddl_text(self) -> str:
         """Wrap CREATE TABLE in a T-SQL sys.tables existence probe."""
         schema_name, table_name = _split_schema_table(self.version_table)
-        create_sql = self._get_create_table_sql_text().rstrip().rstrip(";")
+        create_sql = self._tracking_table_ddl_text().rstrip().rstrip(";")
         return (
             "IF NOT EXISTS (SELECT 1 FROM sys.tables "
             f"WHERE name = '{_escape_sql_literal(table_name)}' "
@@ -55,10 +55,10 @@ class MssqlPythonMigrationTrackerMixin:
             f"BEGIN {create_sql}; END;"
         )
 
-    def _get_create_table_sql_text(self) -> str:
+    def _tracking_table_ddl_text(self) -> str:
         """Render CREATE TABLE text without routing SQL Server types through sqlglot."""
         column_lines: list[str] = []
-        for column_def in self._get_create_table_sql().columns:
+        for column_def in self._tracking_table_ddl().columns:
             default_clause = f" DEFAULT {column_def.default}" if column_def.default else ""
             not_null_clause = " NOT NULL" if column_def.not_null else ""
             primary_key_clause = " PRIMARY KEY" if column_def.primary_key else ""
@@ -67,7 +67,7 @@ class MssqlPythonMigrationTrackerMixin:
             )
         return f"CREATE TABLE {self.version_table} (\n" + ",\n".join(column_lines) + "\n)"
 
-    def _get_existing_columns_sql(self) -> str:
+    def _existing_columns_query(self) -> str:
         """Return T-SQL query text for migration tracking table columns."""
         schema_name, table_name = _split_schema_table(self.version_table)
         return f"""
@@ -78,9 +78,9 @@ class MssqlPythonMigrationTrackerMixin:
               AND t.schema_id = SCHEMA_ID('{_escape_sql_literal(schema_name)}')
         """
 
-    def _get_add_column_sql_text(self, column_name: str) -> str | None:
+    def _add_column_statement_text(self, column_name: str) -> str | None:
         """Return T-SQL ALTER TABLE text for a missing migration column."""
-        target_create = self._get_create_table_sql()
+        target_create = self._tracking_table_ddl()
         column_def = next((col for col in target_create.columns if col.name.lower() == column_name), None)
         if column_def is None:
             return None
@@ -94,7 +94,7 @@ class MssqlPythonSyncMigrationTracker(MssqlPythonMigrationTrackerMixin, SyncMigr
 
     def ensure_tracking_table(self, driver: "SyncDriverAdapterBase") -> None:
         """Create the migration tracking table if it does not exist."""
-        driver.execute_script(self._get_idempotent_create_table_sql_text())
+        driver.execute_script(self._idempotent_tracking_table_ddl_text())
         driver.commit()
         self._migrate_schema_if_needed(driver)
 
@@ -104,10 +104,10 @@ class MssqlPythonSyncMigrationTracker(MssqlPythonMigrationTrackerMixin, SyncMigr
         """Record a successfully applied migration with T-SQL-compatible metadata."""
         parsed_version = parse_version(version)
         version_type = parsed_version.type.value
-        result = driver.execute(self._get_next_execution_sequence_sql())
+        result = driver.execute(self._next_execution_sequence_query())
         next_sequence = result.get_data()[0]["next_seq"] if result.data else 1
         driver.execute(
-            self._get_record_migration_sql(
+            self._record_migration_statement(
                 version,
                 version_type,
                 next_sequence,
@@ -122,7 +122,7 @@ class MssqlPythonSyncMigrationTracker(MssqlPythonMigrationTrackerMixin, SyncMigr
     def _migrate_schema_if_needed(self, driver: "SyncDriverAdapterBase") -> None:
         """Check and add missing tracking table columns through SQL Server catalog views."""
         try:
-            rows = driver.select(self._get_existing_columns_sql())
+            rows = driver.select(self._existing_columns_query())
             existing_columns = {str(row["column_name"]).lower() for row in rows if row.get("column_name") is not None}
             missing_columns = self._detect_missing_columns(existing_columns)
             if not missing_columns:
@@ -146,7 +146,7 @@ class MssqlPythonSyncMigrationTracker(MssqlPythonMigrationTrackerMixin, SyncMigr
 
     def _add_column(self, driver: "SyncDriverAdapterBase", column_name: str) -> None:
         """Add a single missing migration tracking column."""
-        add_column_sql = self._get_add_column_sql_text(column_name)
+        add_column_sql = self._add_column_statement_text(column_name)
         if add_column_sql is None:
             return
         driver.execute_script(add_column_sql)
@@ -157,7 +157,7 @@ class MssqlPythonAsyncMigrationTracker(MssqlPythonMigrationTrackerMixin, AsyncMi
 
     async def ensure_tracking_table(self, driver: "AsyncDriverAdapterBase") -> None:
         """Create the migration tracking table if it does not exist."""
-        await driver.execute_script(self._get_idempotent_create_table_sql_text())
+        await driver.execute_script(self._idempotent_tracking_table_ddl_text())
         await driver.commit()
         await self._migrate_schema_if_needed(driver)
 
@@ -167,10 +167,10 @@ class MssqlPythonAsyncMigrationTracker(MssqlPythonMigrationTrackerMixin, AsyncMi
         """Record a successfully applied migration with T-SQL-compatible metadata."""
         parsed_version = parse_version(version)
         version_type = parsed_version.type.value
-        result = await driver.execute(self._get_next_execution_sequence_sql())
+        result = await driver.execute(self._next_execution_sequence_query())
         next_sequence = result.get_data()[0]["next_seq"] if result.data else 1
         await driver.execute(
-            self._get_record_migration_sql(
+            self._record_migration_statement(
                 version,
                 version_type,
                 next_sequence,
@@ -185,7 +185,7 @@ class MssqlPythonAsyncMigrationTracker(MssqlPythonMigrationTrackerMixin, AsyncMi
     async def _migrate_schema_if_needed(self, driver: "AsyncDriverAdapterBase") -> None:
         """Check and add missing tracking table columns through SQL Server catalog views."""
         try:
-            rows = await driver.select(self._get_existing_columns_sql())
+            rows = await driver.select(self._existing_columns_query())
             existing_columns = {str(row["column_name"]).lower() for row in rows if row.get("column_name") is not None}
             missing_columns = self._detect_missing_columns(existing_columns)
             if not missing_columns:
@@ -209,7 +209,7 @@ class MssqlPythonAsyncMigrationTracker(MssqlPythonMigrationTrackerMixin, AsyncMi
 
     async def _add_column(self, driver: "AsyncDriverAdapterBase", column_name: str) -> None:
         """Add a single missing migration tracking column."""
-        add_column_sql = self._get_add_column_sql_text(column_name)
+        add_column_sql = self._add_column_statement_text(column_name)
         if add_column_sql is None:
             return
         await driver.execute_script(add_column_sql)

--- a/sqlspec/adapters/mysqlconnector/adk/store.py
+++ b/sqlspec/adapters/mysqlconnector/adk/store.py
@@ -68,12 +68,12 @@ class MysqlConnectorAsyncADKStore(BaseAsyncADKStore["MysqlConnectorAsyncConfig"]
 
     async def create_tables(self) -> None:
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_sessions_table_sql())
-            await driver.execute_script(await self._get_create_events_table_sql())
-            await driver.execute_script(await self._get_create_app_states_table_sql())
-            await driver.execute_script(await self._get_create_user_states_table_sql())
-            await driver.execute_script(await self._get_create_metadata_table_sql())
-            await driver.execute_script(await self._get_seed_metadata_sql())
+            await driver.execute_script(await self._sessions_table_ddl())
+            await driver.execute_script(await self._events_table_ddl())
+            await driver.execute_script(await self._app_states_table_ddl())
+            await driver.execute_script(await self._user_states_table_ddl())
+            await driver.execute_script(await self._metadata_table_ddl())
+            await driver.execute_script(await self._metadata_seed_sql())
 
     async def create_session(
         self, session_id: str, app_name: str, user_id: str, state: "dict[str, Any]", owner_id: "Any | None" = None
@@ -365,44 +365,44 @@ class MysqlConnectorAsyncADKStore(BaseAsyncADKStore["MysqlConnectorAsyncConfig"]
     async def set_metadata(self, key: str, value: str) -> None:
         await _async_execute_commit(self, _mysql_upsert_metadata_sql(self._metadata_table), (key, value))
 
-    async def _get_create_sessions_table_sql(self) -> str:
+    async def _sessions_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         table_options = _mysql_table_options(adk_config, "session_table_options")
         return _mysql_sessions_ddl(self._session_table, self._owner_id_column_ddl, table_options)
 
-    async def _get_create_events_table_sql(self) -> str:
+    async def _events_table_ddl(self) -> str:
         return _mysql_events_ddl(self._events_table, self._session_table, _adk_config(self._config))
 
-    async def _get_create_app_states_table_sql(self) -> str:
+    async def _app_states_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         table_options = _mysql_table_options(adk_config, "app_state_table_options")
         return _mysql_app_state_ddl(self._app_state_table, table_options)
 
-    async def _get_create_user_states_table_sql(self) -> str:
+    async def _user_states_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         table_options = _mysql_table_options(adk_config, "user_state_table_options")
         return _mysql_user_state_ddl(self._user_state_table, table_options)
 
-    async def _get_create_metadata_table_sql(self) -> str:
+    async def _metadata_table_ddl(self) -> str:
         return _mysql_metadata_ddl(self._metadata_table)
 
-    async def _get_seed_metadata_sql(self) -> str:
+    async def _metadata_seed_sql(self) -> str:
         return f"INSERT IGNORE INTO {self._metadata_table} (`key`, value) VALUES ('schema_version', '1')"
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._app_state_table}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._user_state_table}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {self._events_table}",
             f"DROP TABLE IF EXISTS {self._session_table}",
         ]
@@ -509,12 +509,12 @@ class MysqlConnectorSyncADKStore(BaseSyncADKStore["MysqlConnectorSyncConfig"]):
 
     def _create_tables(self) -> None:
         with self._config.provide_session() as driver:
-            driver.execute_script(self._get_create_sessions_table_sql())
-            driver.execute_script(self._get_create_events_table_sql())
-            driver.execute_script(self._get_create_app_states_table_sql())
-            driver.execute_script(self._get_create_user_states_table_sql())
-            driver.execute_script(self._get_create_metadata_table_sql())
-            driver.execute_script(self._get_seed_metadata_sql())
+            driver.execute_script(self._sessions_table_ddl())
+            driver.execute_script(self._events_table_ddl())
+            driver.execute_script(self._app_states_table_ddl())
+            driver.execute_script(self._user_states_table_ddl())
+            driver.execute_script(self._metadata_table_ddl())
+            driver.execute_script(self._metadata_seed_sql())
 
     def _create_session(
         self, session_id: str, app_name: str, user_id: str, state: "dict[str, Any]", owner_id: "Any | None" = None
@@ -803,44 +803,44 @@ class MysqlConnectorSyncADKStore(BaseSyncADKStore["MysqlConnectorSyncConfig"]):
     def _set_metadata(self, key: str, value: str) -> None:
         _sync_execute_commit(self, _mysql_upsert_metadata_sql(self._metadata_table), (key, value))
 
-    def _get_create_sessions_table_sql(self) -> str:
+    def _sessions_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         table_options = _mysql_table_options(adk_config, "session_table_options")
         return _mysql_sessions_ddl(self._session_table, self._owner_id_column_ddl, table_options)
 
-    def _get_create_events_table_sql(self) -> str:
+    def _events_table_ddl(self) -> str:
         return _mysql_events_ddl(self._events_table, self._session_table, _adk_config(self._config))
 
-    def _get_create_app_states_table_sql(self) -> str:
+    def _app_states_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         table_options = _mysql_table_options(adk_config, "app_state_table_options")
         return _mysql_app_state_ddl(self._app_state_table, table_options)
 
-    def _get_create_user_states_table_sql(self) -> str:
+    def _user_states_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         table_options = _mysql_table_options(adk_config, "user_state_table_options")
         return _mysql_user_state_ddl(self._user_state_table, table_options)
 
-    def _get_create_metadata_table_sql(self) -> str:
+    def _metadata_table_ddl(self) -> str:
         return _mysql_metadata_ddl(self._metadata_table)
 
-    def _get_seed_metadata_sql(self) -> str:
+    def _metadata_seed_sql(self) -> str:
         return f"INSERT IGNORE INTO {self._metadata_table} (`key`, value) VALUES ('schema_version', '1')"
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._app_state_table}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._user_state_table}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {self._events_table}",
             f"DROP TABLE IF EXISTS {self._session_table}",
         ]
@@ -859,7 +859,7 @@ class MysqlConnectorAsyncADKMemoryStore(BaseAsyncADKMemoryStore["MysqlConnectorA
             return
 
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_memory_table_sql())
+            await driver.execute_script(await self._memory_table_ddl())
 
     async def insert_memory_entries(self, entries: "list[MemoryRecord]", owner_id: "object | None" = None) -> int:
         if not self._enabled:
@@ -1000,7 +1000,7 @@ class MysqlConnectorAsyncADKMemoryStore(BaseAsyncADKMemoryStore["MysqlConnectorA
             finally:
                 await cursor.close()
 
-    async def _get_create_memory_table_sql(self) -> str:
+    async def _memory_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         owner_id_line = ""
         fk_constraint = ""
@@ -1033,7 +1033,7 @@ class MysqlConnectorAsyncADKMemoryStore(BaseAsyncADKMemoryStore["MysqlConnectorA
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci{table_options}
         """
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         return [f"DROP TABLE IF EXISTS {self._memory_table}"]
 
 
@@ -1067,7 +1067,7 @@ class MysqlConnectorSyncADKMemoryStore(BaseSyncADKMemoryStore["MysqlConnectorSyn
         """Delete memory entries older than specified days."""
         return self._delete_entries_older_than(days)
 
-    def _get_create_memory_table_sql(self) -> str:
+    def _memory_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         owner_id_line = ""
         fk_constraint = ""
@@ -1100,7 +1100,7 @@ class MysqlConnectorSyncADKMemoryStore(BaseSyncADKMemoryStore["MysqlConnectorSyn
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci{table_options}
         """
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         return [f"DROP TABLE IF EXISTS {self._memory_table}"]
 
     def _create_tables(self) -> None:
@@ -1108,7 +1108,7 @@ class MysqlConnectorSyncADKMemoryStore(BaseSyncADKMemoryStore["MysqlConnectorSyn
             return
 
         with self._config.provide_session() as driver:
-            driver.execute_script(self._get_create_memory_table_sql())
+            driver.execute_script(self._memory_table_ddl())
 
     def _insert_memory_entries(self, entries: "list[MemoryRecord]", owner_id: "object | None" = None) -> int:
         if not self._enabled:

--- a/sqlspec/adapters/mysqlconnector/events/store.py
+++ b/sqlspec/adapters/mysqlconnector/events/store.py
@@ -25,8 +25,8 @@ class MysqlConnectorSyncEventQueueStore(BaseEventQueueStore[MysqlConnectorSyncCo
     def _timestamp_default(self) -> str:
         return _mysql_timestamp_default()
 
-    def _build_index_sql(self) -> str | None:
-        return _mysql_build_index_sql(self)
+    def _index_ddl(self) -> str | None:
+        return _mysql_index_ddl(self)
 
 
 def _mysql_column_types() -> "tuple[str, str, str]":
@@ -39,8 +39,8 @@ def _mysql_timestamp_default() -> str:
     return "CURRENT_TIMESTAMP(6)"
 
 
-def _mysql_build_index_sql(store: Any) -> str | None:
-    """Build MySQL-specific index SQL that checks for existing indexes.
+def _mysql_index_ddl(store: Any) -> str | None:
+    """Return MySQL-specific index DDL that checks for existing indexes.
 
     MySQL doesn't support CREATE INDEX IF NOT EXISTS, so we use a workaround
     with information_schema to check if the index already exists.
@@ -94,5 +94,5 @@ class MysqlConnectorAsyncEventQueueStore(BaseEventQueueStore[MysqlConnectorAsync
     def _timestamp_default(self) -> str:
         return _mysql_timestamp_default()
 
-    def _build_index_sql(self) -> str | None:
-        return _mysql_build_index_sql(self)
+    def _index_ddl(self) -> str | None:
+        return _mysql_index_ddl(self)

--- a/sqlspec/adapters/mysqlconnector/litestar/store.py
+++ b/sqlspec/adapters/mysqlconnector/litestar/store.py
@@ -26,7 +26,7 @@ class MysqlConnectorAsyncStore(BaseSQLSpecStore["MysqlConnectorAsyncConfig"]):
     def __init__(self, config: "MysqlConnectorAsyncConfig") -> None:
         super().__init__(config)
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._table_name} (
             session_id VARCHAR(255) PRIMARY KEY,
@@ -38,14 +38,14 @@ class MysqlConnectorAsyncStore(BaseSQLSpecStore["MysqlConnectorAsyncConfig"]):
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         return [
             f"DROP INDEX idx_{self._table_name}_expires_at ON {self._table_name}",
             f"DROP TABLE IF EXISTS {self._table_name}",
         ]
 
     async def create_table(self) -> None:
-        sql = self._get_create_table_sql()
+        sql = self._table_ddl()
         async with self._config.provide_session() as driver:
             await driver.execute_script(sql)
         self._log_table_created()
@@ -223,7 +223,7 @@ class MysqlConnectorSyncStore(BaseSQLSpecStore["MysqlConnectorSyncConfig"]):
     def __init__(self, config: "MysqlConnectorSyncConfig") -> None:
         super().__init__(config)
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._table_name} (
             session_id VARCHAR(255) PRIMARY KEY,
@@ -235,14 +235,14 @@ class MysqlConnectorSyncStore(BaseSQLSpecStore["MysqlConnectorSyncConfig"]):
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         return [
             f"DROP INDEX idx_{self._table_name}_expires_at ON {self._table_name}",
             f"DROP TABLE IF EXISTS {self._table_name}",
         ]
 
     def _create_table(self) -> None:
-        sql = self._get_create_table_sql()
+        sql = self._table_ddl()
         with self._config.provide_session() as driver:
             driver.execute_script(sql)
             driver.commit()

--- a/sqlspec/adapters/oracledb/adk/store.py
+++ b/sqlspec/adapters/oracledb/adk/store.py
@@ -222,13 +222,13 @@ class OracleAsyncADKStore(BaseAsyncADKStore["OracleAsyncConfig"]):
         logger.debug("Creating ADK tables with storage type: %s", storage_type)
 
         async with self._config.provide_session() as driver:
-            await driver.execute_script(self._get_create_sessions_table_sql_for_type(storage_type))
+            await driver.execute_script(self._sessions_table_ddl_for_type(storage_type))
 
-            await driver.execute_script(self._get_create_events_table_sql_for_type(storage_type))
-            await driver.execute_script(self._get_create_app_states_table_sql_for_type(storage_type))
-            await driver.execute_script(self._get_create_user_states_table_sql_for_type(storage_type))
-            await driver.execute_script(await self._get_create_metadata_table_sql())
-            await driver.execute_script(await self._get_seed_metadata_sql())
+            await driver.execute_script(self._events_table_ddl_for_type(storage_type))
+            await driver.execute_script(self._app_states_table_ddl_for_type(storage_type))
+            await driver.execute_script(self._user_states_table_ddl_for_type(storage_type))
+            await driver.execute_script(await self._metadata_table_ddl())
+            await driver.execute_script(await self._metadata_seed_sql())
             await driver.commit()
 
     async def create_session(
@@ -780,35 +780,35 @@ class OracleAsyncADKStore(BaseAsyncADKStore["OracleAsyncConfig"]):
             await cursor.execute(sql, {"key": key, "value": value})
             await conn.commit()
 
-    async def _get_create_sessions_table_sql(self) -> str:
+    async def _sessions_table_ddl(self) -> str:
         """Get Oracle CREATE TABLE SQL for sessions table.
 
         Auto-detects optimal JSON storage type based on Oracle version.
         Result is cached to minimize database queries.
         """
         storage_type = await self._detect_json_storage_type()
-        return self._get_create_sessions_table_sql_for_type(storage_type)
+        return self._sessions_table_ddl_for_type(storage_type)
 
-    async def _get_create_events_table_sql(self) -> str:
+    async def _events_table_ddl(self) -> str:
         """Get Oracle CREATE TABLE SQL for events table.
 
         Auto-detects optimal JSON storage type based on Oracle version.
         Result is cached to minimize database queries.
         """
         storage_type = await self._detect_json_storage_type()
-        return self._get_create_events_table_sql_for_type(storage_type)
+        return self._events_table_ddl_for_type(storage_type)
 
-    async def _get_create_app_states_table_sql(self) -> str:
+    async def _app_states_table_ddl(self) -> str:
         """Get Oracle CREATE TABLE SQL for app-scoped state."""
         storage_type = await self._detect_json_storage_type()
-        return self._get_create_app_states_table_sql_for_type(storage_type)
+        return self._app_states_table_ddl_for_type(storage_type)
 
-    async def _get_create_user_states_table_sql(self) -> str:
+    async def _user_states_table_ddl(self) -> str:
         """Get Oracle CREATE TABLE SQL for user-scoped state."""
         storage_type = await self._detect_json_storage_type()
-        return self._get_create_user_states_table_sql_for_type(storage_type)
+        return self._user_states_table_ddl_for_type(storage_type)
 
-    async def _get_create_metadata_table_sql(self) -> str:
+    async def _metadata_table_ddl(self) -> str:
         """Get Oracle CREATE TABLE SQL for ADK internal metadata."""
         return f"""
         BEGIN
@@ -824,7 +824,7 @@ class OracleAsyncADKStore(BaseAsyncADKStore["OracleAsyncConfig"]):
         END;
         """
 
-    async def _get_seed_metadata_sql(self) -> str:
+    async def _metadata_seed_sql(self) -> str:
         """Get Oracle SQL to seed the ADK schema-version metadata row."""
         return f"""
         BEGIN
@@ -954,7 +954,7 @@ class OracleAsyncADKStore(BaseAsyncADKStore["OracleAsyncConfig"]):
 
         return str(data)
 
-    def _get_create_sessions_table_sql_for_type(self, storage_type: JSONStorageType) -> str:
+    def _sessions_table_ddl_for_type(self, storage_type: JSONStorageType) -> str:
         """Get Oracle CREATE TABLE SQL for sessions with specified storage type.
 
         Args:
@@ -1017,7 +1017,7 @@ class OracleAsyncADKStore(BaseAsyncADKStore["OracleAsyncConfig"]):
         END;
         """
 
-    def _get_create_events_table_sql_for_type(self, storage_type: JSONStorageType) -> str:
+    def _events_table_ddl_for_type(self, storage_type: JSONStorageType) -> str:
         """Get Oracle CREATE TABLE SQL for events with specified storage type.
 
         The events table stores the full ADK Event in ``event_data`` and
@@ -1087,7 +1087,7 @@ class OracleAsyncADKStore(BaseAsyncADKStore["OracleAsyncConfig"]):
         END;
         """
 
-    def _get_create_app_states_table_sql_for_type(self, storage_type: JSONStorageType) -> str:
+    def _app_states_table_ddl_for_type(self, storage_type: JSONStorageType) -> str:
         """Get Oracle CREATE TABLE SQL for app-scoped state with specified storage type."""
         state_column = _json_column_ddl("state", storage_type)
 
@@ -1106,7 +1106,7 @@ class OracleAsyncADKStore(BaseAsyncADKStore["OracleAsyncConfig"]):
         END;
         """
 
-    def _get_create_user_states_table_sql_for_type(self, storage_type: JSONStorageType) -> str:
+    def _user_states_table_ddl_for_type(self, storage_type: JSONStorageType) -> str:
         """Get Oracle CREATE TABLE SQL for user-scoped state with specified storage type."""
         state_column = _json_column_ddl("state", storage_type)
 
@@ -1127,7 +1127,7 @@ class OracleAsyncADKStore(BaseAsyncADKStore["OracleAsyncConfig"]):
         END;
         """
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return f"""
         BEGIN
             EXECUTE IMMEDIATE 'DROP TABLE {self._app_state_table}';
@@ -1139,7 +1139,7 @@ class OracleAsyncADKStore(BaseAsyncADKStore["OracleAsyncConfig"]):
         END;
         """
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return f"""
         BEGIN
             EXECUTE IMMEDIATE 'DROP TABLE {self._user_state_table}';
@@ -1151,7 +1151,7 @@ class OracleAsyncADKStore(BaseAsyncADKStore["OracleAsyncConfig"]):
         END;
         """
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"""
         BEGIN
             EXECUTE IMMEDIATE 'DROP TABLE {self._metadata_table}';
@@ -1163,7 +1163,7 @@ class OracleAsyncADKStore(BaseAsyncADKStore["OracleAsyncConfig"]):
         END;
         """
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         """Get Oracle DROP TABLE SQL statements.
 
         Returns:
@@ -1174,9 +1174,9 @@ class OracleAsyncADKStore(BaseAsyncADKStore["OracleAsyncConfig"]):
             Oracle automatically drops indexes when dropping tables.
         """
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"""
             BEGIN
                 EXECUTE IMMEDIATE 'DROP INDEX idx_{self._events_table}_session';
@@ -1369,35 +1369,35 @@ class OracleSyncADKStore(BaseSyncADKStore["OracleSyncConfig"]):
         """Set a value in the ADK internal metadata table."""
         self._set_metadata(key, value)
 
-    def _get_create_sessions_table_sql(self) -> str:
+    def _sessions_table_ddl(self) -> str:
         """Get Oracle CREATE TABLE SQL for sessions table.
 
         Auto-detects optimal JSON storage type based on Oracle version.
         Result is cached to minimize database queries.
         """
         storage_type = self._detect_json_storage_type()
-        return self._get_create_sessions_table_sql_for_type(storage_type)
+        return self._sessions_table_ddl_for_type(storage_type)
 
-    def _get_create_events_table_sql(self) -> str:
+    def _events_table_ddl(self) -> str:
         """Get Oracle CREATE TABLE SQL for events table.
 
         Auto-detects optimal JSON storage type based on Oracle version.
         Result is cached to minimize database queries.
         """
         storage_type = self._detect_json_storage_type()
-        return self._get_create_events_table_sql_for_type(storage_type)
+        return self._events_table_ddl_for_type(storage_type)
 
-    def _get_create_app_states_table_sql(self) -> str:
+    def _app_states_table_ddl(self) -> str:
         """Get Oracle CREATE TABLE SQL for app-scoped state."""
         storage_type = self._detect_json_storage_type()
-        return self._get_create_app_states_table_sql_for_type(storage_type)
+        return self._app_states_table_ddl_for_type(storage_type)
 
-    def _get_create_user_states_table_sql(self) -> str:
+    def _user_states_table_ddl(self) -> str:
         """Get Oracle CREATE TABLE SQL for user-scoped state."""
         storage_type = self._detect_json_storage_type()
-        return self._get_create_user_states_table_sql_for_type(storage_type)
+        return self._user_states_table_ddl_for_type(storage_type)
 
-    def _get_create_metadata_table_sql(self) -> str:
+    def _metadata_table_ddl(self) -> str:
         """Get Oracle CREATE TABLE SQL for ADK internal metadata."""
         return f"""
         BEGIN
@@ -1413,7 +1413,7 @@ class OracleSyncADKStore(BaseSyncADKStore["OracleSyncConfig"]):
         END;
         """
 
-    def _get_seed_metadata_sql(self) -> str:
+    def _metadata_seed_sql(self) -> str:
         """Get Oracle SQL to seed the ADK schema-version metadata row."""
         return f"""
         BEGIN
@@ -1539,7 +1539,7 @@ class OracleSyncADKStore(BaseSyncADKStore["OracleSyncConfig"]):
 
         return str(data)
 
-    def _get_create_sessions_table_sql_for_type(self, storage_type: JSONStorageType) -> str:
+    def _sessions_table_ddl_for_type(self, storage_type: JSONStorageType) -> str:
         """Get Oracle CREATE TABLE SQL for sessions with specified storage type.
 
         Args:
@@ -1602,7 +1602,7 @@ class OracleSyncADKStore(BaseSyncADKStore["OracleSyncConfig"]):
         END;
         """
 
-    def _get_create_events_table_sql_for_type(self, storage_type: JSONStorageType) -> str:
+    def _events_table_ddl_for_type(self, storage_type: JSONStorageType) -> str:
         """Get Oracle CREATE TABLE SQL for events with specified storage type.
 
         The events table stores the full ADK Event in ``event_data`` and
@@ -1672,7 +1672,7 @@ class OracleSyncADKStore(BaseSyncADKStore["OracleSyncConfig"]):
         END;
         """
 
-    def _get_create_app_states_table_sql_for_type(self, storage_type: JSONStorageType) -> str:
+    def _app_states_table_ddl_for_type(self, storage_type: JSONStorageType) -> str:
         """Get Oracle CREATE TABLE SQL for app-scoped state with specified storage type."""
         state_column = _json_column_ddl("state", storage_type)
 
@@ -1691,7 +1691,7 @@ class OracleSyncADKStore(BaseSyncADKStore["OracleSyncConfig"]):
         END;
         """
 
-    def _get_create_user_states_table_sql_for_type(self, storage_type: JSONStorageType) -> str:
+    def _user_states_table_ddl_for_type(self, storage_type: JSONStorageType) -> str:
         """Get Oracle CREATE TABLE SQL for user-scoped state with specified storage type."""
         state_column = _json_column_ddl("state", storage_type)
 
@@ -1712,7 +1712,7 @@ class OracleSyncADKStore(BaseSyncADKStore["OracleSyncConfig"]):
         END;
         """
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return f"""
         BEGIN
             EXECUTE IMMEDIATE 'DROP TABLE {self._app_state_table}';
@@ -1724,7 +1724,7 @@ class OracleSyncADKStore(BaseSyncADKStore["OracleSyncConfig"]):
         END;
         """
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return f"""
         BEGIN
             EXECUTE IMMEDIATE 'DROP TABLE {self._user_state_table}';
@@ -1736,7 +1736,7 @@ class OracleSyncADKStore(BaseSyncADKStore["OracleSyncConfig"]):
         END;
         """
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"""
         BEGIN
             EXECUTE IMMEDIATE 'DROP TABLE {self._metadata_table}';
@@ -1748,7 +1748,7 @@ class OracleSyncADKStore(BaseSyncADKStore["OracleSyncConfig"]):
         END;
         """
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         """Get Oracle DROP TABLE SQL statements.
 
         Returns:
@@ -1759,9 +1759,9 @@ class OracleSyncADKStore(BaseSyncADKStore["OracleSyncConfig"]):
             Oracle automatically drops indexes when dropping tables.
         """
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"""
             BEGIN
                 EXECUTE IMMEDIATE 'DROP INDEX idx_{self._events_table}_session';
@@ -1825,15 +1825,15 @@ class OracleSyncADKStore(BaseSyncADKStore["OracleSyncConfig"]):
         logger.info("Creating ADK tables with storage type: %s", storage_type)
 
         with self._config.provide_session() as driver:
-            sessions_sql = SQL(self._get_create_sessions_table_sql_for_type(storage_type))
+            sessions_sql = SQL(self._sessions_table_ddl_for_type(storage_type))
             driver.execute_script(sessions_sql)
 
-            events_sql = SQL(self._get_create_events_table_sql_for_type(storage_type))
+            events_sql = SQL(self._events_table_ddl_for_type(storage_type))
             driver.execute_script(events_sql)
-            driver.execute_script(SQL(self._get_create_app_states_table_sql_for_type(storage_type)))
-            driver.execute_script(SQL(self._get_create_user_states_table_sql_for_type(storage_type)))
-            driver.execute_script(SQL(self._get_create_metadata_table_sql()))
-            driver.execute_script(SQL(self._get_seed_metadata_sql()))
+            driver.execute_script(SQL(self._app_states_table_ddl_for_type(storage_type)))
+            driver.execute_script(SQL(self._user_states_table_ddl_for_type(storage_type)))
+            driver.execute_script(SQL(self._metadata_table_ddl()))
+            driver.execute_script(SQL(self._metadata_seed_sql()))
             driver.commit()
 
     def _create_session(
@@ -2391,7 +2391,7 @@ class OracleAsyncADKMemoryStore(BaseAsyncADKMemoryStore["OracleAsyncConfig"]):
             return
 
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_memory_table_sql())
+            await driver.execute_script(await self._memory_table_ddl())
 
     async def insert_memory_entries(self, entries: "list[MemoryRecord]", owner_id: "object | None" = None) -> int:
         if not self._enabled:
@@ -2517,11 +2517,11 @@ class OracleAsyncADKMemoryStore(BaseAsyncADKMemoryStore["OracleAsyncConfig"]):
 
         return _extract_json_value(data)
 
-    async def _get_create_memory_table_sql(self) -> str:
+    async def _memory_table_ddl(self) -> str:
         storage_type = await self._detect_json_storage_type()
-        return self._get_create_memory_table_sql_for_type(storage_type)
+        return self._memory_table_ddl_for_type(storage_type)
 
-    def _get_create_memory_table_sql_for_type(self, storage_type: "JSONStorageType") -> str:
+    def _memory_table_ddl_for_type(self, storage_type: "JSONStorageType") -> str:
         if storage_type == JSONStorageType.JSON_NATIVE:
             json_columns = """
                 content_json JSON,
@@ -2604,7 +2604,7 @@ class OracleAsyncADKMemoryStore(BaseAsyncADKMemoryStore["OracleAsyncConfig"]):
         {fts_index}
         """
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         return [
             f"""
             BEGIN
@@ -2792,11 +2792,11 @@ class OracleSyncADKMemoryStore(BaseSyncADKMemoryStore["OracleSyncConfig"]):
 
         return _extract_json_value(data)
 
-    def _get_create_memory_table_sql(self) -> str:
+    def _memory_table_ddl(self) -> str:
         storage_type = self._detect_json_storage_type()
-        return self._get_create_memory_table_sql_for_type(storage_type)
+        return self._memory_table_ddl_for_type(storage_type)
 
-    def _get_create_memory_table_sql_for_type(self, storage_type: "JSONStorageType") -> str:
+    def _memory_table_ddl_for_type(self, storage_type: "JSONStorageType") -> str:
         if storage_type == JSONStorageType.JSON_NATIVE:
             json_columns = """
                 content_json JSON,
@@ -2879,7 +2879,7 @@ class OracleSyncADKMemoryStore(BaseSyncADKMemoryStore["OracleSyncConfig"]):
         {fts_index}
         """
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         return [
             f"""
             BEGIN
@@ -2918,7 +2918,7 @@ class OracleSyncADKMemoryStore(BaseSyncADKMemoryStore["OracleSyncConfig"]):
             return
 
         with self._config.provide_session() as driver:
-            driver.execute_script(self._get_create_memory_table_sql())
+            driver.execute_script(self._memory_table_ddl())
 
     def _execute_insert_entry(self, cursor: Any, sql: str, params: "dict[str, Any]") -> bool:
         """Execute an insert and skip duplicate key errors."""

--- a/sqlspec/adapters/oracledb/events/store.py
+++ b/sqlspec/adapters/oracledb/events/store.py
@@ -101,9 +101,7 @@ def _init_oracle_settings(extension_settings: "dict[str, Any]") -> "tuple[bool, 
     return in_memory, json_storage
 
 
-def _build_oracle_create_table_sql(
-    table_name: str, storage_type: "JSONStorageType", in_memory: bool, index_name: str
-) -> str:
+def _oracle_table_ddl(table_name: str, storage_type: "JSONStorageType", in_memory: bool, index_name: str) -> str:
     """Build Oracle CREATE TABLE and INDEX SQL as a single PL/SQL script.
 
     Args:
@@ -160,7 +158,7 @@ def _build_oracle_create_table_sql(
         """
 
 
-def _build_oracle_drop_sql(table_name: str, index_name: str) -> "list[str]":
+def _oracle_drop_sql(table_name: str, index_name: str) -> "list[str]":
     """Build Oracle DROP TABLE SQL with PL/SQL error handling.
 
     Args:
@@ -237,11 +235,11 @@ class OracleSyncEventQueueStore(BaseEventQueueStore["OracleSyncConfig"]):
         For auto-detection, use create_table() instead.
         """
         storage_type = self._json_storage or JSONStorageType.BLOB_JSON
-        return [_build_oracle_create_table_sql(self.table_name, storage_type, self._in_memory, self._index_name())]
+        return [_oracle_table_ddl(self.table_name, storage_type, self._in_memory, self._index_name())]
 
     def drop_statements(self) -> "list[str]":
         """Return drop statements in reverse dependency order."""
-        return _build_oracle_drop_sql(self.table_name, self._index_name())
+        return _oracle_drop_sql(self.table_name, self._index_name())
 
     def _detect_json_storage_type(self) -> JSONStorageType:
         """Detect the appropriate JSON storage type based on Oracle version.
@@ -283,13 +281,13 @@ class OracleSyncEventQueueStore(BaseEventQueueStore["OracleSyncConfig"]):
         )
 
         with self._config.provide_session() as driver:
-            sql = _build_oracle_create_table_sql(self.table_name, storage_type, self._in_memory, self._index_name())
+            sql = _oracle_table_ddl(self.table_name, storage_type, self._in_memory, self._index_name())
             driver.execute_script(sql)
 
     def drop_table(self) -> None:
         """Drop the event queue table and index."""
         with self._config.provide_session() as driver:
-            for stmt in _build_oracle_drop_sql(self.table_name, self._index_name()):
+            for stmt in _oracle_drop_sql(self.table_name, self._index_name()):
                 driver.execute_script(stmt)
 
 
@@ -336,11 +334,11 @@ class OracleAsyncEventQueueStore(BaseEventQueueStore["OracleAsyncConfig"]):
         For auto-detection, use create_table() instead.
         """
         storage_type = self._json_storage or JSONStorageType.BLOB_JSON
-        return [_build_oracle_create_table_sql(self.table_name, storage_type, self._in_memory, self._index_name())]
+        return [_oracle_table_ddl(self.table_name, storage_type, self._in_memory, self._index_name())]
 
     def drop_statements(self) -> "list[str]":
         """Return drop statements in reverse dependency order."""
-        return _build_oracle_drop_sql(self.table_name, self._index_name())
+        return _oracle_drop_sql(self.table_name, self._index_name())
 
     async def _detect_json_storage_type(self) -> JSONStorageType:
         """Detect the appropriate JSON storage type based on Oracle version.
@@ -382,11 +380,11 @@ class OracleAsyncEventQueueStore(BaseEventQueueStore["OracleAsyncConfig"]):
         )
 
         async with self._config.provide_session() as driver:
-            sql = _build_oracle_create_table_sql(self.table_name, storage_type, self._in_memory, self._index_name())
+            sql = _oracle_table_ddl(self.table_name, storage_type, self._in_memory, self._index_name())
             await driver.execute_script(sql)
 
     async def drop_table(self) -> None:
         """Drop the event queue table and index."""
         async with self._config.provide_session() as driver:
-            for stmt in _build_oracle_drop_sql(self.table_name, self._index_name()):
+            for stmt in _oracle_drop_sql(self.table_name, self._index_name()):
                 await driver.execute_script(stmt)

--- a/sqlspec/adapters/oracledb/litestar/store.py
+++ b/sqlspec/adapters/oracledb/litestar/store.py
@@ -71,7 +71,7 @@ class OracleAsyncStore(BaseSQLSpecStore["OracleAsyncConfig"]):
         litestar_config = config.extension_config.get("litestar", {})
         self._in_memory = bool(litestar_config.get("in_memory", False))
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get Oracle CREATE TABLE SQL with optimized schema.
 
         Returns:
@@ -105,7 +105,7 @@ class OracleAsyncStore(BaseSQLSpecStore["OracleAsyncConfig"]):
         END;
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         """Get Oracle DROP TABLE SQL with PL/SQL error handling.
 
         Returns:
@@ -136,7 +136,7 @@ class OracleAsyncStore(BaseSQLSpecStore["OracleAsyncConfig"]):
 
     async def create_table(self) -> None:
         """Create the session table if it doesn't exist."""
-        sql = self._get_create_table_sql()
+        sql = self._table_ddl()
         async with self._config.provide_session() as driver:
             await driver.execute_script(sql)
 
@@ -374,7 +374,7 @@ class OracleSyncStore(BaseSQLSpecStore["OracleSyncConfig"]):
         litestar_config = config.extension_config.get("litestar", {})
         self._in_memory = bool(litestar_config.get("in_memory", False))
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get Oracle CREATE TABLE SQL with optimized schema.
 
         Returns:
@@ -408,7 +408,7 @@ class OracleSyncStore(BaseSQLSpecStore["OracleSyncConfig"]):
         END;
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         """Get Oracle DROP TABLE SQL with PL/SQL error handling.
 
         Returns:
@@ -439,7 +439,7 @@ class OracleSyncStore(BaseSQLSpecStore["OracleSyncConfig"]):
 
     def _create_table(self) -> None:
         """Synchronous implementation of create_table."""
-        sql = self._get_create_table_sql()
+        sql = self._table_ddl()
         with self._config.provide_session() as driver:
             driver.execute_script(sql)
 

--- a/sqlspec/adapters/oracledb/migrations.py
+++ b/sqlspec/adapters/oracledb/migrations.py
@@ -59,7 +59,7 @@ class OracleMigrationTrackerMixin:
             return f"{self._quote_oracle_identifier(version_table_schema)}.{quoted_table_name}"
         return quoted_table_name
 
-    def _get_create_table_builder(self) -> CreateTable:
+    def _tracking_table_builder(self) -> CreateTable:
         """Return an Oracle CREATE TABLE builder for the tracker table."""
         table_name = self._normalize_oracle_identifier(self.version_table_name)
         builder = sql.create_table(table_name)
@@ -67,7 +67,7 @@ class OracleMigrationTrackerMixin:
             builder.in_schema(self._normalize_oracle_identifier(self.version_table_schema))
         return builder
 
-    def _get_create_table_sql(self) -> CreateTable:
+    def _tracking_table_ddl(self) -> CreateTable:
         """Get Oracle-specific SQL builder for creating the tracking table.
 
         Oracle doesn't support:
@@ -80,7 +80,7 @@ class OracleMigrationTrackerMixin:
         """
         return (
             self
-            ._get_create_table_builder()
+            ._tracking_table_builder()
             .column("version_num", "VARCHAR2(32)", primary_key=True)
             .column("version_type", "VARCHAR2(16)")
             .column("execution_sequence", "INTEGER")
@@ -91,7 +91,7 @@ class OracleMigrationTrackerMixin:
             .column("applied_by", "VARCHAR2(255)")
         )
 
-    def _get_current_version_sql(self) -> Select:
+    def _current_version_query(self) -> Select:
         """Get Oracle-specific SQL for retrieving current version.
 
         Uses uppercase column names with lowercase aliases to match Python expectations.
@@ -109,7 +109,7 @@ class OracleMigrationTrackerMixin:
             .limit(1)
         )
 
-    def _get_applied_migrations_sql(self) -> Select:
+    def _applied_migrations_query(self) -> Select:
         """Get Oracle-specific SQL for retrieving all applied migrations.
 
         Uses uppercase column names with lowercase aliases to match Python expectations.
@@ -135,7 +135,7 @@ class OracleMigrationTrackerMixin:
             .order_by("EXECUTION_SEQUENCE")
         )
 
-    def _get_next_execution_sequence_sql(self) -> Select:
+    def _next_execution_sequence_query(self) -> Select:
         """Get Oracle-specific SQL for retrieving next execution sequence.
 
         Uses uppercase column names with lowercase alias to match Python expectations.
@@ -156,7 +156,7 @@ class OracleMigrationTrackerMixin:
         Returns:
             Set of missing column names (lowercase).
         """
-        target_create = self._get_create_table_sql()
+        target_create = self._tracking_table_ddl()
         target_columns = {col.name.lower() for col in target_create.columns}
         existing_lower = {col.lower() for col in existing_columns}
         return target_columns - existing_lower
@@ -212,7 +212,7 @@ class OracleSyncMigrationTracker(OracleMigrationTrackerMixin, BaseMigrationTrack
             driver: The database driver to use.
             column_name: Name of the column to add (lowercase).
         """
-        target_create = self._get_create_table_sql()
+        target_create = self._tracking_table_ddl()
         column_def = next((col for col in target_create.columns if col.name.lower() == column_name), None)
 
         if not column_def:
@@ -274,7 +274,7 @@ class OracleSyncMigrationTracker(OracleMigrationTrackerMixin, BaseMigrationTrack
         Returns:
             The current migration version or None if no migrations applied.
         """
-        result = driver.execute(self._get_current_version_sql())
+        result = driver.execute(self._current_version_query())
         data = result.get_data()
         return data[0]["version_num"] if data else None
 
@@ -287,7 +287,7 @@ class OracleSyncMigrationTracker(OracleMigrationTrackerMixin, BaseMigrationTrack
         Returns:
             List of migration records as dictionaries with lowercase keys.
         """
-        result = driver.execute(self._get_applied_migrations_sql())
+        result = driver.execute(self._applied_migrations_query())
         return result.get_data()
 
     def record_migration(
@@ -306,11 +306,11 @@ class OracleSyncMigrationTracker(OracleMigrationTrackerMixin, BaseMigrationTrack
         parsed_version = parse_version(version)
         version_type = parsed_version.type.value
 
-        next_seq_result = driver.execute(self._get_next_execution_sequence_sql())
+        next_seq_result = driver.execute(self._next_execution_sequence_query())
         seq_data = next_seq_result.get_data()
         execution_sequence = seq_data[0]["next_seq"] if seq_data else 1
 
-        record_sql = self._get_record_migration_sql(
+        record_sql = self._record_migration_statement(
             version, version_type, execution_sequence, description, execution_time_ms, checksum, applied_by
         )
         driver.execute(record_sql)
@@ -323,7 +323,7 @@ class OracleSyncMigrationTracker(OracleMigrationTrackerMixin, BaseMigrationTrack
             driver: The database driver to use.
             version: Version number to remove.
         """
-        remove_sql = self._get_remove_migration_sql(version)
+        remove_sql = self._remove_migration_statement(version)
         driver.execute(remove_sql)
         driver.commit()
 
@@ -347,10 +347,10 @@ class OracleSyncMigrationTracker(OracleMigrationTrackerMixin, BaseMigrationTrack
         parsed_new_version = parse_version(new_version)
         new_version_type = parsed_new_version.type.value
 
-        result = driver.execute(self._get_update_version_sql(old_version, new_version, new_version_type))
+        result = driver.execute(self._update_version_statement(old_version, new_version, new_version_type))
 
         if result.rows_affected == 0:
-            check_result = driver.execute(self._get_applied_migrations_sql())
+            check_result = driver.execute(self._applied_migrations_query())
             applied_versions = {row["version_num"] for row in check_result.get_data()} if check_result.data else set()
 
             if new_version in applied_versions:
@@ -413,7 +413,7 @@ class OracleAsyncMigrationTracker(OracleMigrationTrackerMixin, BaseMigrationTrac
             driver: The database driver to use.
             column_name: Name of the column to add (lowercase).
         """
-        target_create = self._get_create_table_sql()
+        target_create = self._tracking_table_ddl()
         column_def = next((col for col in target_create.columns if col.name.lower() == column_name), None)
 
         if not column_def:
@@ -475,7 +475,7 @@ class OracleAsyncMigrationTracker(OracleMigrationTrackerMixin, BaseMigrationTrac
         Returns:
             The current migration version or None if no migrations applied.
         """
-        result = await driver.execute(self._get_current_version_sql())
+        result = await driver.execute(self._current_version_query())
         data = result.get_data()
         return data[0]["version_num"] if data else None
 
@@ -488,7 +488,7 @@ class OracleAsyncMigrationTracker(OracleMigrationTrackerMixin, BaseMigrationTrac
         Returns:
             List of migration records as dictionaries with lowercase keys.
         """
-        result = await driver.execute(self._get_applied_migrations_sql())
+        result = await driver.execute(self._applied_migrations_query())
         return result.get_data()
 
     async def record_migration(
@@ -508,11 +508,11 @@ class OracleAsyncMigrationTracker(OracleMigrationTrackerMixin, BaseMigrationTrac
         parsed_version = parse_version(version)
         version_type = parsed_version.type.value
 
-        next_seq_result = await driver.execute(self._get_next_execution_sequence_sql())
+        next_seq_result = await driver.execute(self._next_execution_sequence_query())
         seq_data = next_seq_result.get_data()
         execution_sequence = seq_data[0]["next_seq"] if seq_data else 1
 
-        record_sql = self._get_record_migration_sql(
+        record_sql = self._record_migration_statement(
             version, version_type, execution_sequence, description, execution_time_ms, checksum, applied_by
         )
         await driver.execute(record_sql)
@@ -525,7 +525,7 @@ class OracleAsyncMigrationTracker(OracleMigrationTrackerMixin, BaseMigrationTrac
             driver: The database driver to use.
             version: Version number to remove.
         """
-        remove_sql = self._get_remove_migration_sql(version)
+        remove_sql = self._remove_migration_statement(version)
         await driver.execute(remove_sql)
         await driver.commit()
 
@@ -549,10 +549,10 @@ class OracleAsyncMigrationTracker(OracleMigrationTrackerMixin, BaseMigrationTrac
         parsed_new_version = parse_version(new_version)
         new_version_type = parsed_new_version.type.value
 
-        result = await driver.execute(self._get_update_version_sql(old_version, new_version, new_version_type))
+        result = await driver.execute(self._update_version_statement(old_version, new_version, new_version_type))
 
         if result.rows_affected == 0:
-            check_result = await driver.execute(self._get_applied_migrations_sql())
+            check_result = await driver.execute(self._applied_migrations_query())
             applied_versions = {row["version_num"] for row in check_result.get_data()} if check_result.data else set()
 
             if new_version in applied_versions:

--- a/sqlspec/adapters/psqlpy/adk/store.py
+++ b/sqlspec/adapters/psqlpy/adk/store.py
@@ -67,12 +67,12 @@ class PsqlpyADKStore(BaseAsyncADKStore["PsqlpyConfig"]):
 
     async def create_tables(self) -> None:
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_sessions_table_sql())
-            await driver.execute_script(await self._get_create_events_table_sql())
-            await driver.execute_script(await self._get_create_app_states_table_sql())
-            await driver.execute_script(await self._get_create_user_states_table_sql())
-            await driver.execute_script(await self._get_create_metadata_table_sql())
-            await driver.execute_script(await self._get_seed_metadata_sql())
+            await driver.execute_script(await self._sessions_table_ddl())
+            await driver.execute_script(await self._events_table_ddl())
+            await driver.execute_script(await self._app_states_table_ddl())
+            await driver.execute_script(await self._user_states_table_ddl())
+            await driver.execute_script(await self._metadata_table_ddl())
+            await driver.execute_script(await self._metadata_seed_sql())
 
     async def create_session(
         self, session_id: str, app_name: str, user_id: str, state: "dict[str, Any]", owner_id: "Any | None" = None
@@ -442,7 +442,7 @@ class PsqlpyADKStore(BaseAsyncADKStore["PsqlpyConfig"]):
         async with self._config.provide_connection() as conn:  # pyright: ignore[reportAttributeAccessIssue]
             await conn.execute(sql, [key, value])
 
-    async def _get_create_sessions_table_sql(self) -> str:
+    async def _sessions_table_ddl(self) -> str:
         owner_id_line = ""
         if self._owner_id_column_ddl:
             owner_id_line = f",\n            {self._owner_id_column_ddl}"
@@ -468,7 +468,7 @@ class PsqlpyADKStore(BaseAsyncADKStore["PsqlpyConfig"]):
             WHERE state != '{{}}'::jsonb;
         """
 
-    async def _get_create_events_table_sql(self) -> str:
+    async def _events_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         generated_columns, generated_indexes, covering_columns = _postgres_event_ddl_options(
             adk_config, self._events_table
@@ -489,7 +489,7 @@ class PsqlpyADKStore(BaseAsyncADKStore["PsqlpyConfig"]):
         {generated_indexes}
         """
 
-    async def _get_create_app_states_table_sql(self) -> str:
+    async def _app_states_table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._app_state_table} (
             app_name VARCHAR(128) PRIMARY KEY,
@@ -498,7 +498,7 @@ class PsqlpyADKStore(BaseAsyncADKStore["PsqlpyConfig"]):
         ) WITH (fillfactor = 80);
         """
 
-    async def _get_create_user_states_table_sql(self) -> str:
+    async def _user_states_table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._user_state_table} (
             app_name VARCHAR(128) NOT NULL,
@@ -509,7 +509,7 @@ class PsqlpyADKStore(BaseAsyncADKStore["PsqlpyConfig"]):
         ) WITH (fillfactor = 80);
         """
 
-    async def _get_create_metadata_table_sql(self) -> str:
+    async def _metadata_table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._metadata_table} (
             key VARCHAR(128) PRIMARY KEY,
@@ -517,27 +517,27 @@ class PsqlpyADKStore(BaseAsyncADKStore["PsqlpyConfig"]):
         );
         """
 
-    async def _get_seed_metadata_sql(self) -> str:
+    async def _metadata_seed_sql(self) -> str:
         return f"""
         INSERT INTO {self._metadata_table} (key, value)
         VALUES ('schema_version', '1')
         ON CONFLICT (key) DO NOTHING
         """
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._app_state_table}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._user_state_table}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {self._events_table}",
             f"DROP TABLE IF EXISTS {self._session_table}",
         ]
@@ -558,7 +558,7 @@ class PsqlpyADKMemoryStore(BaseAsyncADKMemoryStore["PsqlpyConfig"]):
             return
 
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_memory_table_sql())
+            await driver.execute_script(await self._memory_table_ddl())
 
     async def insert_memory_entries(self, entries: "list[MemoryRecord]", owner_id: "object | None" = None) -> int:
         """Bulk insert memory entries with deduplication."""
@@ -699,7 +699,7 @@ class PsqlpyADKMemoryStore(BaseAsyncADKMemoryStore["PsqlpyConfig"]):
                     return 0
             raise
 
-    async def _get_create_memory_table_sql(self) -> str:
+    async def _memory_table_ddl(self) -> str:
         """Get PostgreSQL CREATE TABLE SQL for memory entries."""
         owner_id_line = ""
         if self._owner_id_column_ddl:
@@ -735,7 +735,7 @@ class PsqlpyADKMemoryStore(BaseAsyncADKMemoryStore["PsqlpyConfig"]):
         {fts_index}
         """
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         """Get PostgreSQL DROP TABLE SQL statements."""
         return [f"DROP TABLE IF EXISTS {self._memory_table}"]
 

--- a/sqlspec/adapters/psqlpy/events/backend.py
+++ b/sqlspec/adapters/psqlpy/events/backend.py
@@ -161,7 +161,7 @@ class PsqlpyHybridEventsBackend:
         async with self._config.provide_session() as driver:
             await driver.execute(
                 SQL(
-                    self._queue._upsert_sql,  # pyright: ignore[reportPrivateUsage]
+                    self._queue._insert_statement,  # pyright: ignore[reportPrivateUsage]
                     {
                         "event_id": event_id,
                         "channel": channel,

--- a/sqlspec/adapters/psqlpy/litestar/store.py
+++ b/sqlspec/adapters/psqlpy/litestar/store.py
@@ -37,7 +37,7 @@ class PsqlpyStore(BaseSQLSpecStore["PsqlpyConfig"]):
         """
         super().__init__(config)
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get PostgreSQL CREATE TABLE SQL with optimized schema.
 
         Returns:
@@ -61,7 +61,7 @@ class PsqlpyStore(BaseSQLSpecStore["PsqlpyConfig"]):
         );
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         """Get PostgreSQL DROP TABLE SQL statements.
 
         Returns:
@@ -71,7 +71,7 @@ class PsqlpyStore(BaseSQLSpecStore["PsqlpyConfig"]):
 
     async def create_table(self) -> None:
         """Create the session table if it doesn't exist."""
-        sql = self._get_create_table_sql()
+        sql = self._table_ddl()
         async with self._config.provide_session() as driver:
             await driver.execute_script(sql)
         self._log_table_created()

--- a/sqlspec/adapters/psycopg/adk/store.py
+++ b/sqlspec/adapters/psycopg/adk/store.py
@@ -72,12 +72,12 @@ class PsycopgAsyncADKStore(BaseAsyncADKStore["PsycopgAsyncConfig"]):
 
     async def create_tables(self) -> None:
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_sessions_table_sql())
-            await driver.execute_script(await self._get_create_events_table_sql())
-            await driver.execute_script(await self._get_create_app_states_table_sql())
-            await driver.execute_script(await self._get_create_user_states_table_sql())
-            await driver.execute_script(await self._get_create_metadata_table_sql())
-            await driver.execute_script(await self._get_seed_metadata_sql())
+            await driver.execute_script(await self._sessions_table_ddl())
+            await driver.execute_script(await self._events_table_ddl())
+            await driver.execute_script(await self._app_states_table_ddl())
+            await driver.execute_script(await self._user_states_table_ddl())
+            await driver.execute_script(await self._metadata_table_ddl())
+            await driver.execute_script(await self._metadata_seed_sql())
 
     async def create_session(
         self, session_id: str, app_name: str, user_id: str, state: "dict[str, Any]", owner_id: "Any | None" = None
@@ -455,7 +455,7 @@ class PsycopgAsyncADKStore(BaseAsyncADKStore["PsycopgAsyncConfig"]):
         async with self._config.provide_connection() as conn, conn.cursor(row_factory=dict_row) as cur:
             await cur.execute(query, (key, value))
 
-    async def _get_create_sessions_table_sql(self) -> str:
+    async def _sessions_table_ddl(self) -> str:
         owner_id_line = ""
         if self._owner_id_column_ddl:
             owner_id_line = f",\n            {self._owner_id_column_ddl}"
@@ -481,7 +481,7 @@ class PsycopgAsyncADKStore(BaseAsyncADKStore["PsycopgAsyncConfig"]):
             WHERE state != '{{}}'::jsonb;
         """
 
-    async def _get_create_events_table_sql(self) -> str:
+    async def _events_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         generated_columns, generated_indexes, covering_columns = _postgres_event_ddl_options(
             adk_config, self._events_table
@@ -502,7 +502,7 @@ class PsycopgAsyncADKStore(BaseAsyncADKStore["PsycopgAsyncConfig"]):
         {generated_indexes}
         """
 
-    async def _get_create_app_states_table_sql(self) -> str:
+    async def _app_states_table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._app_state_table} (
             app_name VARCHAR(128) PRIMARY KEY,
@@ -511,7 +511,7 @@ class PsycopgAsyncADKStore(BaseAsyncADKStore["PsycopgAsyncConfig"]):
         ) WITH (fillfactor = 80);
         """
 
-    async def _get_create_user_states_table_sql(self) -> str:
+    async def _user_states_table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._user_state_table} (
             app_name VARCHAR(128) NOT NULL,
@@ -522,7 +522,7 @@ class PsycopgAsyncADKStore(BaseAsyncADKStore["PsycopgAsyncConfig"]):
         ) WITH (fillfactor = 80);
         """
 
-    async def _get_create_metadata_table_sql(self) -> str:
+    async def _metadata_table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._metadata_table} (
             key VARCHAR(128) PRIMARY KEY,
@@ -530,27 +530,27 @@ class PsycopgAsyncADKStore(BaseAsyncADKStore["PsycopgAsyncConfig"]):
         );
         """
 
-    async def _get_seed_metadata_sql(self) -> str:
+    async def _metadata_seed_sql(self) -> str:
         return f"""
         INSERT INTO {self._metadata_table} (key, value)
         VALUES ('schema_version', '1')
         ON CONFLICT (key) DO NOTHING
         """
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._app_state_table}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._user_state_table}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {self._events_table}",
             f"DROP TABLE IF EXISTS {self._session_table}",
         ]
@@ -655,7 +655,7 @@ class PsycopgSyncADKStore(BaseSyncADKStore["PsycopgSyncConfig"]):
         """Set a value in the ADK internal metadata table."""
         self._set_metadata(key, value)
 
-    def _get_create_sessions_table_sql(self) -> str:
+    def _sessions_table_ddl(self) -> str:
         owner_id_line = ""
         if self._owner_id_column_ddl:
             owner_id_line = f",\n            {self._owner_id_column_ddl}"
@@ -681,7 +681,7 @@ class PsycopgSyncADKStore(BaseSyncADKStore["PsycopgSyncConfig"]):
             WHERE state != '{{}}'::jsonb;
         """
 
-    def _get_create_events_table_sql(self) -> str:
+    def _events_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         generated_columns, generated_indexes, covering_columns = _postgres_event_ddl_options(
             adk_config, self._events_table
@@ -702,7 +702,7 @@ class PsycopgSyncADKStore(BaseSyncADKStore["PsycopgSyncConfig"]):
         {generated_indexes}
         """
 
-    def _get_create_app_states_table_sql(self) -> str:
+    def _app_states_table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._app_state_table} (
             app_name VARCHAR(128) PRIMARY KEY,
@@ -711,7 +711,7 @@ class PsycopgSyncADKStore(BaseSyncADKStore["PsycopgSyncConfig"]):
         ) WITH (fillfactor = 80);
         """
 
-    def _get_create_user_states_table_sql(self) -> str:
+    def _user_states_table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._user_state_table} (
             app_name VARCHAR(128) NOT NULL,
@@ -722,7 +722,7 @@ class PsycopgSyncADKStore(BaseSyncADKStore["PsycopgSyncConfig"]):
         ) WITH (fillfactor = 80);
         """
 
-    def _get_create_metadata_table_sql(self) -> str:
+    def _metadata_table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._metadata_table} (
             key VARCHAR(128) PRIMARY KEY,
@@ -730,39 +730,39 @@ class PsycopgSyncADKStore(BaseSyncADKStore["PsycopgSyncConfig"]):
         );
         """
 
-    def _get_seed_metadata_sql(self) -> str:
+    def _metadata_seed_sql(self) -> str:
         return f"""
         INSERT INTO {self._metadata_table} (key, value)
         VALUES ('schema_version', '1')
         ON CONFLICT (key) DO NOTHING
         """
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._app_state_table}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._user_state_table}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {self._events_table}",
             f"DROP TABLE IF EXISTS {self._session_table}",
         ]
 
     def _create_tables(self) -> None:
         with self._config.provide_session() as driver:
-            driver.execute_script(self._get_create_sessions_table_sql())
-            driver.execute_script(self._get_create_events_table_sql())
-            driver.execute_script(self._get_create_app_states_table_sql())
-            driver.execute_script(self._get_create_user_states_table_sql())
-            driver.execute_script(self._get_create_metadata_table_sql())
-            driver.execute_script(self._get_seed_metadata_sql())
+            driver.execute_script(self._sessions_table_ddl())
+            driver.execute_script(self._events_table_ddl())
+            driver.execute_script(self._app_states_table_ddl())
+            driver.execute_script(self._user_states_table_ddl())
+            driver.execute_script(self._metadata_table_ddl())
+            driver.execute_script(self._metadata_seed_sql())
 
     def _create_session(
         self, session_id: str, app_name: str, user_id: str, state: "dict[str, Any]", owner_id: "Any | None" = None
@@ -1164,7 +1164,7 @@ class PsycopgAsyncADKMemoryStore(BaseAsyncADKMemoryStore["PsycopgAsyncConfig"]):
             return
 
         async with self._config.provide_session() as driver:
-            await driver.execute_script(await self._get_create_memory_table_sql())
+            await driver.execute_script(await self._memory_table_ddl())
 
     async def insert_memory_entries(self, entries: "list[MemoryRecord]", owner_id: "object | None" = None) -> int:
         """Bulk insert memory entries with deduplication."""
@@ -1254,7 +1254,7 @@ class PsycopgAsyncADKMemoryStore(BaseAsyncADKMemoryStore["PsycopgAsyncConfig"]):
             await cur.execute(sql)
             return cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
 
-    async def _get_create_memory_table_sql(self) -> str:
+    async def _memory_table_ddl(self) -> str:
         """Get PostgreSQL CREATE TABLE SQL for memory entries."""
         owner_id_line = ""
         if self._owner_id_column_ddl:
@@ -1290,7 +1290,7 @@ class PsycopgAsyncADKMemoryStore(BaseAsyncADKMemoryStore["PsycopgAsyncConfig"]):
         {fts_index}
         """
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         """Get PostgreSQL DROP TABLE SQL statements."""
         return [f"DROP TABLE IF EXISTS {self._memory_table}"]
 
@@ -1366,7 +1366,7 @@ class PsycopgSyncADKMemoryStore(BaseSyncADKMemoryStore["PsycopgSyncConfig"]):
         """Delete memory entries older than specified days."""
         return self._delete_entries_older_than(days)
 
-    def _get_create_memory_table_sql(self) -> str:
+    def _memory_table_ddl(self) -> str:
         """Get PostgreSQL CREATE TABLE SQL for memory entries."""
         owner_id_line = ""
         if self._owner_id_column_ddl:
@@ -1402,7 +1402,7 @@ class PsycopgSyncADKMemoryStore(BaseSyncADKMemoryStore["PsycopgSyncConfig"]):
         {fts_index}
         """
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         """Get PostgreSQL DROP TABLE SQL statements."""
         return [f"DROP TABLE IF EXISTS {self._memory_table}"]
 
@@ -1412,7 +1412,7 @@ class PsycopgSyncADKMemoryStore(BaseSyncADKMemoryStore["PsycopgSyncConfig"]):
             return
 
         with self._config.provide_session() as driver:
-            driver.execute_script(self._get_create_memory_table_sql())
+            driver.execute_script(self._memory_table_ddl())
 
     def _insert_memory_entries(self, entries: "list[MemoryRecord]", owner_id: "object | None" = None) -> int:
         """Bulk insert memory entries with deduplication."""

--- a/sqlspec/adapters/psycopg/events/backend.py
+++ b/sqlspec/adapters/psycopg/events/backend.py
@@ -233,7 +233,7 @@ class PsycopgSyncHybridEventsBackend:
         with self._config.provide_session() as driver:
             driver.execute(
                 SQL(
-                    self._queue._upsert_sql,
+                    self._queue._insert_statement,
                     {
                         "event_id": event_id,
                         "channel": channel,
@@ -322,7 +322,7 @@ class PsycopgAsyncHybridEventsBackend:
         async with self._config.provide_session() as driver:
             await driver.execute(
                 SQL(
-                    self._queue._upsert_sql,
+                    self._queue._insert_statement,
                     {
                         "event_id": event_id,
                         "channel": channel,

--- a/sqlspec/adapters/psycopg/litestar/store.py
+++ b/sqlspec/adapters/psycopg/litestar/store.py
@@ -43,7 +43,7 @@ class PsycopgAsyncStore(BaseSQLSpecStore["PsycopgAsyncConfig"]):
         """
         super().__init__(config)
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get PostgreSQL CREATE TABLE SQL with optimized schema.
 
         Returns:
@@ -67,7 +67,7 @@ class PsycopgAsyncStore(BaseSQLSpecStore["PsycopgAsyncConfig"]):
         );
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         """Get PostgreSQL DROP TABLE SQL statements.
 
         Returns:
@@ -77,7 +77,7 @@ class PsycopgAsyncStore(BaseSQLSpecStore["PsycopgAsyncConfig"]):
 
     async def create_table(self) -> None:
         """Create the session table if it doesn't exist."""
-        sql = self._get_create_table_sql()
+        sql = self._table_ddl()
         async with self._config.provide_session() as driver:
             await driver.execute_script(sql)
             await driver.commit()
@@ -267,7 +267,7 @@ class PsycopgSyncStore(BaseSQLSpecStore["PsycopgSyncConfig"]):
         """
         super().__init__(config)
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get PostgreSQL CREATE TABLE SQL with optimized schema.
 
         Returns:
@@ -291,7 +291,7 @@ class PsycopgSyncStore(BaseSQLSpecStore["PsycopgSyncConfig"]):
         );
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         """Get PostgreSQL DROP TABLE SQL statements.
 
         Returns:
@@ -301,7 +301,7 @@ class PsycopgSyncStore(BaseSQLSpecStore["PsycopgSyncConfig"]):
 
     def _create_table(self) -> None:
         """Synchronous implementation of create_table."""
-        sql = self._get_create_table_sql()
+        sql = self._table_ddl()
         with self._config.provide_session() as driver:
             driver.execute_script(sql)
             driver.commit()

--- a/sqlspec/adapters/pymssql/adk/store.py
+++ b/sqlspec/adapters/pymssql/adk/store.py
@@ -63,12 +63,12 @@ class PymssqlSyncADKStore(BaseSyncADKStore["PymssqlConfig"]):
     def create_tables(self) -> None:
         """Create all ADK session tables if they do not exist."""
         with self._config.provide_session() as driver:
-            driver.execute_script(self._get_create_sessions_table_sql())
-            driver.execute_script(self._get_create_events_table_sql())
-            driver.execute_script(self._get_create_app_states_table_sql())
-            driver.execute_script(self._get_create_user_states_table_sql())
-            driver.execute_script(self._get_create_metadata_table_sql())
-            driver.execute_script(self._get_seed_metadata_sql())
+            driver.execute_script(self._sessions_table_ddl())
+            driver.execute_script(self._events_table_ddl())
+            driver.execute_script(self._app_states_table_ddl())
+            driver.execute_script(self._user_states_table_ddl())
+            driver.execute_script(self._metadata_table_ddl())
+            driver.execute_script(self._metadata_seed_sql())
             driver.commit()
 
     def create_session(
@@ -172,7 +172,7 @@ class PymssqlSyncADKStore(BaseSyncADKStore["PymssqlConfig"]):
 
     def append_event(self, event_record: EventRecord) -> None:
         """Append an event to a session."""
-        self._execute(_get_insert_event_sql(self._events_table), _event_insert_params(event_record), commit=True)
+        self._execute(_insert_event_sql(self._events_table), _event_insert_params(event_record), commit=True)
 
     def append_event_and_update_state(
         self,
@@ -198,11 +198,11 @@ class PymssqlSyncADKStore(BaseSyncADKStore["PymssqlConfig"]):
                 row = cursor.fetchone()
                 if row is None:
                     _raise_session_not_found(session_id)
-                cursor.execute(_get_insert_event_sql(self._events_table), _event_insert_params(event_record))
+                cursor.execute(_insert_event_sql(self._events_table), _event_insert_params(event_record))
                 if app_state is not None:
-                    cursor.execute(self._get_upsert_app_state_sql(), (app_name, to_json(app_state)))
+                    cursor.execute(self._upsert_app_state_sql(), (app_name, to_json(app_state)))
                 if user_state is not None:
-                    cursor.execute(self._get_upsert_user_state_sql(), (app_name, user_id, to_json(user_state)))
+                    cursor.execute(self._upsert_user_state_sql(), (app_name, user_id, to_json(user_state)))
             except Exception:
                 conn.rollback()
                 raise
@@ -220,7 +220,7 @@ class PymssqlSyncADKStore(BaseSyncADKStore["PymssqlConfig"]):
         """Return events for a scoped session ordered by event timestamp."""
         if limit == 0:
             return []
-        sql, params = self._get_events_query(app_name, user_id, session_id, after_timestamp, limit)
+        sql, params = self._events_query(app_name, user_id, session_id, after_timestamp, limit)
         try:
             rows = self._execute_fetchall(sql, params)
         except MSSQL_ERROR as exc:
@@ -282,11 +282,11 @@ class PymssqlSyncADKStore(BaseSyncADKStore["PymssqlConfig"]):
 
     def upsert_app_state(self, app_name: str, state: "dict[str, Any]") -> None:
         """Insert or replace app-scoped state."""
-        self._execute(self._get_upsert_app_state_sql(), (app_name, to_json(state)), commit=True)
+        self._execute(self._upsert_app_state_sql(), (app_name, to_json(state)), commit=True)
 
     def upsert_user_state(self, app_name: str, user_id: str, state: "dict[str, Any]") -> None:
         """Insert or replace user-scoped state."""
-        self._execute(self._get_upsert_user_state_sql(), (app_name, user_id, to_json(state)), commit=True)
+        self._execute(self._upsert_user_state_sql(), (app_name, user_id, to_json(state)), commit=True)
 
     def get_metadata(self, key: str) -> "str | None":
         """Return an ADK metadata value."""
@@ -302,59 +302,57 @@ class PymssqlSyncADKStore(BaseSyncADKStore["PymssqlConfig"]):
 
     def set_metadata(self, key: str, value: str) -> None:
         """Set an ADK metadata value."""
-        self._execute(_get_upsert_metadata_sql(self._metadata_table), (key, value), commit=True)
+        self._execute(_upsert_metadata_sql(self._metadata_table), (key, value), commit=True)
 
-    def _get_create_sessions_table_sql(self) -> str:
+    def _sessions_table_ddl(self) -> str:
         """Return T-SQL DDL for the ADK session table."""
-        return _get_create_sessions_table_sql(
-            self._session_table, self._json_column_type_sync(), self._owner_id_column_ddl
-        )
+        return _sessions_table_ddl(self._session_table, self._json_column_type_sync(), self._owner_id_column_ddl)
 
-    def _get_create_events_table_sql(self) -> str:
+    def _events_table_ddl(self) -> str:
         """Return T-SQL DDL for the ADK event table."""
-        return _get_create_events_table_sql(self._events_table, self._session_table, self._json_column_type_sync())
+        return _events_table_ddl(self._events_table, self._session_table, self._json_column_type_sync())
 
-    def _get_create_app_states_table_sql(self) -> str:
+    def _app_states_table_ddl(self) -> str:
         """Return T-SQL DDL for the app-scoped state table."""
-        return _get_create_app_states_table_sql(self._app_state_table, self._json_column_type_sync())
+        return _app_states_table_ddl(self._app_state_table, self._json_column_type_sync())
 
-    def _get_create_user_states_table_sql(self) -> str:
+    def _user_states_table_ddl(self) -> str:
         """Return T-SQL DDL for the user-scoped state table."""
-        return _get_create_user_states_table_sql(self._user_state_table, self._json_column_type_sync())
+        return _user_states_table_ddl(self._user_state_table, self._json_column_type_sync())
 
-    def _get_create_metadata_table_sql(self) -> str:
+    def _metadata_table_ddl(self) -> str:
         """Return T-SQL DDL for the ADK metadata table."""
-        return _get_create_metadata_table_sql(self._metadata_table)
+        return _metadata_table_ddl(self._metadata_table)
 
-    def _get_seed_metadata_sql(self) -> str:
+    def _metadata_seed_sql(self) -> str:
         """Return T-SQL to seed schema-version metadata."""
-        return _get_seed_metadata_sql(self._metadata_table)
+        return _metadata_seed_sql(self._metadata_table)
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {_table_ref(self._app_state_table)}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {_table_ref(self._user_state_table)}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {_table_ref(self._metadata_table)}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {_table_ref(self._events_table)}",
             f"DROP TABLE IF EXISTS {_table_ref(self._session_table)}",
         ]
 
-    def _get_upsert_app_state_sql(self) -> str:
-        return _get_upsert_state_sql(self._app_state_table, ("app_name",), ("%s",))
+    def _upsert_app_state_sql(self) -> str:
+        return _upsert_state_sql(self._app_state_table, ("app_name",), ("%s",))
 
-    def _get_upsert_user_state_sql(self) -> str:
-        return _get_upsert_state_sql(self._user_state_table, ("app_name", "user_id"), ("%s", "%s"))
+    def _upsert_user_state_sql(self) -> str:
+        return _upsert_state_sql(self._user_state_table, ("app_name", "user_id"), ("%s", "%s"))
 
-    def _get_events_query(
+    def _events_query(
         self,
         app_name: str,
         user_id: str,
@@ -362,7 +360,7 @@ class PymssqlSyncADKStore(BaseSyncADKStore["PymssqlConfig"]):
         after_timestamp: "datetime | None" = None,
         limit: "int | None" = None,
     ) -> "tuple[str, tuple[Any, ...]]":
-        return _get_events_query(self._events_table, app_name, user_id, session_id, after_timestamp, limit)
+        return _events_query(self._events_table, app_name, user_id, session_id, after_timestamp, limit)
 
     def _json_column_type_sync(self) -> str:
         if self._json_column_type is not None:
@@ -409,7 +407,7 @@ class PymssqlADKMemoryStore(BaseSyncADKMemoryStore["PymssqlConfig"]):
         """Create memory tables if they don't exist."""
         if not self._enabled:
             return
-        statements = self._get_create_memory_table_sql()
+        statements = self._memory_table_ddl()
         if isinstance(statements, str):
             statements = [statements]
         with self._config.provide_session() as driver:
@@ -493,7 +491,7 @@ class PymssqlADKMemoryStore(BaseSyncADKMemoryStore["PymssqlConfig"]):
             commit=True,
         )
 
-    def _get_create_memory_table_sql(self) -> "str | list[str]":
+    def _memory_table_ddl(self) -> "str | list[str]":
         owner_line = f",\n            {self._owner_id_column_ddl}" if self._owner_id_column_ddl else ""
         return [
             f"""
@@ -518,12 +516,12 @@ BEGIN
     );
 END;
 """,
-            _get_create_index_sql(self._memory_table, f"idx_{self._memory_table}_scope", "app_name, user_id"),
-            _get_create_index_sql(self._memory_table, f"idx_{self._memory_table}_session", "session_id"),
-            _get_create_index_sql(self._memory_table, f"idx_{self._memory_table}_timestamp", "timestamp DESC"),
+            _create_index_sql(self._memory_table, f"idx_{self._memory_table}_scope", "app_name, user_id"),
+            _create_index_sql(self._memory_table, f"idx_{self._memory_table}_session", "session_id"),
+            _create_index_sql(self._memory_table, f"idx_{self._memory_table}_timestamp", "timestamp DESC"),
         ]
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         return [f"DROP TABLE IF EXISTS {_table_ref(self._memory_table)}"]
 
     def _execute_fetchall(self, sql: str, params: "tuple[Any, ...]" = ()) -> "list[Any]":
@@ -563,7 +561,7 @@ def _json_column_type_from_sync_driver(driver: "PymssqlDriver") -> str:
     return JSON_FALLBACK_COLUMN_TYPE
 
 
-def _get_create_sessions_table_sql(table: str, json_column_type: str, owner_id_column_ddl: "str | None") -> str:
+def _sessions_table_ddl(table: str, json_column_type: str, owner_id_column_ddl: "str | None") -> str:
     owner_line = f",\n        {owner_id_column_ddl}" if owner_id_column_ddl else ""
     return f"""
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = N'{_escape_sql_literal(table)}' AND schema_id = SCHEMA_ID(N'dbo'))
@@ -580,12 +578,12 @@ BEGIN
         CONSTRAINT {_constraint_ref("uq", table, "id")} UNIQUE (id)
     );
 END;
-{_get_create_index_sql(table, f"idx_{table}_app_user", "app_name, user_id")}
-{_get_create_index_sql(table, f"idx_{table}_update_time", "update_time DESC")}
+{_create_index_sql(table, f"idx_{table}_app_user", "app_name, user_id")}
+{_create_index_sql(table, f"idx_{table}_update_time", "update_time DESC")}
 """
 
 
-def _get_create_events_table_sql(table: str, session_table: str, json_column_type: str) -> str:
+def _events_table_ddl(table: str, session_table: str, json_column_type: str) -> str:
     return f"""
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = N'{_escape_sql_literal(table)}' AND schema_id = SCHEMA_ID(N'dbo'))
 BEGIN
@@ -604,14 +602,14 @@ BEGIN
             REFERENCES {_table_ref(session_table)}(id) ON DELETE CASCADE
     );
 END;
-{_get_create_index_sql(table, f"idx_{table}_scope", "app_name, user_id, session_id, timestamp ASC")}
-{_get_create_index_sql(table, f"idx_{table}_session", "session_id, timestamp ASC")}
-{_get_create_index_sql(table, f"idx_{table}_invocation", "invocation_id")}
-{_get_create_index_sql(table, f"idx_{table}_timestamp", "timestamp ASC")}
+{_create_index_sql(table, f"idx_{table}_scope", "app_name, user_id, session_id, timestamp ASC")}
+{_create_index_sql(table, f"idx_{table}_session", "session_id, timestamp ASC")}
+{_create_index_sql(table, f"idx_{table}_invocation", "invocation_id")}
+{_create_index_sql(table, f"idx_{table}_timestamp", "timestamp ASC")}
 """
 
 
-def _get_create_app_states_table_sql(table: str, json_column_type: str) -> str:
+def _app_states_table_ddl(table: str, json_column_type: str) -> str:
     return f"""
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = N'{_escape_sql_literal(table)}' AND schema_id = SCHEMA_ID(N'dbo'))
 BEGIN
@@ -625,7 +623,7 @@ END;
 """
 
 
-def _get_create_user_states_table_sql(table: str, json_column_type: str) -> str:
+def _user_states_table_ddl(table: str, json_column_type: str) -> str:
     return f"""
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = N'{_escape_sql_literal(table)}' AND schema_id = SCHEMA_ID(N'dbo'))
 BEGIN
@@ -640,7 +638,7 @@ END;
 """
 
 
-def _get_create_metadata_table_sql(table: str) -> str:
+def _metadata_table_ddl(table: str) -> str:
     return f"""
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = N'{_escape_sql_literal(table)}' AND schema_id = SCHEMA_ID(N'dbo'))
 BEGIN
@@ -653,7 +651,7 @@ END;
 """
 
 
-def _get_create_index_sql(table: str, index_name: str, columns: str) -> str:
+def _create_index_sql(table: str, index_name: str, columns: str) -> str:
     return f"""
 IF NOT EXISTS (
     SELECT 1 FROM sys.indexes
@@ -666,7 +664,7 @@ END;
 """
 
 
-def _get_insert_event_sql(table: str) -> str:
+def _insert_event_sql(table: str) -> str:
     return f"""
     INSERT INTO {_table_ref(table)} (
         id, app_name, user_id, session_id, invocation_id, timestamp, event_data
@@ -675,7 +673,7 @@ def _get_insert_event_sql(table: str) -> str:
     """
 
 
-def _get_upsert_state_sql(table: str, key_columns: "tuple[str, ...]", key_params: "tuple[str, ...]") -> str:
+def _upsert_state_sql(table: str, key_columns: "tuple[str, ...]", key_params: "tuple[str, ...]") -> str:
     source_columns = ", ".join(
         f"{param} AS {_quote_identifier(column)}" for column, param in zip(key_columns, key_params, strict=False)
     )
@@ -697,7 +695,7 @@ def _get_upsert_state_sql(table: str, key_columns: "tuple[str, ...]", key_params
     """
 
 
-def _get_upsert_metadata_sql(table: str) -> str:
+def _upsert_metadata_sql(table: str) -> str:
     return f"""
     MERGE INTO {_table_ref(table)} WITH (HOLDLOCK) AS target
     USING (SELECT %s AS [key], %s AS value) AS source
@@ -710,7 +708,7 @@ def _get_upsert_metadata_sql(table: str) -> str:
     """
 
 
-def _get_seed_metadata_sql(table: str) -> str:
+def _metadata_seed_sql(table: str) -> str:
     return f"""
     MERGE INTO {_table_ref(table)} WITH (HOLDLOCK) AS target
     USING (SELECT N'schema_version' AS [key], N'1' AS value) AS source
@@ -723,7 +721,7 @@ def _get_seed_metadata_sql(table: str) -> str:
     """
 
 
-def _get_events_query(
+def _events_query(
     table: str, app_name: str, user_id: str, session_id: str, after_timestamp: "datetime | None", limit: "int | None"
 ) -> "tuple[str, tuple[Any, ...]]":
     top_clause = "TOP (%s) " if limit is not None else ""

--- a/sqlspec/adapters/pymssql/litestar/store.py
+++ b/sqlspec/adapters/pymssql/litestar/store.py
@@ -20,7 +20,7 @@ class PymssqlStore(BaseSQLSpecStore["PymssqlConfig"]):
     def __init__(self, config: "PymssqlConfig") -> None:
         super().__init__(config)
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get SQL Server CREATE TABLE SQL with idempotent guards."""
         return f"""
         IF NOT EXISTS (
@@ -44,13 +44,13 @@ class PymssqlStore(BaseSQLSpecStore["PymssqlConfig"]):
         END;
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         """Get SQL Server DROP TABLE statements."""
         return [f"IF OBJECT_ID(N'dbo.{self._table_name}', N'U') IS NOT NULL DROP TABLE dbo.{self._table_name};"]
 
     def _create_table(self) -> None:
         with self._config.provide_session() as driver:
-            driver.execute_script(self._get_create_table_sql())
+            driver.execute_script(self._table_ddl())
             driver.commit()
         self._log_table_created()
 

--- a/sqlspec/adapters/pymssql/migrations.py
+++ b/sqlspec/adapters/pymssql/migrations.py
@@ -28,7 +28,7 @@ class PymssqlMigrationTrackerMixin:
 
     version_table: str
 
-    def _get_create_table_sql(self) -> CreateTable:
+    def _tracking_table_ddl(self) -> CreateTable:
         """Return T-SQL-compatible migration tracking table DDL."""
         return (
             sql
@@ -44,10 +44,10 @@ class PymssqlMigrationTrackerMixin:
             .column("replaces", "NVARCHAR(MAX)")
         )
 
-    def _get_idempotent_create_table_sql_text(self) -> str:
+    def _idempotent_tracking_table_ddl_text(self) -> str:
         """Wrap CREATE TABLE in a T-SQL sys.tables existence probe."""
         schema_name, table_name = _split_schema_table(self.version_table)
-        create_sql = self._get_create_table_sql_text().rstrip().rstrip(";")
+        create_sql = self._tracking_table_ddl_text().rstrip().rstrip(";")
         return (
             "IF NOT EXISTS (SELECT 1 FROM sys.tables "
             f"WHERE name = '{_escape_sql_literal(table_name)}' "
@@ -55,10 +55,10 @@ class PymssqlMigrationTrackerMixin:
             f"BEGIN {create_sql}; END;"
         )
 
-    def _get_create_table_sql_text(self) -> str:
+    def _tracking_table_ddl_text(self) -> str:
         """Render CREATE TABLE text without routing SQL Server types through sqlglot."""
         column_lines: list[str] = []
-        for column_def in self._get_create_table_sql().columns:
+        for column_def in self._tracking_table_ddl().columns:
             default_clause = f" DEFAULT {column_def.default}" if column_def.default else ""
             not_null_clause = " NOT NULL" if column_def.not_null else ""
             primary_key_clause = " PRIMARY KEY" if column_def.primary_key else ""
@@ -67,7 +67,7 @@ class PymssqlMigrationTrackerMixin:
             )
         return f"CREATE TABLE {self.version_table} (\n" + ",\n".join(column_lines) + "\n)"
 
-    def _get_existing_columns_sql(self) -> str:
+    def _existing_columns_query(self) -> str:
         """Return T-SQL query text for migration tracking table columns."""
         schema_name, table_name = _split_schema_table(self.version_table)
         return f"""
@@ -78,9 +78,9 @@ class PymssqlMigrationTrackerMixin:
               AND t.schema_id = SCHEMA_ID('{_escape_sql_literal(schema_name)}')
         """
 
-    def _get_add_column_sql_text(self, column_name: str) -> str | None:
+    def _add_column_statement_text(self, column_name: str) -> str | None:
         """Return T-SQL ALTER TABLE text for a missing migration column."""
-        target_create = self._get_create_table_sql()
+        target_create = self._tracking_table_ddl()
         column_def = next((col for col in target_create.columns if col.name.lower() == column_name), None)
         if column_def is None:
             return None
@@ -94,7 +94,7 @@ class PymssqlSyncMigrationTracker(PymssqlMigrationTrackerMixin, SyncMigrationTra
 
     def ensure_tracking_table(self, driver: "SyncDriverAdapterBase") -> None:
         """Create the migration tracking table if it does not exist."""
-        driver.execute_script(self._get_idempotent_create_table_sql_text())
+        driver.execute_script(self._idempotent_tracking_table_ddl_text())
         driver.commit()
         self._migrate_schema_if_needed(driver)
 
@@ -104,10 +104,10 @@ class PymssqlSyncMigrationTracker(PymssqlMigrationTrackerMixin, SyncMigrationTra
         """Record a successfully applied migration with T-SQL-compatible metadata."""
         parsed_version = parse_version(version)
         version_type = parsed_version.type.value
-        result = driver.execute(self._get_next_execution_sequence_sql())
+        result = driver.execute(self._next_execution_sequence_query())
         next_sequence = result.get_data()[0]["next_seq"] if result.data else 1
         driver.execute(
-            self._get_record_migration_sql(
+            self._record_migration_statement(
                 version,
                 version_type,
                 next_sequence,
@@ -122,7 +122,7 @@ class PymssqlSyncMigrationTracker(PymssqlMigrationTrackerMixin, SyncMigrationTra
     def _migrate_schema_if_needed(self, driver: "SyncDriverAdapterBase") -> None:
         """Check and add missing tracking table columns through SQL Server catalog views."""
         try:
-            rows = driver.select(self._get_existing_columns_sql())
+            rows = driver.select(self._existing_columns_query())
             existing_columns = {str(row["column_name"]).lower() for row in rows if row.get("column_name") is not None}
             missing_columns = self._detect_missing_columns(existing_columns)
             if not missing_columns:
@@ -146,7 +146,7 @@ class PymssqlSyncMigrationTracker(PymssqlMigrationTrackerMixin, SyncMigrationTra
 
     def _add_column(self, driver: "SyncDriverAdapterBase", column_name: str) -> None:
         """Add a single missing migration tracking column."""
-        add_column_sql = self._get_add_column_sql_text(column_name)
+        add_column_sql = self._add_column_statement_text(column_name)
         if add_column_sql is None:
             return
         driver.execute_script(add_column_sql)

--- a/sqlspec/adapters/pymysql/adk/store.py
+++ b/sqlspec/adapters/pymysql/adk/store.py
@@ -151,54 +151,54 @@ class PyMysqlADKStore(BaseSyncADKStore["PyMysqlConfig"]):
         """Set a value in the ADK internal metadata table."""
         _set_metadata(self, key, value)
 
-    def _get_create_sessions_table_sql(self) -> str:
+    def _sessions_table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL for sessions."""
         adk_config = _adk_config(self._config)
         table_options = _mysql_table_options(adk_config, "session_table_options")
         return _mysql_sessions_ddl(self._session_table, self._owner_id_column_ddl, table_options)
 
-    def _get_create_events_table_sql(self) -> str:
+    def _events_table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL for events."""
         return _mysql_events_ddl(self._events_table, self._session_table, _adk_config(self._config))
 
-    def _get_create_app_states_table_sql(self) -> str:
+    def _app_states_table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL for app-scoped state."""
         adk_config = _adk_config(self._config)
         table_options = _mysql_table_options(adk_config, "app_state_table_options")
         return _mysql_app_state_ddl(self._app_state_table, table_options)
 
-    def _get_create_user_states_table_sql(self) -> str:
+    def _user_states_table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL for user-scoped state."""
         adk_config = _adk_config(self._config)
         table_options = _mysql_table_options(adk_config, "user_state_table_options")
         return _mysql_user_state_ddl(self._user_state_table, table_options)
 
-    def _get_create_metadata_table_sql(self) -> str:
+    def _metadata_table_ddl(self) -> str:
         """Get MySQL CREATE TABLE SQL for ADK metadata."""
         return _mysql_metadata_ddl(self._metadata_table)
 
-    def _get_seed_metadata_sql(self) -> str:
+    def _metadata_seed_sql(self) -> str:
         """Get MySQL metadata seed SQL."""
         return f"INSERT IGNORE INTO {self._metadata_table} (`key`, value) VALUES ('schema_version', '1')"
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         """Get MySQL DROP TABLE SQL for app-scoped state."""
         return f"DROP TABLE IF EXISTS {self._app_state_table}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         """Get MySQL DROP TABLE SQL for user-scoped state."""
         return f"DROP TABLE IF EXISTS {self._user_state_table}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         """Get MySQL DROP TABLE SQL for ADK metadata."""
         return f"DROP TABLE IF EXISTS {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         """Get MySQL DROP TABLE SQL statements."""
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {self._events_table}",
             f"DROP TABLE IF EXISTS {self._session_table}",
         ]
@@ -234,7 +234,7 @@ class PyMysqlADKMemoryStore(BaseSyncADKMemoryStore["PyMysqlConfig"]):
         """Delete memory entries older than specified days."""
         return self._delete_entries_older_than(days)
 
-    def _get_create_memory_table_sql(self) -> str:
+    def _memory_table_ddl(self) -> str:
         adk_config = _adk_config(self._config)
         owner_id_line = ""
         fk_constraint = ""
@@ -267,7 +267,7 @@ class PyMysqlADKMemoryStore(BaseSyncADKMemoryStore["PyMysqlConfig"]):
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci{table_options}
         """
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         return [f"DROP TABLE IF EXISTS {self._memory_table}"]
 
     def _create_tables(self) -> None:
@@ -275,7 +275,7 @@ class PyMysqlADKMemoryStore(BaseSyncADKMemoryStore["PyMysqlConfig"]):
             return
 
         with self._config.provide_session() as driver:
-            driver.execute_script(self._get_create_memory_table_sql())
+            driver.execute_script(self._memory_table_ddl())
 
     def _insert_memory_entries(self, entries: "list[MemoryRecord]", owner_id: "object | None" = None) -> int:
         if not self._enabled:
@@ -419,12 +419,12 @@ class PyMysqlADKMemoryStore(BaseSyncADKMemoryStore["PyMysqlConfig"]):
 
 def _create_tables(store: PyMysqlADKStore) -> None:
     with store._config.provide_session() as driver:
-        driver.execute_script(store._get_create_sessions_table_sql())
-        driver.execute_script(store._get_create_events_table_sql())
-        driver.execute_script(store._get_create_app_states_table_sql())
-        driver.execute_script(store._get_create_user_states_table_sql())
-        driver.execute_script(store._get_create_metadata_table_sql())
-        driver.execute_script(store._get_seed_metadata_sql())
+        driver.execute_script(store._sessions_table_ddl())
+        driver.execute_script(store._events_table_ddl())
+        driver.execute_script(store._app_states_table_ddl())
+        driver.execute_script(store._user_states_table_ddl())
+        driver.execute_script(store._metadata_table_ddl())
+        driver.execute_script(store._metadata_seed_sql())
 
 
 def _create_session(

--- a/sqlspec/adapters/pymysql/events/store.py
+++ b/sqlspec/adapters/pymysql/events/store.py
@@ -21,7 +21,7 @@ class PyMysqlEventQueueStore(BaseEventQueueStore[PyMysqlConfig]):
     def _timestamp_default(self) -> str:
         return "CURRENT_TIMESTAMP(6)"
 
-    def _build_index_sql(self) -> str | None:
+    def _index_ddl(self) -> str | None:
         table_name = self.table_name
         segments = table_name.split(".", 1)
 

--- a/sqlspec/adapters/pymysql/litestar/store.py
+++ b/sqlspec/adapters/pymysql/litestar/store.py
@@ -26,7 +26,7 @@ class PyMysqlStore(BaseSQLSpecStore["PyMysqlConfig"]):
     def __init__(self, config: "PyMysqlConfig") -> None:
         super().__init__(config)
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         return f"""
         CREATE TABLE IF NOT EXISTS {self._table_name} (
             session_id VARCHAR(255) PRIMARY KEY,
@@ -38,14 +38,14 @@ class PyMysqlStore(BaseSQLSpecStore["PyMysqlConfig"]):
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         return [
             f"DROP INDEX idx_{self._table_name}_expires_at ON {self._table_name}",
             f"DROP TABLE IF EXISTS {self._table_name}",
         ]
 
     def _create_table(self) -> None:
-        sql = self._get_create_table_sql()
+        sql = self._table_ddl()
         with self._config.provide_session() as driver:
             driver.execute_script(sql)
             driver.commit()

--- a/sqlspec/adapters/spanner/adk/store.py
+++ b/sqlspec/adapters/spanner/adk/store.py
@@ -190,8 +190,8 @@ class SpannerSyncADKStore(BaseSyncADKStore[SpannerSyncConfig]):
     def _database(self) -> "Database":
         return self._config.get_database()
 
-    def _get_reset_drop_tables_sql(self) -> "list[str]":
-        return _filter_existing_spanner_drops(super()._get_reset_drop_tables_sql(), self._existing_tables())
+    def _reset_drop_tables_sql(self) -> "list[str]":
+        return _filter_existing_spanner_drops(super()._reset_drop_tables_sql(), self._existing_tables())
 
     def _existing_tables(self) -> "set[str]":
         database = self._database()
@@ -648,23 +648,23 @@ class SpannerSyncADKStore(BaseSyncADKStore[SpannerSyncConfig]):
 
         ddl_statements: list[str] = []
         if self._session_table not in existing_tables:
-            ddl_statements.append(self._get_create_sessions_table_sql())
+            ddl_statements.append(self._sessions_table_ddl())
         if self._events_table not in existing_tables:
-            ddl_statements.append(self._get_create_events_table_sql())
+            ddl_statements.append(self._events_table_ddl())
         if self._app_state_table not in existing_tables:
-            ddl_statements.append(self._get_create_app_states_table_sql())
+            ddl_statements.append(self._app_states_table_ddl())
         if self._user_state_table not in existing_tables:
-            ddl_statements.append(self._get_create_user_states_table_sql())
+            ddl_statements.append(self._user_states_table_ddl())
         if self._metadata_table not in existing_tables:
-            ddl_statements.append(self._get_create_metadata_table_sql())
-        ddl_statements.extend(self._get_create_expiration_index_sql())
+            ddl_statements.append(self._metadata_table_ddl())
+        ddl_statements.extend(self._expiration_index_ddl())
 
         if ddl_statements:
             database.update_ddl(ddl_statements).result(300)  # type: ignore[no-untyped-call]
             if self._metadata_table not in existing_tables:
-                self._run_write([(self._get_seed_metadata_sql(), {}, {})])
+                self._run_write([(self._metadata_seed_sql(), {}, {})])
 
-    def _get_create_sessions_table_sql(self) -> str:
+    def _sessions_table_ddl(self) -> str:
         owner_line = ""
         if self._owner_id_column_ddl:
             owner_line = f",\n  {self._owner_id_column_ddl}"
@@ -687,7 +687,7 @@ CREATE TABLE {self._session_table} (
 ) {pk}{options}{self._session_row_deletion_policy}
 """
 
-    def _get_create_events_table_sql(self) -> str:
+    def _events_table_ddl(self) -> str:
         shard_column = ""
         pk = "PRIMARY KEY (session_id, timestamp)"
         if self._shard_count > 1:
@@ -706,7 +706,7 @@ CREATE TABLE {self._events_table} (
 ) {pk}{options}{self._events_row_deletion_policy}
 """
 
-    def _get_create_app_states_table_sql(self) -> str:
+    def _app_states_table_ddl(self) -> str:
         return f"""
 CREATE TABLE {self._app_state_table} (
   app_name STRING(128) NOT NULL,
@@ -715,7 +715,7 @@ CREATE TABLE {self._app_state_table} (
 ) PRIMARY KEY (app_name)
 """
 
-    def _get_create_user_states_table_sql(self) -> str:
+    def _user_states_table_ddl(self) -> str:
         return f"""
 CREATE TABLE {self._user_state_table} (
   app_name STRING(128) NOT NULL,
@@ -725,7 +725,7 @@ CREATE TABLE {self._user_state_table} (
 ) PRIMARY KEY (app_name, user_id)
 """
 
-    def _get_create_metadata_table_sql(self) -> str:
+    def _metadata_table_ddl(self) -> str:
         return f"""
 CREATE TABLE {self._metadata_table} (
   key STRING(128) NOT NULL,
@@ -733,13 +733,13 @@ CREATE TABLE {self._metadata_table} (
 ) PRIMARY KEY (key)
 """
 
-    def _get_seed_metadata_sql(self) -> str:
+    def _metadata_seed_sql(self) -> str:
         return f"""
 INSERT INTO {self._metadata_table} (key, value)
 VALUES ('schema_version', '1')
 """
 
-    def _get_create_expiration_index_sql(self) -> "list[str]":
+    def _expiration_index_ddl(self) -> "list[str]":
         options = f" OPTIONS ({self._expires_index_options})" if self._expires_index_options else ""
         return [
             f"CREATE INDEX IF NOT EXISTS idx_{self._session_table}_update_time "
@@ -748,22 +748,22 @@ VALUES ('schema_version', '1')
             f"ON {self._events_table}(timestamp){options}",
         ]
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return f"DROP TABLE {self._app_state_table}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return f"DROP TABLE {self._user_state_table}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"DROP TABLE {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         return [
             f"DROP INDEX idx_{self._events_table}_timestamp",
             f"DROP INDEX idx_{self._session_table}_update_time",
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE {self._events_table}",
             f"DROP TABLE {self._session_table}",
         ]
@@ -807,8 +807,8 @@ class SpannerSyncADKMemoryStore(BaseSyncADKMemoryStore[SpannerSyncConfig]):
     def _database(self) -> "Database":
         return self._config.get_database()
 
-    def _get_reset_drop_memory_table_sql(self) -> "list[str]":
-        return _filter_existing_spanner_drops(super()._get_reset_drop_memory_table_sql(), self._existing_tables())
+    def _reset_drop_memory_table_sql(self) -> "list[str]":
+        return _filter_existing_spanner_drops(super()._reset_drop_memory_table_sql(), self._existing_tables())
 
     def _existing_tables(self) -> "set[str]":
         database = self._database()
@@ -862,12 +862,12 @@ class SpannerSyncADKMemoryStore(BaseSyncADKMemoryStore[SpannerSyncConfig]):
 
         ddl_statements: list[str] = []
         if self._memory_table not in existing_tables:
-            ddl_statements.extend(self._get_create_memory_table_sql())
+            ddl_statements.extend(self._memory_table_ddl())
 
         if ddl_statements:
             database.update_ddl(ddl_statements).result(300)  # type: ignore[no-untyped-call]
 
-    def _get_create_memory_table_sql(self) -> "list[str]":
+    def _memory_table_ddl(self) -> "list[str]":
         owner_line = ""
         if self._owner_id_column_ddl:
             owner_line = f",\n  {self._owner_id_column_ddl}"
@@ -914,7 +914,7 @@ CREATE TABLE {self._memory_table} (
             statements.append(fts_index)
         return statements
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         """Get SQL to drop the memory table and its indexes.
 
         Returns:

--- a/sqlspec/adapters/spanner/events/store.py
+++ b/sqlspec/adapters/spanner/events/store.py
@@ -48,7 +48,7 @@ class SpannerSyncEventQueueStore(BaseEventQueueStore["SpannerSyncConfig"]):
         """Return Spanner inline PRIMARY KEY clause."""
         return " PRIMARY KEY (event_id)"
 
-    def _build_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Build Spanner CREATE TABLE with PRIMARY KEY inline.
 
         Spanner does not support DEFAULT clauses on non-computed columns,
@@ -76,7 +76,7 @@ class SpannerSyncEventQueueStore(BaseEventQueueStore["SpannerSyncConfig"]):
             f"){pk_inline}"
         )
 
-    def _build_index_sql(self) -> str | None:
+    def _index_ddl(self) -> str | None:
         """Build Spanner secondary index for queue operations."""
         index_name = self._index_name()
         return f"CREATE INDEX {index_name} ON {self.table_name}(channel, status, available_at)"
@@ -104,8 +104,8 @@ class SpannerSyncEventQueueStore(BaseEventQueueStore["SpannerSyncConfig"]):
         Spanner requires DDL statements to be executed individually.
         The caller should handle errors for already-existing objects.
         """
-        statements = [self._build_create_table_sql()]
-        index_sql = self._build_index_sql()
+        statements = [self._table_ddl()]
+        index_sql = self._index_ddl()
         if index_sql:
             statements.append(index_sql)
         return statements

--- a/sqlspec/adapters/spanner/litestar/store.py
+++ b/sqlspec/adapters/spanner/litestar/store.py
@@ -256,10 +256,10 @@ class SpannerSyncStore(BaseSQLSpecStore["SpannerSyncConfig"]):
         existing_tables = {t.table_id for t in database.list_tables()}  # type: ignore[no-untyped-call]
 
         if self._table_name not in existing_tables:
-            ddl_statements = [self._get_create_table_sql(), self._get_create_index_sql()]
+            ddl_statements = [self._table_ddl(), self._index_ddl()]
             database.update_ddl(ddl_statements).result(300)  # type: ignore[no-untyped-call]
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         shard_column = ""
         pk = "PRIMARY KEY (session_id)"
         if self._shard_count > 1:
@@ -278,7 +278,7 @@ CREATE TABLE {self._table_name} (
 ) {pk}{options}
 """
 
-    def _get_create_index_sql(self) -> str:
+    def _index_ddl(self) -> str:
         leading = "expires_at"
         if self._shard_count > 1:
             leading = "shard_id, expires_at"
@@ -287,5 +287,5 @@ CREATE TABLE {self._table_name} (
             opts = f" OPTIONS ({self._index_options})"
         return f"CREATE INDEX idx_{self._table_name}_expires_at ON {self._table_name}({leading}){opts}"
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         return [f"DROP INDEX idx_{self._table_name}_expires_at", f"DROP TABLE {self._table_name}"]

--- a/sqlspec/adapters/sqlite/adk/store.py
+++ b/sqlspec/adapters/sqlite/adk/store.py
@@ -314,12 +314,12 @@ class SqliteADKStore(BaseSyncADKStore["SqliteConfig"]):
         """Synchronous implementation of create_tables."""
         with self._config.provide_session() as driver:
             self._apply_pragmas(driver.connection)
-            driver.execute_script(self._get_create_sessions_table_sql())
-            driver.execute_script(self._get_create_events_table_sql())
-            driver.execute_script(self._get_create_app_states_table_sql())
-            driver.execute_script(self._get_create_user_states_table_sql())
-            driver.execute_script(self._get_create_metadata_table_sql())
-            driver.execute_script(self._get_seed_metadata_sql())
+            driver.execute_script(self._sessions_table_ddl())
+            driver.execute_script(self._events_table_ddl())
+            driver.execute_script(self._app_states_table_ddl())
+            driver.execute_script(self._user_states_table_ddl())
+            driver.execute_script(self._metadata_table_ddl())
+            driver.execute_script(self._metadata_seed_sql())
 
     def _create_session(
         self, session_id: str, app_name: str, user_id: str, state: "dict[str, Any]", owner_id: "Any | None" = None
@@ -761,7 +761,7 @@ class SqliteADKStore(BaseSyncADKStore["SqliteConfig"]):
             conn.execute(sql, (key, value))
             conn.commit()
 
-    def _get_create_sessions_table_sql(self) -> str:
+    def _sessions_table_ddl(self) -> str:
         """Get SQLite CREATE TABLE SQL for sessions.
 
         Returns:
@@ -786,7 +786,7 @@ class SqliteADKStore(BaseSyncADKStore["SqliteConfig"]):
             ON {self._session_table}(update_time DESC);
         """
 
-    def _get_create_events_table_sql(self) -> str:
+    def _events_table_ddl(self) -> str:
         """Get SQLite CREATE TABLE SQL for events."""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._events_table} (
@@ -807,7 +807,7 @@ class SqliteADKStore(BaseSyncADKStore["SqliteConfig"]):
             ON {self._events_table}(timestamp ASC);
         """
 
-    def _get_create_app_states_table_sql(self) -> str:
+    def _app_states_table_ddl(self) -> str:
         """Get SQLite CREATE TABLE SQL for app-scoped state."""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._app_state_table} (
@@ -817,7 +817,7 @@ class SqliteADKStore(BaseSyncADKStore["SqliteConfig"]):
         );
         """
 
-    def _get_create_user_states_table_sql(self) -> str:
+    def _user_states_table_ddl(self) -> str:
         """Get SQLite CREATE TABLE SQL for user-scoped state."""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._user_state_table} (
@@ -829,7 +829,7 @@ class SqliteADKStore(BaseSyncADKStore["SqliteConfig"]):
         );
         """
 
-    def _get_create_metadata_table_sql(self) -> str:
+    def _metadata_table_ddl(self) -> str:
         """Get SQLite CREATE TABLE SQL for ADK internal metadata."""
         return f"""
         CREATE TABLE IF NOT EXISTS {self._metadata_table} (
@@ -838,7 +838,7 @@ class SqliteADKStore(BaseSyncADKStore["SqliteConfig"]):
         );
         """
 
-    def _get_seed_metadata_sql(self) -> str:
+    def _metadata_seed_sql(self) -> str:
         """Get SQLite SQL to seed the ADK schema-version metadata row."""
         return f"""
         INSERT INTO {self._metadata_table} (key, value)
@@ -846,24 +846,24 @@ class SqliteADKStore(BaseSyncADKStore["SqliteConfig"]):
         ON CONFLICT(key) DO NOTHING;
         """
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         """Get SQLite DROP TABLE SQL for app-scoped state."""
         return f"DROP TABLE IF EXISTS {self._app_state_table}"
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         """Get SQLite DROP TABLE SQL for user-scoped state."""
         return f"DROP TABLE IF EXISTS {self._user_state_table}"
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         """Get SQLite DROP TABLE SQL for ADK internal metadata."""
         return f"DROP TABLE IF EXISTS {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         """Get SQLite DROP TABLE SQL statements."""
         return [
-            self._get_drop_metadata_table_sql(),
-            self._get_drop_user_states_table_sql(),
-            self._get_drop_app_states_table_sql(),
+            self._drop_metadata_table_sql(),
+            self._drop_user_states_table_sql(),
+            self._drop_app_states_table_sql(),
             f"DROP TABLE IF EXISTS {self._events_table}",
             f"DROP TABLE IF EXISTS {self._session_table}",
         ]
@@ -918,7 +918,7 @@ class SqliteADKMemoryStore(BaseSyncADKMemoryStore["SqliteConfig"]):
         """Delete memory entries older than specified days."""
         return self._delete_entries_older_than(days)
 
-    def _get_create_memory_table_sql(self) -> str:
+    def _memory_table_ddl(self) -> str:
         """Get SQLite CREATE TABLE SQL for memory entries.
 
         Returns:
@@ -977,7 +977,7 @@ class SqliteADKMemoryStore(BaseSyncADKMemoryStore["SqliteConfig"]):
         {fts_table}
         """
 
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         """Get SQLite DROP TABLE SQL statements.
 
         Returns:
@@ -1006,7 +1006,7 @@ class SqliteADKMemoryStore(BaseSyncADKMemoryStore["SqliteConfig"]):
 
         with self._config.provide_session() as driver:
             self._enable_foreign_keys(driver.connection)
-            driver.execute_script(self._get_create_memory_table_sql())
+            driver.execute_script(self._memory_table_ddl())
 
     def _insert_memory_entries(self, entries: "list[MemoryRecord]", owner_id: "object | None" = None) -> int:
         """Bulk insert memory entries with deduplication.

--- a/sqlspec/adapters/sqlite/litestar/store.py
+++ b/sqlspec/adapters/sqlite/litestar/store.py
@@ -43,7 +43,7 @@ class SQLiteStore(BaseSQLSpecStore["SqliteConfig"]):
         """
         super().__init__(config)
 
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get SQLite CREATE TABLE SQL.
 
         Returns:
@@ -59,7 +59,7 @@ class SQLiteStore(BaseSQLSpecStore["SqliteConfig"]):
         ON {self._table_name}(expires_at) WHERE expires_at IS NOT NULL;
         """
 
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         """Get SQLite DROP TABLE SQL statements.
 
         Returns:
@@ -101,7 +101,7 @@ class SQLiteStore(BaseSQLSpecStore["SqliteConfig"]):
 
     def _create_table(self) -> None:
         """Synchronous implementation of create_table."""
-        sql = self._get_create_table_sql()
+        sql = self._table_ddl()
         with self._config.provide_session() as driver:
             driver.execute_script(sql)
         self._log_table_created()

--- a/sqlspec/core/statement.py
+++ b/sqlspec/core/statement.py
@@ -364,7 +364,7 @@ class SQL:
         return (
             _rebuild_sql,
             (
-                self._get_raw_sql(),
+                self._materialized_raw_sql(),
                 self._original_parameters,
                 tuple(self._filters),
                 self._statement_config,
@@ -380,7 +380,7 @@ class SQL:
         if self._hash is None:
             positional_tuple = tuple(self._positional_parameters)
             named_tuple = tuple(sorted(self._named_parameters.items())) if self._named_parameters else ()
-            raw_sql = self._get_raw_sql()
+            raw_sql = self._materialized_raw_sql()
             is_many = self._is_many
             is_script = self._is_script
             self._hash = hash((raw_sql, positional_tuple, named_tuple, is_many, is_script))
@@ -391,7 +391,7 @@ class SQL:
         if not isinstance(other, SQL):
             return False
         return (
-            self._get_raw_sql() == other._get_raw_sql()
+            self._materialized_raw_sql() == other._materialized_raw_sql()
             and self._positional_parameters == other._positional_parameters
             and self._named_parameters == other._named_parameters
             and self._is_many == other._is_many
@@ -414,7 +414,7 @@ class SQL:
             flags.append("is_script")
         flags_str = f", {', '.join(flags)}" if flags else ""
 
-        return f"SQL({self._get_raw_sql()!r}{params_str}{flags_str})"
+        return f"SQL({self._materialized_raw_sql()!r}{params_str}{flags_str})"
 
     def reset(self) -> None:
         """Reset SQL object for reuse in pooling scenarios."""
@@ -456,7 +456,7 @@ class SQL:
             return dialect.__name__.lower()
         return type(dialect).__name__.lower()
 
-    def _get_raw_sql(self) -> str:
+    def _materialized_raw_sql(self) -> str:
         """Return raw SQL, materializing deferred expression SQL when needed."""
         if self._raw_sql == "" and self._raw_expression is not None:
             dialect = self._dialect
@@ -570,7 +570,7 @@ class SQL:
     @property
     def sql(self) -> str:
         """Get the raw SQL string (alias of :attr:`raw_sql`)."""
-        return self._get_raw_sql()
+        return self._materialized_raw_sql()
 
     @property
     def raw_sql(self) -> str:
@@ -579,7 +579,7 @@ class SQL:
         Returns:
             The raw SQL string
         """
-        return self._get_raw_sql()
+        return self._materialized_raw_sql()
 
     @property
     def parameters(self) -> Any:
@@ -773,7 +773,7 @@ class SQL:
         if self._processed_state is Empty:
             try:
                 config = self._statement_config
-                raw_sql = self._get_raw_sql()
+                raw_sql = self._materialized_raw_sql()
                 params = self._named_parameters or self._positional_parameters
                 is_many = self._is_many
                 param_fingerprint = structural_fingerprint(params, is_many=is_many)
@@ -968,7 +968,7 @@ class SQL:
         logger.debug("Processing failed, using fallback: %s", error, exc_info=(type(error), error, error.__traceback__))
         params = self._named_parameters or self._positional_parameters
         return self._build_processed_state(
-            compiled_sql=self._get_raw_sql(),
+            compiled_sql=self._materialized_raw_sql(),
             execution_parameters=self._named_parameters or self._positional_parameters,
             parsed_expression=None,
             operation_type="COMMAND",
@@ -1507,7 +1507,7 @@ class SQL:
             self._statement_config.parameter_validator
         )
         raw_params = self.parameters
-        raw_sql_for_builder = self._get_raw_sql()
+        raw_sql_for_builder = self._materialized_raw_sql()
         converted_sql, converted_params = converter.convert_placeholder_style(
             raw_sql_for_builder, raw_params, ParameterStyle.NAMED_COLON, is_many=False
         )

--- a/sqlspec/extensions/adk/memory/store.py
+++ b/sqlspec/extensions/adk/memory/store.py
@@ -198,7 +198,7 @@ class BaseAsyncADKMemoryStore(ABC, Generic[ConfigT]):
         return _adk_memory_store_config(self._config)
 
     @abstractmethod
-    async def _get_create_memory_table_sql(self) -> "str | list[str]":
+    async def _memory_table_ddl(self) -> "str | list[str]":
         """Get the CREATE TABLE SQL for the memory table.
 
         Returns:
@@ -207,7 +207,7 @@ class BaseAsyncADKMemoryStore(ABC, Generic[ConfigT]):
         raise NotImplementedError
 
     @abstractmethod
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         """Get the DROP TABLE SQL statements for this database dialect.
 
         Returns:
@@ -215,17 +215,17 @@ class BaseAsyncADKMemoryStore(ABC, Generic[ConfigT]):
         """
         raise NotImplementedError
 
-    def _get_reset_drop_memory_table_sql(self) -> "list[str]":
+    def _reset_drop_memory_table_sql(self) -> "list[str]":
         """Return memory drops needed before recreating the clean-break schema."""
         return reset_drop_sql(
-            list(self._get_drop_memory_table_sql()), ADK_RESET_MEMORY_TABLES, self._get_drop_memory_table_sql_for_table
+            list(self._drop_memory_table_sql()), ADK_RESET_MEMORY_TABLES, self._drop_memory_sql_for_table
         )
 
-    def _get_drop_memory_table_sql_for_table(self, table_name: str) -> "list[str]":
+    def _drop_memory_sql_for_table(self, table_name: str) -> "list[str]":
         current_table = self._memory_table
         self._memory_table = table_name
         try:
-            return list(self._get_drop_memory_table_sql())
+            return list(self._drop_memory_table_sql())
         finally:
             self._memory_table = current_table
 
@@ -424,7 +424,7 @@ class BaseSyncADKMemoryStore(ABC, Generic[ConfigT]):
         return _adk_memory_store_config(self._config)
 
     @abstractmethod
-    def _get_create_memory_table_sql(self) -> "str | list[str]":
+    def _memory_table_ddl(self) -> "str | list[str]":
         """Get the CREATE TABLE SQL for the memory table.
 
         Returns:
@@ -432,17 +432,17 @@ class BaseSyncADKMemoryStore(ABC, Generic[ConfigT]):
         """
         raise NotImplementedError
 
-    def _get_reset_drop_memory_table_sql(self) -> "list[str]":
+    def _reset_drop_memory_table_sql(self) -> "list[str]":
         """Return memory drops needed before recreating the clean-break schema."""
         return reset_drop_sql(
-            list(self._get_drop_memory_table_sql()), ADK_RESET_MEMORY_TABLES, self._get_drop_memory_table_sql_for_table
+            list(self._drop_memory_table_sql()), ADK_RESET_MEMORY_TABLES, self._drop_memory_sql_for_table
         )
 
-    def _get_drop_memory_table_sql_for_table(self, table_name: str) -> "list[str]":
+    def _drop_memory_sql_for_table(self, table_name: str) -> "list[str]":
         current_table = self._memory_table
         self._memory_table = table_name
         try:
-            return list(self._get_drop_memory_table_sql())
+            return list(self._drop_memory_table_sql())
         finally:
             self._memory_table = current_table
 
@@ -466,7 +466,7 @@ class BaseSyncADKMemoryStore(ABC, Generic[ConfigT]):
         )
 
     @abstractmethod
-    def _get_drop_memory_table_sql(self) -> "list[str]":
+    def _drop_memory_table_sql(self) -> "list[str]":
         """Get the DROP TABLE SQL statements for this database dialect.
 
         Returns:

--- a/sqlspec/extensions/adk/migrations/0002_reset_adk_tables.py
+++ b/sqlspec/extensions/adk/migrations/0002_reset_adk_tables.py
@@ -43,23 +43,23 @@ async def up(context: "MigrationContext | None" = None) -> "list[str]":
     memory_store_class = _get_memory_store_class(context)
     if memory_store_class is not None:
         memory_store = memory_store_class(config=context.config)
-        statements.extend(memory_store._get_reset_drop_memory_table_sql())  # pyright: ignore[reportPrivateUsage]
+        statements.extend(memory_store._reset_drop_memory_table_sql())  # pyright: ignore[reportPrivateUsage]
         log_with_context(logger, logging.DEBUG, "adk.migration.reset.memory.drop", table_name=memory_store.memory_table)
 
-    statements.extend(store_instance._get_reset_drop_tables_sql())  # pyright: ignore[reportPrivateUsage]
+    statements.extend(store_instance._reset_drop_tables_sql())  # pyright: ignore[reportPrivateUsage]
 
     statements.extend([
-        await _resolve_sql(store_instance._get_create_sessions_table_sql()),  # pyright: ignore[reportPrivateUsage]
-        await _resolve_sql(store_instance._get_create_events_table_sql()),  # pyright: ignore[reportPrivateUsage]
-        await _resolve_sql(store_instance._get_create_app_states_table_sql()),  # pyright: ignore[reportPrivateUsage]
-        await _resolve_sql(store_instance._get_create_user_states_table_sql()),  # pyright: ignore[reportPrivateUsage]
-        await _resolve_sql(store_instance._get_create_metadata_table_sql()),  # pyright: ignore[reportPrivateUsage]
-        await _resolve_sql(store_instance._get_seed_metadata_sql()),  # pyright: ignore[reportPrivateUsage]
+        await _resolve_sql(store_instance._sessions_table_ddl()),  # pyright: ignore[reportPrivateUsage]
+        await _resolve_sql(store_instance._events_table_ddl()),  # pyright: ignore[reportPrivateUsage]
+        await _resolve_sql(store_instance._app_states_table_ddl()),  # pyright: ignore[reportPrivateUsage]
+        await _resolve_sql(store_instance._user_states_table_ddl()),  # pyright: ignore[reportPrivateUsage]
+        await _resolve_sql(store_instance._metadata_table_ddl()),  # pyright: ignore[reportPrivateUsage]
+        await _resolve_sql(store_instance._metadata_seed_sql()),  # pyright: ignore[reportPrivateUsage]
     ])
 
     if _is_memory_enabled(context) and memory_store_class is not None:
         memory_store = memory_store_class(config=context.config)
-        memory_sql = memory_store._get_create_memory_table_sql()  # pyright: ignore[reportPrivateUsage]
+        memory_sql = memory_store._memory_table_ddl()  # pyright: ignore[reportPrivateUsage]
         if inspect.isawaitable(memory_sql):
             memory_sql = await memory_sql
         if isinstance(memory_sql, list):
@@ -85,9 +85,9 @@ async def down(context: "MigrationContext | None" = None) -> "list[str]":
         memory_store_class = _get_memory_store_class(context)
         if memory_store_class is not None:
             memory_store = memory_store_class(config=context.config)
-            statements.extend(memory_store._get_reset_drop_memory_table_sql())  # pyright: ignore[reportPrivateUsage]
+            statements.extend(memory_store._reset_drop_memory_table_sql())  # pyright: ignore[reportPrivateUsage]
 
-    statements.extend(store_instance._get_reset_drop_tables_sql())  # pyright: ignore[reportPrivateUsage]
+    statements.extend(store_instance._reset_drop_tables_sql())  # pyright: ignore[reportPrivateUsage]
 
     return statements
 

--- a/sqlspec/extensions/adk/store.py
+++ b/sqlspec/extensions/adk/store.py
@@ -394,7 +394,7 @@ class BaseAsyncADKStore(ABC, Generic[ConfigT]):
 
     async def drop_tables(self) -> None:
         """Drop all ADK tables managed by this store in FK-safe order."""
-        await self._execute_lifecycle_scripts(self._get_drop_tables_sql())
+        await self._execute_lifecycle_scripts(self._drop_tables_sql())
         self._log_tables_dropped()
 
     async def recreate_tables(self) -> None:
@@ -403,11 +403,11 @@ class BaseAsyncADKStore(ABC, Generic[ConfigT]):
         await self.ensure_tables()
         self._log_tables_recreated()
 
-    def _get_reset_drop_tables_sql(self) -> "list[str]":
+    def _reset_drop_tables_sql(self) -> "list[str]":
         """Return all table drops needed before recreating the clean-break schema."""
-        statements = list(self._get_drop_tables_sql())
+        statements = list(self._drop_tables_sql())
         for table_profile in ADK_RESET_TABLE_PROFILES:
-            statements.extend(self._get_drop_tables_sql_for_table_profile(table_profile))
+            statements.extend(self._drop_sql_for_table_profile(table_profile))
         return unique_statements(statements)
 
     def _store_config_from_extension(self) -> "dict[str, Any]":
@@ -464,7 +464,7 @@ class BaseAsyncADKStore(ABC, Generic[ConfigT]):
         await async_(_execute_sync)()
 
     @abstractmethod
-    async def _get_create_sessions_table_sql(self) -> str:
+    async def _sessions_table_ddl(self) -> str:
         """Get the CREATE TABLE SQL for the sessions table.
 
         Returns:
@@ -473,7 +473,7 @@ class BaseAsyncADKStore(ABC, Generic[ConfigT]):
         raise NotImplementedError
 
     @abstractmethod
-    async def _get_create_events_table_sql(self) -> str:
+    async def _events_table_ddl(self) -> str:
         """Get the CREATE TABLE SQL for the events table.
 
         Returns:
@@ -482,7 +482,7 @@ class BaseAsyncADKStore(ABC, Generic[ConfigT]):
         raise NotImplementedError
 
     @abstractmethod
-    async def _get_create_app_states_table_sql(self) -> str:
+    async def _app_states_table_ddl(self) -> str:
         """Get the CREATE TABLE SQL for the app-scoped state table.
 
         Returns:
@@ -491,7 +491,7 @@ class BaseAsyncADKStore(ABC, Generic[ConfigT]):
         raise NotImplementedError
 
     @abstractmethod
-    async def _get_create_user_states_table_sql(self) -> str:
+    async def _user_states_table_ddl(self) -> str:
         """Get the CREATE TABLE SQL for the user-scoped state table.
 
         Returns:
@@ -500,7 +500,7 @@ class BaseAsyncADKStore(ABC, Generic[ConfigT]):
         raise NotImplementedError
 
     @abstractmethod
-    async def _get_create_metadata_table_sql(self) -> str:
+    async def _metadata_table_ddl(self) -> str:
         """Get the CREATE TABLE SQL for the ADK internal metadata table.
 
         Returns:
@@ -509,7 +509,7 @@ class BaseAsyncADKStore(ABC, Generic[ConfigT]):
         raise NotImplementedError
 
     @abstractmethod
-    async def _get_seed_metadata_sql(self) -> str:
+    async def _metadata_seed_sql(self) -> str:
         """Get the SQL statement that seeds the ADK schema-version metadata row.
 
         Returns:
@@ -518,7 +518,7 @@ class BaseAsyncADKStore(ABC, Generic[ConfigT]):
         raise NotImplementedError
 
     @abstractmethod
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         """Get the DROP TABLE SQL statement for the app-scoped state table.
 
         Returns:
@@ -527,7 +527,7 @@ class BaseAsyncADKStore(ABC, Generic[ConfigT]):
         raise NotImplementedError
 
     @abstractmethod
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         """Get the DROP TABLE SQL statement for the user-scoped state table.
 
         Returns:
@@ -536,7 +536,7 @@ class BaseAsyncADKStore(ABC, Generic[ConfigT]):
         raise NotImplementedError
 
     @abstractmethod
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         """Get the DROP TABLE SQL statement for the ADK internal metadata table.
 
         Returns:
@@ -545,7 +545,7 @@ class BaseAsyncADKStore(ABC, Generic[ConfigT]):
         raise NotImplementedError
 
     @abstractmethod
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         """Get the DROP TABLE SQL statements for this database dialect.
 
         Returns:
@@ -558,7 +558,7 @@ class BaseAsyncADKStore(ABC, Generic[ConfigT]):
         """
         raise NotImplementedError
 
-    def _get_drop_tables_sql_for_table_profile(self, table_profile: "tuple[str, str, str, str, str]") -> "list[str]":
+    def _drop_sql_for_table_profile(self, table_profile: "tuple[str, str, str, str, str]") -> "list[str]":
         session_table, events_table, app_state_table, user_state_table, metadata_table = table_profile
         current_session_table = self._session_table
         current_events_table = self._events_table
@@ -571,7 +571,7 @@ class BaseAsyncADKStore(ABC, Generic[ConfigT]):
         self._user_state_table = user_state_table
         self._metadata_table = metadata_table
         try:
-            return list(self._get_drop_tables_sql())
+            return list(self._drop_tables_sql())
         finally:
             self._session_table = current_session_table
             self._events_table = current_events_table
@@ -809,7 +809,7 @@ class BaseSyncADKStore(ABC, Generic[ConfigT]):
 
     def drop_tables(self) -> None:
         """Drop all ADK tables managed by this store in FK-safe order."""
-        self._execute_lifecycle_scripts(self._get_drop_tables_sql())
+        self._execute_lifecycle_scripts(self._drop_tables_sql())
         self._log_tables_dropped()
 
     def recreate_tables(self) -> None:
@@ -844,63 +844,63 @@ class BaseSyncADKStore(ABC, Generic[ConfigT]):
                 commit()
 
     @abstractmethod
-    def _get_create_sessions_table_sql(self) -> str:
+    def _sessions_table_ddl(self) -> str:
         """Get the CREATE TABLE SQL for the sessions table."""
         raise NotImplementedError
 
     @abstractmethod
-    def _get_create_events_table_sql(self) -> str:
+    def _events_table_ddl(self) -> str:
         """Get the CREATE TABLE SQL for the events table."""
         raise NotImplementedError
 
     @abstractmethod
-    def _get_create_app_states_table_sql(self) -> str:
+    def _app_states_table_ddl(self) -> str:
         """Get the CREATE TABLE SQL for the app-scoped state table."""
         raise NotImplementedError
 
     @abstractmethod
-    def _get_create_user_states_table_sql(self) -> str:
+    def _user_states_table_ddl(self) -> str:
         """Get the CREATE TABLE SQL for the user-scoped state table."""
         raise NotImplementedError
 
     @abstractmethod
-    def _get_create_metadata_table_sql(self) -> str:
+    def _metadata_table_ddl(self) -> str:
         """Get the CREATE TABLE SQL for the ADK internal metadata table."""
         raise NotImplementedError
 
     @abstractmethod
-    def _get_seed_metadata_sql(self) -> str:
+    def _metadata_seed_sql(self) -> str:
         """Get the SQL statement that seeds the ADK schema-version metadata row."""
         raise NotImplementedError
 
     @abstractmethod
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         """Get the DROP TABLE SQL statement for the app-scoped state table."""
         raise NotImplementedError
 
     @abstractmethod
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         """Get the DROP TABLE SQL statement for the user-scoped state table."""
         raise NotImplementedError
 
     @abstractmethod
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         """Get the DROP TABLE SQL statement for the ADK internal metadata table."""
         raise NotImplementedError
 
     @abstractmethod
-    def _get_drop_tables_sql(self) -> "list[str]":
+    def _drop_tables_sql(self) -> "list[str]":
         """Get the DROP TABLE SQL statements for this database dialect."""
         raise NotImplementedError
 
-    def _get_reset_drop_tables_sql(self) -> "list[str]":
+    def _reset_drop_tables_sql(self) -> "list[str]":
         """Return all table drops needed before recreating the clean-break schema."""
-        statements = list(self._get_drop_tables_sql())
+        statements = list(self._drop_tables_sql())
         for table_profile in ADK_RESET_TABLE_PROFILES:
-            statements.extend(self._get_drop_tables_sql_for_table_profile(table_profile))
+            statements.extend(self._drop_sql_for_table_profile(table_profile))
         return unique_statements(statements)
 
-    def _get_drop_tables_sql_for_table_profile(self, table_profile: "tuple[str, str, str, str, str]") -> "list[str]":
+    def _drop_sql_for_table_profile(self, table_profile: "tuple[str, str, str, str, str]") -> "list[str]":
         session_table, events_table, app_state_table, user_state_table, metadata_table = table_profile
         current_session_table = self._session_table
         current_events_table = self._events_table
@@ -913,7 +913,7 @@ class BaseSyncADKStore(ABC, Generic[ConfigT]):
         self._user_state_table = user_state_table
         self._metadata_table = metadata_table
         try:
-            return list(self._get_drop_tables_sql())
+            return list(self._drop_tables_sql())
         finally:
             self._session_table = current_session_table
             self._events_table = current_events_table

--- a/sqlspec/extensions/events/_queue.py
+++ b/sqlspec/extensions/events/_queue.py
@@ -37,21 +37,21 @@ class _BaseTableEventQueue:
     """Base class with shared SQL generation and hydration logic."""
 
     __slots__ = (
-        "_ack_sql",
-        "_acked_cleanup_sql",
-        "_claim_sql",
+        "_ack_statement",
+        "_acked_cleanup_statement",
+        "_claim_statement",
         "_config",
         "_dialect",
+        "_insert_statement",
         "_lease_seconds",
         "_max_claim_attempts",
-        "_nack_sql",
+        "_nack_statement",
         "_retention_seconds",
         "_runtime",
-        "_select_by_id_sql",
-        "_select_sql",
+        "_select_by_id_statement",
+        "_select_statement",
         "_statement_config",
         "_table_name",
-        "_upsert_sql",
     )
 
     def __init__(
@@ -72,24 +72,24 @@ class _BaseTableEventQueue:
         self._lease_seconds = lease_seconds or 30
         self._retention_seconds = retention_seconds or 86_400
         self._max_claim_attempts = 5
-        self._upsert_sql = self._build_insert_sql()
-        self._select_sql = self._build_select_sql(bool(select_for_update), bool(skip_locked))
-        self._select_by_id_sql = self._build_select_by_id_sql()
-        self._claim_sql = self._build_claim_sql()
-        self._ack_sql = self._build_ack_sql()
-        self._nack_sql = self._build_nack_sql()
-        self._acked_cleanup_sql = self._build_cleanup_sql()
+        self._insert_statement = self._insert_sql()
+        self._select_statement = self._select_sql(bool(select_for_update), bool(skip_locked))
+        self._select_by_id_statement = self._select_by_id_sql()
+        self._claim_statement = self._claim_sql()
+        self._ack_statement = self._ack_sql()
+        self._nack_statement = self._nack_sql()
+        self._acked_cleanup_statement = self._cleanup_sql()
 
     @property
     def statement_config(self) -> "StatementConfig":
         return self._statement_config
 
-    def _build_insert_sql(self) -> str:
+    def _insert_sql(self) -> str:
         columns = "event_id, channel, payload_json, metadata_json, status, available_at, lease_expires_at, attempts, created_at"
         values = ":event_id, :channel, :payload_json, :metadata_json, :status, :available_at, :lease_expires_at, :attempts, :created_at"
         return f"INSERT INTO {self._table_name} ({columns}) VALUES ({values})"
 
-    def _build_select_sql(self, select_for_update: bool, skip_locked: bool) -> str:
+    def _select_sql(self, select_for_update: bool, skip_locked: bool) -> str:
         top_clause = "TOP 1 " if self._uses_tsql_limit() else ""
         limit_clause = self._row_limit_clause()
         base = (
@@ -106,7 +106,7 @@ class _BaseTableEventQueue:
                 locking_clause += " SKIP LOCKED"
         return base + limit_clause + locking_clause
 
-    def _build_select_by_id_sql(self) -> str:
+    def _select_by_id_sql(self) -> str:
         top_clause = "TOP 1 " if self._uses_tsql_limit() else ""
         limit_clause = self._row_limit_clause()
         return (
@@ -124,7 +124,7 @@ class _BaseTableEventQueue:
             return " FETCH FIRST 1 ROWS ONLY"
         return " LIMIT 1"
 
-    def _build_claim_sql(self) -> str:
+    def _claim_sql(self) -> str:
         return (
             f"UPDATE {self._table_name} SET status = :claimed_status, lease_expires_at = :lease_expires_at, attempts = attempts + 1 "
             "WHERE event_id = :event_id AND ("
@@ -132,13 +132,13 @@ class _BaseTableEventQueue:
             ")"
         )
 
-    def _build_ack_sql(self) -> str:
+    def _ack_sql(self) -> str:
         return f"UPDATE {self._table_name} SET status = :acked, acknowledged_at = :acked_at WHERE event_id = :event_id"
 
-    def _build_nack_sql(self) -> str:
+    def _nack_sql(self) -> str:
         return f"UPDATE {self._table_name} SET status = :pending, lease_expires_at = NULL, attempts = attempts + 1 WHERE event_id = :event_id"
 
-    def _build_cleanup_sql(self) -> str:
+    def _cleanup_sql(self) -> str:
         return f"DELETE FROM {self._table_name} WHERE status = :acked AND acknowledged_at IS NOT NULL AND acknowledged_at <= :cutoff"
 
     @staticmethod
@@ -196,7 +196,7 @@ class SyncTableEventQueue(_BaseTableEventQueue):
         event_id = uuid4().hex
         now = self._utcnow()
         self._execute(
-            self._upsert_sql,
+            self._insert_statement,
             {
                 "event_id": event_id,
                 "channel": channel,
@@ -224,7 +224,7 @@ class SyncTableEventQueue(_BaseTableEventQueue):
             now = self._utcnow()
             leased_until = now + timedelta(seconds=self._lease_seconds)
             claimed = self._execute(
-                self._claim_sql,
+                self._claim_statement,
                 {
                     "claimed_status": _LEASED_STATUS,
                     "lease_expires_at": leased_until,
@@ -245,7 +245,7 @@ class SyncTableEventQueue(_BaseTableEventQueue):
         now = self._utcnow()
         leased_until = now + timedelta(seconds=self._lease_seconds)
         claimed = self._execute(
-            self._claim_sql,
+            self._claim_statement,
             {
                 "claimed_status": _LEASED_STATUS,
                 "lease_expires_at": leased_until,
@@ -261,12 +261,12 @@ class SyncTableEventQueue(_BaseTableEventQueue):
 
     def ack(self, event_id: str) -> None:
         now = self._utcnow()
-        self._execute(self._ack_sql, {"acked": _ACKED_STATUS, "acked_at": now, "event_id": event_id})
+        self._execute(self._ack_statement, {"acked": _ACKED_STATUS, "acked_at": now, "event_id": event_id})
         self._cleanup(now)
         self._runtime.increment_metric("events.ack")
 
     def nack(self, event_id: str) -> None:
-        self._execute(self._nack_sql, {"pending": _PENDING_STATUS, "event_id": event_id})
+        self._execute(self._nack_statement, {"pending": _PENDING_STATUS, "event_id": event_id})
         self._runtime.increment_metric("events.nack")
 
     def shutdown(self) -> None:
@@ -274,7 +274,7 @@ class SyncTableEventQueue(_BaseTableEventQueue):
 
     def _cleanup(self, reference: "datetime") -> None:
         cutoff = reference - timedelta(seconds=self._retention_seconds)
-        self._execute(self._acked_cleanup_sql, {"acked": _ACKED_STATUS, "cutoff": cutoff})
+        self._execute(self._acked_cleanup_statement, {"acked": _ACKED_STATUS, "cutoff": cutoff})
 
     def _fetch_candidate(self, channel: str) -> "dict[str, Any] | None":
         current_time = self._utcnow()
@@ -283,7 +283,7 @@ class SyncTableEventQueue(_BaseTableEventQueue):
                 # SQL allocation here is intentional: DB round-trip dominates by >=100x,
                 # and the pipeline LRU avoids re-parsing after first use via structural_fingerprint.
                 SQL(
-                    self._select_sql,
+                    self._select_statement,
                     {
                         "channel": channel,
                         "available_cutoff": current_time,
@@ -298,7 +298,7 @@ class SyncTableEventQueue(_BaseTableEventQueue):
     def _fetch_by_event_id(self, event_id: str) -> "dict[str, Any] | None":
         with cast("AbstractContextManager[SyncDriverAdapterBase]", self._config.provide_session()) as driver:
             return driver.select_one_or_none(
-                SQL(self._select_by_id_sql, {"event_id": event_id}, statement_config=self._statement_config)
+                SQL(self._select_by_id_statement, {"event_id": event_id}, statement_config=self._statement_config)
             )
 
     def _execute(self, sql: str, parameters: "dict[str, Any]") -> int:
@@ -324,7 +324,7 @@ class AsyncTableEventQueue(_BaseTableEventQueue):
         event_id = uuid4().hex
         now = self._utcnow()
         await self._execute(
-            self._upsert_sql,
+            self._insert_statement,
             {
                 "event_id": event_id,
                 "channel": channel,
@@ -352,7 +352,7 @@ class AsyncTableEventQueue(_BaseTableEventQueue):
             now = self._utcnow()
             leased_until = now + timedelta(seconds=self._lease_seconds)
             claimed = await self._execute(
-                self._claim_sql,
+                self._claim_statement,
                 {
                     "claimed_status": _LEASED_STATUS,
                     "lease_expires_at": leased_until,
@@ -373,7 +373,7 @@ class AsyncTableEventQueue(_BaseTableEventQueue):
         now = self._utcnow()
         leased_until = now + timedelta(seconds=self._lease_seconds)
         claimed = await self._execute(
-            self._claim_sql,
+            self._claim_statement,
             {
                 "claimed_status": _LEASED_STATUS,
                 "lease_expires_at": leased_until,
@@ -389,12 +389,12 @@ class AsyncTableEventQueue(_BaseTableEventQueue):
 
     async def ack(self, event_id: str) -> None:
         now = self._utcnow()
-        await self._execute(self._ack_sql, {"acked": _ACKED_STATUS, "acked_at": now, "event_id": event_id})
+        await self._execute(self._ack_statement, {"acked": _ACKED_STATUS, "acked_at": now, "event_id": event_id})
         await self._cleanup(now)
         self._runtime.increment_metric("events.ack")
 
     async def nack(self, event_id: str) -> None:
-        await self._execute(self._nack_sql, {"pending": _PENDING_STATUS, "event_id": event_id})
+        await self._execute(self._nack_statement, {"pending": _PENDING_STATUS, "event_id": event_id})
         self._runtime.increment_metric("events.nack")
 
     async def shutdown(self) -> None:
@@ -402,7 +402,7 @@ class AsyncTableEventQueue(_BaseTableEventQueue):
 
     async def _cleanup(self, reference: "datetime") -> None:
         cutoff = reference - timedelta(seconds=self._retention_seconds)
-        await self._execute(self._acked_cleanup_sql, {"acked": _ACKED_STATUS, "cutoff": cutoff})
+        await self._execute(self._acked_cleanup_statement, {"acked": _ACKED_STATUS, "cutoff": cutoff})
 
     async def _fetch_candidate(self, channel: str) -> "dict[str, Any] | None":
         current_time = self._utcnow()
@@ -413,7 +413,7 @@ class AsyncTableEventQueue(_BaseTableEventQueue):
                 # SQL allocation here is intentional: DB round-trip dominates by >=100x,
                 # and the pipeline LRU avoids re-parsing after first use via structural_fingerprint.
                 SQL(
-                    self._select_sql,
+                    self._select_statement,
                     {
                         "channel": channel,
                         "available_cutoff": current_time,
@@ -430,7 +430,7 @@ class AsyncTableEventQueue(_BaseTableEventQueue):
             "AbstractAsyncContextManager[AsyncDriverAdapterBase]", self._config.provide_session()
         ) as driver:
             return await driver.select_one_or_none(
-                SQL(self._select_by_id_sql, {"event_id": event_id}, statement_config=self._statement_config)
+                SQL(self._select_by_id_statement, {"event_id": event_id}, statement_config=self._statement_config)
             )
 
     async def _execute(self, sql: str, parameters: "dict[str, Any]") -> int:

--- a/sqlspec/extensions/events/_store.py
+++ b/sqlspec/extensions/events/_store.py
@@ -27,7 +27,7 @@ class BaseEventQueueStore(ABC, Generic[ConfigT]):
     - `_table_clause()`: Additional table options (default: empty)
 
     For complex dialects (Oracle PL/SQL, BigQuery CLUSTER BY), adapters may
-    override `_build_create_table_sql()` directly.
+    override `_table_ddl()` directly.
     """
 
     __slots__ = ("_config", "_extension_settings", "_table_name")
@@ -51,8 +51,8 @@ class BaseEventQueueStore(ABC, Generic[ConfigT]):
 
     def create_statements(self) -> "list[str]":
         """Return statements required to create the queue table and indexes."""
-        statements = [self._wrap_create_statement(self._build_create_table_sql(), "table")]
-        index_statement = self._build_index_sql()
+        statements = [self._wrap_create_statement(self._table_ddl(), "table")]
+        index_statement = self._index_ddl()
         if index_statement:
             statements.append(self._wrap_create_statement(index_statement, "index"))
         return statements
@@ -105,7 +105,7 @@ class BaseEventQueueStore(ABC, Generic[ConfigT]):
         """
         return ""
 
-    def _build_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Build CREATE TABLE SQL using hook methods.
 
         Most adapters should NOT override this method. Instead, override the
@@ -141,7 +141,7 @@ class BaseEventQueueStore(ABC, Generic[ConfigT]):
             f"){pk_inline}{table_clause}"
         )
 
-    def _build_index_sql(self) -> str | None:
+    def _index_ddl(self) -> str | None:
         """Build CREATE INDEX SQL for queue operations."""
         index_name = self._index_name()
         return f"CREATE INDEX {index_name} ON {self.table_name}(channel, status, available_at)"

--- a/sqlspec/extensions/litestar/migrations/0001_create_session_table.py
+++ b/sqlspec/extensions/litestar/migrations/0001_create_session_table.py
@@ -33,7 +33,7 @@ async def up(context: "MigrationContext | None" = None) -> "list[str]":
         _raise_missing_config()
     store = store_class(config=context.config)
 
-    return [store._get_create_table_sql()]  # pyright: ignore[reportPrivateUsage]
+    return [store._table_ddl()]  # pyright: ignore[reportPrivateUsage]
 
 
 async def down(context: "MigrationContext | None" = None) -> "list[str]":
@@ -54,7 +54,7 @@ async def down(context: "MigrationContext | None" = None) -> "list[str]":
         _raise_missing_config()
     store = store_class(config=context.config)
 
-    return store._get_drop_table_sql()  # pyright: ignore[reportPrivateUsage]
+    return store._drop_table_sql()  # pyright: ignore[reportPrivateUsage]
 
 
 def _get_store_class(context: "MigrationContext | None") -> "type[BaseSQLSpecStore]":

--- a/sqlspec/extensions/litestar/store.py
+++ b/sqlspec/extensions/litestar/store.py
@@ -162,7 +162,7 @@ class BaseSQLSpecStore(ABC, Generic[ConfigT]):
         raise NotImplementedError
 
     @abstractmethod
-    def _get_create_table_sql(self) -> str:
+    def _table_ddl(self) -> str:
         """Get the CREATE TABLE SQL for this database dialect.
 
         Returns:
@@ -171,7 +171,7 @@ class BaseSQLSpecStore(ABC, Generic[ConfigT]):
         raise NotImplementedError
 
     @abstractmethod
-    def _get_drop_table_sql(self) -> "list[str]":
+    def _drop_table_sql(self) -> "list[str]":
         """Get the DROP TABLE SQL statements for this database dialect.
 
         Returns:

--- a/sqlspec/migrations/base.py
+++ b/sqlspec/migrations/base.py
@@ -69,7 +69,7 @@ class BaseMigrationTracker(ABC, Generic[DriverT]):
             return f"{version_table_schema}.{version_table_name}"
         return version_table_name
 
-    def _get_create_table_builder(self) -> CreateTable:
+    def _tracking_table_builder(self) -> CreateTable:
         """Return a CREATE TABLE builder for the tracker table."""
         builder = sql.create_table(self.version_table_name)
         if self.version_table_schema:
@@ -88,7 +88,7 @@ class BaseMigrationTracker(ABC, Generic[DriverT]):
         """Return True when logger output is preferred."""
         return bool(self._output_policy.get("use_logger", False))
 
-    def _get_create_table_sql(self) -> CreateTable:
+    def _tracking_table_ddl(self) -> CreateTable:
         """Get SQL builder for creating the tracking table.
 
         Schema includes both legacy and new versioning columns:
@@ -106,7 +106,7 @@ class BaseMigrationTracker(ABC, Generic[DriverT]):
         """
         return (
             self
-            ._get_create_table_builder()
+            ._tracking_table_builder()
             .if_not_exists()
             .column("version_num", "VARCHAR(32)", primary_key=True)
             .column("version_type", "VARCHAR(16)")
@@ -119,7 +119,7 @@ class BaseMigrationTracker(ABC, Generic[DriverT]):
             .column("replaces", "TEXT")
         )
 
-    def _get_current_version_sql(self) -> Select:
+    def _current_version_query(self) -> Select:
         """Get SQL builder for retrieving current version.
 
         Uses execution_sequence to get the last applied migration,
@@ -130,7 +130,7 @@ class BaseMigrationTracker(ABC, Generic[DriverT]):
         """
         return sql.select("version_num").from_(self.version_table).order_by("execution_sequence DESC").limit(1)
 
-    def _get_applied_migrations_sql(self) -> Select:
+    def _applied_migrations_query(self) -> Select:
         """Get SQL builder for retrieving all applied migrations.
 
         Orders by execution_sequence to show migrations in application order,
@@ -141,7 +141,7 @@ class BaseMigrationTracker(ABC, Generic[DriverT]):
         """
         return sql.select("*").from_(self.version_table).order_by("execution_sequence")
 
-    def _get_next_execution_sequence_sql(self) -> Select:
+    def _next_execution_sequence_query(self) -> Select:
         """Get SQL builder for retrieving next execution sequence.
 
         Returns:
@@ -149,7 +149,7 @@ class BaseMigrationTracker(ABC, Generic[DriverT]):
         """
         return sql.select("COALESCE(MAX(execution_sequence), 0) + 1 AS next_seq").from_(self.version_table)
 
-    def _get_record_migration_sql(
+    def _record_migration_statement(
         self,
         version: str,
         version_type: str,
@@ -188,7 +188,7 @@ class BaseMigrationTracker(ABC, Generic[DriverT]):
             .values(version, version_type, execution_sequence, description, execution_time_ms, checksum, applied_by)
         )
 
-    def _get_remove_migration_sql(self, version: str) -> Delete:
+    def _remove_migration_statement(self, version: str) -> Delete:
         """Get SQL builder for removing a migration record.
 
         Args:
@@ -199,7 +199,7 @@ class BaseMigrationTracker(ABC, Generic[DriverT]):
         """
         return sql.delete().from_(self.version_table).where(sql.version_num == version)
 
-    def _get_update_version_sql(self, old_version: str, new_version: str, new_version_type: str) -> Update:
+    def _update_version_statement(self, old_version: str, new_version: str, new_version_type: str) -> Update:
         """Get SQL builder for updating version record.
 
         Updates version_num and version_type while preserving execution_sequence,
@@ -222,7 +222,7 @@ class BaseMigrationTracker(ABC, Generic[DriverT]):
             .where(sql.version_num == old_version)
         )
 
-    def _get_delete_versions_sql(self, versions: "list[str]") -> Delete:
+    def _delete_versions_statement(self, versions: "list[str]") -> Delete:
         """Get SQL builder for deleting multiple version records.
 
         Used by squash operations to remove replaced migration records.
@@ -235,7 +235,7 @@ class BaseMigrationTracker(ABC, Generic[DriverT]):
         """
         return sql.delete().from_(self.version_table).where(sql.version_num.in_(versions))
 
-    def _get_check_versions_exist_sql(self, versions: "list[str]") -> Select:
+    def _check_versions_query(self, versions: "list[str]") -> Select:
         """Get SQL builder for checking whether any versions exist.
 
         Args:
@@ -246,7 +246,7 @@ class BaseMigrationTracker(ABC, Generic[DriverT]):
         """
         return sql.select("version_num").from_(self.version_table).where(sql.version_num.in_(versions))
 
-    def _get_record_squashed_migration_sql(
+    def _record_squashed_migration_statement(
         self,
         version: str,
         version_type: str,
@@ -297,7 +297,7 @@ class BaseMigrationTracker(ABC, Generic[DriverT]):
             )
         )
 
-    def _get_check_column_exists_sql(self) -> Select:
+    def _column_exists_query(self) -> Select:
         """Get SQL to check what columns exist in the tracking table.
 
         Returns a query that will fail gracefully if the table doesn't exist,
@@ -317,7 +317,7 @@ class BaseMigrationTracker(ABC, Generic[DriverT]):
         Returns:
             Set of missing column names (lowercase).
         """
-        target_create = self._get_create_table_sql()
+        target_create = self._tracking_table_ddl()
         target_columns = {col.name.lower() for col in target_create.columns}
         existing_lower = {col.lower() for col in existing_columns}
         return target_columns - existing_lower

--- a/sqlspec/migrations/runner.py
+++ b/sqlspec/migrations/runner.py
@@ -517,7 +517,7 @@ class SyncMigrationRunner(BaseMigrationRunner):
             has_upgrade, has_downgrade = self.loader.has_query(up_query), self.loader.has_query(down_query)
         else:
             try:
-                has_downgrade = bool(self._migration_sql_sync({"loader": loader, "file_path": file_path}, "down"))
+                has_downgrade = bool(self._migration_sql({"loader": loader, "file_path": file_path}, "down"))
             except Exception:
                 has_downgrade = False
 
@@ -580,7 +580,7 @@ class SyncMigrationRunner(BaseMigrationRunner):
         Returns:
             Tuple of (sql_content, execution_time_ms).
         """
-        upgrade_sql_list = self._migration_sql_sync(migration, "up")
+        upgrade_sql_list = self._migration_sql(migration, "up")
         if upgrade_sql_list is None:
             self._metric("migrations.upgrade.skipped")
             self._log_migration_event(
@@ -671,7 +671,7 @@ class SyncMigrationRunner(BaseMigrationRunner):
         Returns:
             Tuple of (sql_content, execution_time_ms).
         """
-        downgrade_sql_list = self._migration_sql_sync(migration, "down")
+        downgrade_sql_list = self._migration_sql(migration, "down")
         if downgrade_sql_list is None:
             self._metric("migrations.downgrade.skipped")
             self._log_migration_event(
@@ -747,7 +747,7 @@ class SyncMigrationRunner(BaseMigrationRunner):
 
         return None, execution_time
 
-    def _migration_sql_sync(self, migration: "dict[str, Any]", direction: str) -> "list[str] | None":
+    def _migration_sql(self, migration: "dict[str, Any]", direction: str) -> "list[str] | None":
         """Get migration SQL for given direction (sync version).
 
         Args:
@@ -863,9 +863,7 @@ class AsyncMigrationRunner(BaseMigrationRunner):
             has_upgrade, has_downgrade = self.loader.has_query(up_query), self.loader.has_query(down_query)
         else:
             try:
-                has_downgrade = bool(
-                    await self._migration_sql_async({"loader": loader, "file_path": file_path}, "down")
-                )
+                has_downgrade = bool(await self._migration_sql({"loader": loader, "file_path": file_path}, "down"))
             except Exception:
                 has_downgrade = False
 
@@ -928,7 +926,7 @@ class AsyncMigrationRunner(BaseMigrationRunner):
         Returns:
             Tuple of (sql_content, execution_time_ms).
         """
-        upgrade_sql_list = await self._migration_sql_async(migration, "up")
+        upgrade_sql_list = await self._migration_sql(migration, "up")
         if upgrade_sql_list is None:
             self._metric("migrations.upgrade.skipped")
             self._log_migration_event(
@@ -1019,7 +1017,7 @@ class AsyncMigrationRunner(BaseMigrationRunner):
         Returns:
             Tuple of (sql_content, execution_time_ms).
         """
-        downgrade_sql_list = await self._migration_sql_async(migration, "down")
+        downgrade_sql_list = await self._migration_sql(migration, "down")
         if downgrade_sql_list is None:
             self._metric("migrations.downgrade.skipped")
             self._log_migration_event(
@@ -1095,7 +1093,7 @@ class AsyncMigrationRunner(BaseMigrationRunner):
 
         return None, execution_time
 
-    async def _migration_sql_async(self, migration: "dict[str, Any]", direction: str) -> "list[str] | None":
+    async def _migration_sql(self, migration: "dict[str, Any]", direction: str) -> "list[str] | None":
         """Get migration SQL for given direction (async version).
 
         Args:

--- a/sqlspec/migrations/runner.py
+++ b/sqlspec/migrations/runner.py
@@ -517,7 +517,7 @@ class SyncMigrationRunner(BaseMigrationRunner):
             has_upgrade, has_downgrade = self.loader.has_query(up_query), self.loader.has_query(down_query)
         else:
             try:
-                has_downgrade = bool(self._get_migration_sql({"loader": loader, "file_path": file_path}, "down"))
+                has_downgrade = bool(self._migration_sql({"loader": loader, "file_path": file_path}, "down"))
             except Exception:
                 has_downgrade = False
 
@@ -580,7 +580,7 @@ class SyncMigrationRunner(BaseMigrationRunner):
         Returns:
             Tuple of (sql_content, execution_time_ms).
         """
-        upgrade_sql_list = self._get_migration_sql(migration, "up")
+        upgrade_sql_list = self._migration_sql(migration, "up")
         if upgrade_sql_list is None:
             self._metric("migrations.upgrade.skipped")
             self._log_migration_event(
@@ -671,7 +671,7 @@ class SyncMigrationRunner(BaseMigrationRunner):
         Returns:
             Tuple of (sql_content, execution_time_ms).
         """
-        downgrade_sql_list = self._get_migration_sql(migration, "down")
+        downgrade_sql_list = self._migration_sql(migration, "down")
         if downgrade_sql_list is None:
             self._metric("migrations.downgrade.skipped")
             self._log_migration_event(
@@ -747,7 +747,7 @@ class SyncMigrationRunner(BaseMigrationRunner):
 
         return None, execution_time
 
-    def _get_migration_sql(self, migration: "dict[str, Any]", direction: str) -> "list[str] | None":
+    def _migration_sql(self, migration: "dict[str, Any]", direction: str) -> "list[str] | None":
         """Get migration SQL for given direction (sync version).
 
         Args:

--- a/sqlspec/migrations/runner.py
+++ b/sqlspec/migrations/runner.py
@@ -517,7 +517,7 @@ class SyncMigrationRunner(BaseMigrationRunner):
             has_upgrade, has_downgrade = self.loader.has_query(up_query), self.loader.has_query(down_query)
         else:
             try:
-                has_downgrade = bool(self._migration_sql({"loader": loader, "file_path": file_path}, "down"))
+                has_downgrade = bool(self._migration_sql_sync({"loader": loader, "file_path": file_path}, "down"))
             except Exception:
                 has_downgrade = False
 
@@ -580,7 +580,7 @@ class SyncMigrationRunner(BaseMigrationRunner):
         Returns:
             Tuple of (sql_content, execution_time_ms).
         """
-        upgrade_sql_list = self._migration_sql(migration, "up")
+        upgrade_sql_list = self._migration_sql_sync(migration, "up")
         if upgrade_sql_list is None:
             self._metric("migrations.upgrade.skipped")
             self._log_migration_event(
@@ -671,7 +671,7 @@ class SyncMigrationRunner(BaseMigrationRunner):
         Returns:
             Tuple of (sql_content, execution_time_ms).
         """
-        downgrade_sql_list = self._migration_sql(migration, "down")
+        downgrade_sql_list = self._migration_sql_sync(migration, "down")
         if downgrade_sql_list is None:
             self._metric("migrations.downgrade.skipped")
             self._log_migration_event(
@@ -747,7 +747,7 @@ class SyncMigrationRunner(BaseMigrationRunner):
 
         return None, execution_time
 
-    def _migration_sql(self, migration: "dict[str, Any]", direction: str) -> "list[str] | None":
+    def _migration_sql_sync(self, migration: "dict[str, Any]", direction: str) -> "list[str] | None":
         """Get migration SQL for given direction (sync version).
 
         Args:

--- a/sqlspec/migrations/tracker.py
+++ b/sqlspec/migrations/tracker.py
@@ -105,7 +105,7 @@ class SyncMigrationTracker(BaseMigrationTracker["SyncDriverAdapterBase"]):
             driver: The database driver to use.
             column_name: Name of the column to add (lowercase).
         """
-        target_create = self._get_create_table_sql()
+        target_create = self._tracking_table_ddl()
         column_def = next((col for col in target_create.columns if col.name.lower() == column_name), None)
 
         if not column_def:
@@ -134,7 +134,7 @@ class SyncMigrationTracker(BaseMigrationTracker["SyncDriverAdapterBase"]):
         Args:
             driver: The database driver to use.
         """
-        driver.execute(self._get_create_table_sql())
+        driver.execute(self._tracking_table_ddl())
         self._safe_commit(driver)
 
         self._migrate_schema_if_needed(driver)
@@ -148,7 +148,7 @@ class SyncMigrationTracker(BaseMigrationTracker["SyncDriverAdapterBase"]):
         Returns:
             The current version number or None if no migrations applied.
         """
-        result = driver.execute(self._get_current_version_sql())
+        result = driver.execute(self._current_version_query())
         current = result.get_data()[0]["version_num"] if result.data else None
         log_with_context(
             logger,
@@ -169,7 +169,7 @@ class SyncMigrationTracker(BaseMigrationTracker["SyncDriverAdapterBase"]):
         Returns:
             List of migration records.
         """
-        result = driver.execute(self._get_applied_migrations_sql())
+        result = driver.execute(self._applied_migrations_query())
         applied = result.get_data()
         log_with_context(
             logger,
@@ -199,11 +199,11 @@ class SyncMigrationTracker(BaseMigrationTracker["SyncDriverAdapterBase"]):
         parsed_version = parse_version(version)
         version_type = parsed_version.type.value
 
-        result = driver.execute(self._get_next_execution_sequence_sql())
+        result = driver.execute(self._next_execution_sequence_query())
         next_sequence = result.get_data()[0]["next_seq"] if result.data else 1
 
         driver.execute(
-            self._get_record_migration_sql(
+            self._record_migration_statement(
                 version,
                 version_type,
                 next_sequence,
@@ -231,7 +231,7 @@ class SyncMigrationTracker(BaseMigrationTracker["SyncDriverAdapterBase"]):
             driver: The database driver to use.
             version: Version number to remove.
         """
-        driver.execute(self._get_remove_migration_sql(version))
+        driver.execute(self._remove_migration_statement(version))
         self._safe_commit(driver)
         log_with_context(
             logger,
@@ -263,10 +263,10 @@ class SyncMigrationTracker(BaseMigrationTracker["SyncDriverAdapterBase"]):
         parsed_new_version = parse_version(new_version)
         new_version_type = parsed_new_version.type.value
 
-        result = driver.execute(self._get_update_version_sql(old_version, new_version, new_version_type))
+        result = driver.execute(self._update_version_statement(old_version, new_version, new_version_type))
 
         if result.rows_affected == 0:
-            check_result = driver.execute(self._get_applied_migrations_sql())
+            check_result = driver.execute(self._applied_migrations_query())
             applied_versions = {row["version_num"] for row in check_result.get_data()} if check_result.data else set()
 
             if new_version in applied_versions:
@@ -317,9 +317,9 @@ class SyncMigrationTracker(BaseMigrationTracker["SyncDriverAdapterBase"]):
             description: Description of the squashed migration.
             checksum: MD5 checksum of the squashed migration content.
         """
-        driver.execute(self._get_delete_versions_sql(replaced_versions))
+        driver.execute(self._delete_versions_statement(replaced_versions))
 
-        result = driver.execute(self._get_next_execution_sequence_sql())
+        result = driver.execute(self._next_execution_sequence_query())
         next_sequence = result.get_data()[0]["next_seq"] if result.data else 1
 
         parsed_version = parse_version(squashed_version)
@@ -327,7 +327,7 @@ class SyncMigrationTracker(BaseMigrationTracker["SyncDriverAdapterBase"]):
 
         replaces_str = ",".join(replaced_versions)
         driver.execute(
-            self._get_record_squashed_migration_sql(
+            self._record_squashed_migration_statement(
                 squashed_version,
                 version_type,
                 next_sequence,
@@ -367,7 +367,7 @@ class SyncMigrationTracker(BaseMigrationTracker["SyncDriverAdapterBase"]):
         Returns:
             True if any replaced version exists (squash already applied), False otherwise.
         """
-        result = driver.execute(self._get_check_versions_exist_sql(replaced_versions))
+        result = driver.execute(self._check_versions_query(replaced_versions))
         return bool(result.data)
 
     def _safe_commit(self, driver: "SyncDriverAdapterBase") -> None:
@@ -493,7 +493,7 @@ class AsyncMigrationTracker(BaseMigrationTracker["AsyncDriverAdapterBase"]):
             driver: The database driver to use.
             column_name: Name of the column to add (lowercase).
         """
-        target_create = self._get_create_table_sql()
+        target_create = self._tracking_table_ddl()
         column_def = next((col for col in target_create.columns if col.name.lower() == column_name), None)
 
         if not column_def:
@@ -522,7 +522,7 @@ class AsyncMigrationTracker(BaseMigrationTracker["AsyncDriverAdapterBase"]):
         Args:
             driver: The database driver to use.
         """
-        await driver.execute(self._get_create_table_sql())
+        await driver.execute(self._tracking_table_ddl())
         await self._safe_commit_async(driver)
 
         await self._migrate_schema_if_needed(driver)
@@ -536,7 +536,7 @@ class AsyncMigrationTracker(BaseMigrationTracker["AsyncDriverAdapterBase"]):
         Returns:
             The current version number or None if no migrations applied.
         """
-        result = await driver.execute(self._get_current_version_sql())
+        result = await driver.execute(self._current_version_query())
         current = result.get_data()[0]["version_num"] if result.data else None
         log_with_context(
             logger,
@@ -557,7 +557,7 @@ class AsyncMigrationTracker(BaseMigrationTracker["AsyncDriverAdapterBase"]):
         Returns:
             List of migration records.
         """
-        result = await driver.execute(self._get_applied_migrations_sql())
+        result = await driver.execute(self._applied_migrations_query())
         applied = result.get_data()
         log_with_context(
             logger,
@@ -587,11 +587,11 @@ class AsyncMigrationTracker(BaseMigrationTracker["AsyncDriverAdapterBase"]):
         parsed_version = parse_version(version)
         version_type = parsed_version.type.value
 
-        result = await driver.execute(self._get_next_execution_sequence_sql())
+        result = await driver.execute(self._next_execution_sequence_query())
         next_sequence = result.get_data()[0]["next_seq"] if result.data else 1
 
         await driver.execute(
-            self._get_record_migration_sql(
+            self._record_migration_statement(
                 version,
                 version_type,
                 next_sequence,
@@ -619,7 +619,7 @@ class AsyncMigrationTracker(BaseMigrationTracker["AsyncDriverAdapterBase"]):
             driver: The database driver to use.
             version: Version number to remove.
         """
-        await driver.execute(self._get_remove_migration_sql(version))
+        await driver.execute(self._remove_migration_statement(version))
         await self._safe_commit_async(driver)
         log_with_context(
             logger,
@@ -651,10 +651,10 @@ class AsyncMigrationTracker(BaseMigrationTracker["AsyncDriverAdapterBase"]):
         parsed_new_version = parse_version(new_version)
         new_version_type = parsed_new_version.type.value
 
-        result = await driver.execute(self._get_update_version_sql(old_version, new_version, new_version_type))
+        result = await driver.execute(self._update_version_statement(old_version, new_version, new_version_type))
 
         if result.rows_affected == 0:
-            check_result = await driver.execute(self._get_applied_migrations_sql())
+            check_result = await driver.execute(self._applied_migrations_query())
             applied_versions = {row["version_num"] for row in check_result.get_data()} if check_result.data else set()
 
             if new_version in applied_versions:
@@ -705,9 +705,9 @@ class AsyncMigrationTracker(BaseMigrationTracker["AsyncDriverAdapterBase"]):
             description: Description of the squashed migration.
             checksum: MD5 checksum of the squashed migration content.
         """
-        await driver.execute(self._get_delete_versions_sql(replaced_versions))
+        await driver.execute(self._delete_versions_statement(replaced_versions))
 
-        result = await driver.execute(self._get_next_execution_sequence_sql())
+        result = await driver.execute(self._next_execution_sequence_query())
         next_sequence = result.get_data()[0]["next_seq"] if result.data else 1
 
         parsed_version = parse_version(squashed_version)
@@ -715,7 +715,7 @@ class AsyncMigrationTracker(BaseMigrationTracker["AsyncDriverAdapterBase"]):
 
         replaces_str = ",".join(replaced_versions)
         await driver.execute(
-            self._get_record_squashed_migration_sql(
+            self._record_squashed_migration_statement(
                 squashed_version,
                 version_type,
                 next_sequence,
@@ -755,7 +755,7 @@ class AsyncMigrationTracker(BaseMigrationTracker["AsyncDriverAdapterBase"]):
         Returns:
             True if any replaced version exists (squash already applied), False otherwise.
         """
-        result = await driver.execute(self._get_check_versions_exist_sql(replaced_versions))
+        result = await driver.execute(self._check_versions_query(replaced_versions))
         return bool(result.data)
 
     async def _safe_commit_async(self, driver: "AsyncDriverAdapterBase") -> None:

--- a/tests/integration/adapters/adbc/extensions/adk/test_dialect_support.py
+++ b/tests/integration/adapters/adbc/extensions/adk/test_dialect_support.py
@@ -47,7 +47,7 @@ def test_postgresql_sessions_ddl_contains_jsonb() -> None:
     """Test PostgreSQL DDL uses JSONB type."""
     config = AdbcConfig(connection_config={"driver_name": "postgresql", "uri": ":memory:"})
     store = AdbcADKStore(config)
-    ddl = store._get_sessions_ddl_postgresql()  # pyright: ignore[reportPrivateUsage]
+    ddl = store._sessions_ddl_postgresql()  # pyright: ignore[reportPrivateUsage]
     assert "JSONB" in ddl
     assert "TIMESTAMPTZ" in ddl
     assert "'{}'::jsonb" in ddl
@@ -57,7 +57,7 @@ def test_sqlite_sessions_ddl_contains_text() -> None:
     """Test SQLite DDL uses TEXT type."""
     config = AdbcConfig(connection_config={"driver_name": "sqlite", "uri": ":memory:"})
     store = AdbcADKStore(config)
-    ddl = store._get_sessions_ddl_sqlite()  # pyright: ignore[reportPrivateUsage]
+    ddl = store._sessions_ddl_sqlite()  # pyright: ignore[reportPrivateUsage]
     assert "TEXT" in ddl
     assert "REAL" in ddl
 
@@ -66,7 +66,7 @@ def test_duckdb_sessions_ddl_contains_json() -> None:
     """Test DuckDB DDL uses JSON type."""
     config = AdbcConfig(connection_config={"driver_name": "duckdb", "uri": ":memory:"})
     store = AdbcADKStore(config)
-    ddl = store._get_sessions_ddl_duckdb()  # pyright: ignore[reportPrivateUsage]
+    ddl = store._sessions_ddl_duckdb()  # pyright: ignore[reportPrivateUsage]
     assert "JSON" in ddl
     assert "TIMESTAMP" in ddl
 
@@ -75,7 +75,7 @@ def test_snowflake_sessions_ddl_contains_variant() -> None:
     """Test Snowflake DDL uses VARIANT type."""
     config = AdbcConfig(connection_config={"driver_name": "snowflake", "uri": "snowflake://test"})
     store = AdbcADKStore(config)
-    ddl = store._get_sessions_ddl_snowflake()  # pyright: ignore[reportPrivateUsage]
+    ddl = store._sessions_ddl_snowflake()  # pyright: ignore[reportPrivateUsage]
     assert "VARIANT" in ddl
     assert "TIMESTAMP_TZ" in ddl
 
@@ -84,7 +84,7 @@ def test_generic_sessions_ddl_contains_text() -> None:
     """Test generic DDL uses TEXT type."""
     config = AdbcConfig(connection_config={"driver_name": "unknown", "uri": ":memory:"})
     store = AdbcADKStore(config)
-    ddl = store._get_sessions_ddl_generic()  # pyright: ignore[reportPrivateUsage]
+    ddl = store._sessions_ddl_generic()  # pyright: ignore[reportPrivateUsage]
     assert "TEXT" in ddl
     assert "TIMESTAMP" in ddl
 
@@ -93,7 +93,7 @@ def test_postgresql_events_ddl_uses_jsonb() -> None:
     """Test PostgreSQL events DDL uses JSONB for event_data."""
     config = AdbcConfig(connection_config={"driver_name": "postgresql", "uri": ":memory:"})
     store = AdbcADKStore(config)
-    ddl = store._get_events_ddl_postgresql()  # pyright: ignore[reportPrivateUsage]
+    ddl = store._events_ddl_postgresql()  # pyright: ignore[reportPrivateUsage]
     assert "JSONB" in ddl
     assert "event_data" in ddl
     assert "session_id" in ddl
@@ -105,7 +105,7 @@ def test_sqlite_events_ddl_uses_text() -> None:
     """Test SQLite events DDL uses TEXT for event_data."""
     config = AdbcConfig(connection_config={"driver_name": "sqlite", "uri": ":memory:"})
     store = AdbcADKStore(config)
-    ddl = store._get_events_ddl_sqlite()  # pyright: ignore[reportPrivateUsage]
+    ddl = store._events_ddl_sqlite()  # pyright: ignore[reportPrivateUsage]
     assert "TEXT" in ddl
     assert "event_data" in ddl
     assert "session_id" in ddl
@@ -116,7 +116,7 @@ def test_duckdb_events_ddl_uses_json() -> None:
     """Test DuckDB events DDL uses JSON type for event_data."""
     config = AdbcConfig(connection_config={"driver_name": "duckdb", "uri": ":memory:"})
     store = AdbcADKStore(config)
-    ddl = store._get_events_ddl_duckdb()  # pyright: ignore[reportPrivateUsage]
+    ddl = store._events_ddl_duckdb()  # pyright: ignore[reportPrivateUsage]
     assert "JSON" in ddl
     assert "event_data" in ddl
 
@@ -125,7 +125,7 @@ def test_snowflake_events_ddl_uses_variant() -> None:
     """Test Snowflake events DDL uses VARIANT for event_data."""
     config = AdbcConfig(connection_config={"driver_name": "snowflake", "uri": "snowflake://test"})
     store = AdbcADKStore(config)
-    ddl = store._get_events_ddl_snowflake()  # pyright: ignore[reportPrivateUsage]
+    ddl = store._events_ddl_snowflake()  # pyright: ignore[reportPrivateUsage]
     assert "VARIANT" in ddl
     assert "event_data" in ddl
 
@@ -135,10 +135,10 @@ def test_ddl_dispatch_uses_correct_dialect() -> None:
     config = AdbcConfig(connection_config={"driver_name": "postgresql", "uri": ":memory:"})
     store = AdbcADKStore(config)
 
-    sessions_ddl = store._get_create_sessions_table_sql()  # pyright: ignore[reportPrivateUsage]
+    sessions_ddl = store._sessions_table_ddl()  # pyright: ignore[reportPrivateUsage]
     assert "JSONB" in sessions_ddl
 
-    events_ddl = store._get_create_events_table_sql()  # pyright: ignore[reportPrivateUsage]
+    events_ddl = store._events_table_ddl()  # pyright: ignore[reportPrivateUsage]
     assert "JSONB" in events_ddl
     assert "event_data" in events_ddl
 
@@ -151,7 +151,7 @@ def test_owner_id_column_included_in_sessions_ddl() -> None:
     )
     store = AdbcADKStore(config)
 
-    ddl = store._get_sessions_ddl_sqlite()  # pyright: ignore[reportPrivateUsage]
+    ddl = store._sessions_ddl_sqlite()  # pyright: ignore[reportPrivateUsage]
     assert "tenant_id INTEGER NOT NULL" in ddl
 
 
@@ -160,7 +160,7 @@ def test_owner_id_column_not_included_when_none() -> None:
     config = AdbcConfig(connection_config={"driver_name": "sqlite", "uri": ":memory:"})
     store = AdbcADKStore(config)
 
-    ddl = store._get_sessions_ddl_sqlite()  # pyright: ignore[reportPrivateUsage]
+    ddl = store._sessions_ddl_sqlite()  # pyright: ignore[reportPrivateUsage]
     assert "tenant_id" not in ddl
 
 
@@ -174,7 +174,7 @@ def test_owner_id_column_postgresql() -> None:
     )
     store = AdbcADKStore(config)
 
-    ddl = store._get_sessions_ddl_postgresql()  # pyright: ignore[reportPrivateUsage]
+    ddl = store._sessions_ddl_postgresql()  # pyright: ignore[reportPrivateUsage]
     assert "organization_id UUID REFERENCES organizations(id)" in ddl
 
 
@@ -186,7 +186,7 @@ def test_owner_id_column_duckdb() -> None:
     )
     store = AdbcADKStore(config)
 
-    ddl = store._get_sessions_ddl_duckdb()  # pyright: ignore[reportPrivateUsage]
+    ddl = store._sessions_ddl_duckdb()  # pyright: ignore[reportPrivateUsage]
     assert "workspace_id VARCHAR(128) NOT NULL" in ddl
 
 
@@ -198,5 +198,5 @@ def test_owner_id_column_snowflake() -> None:
     )
     store = AdbcADKStore(config)
 
-    ddl = store._get_sessions_ddl_snowflake()  # pyright: ignore[reportPrivateUsage]
+    ddl = store._sessions_ddl_snowflake()  # pyright: ignore[reportPrivateUsage]
     assert "account_id VARCHAR NOT NULL" in ddl

--- a/tests/integration/adapters/oracledb/extensions/adk/test_inmemory.py
+++ b/tests/integration/adapters/oracledb/extensions/adk/test_inmemory.py
@@ -50,7 +50,7 @@ async def test_inmemory_enabled_creates_sessions_table_with_inmemory_async(
     finally:
         async with config.provide_connection() as conn:
             cursor = conn.cursor()
-            for stmt in store._get_drop_tables_sql():  # pyright: ignore[reportPrivateUsage]
+            for stmt in store._drop_tables_sql():  # pyright: ignore[reportPrivateUsage]
                 try:
                     await cursor.execute(stmt)
                 except Exception:
@@ -90,7 +90,7 @@ async def test_inmemory_enabled_creates_events_table_with_inmemory_async(
     finally:
         async with config.provide_connection() as conn:
             cursor = conn.cursor()
-            for stmt in store._get_drop_tables_sql():  # pyright: ignore[reportPrivateUsage]
+            for stmt in store._drop_tables_sql():  # pyright: ignore[reportPrivateUsage]
                 try:
                     await cursor.execute(stmt)
                 except Exception:
@@ -130,7 +130,7 @@ async def test_inmemory_disabled_creates_tables_without_inmemory_async(oracle_as
     finally:
         async with config.provide_connection() as conn:
             cursor = conn.cursor()
-            for stmt in store._get_drop_tables_sql():  # pyright: ignore[reportPrivateUsage]
+            for stmt in store._drop_tables_sql():  # pyright: ignore[reportPrivateUsage]
                 try:
                     await cursor.execute(stmt)
                 except Exception:
@@ -165,7 +165,7 @@ async def test_inmemory_default_disabled_async(oracle_async_config: OracleAsyncC
     finally:
         async with config.provide_connection() as conn:
             cursor = conn.cursor()
-            for stmt in store._get_drop_tables_sql():  # pyright: ignore[reportPrivateUsage]
+            for stmt in store._drop_tables_sql():  # pyright: ignore[reportPrivateUsage]
                 try:
                     await cursor.execute(stmt)
                 except Exception:
@@ -231,7 +231,7 @@ async def test_inmemory_with_owner_id_column_async(oracle_async_config: OracleAs
 
         async with config.provide_connection() as conn:
             cursor = conn.cursor()
-            for stmt in store._get_drop_tables_sql():  # pyright: ignore[reportPrivateUsage]
+            for stmt in store._drop_tables_sql():  # pyright: ignore[reportPrivateUsage]
                 try:
                     await cursor.execute(stmt)
                 except Exception:
@@ -293,7 +293,7 @@ async def test_inmemory_tables_functional_async(oracle_async_config: OracleAsync
     finally:
         async with config.provide_connection() as conn:
             cursor = conn.cursor()
-            for stmt in store._get_drop_tables_sql():  # pyright: ignore[reportPrivateUsage]
+            for stmt in store._drop_tables_sql():  # pyright: ignore[reportPrivateUsage]
                 try:
                     await cursor.execute(stmt)
                 except Exception:
@@ -334,7 +334,7 @@ async def test_inmemory_enabled_sync(oracle_sync_config: OracleSyncConfig) -> No
     finally:
         with config.provide_connection() as conn:
             cursor = conn.cursor()
-            for stmt in store._get_drop_tables_sql():  # pyright: ignore[reportPrivateUsage]
+            for stmt in store._drop_tables_sql():  # pyright: ignore[reportPrivateUsage]
                 try:
                     cursor.execute(stmt)
                 except Exception:
@@ -373,7 +373,7 @@ async def test_inmemory_disabled_sync(oracle_sync_config: OracleSyncConfig) -> N
     finally:
         with config.provide_connection() as conn:
             cursor = conn.cursor()
-            for stmt in store._get_drop_tables_sql():  # pyright: ignore[reportPrivateUsage]
+            for stmt in store._drop_tables_sql():  # pyright: ignore[reportPrivateUsage]
                 try:
                     cursor.execute(stmt)
                 except Exception:
@@ -408,7 +408,7 @@ async def test_inmemory_tables_functional_sync(oracle_sync_config: OracleSyncCon
     finally:
         with config.provide_connection() as conn:
             cursor = conn.cursor()
-            for stmt in store._get_drop_tables_sql():  # pyright: ignore[reportPrivateUsage]
+            for stmt in store._drop_tables_sql():  # pyright: ignore[reportPrivateUsage]
                 try:
                     cursor.execute(stmt)
                 except Exception:

--- a/tests/integration/adapters/oracledb/extensions/adk/test_oracle_specific.py
+++ b/tests/integration/adapters/oracledb/extensions/adk/test_oracle_specific.py
@@ -38,7 +38,7 @@ def _event_record(
 
 def _drop_table_statements(store: object) -> "list[str]":
     """Return drop table statements for ADK stores."""
-    dropper = cast("Any", getattr(store, "_get_drop_tables_sql"))
+    dropper = cast("Any", getattr(store, "_drop_tables_sql"))
     return cast("list[str]", dropper())
 
 

--- a/tests/integration/adapters/oracledb/extensions/litestar/test_inmemory.py
+++ b/tests/integration/adapters/oracledb/extensions/litestar/test_inmemory.py
@@ -49,7 +49,7 @@ async def test_inmemory_enabled_creates_session_table_with_inmemory_async(
     finally:
         async with config.provide_connection() as conn:
             cursor = conn.cursor()
-            for stmt in store._get_drop_table_sql():  # pyright: ignore[reportPrivateUsage]
+            for stmt in store._drop_table_sql():  # pyright: ignore[reportPrivateUsage]
                 try:
                     await cursor.execute(stmt)
                 except Exception:
@@ -86,7 +86,7 @@ async def test_inmemory_disabled_creates_table_without_inmemory_async(oracle_asy
     finally:
         async with config.provide_connection() as conn:
             cursor = conn.cursor()
-            for stmt in store._get_drop_table_sql():  # pyright: ignore[reportPrivateUsage]
+            for stmt in store._drop_table_sql():  # pyright: ignore[reportPrivateUsage]
                 try:
                     await cursor.execute(stmt)
                 except Exception:
@@ -123,7 +123,7 @@ async def test_inmemory_default_disabled_async(oracle_async_config: OracleAsyncC
     finally:
         async with config.provide_connection() as conn:
             cursor = conn.cursor()
-            for stmt in store._get_drop_table_sql():  # pyright: ignore[reportPrivateUsage]
+            for stmt in store._drop_table_sql():  # pyright: ignore[reportPrivateUsage]
                 try:
                     await cursor.execute(stmt)
                 except Exception:
@@ -162,7 +162,7 @@ async def test_inmemory_table_functional_async(oracle_async_config: OracleAsyncC
     finally:
         async with config.provide_connection() as conn:
             cursor = conn.cursor()
-            for stmt in store._get_drop_table_sql():  # pyright: ignore[reportPrivateUsage]
+            for stmt in store._drop_table_sql():  # pyright: ignore[reportPrivateUsage]
                 try:
                     await cursor.execute(stmt)
                 except Exception:
@@ -202,7 +202,7 @@ def test_inmemory_enabled_sync(oracle_sync_config: OracleSyncConfig) -> None:
     finally:
         with config.provide_connection() as conn:
             cursor = conn.cursor()
-            for stmt in store._get_drop_table_sql():  # pyright: ignore[reportPrivateUsage]
+            for stmt in store._drop_table_sql():  # pyright: ignore[reportPrivateUsage]
                 try:
                     cursor.execute(stmt)
                 except Exception:
@@ -241,7 +241,7 @@ def test_inmemory_disabled_sync(oracle_sync_config: OracleSyncConfig) -> None:
     finally:
         with config.provide_connection() as conn:
             cursor = conn.cursor()
-            for stmt in store._get_drop_table_sql():  # pyright: ignore[reportPrivateUsage]
+            for stmt in store._drop_table_sql():  # pyright: ignore[reportPrivateUsage]
                 try:
                     cursor.execute(stmt)
                 except Exception:
@@ -274,7 +274,7 @@ def test_inmemory_table_functional_sync(oracle_sync_config: OracleSyncConfig) ->
     finally:
         with config.provide_connection() as conn:
             cursor = conn.cursor()
-            for stmt in store._get_drop_table_sql():  # pyright: ignore[reportPrivateUsage]
+            for stmt in store._drop_table_sql():  # pyright: ignore[reportPrivateUsage]
                 try:
                     cursor.execute(stmt)
                 except Exception:

--- a/tests/integration/adapters/psycopg/extensions/adk/test_owner_id_column.py
+++ b/tests/integration/adapters/psycopg/extensions/adk/test_owner_id_column.py
@@ -166,7 +166,7 @@ async def test_sync_store_without_owner_id_column(postgres_service: "PostgresSer
 
 async def test_async_ddl_includes_owner_id_column(psycopg_async_store_with_fk: PsycopgAsyncADKStore) -> None:
     """Test that the DDL generation includes the owner_id_column."""
-    ddl = await psycopg_async_store_with_fk._get_create_sessions_table_sql()  # pyright: ignore[reportPrivateUsage]
+    ddl = await psycopg_async_store_with_fk._sessions_table_ddl()  # pyright: ignore[reportPrivateUsage]
 
     assert "tenant_id INTEGER NOT NULL" in ddl
     assert "test_sessions_fk" in ddl
@@ -174,7 +174,7 @@ async def test_async_ddl_includes_owner_id_column(psycopg_async_store_with_fk: P
 
 async def test_sync_ddl_includes_owner_id_column(psycopg_sync_store_with_fk: PsycopgSyncADKStore) -> None:
     """Test that the DDL generation includes the owner_id_column."""
-    ddl = psycopg_sync_store_with_fk._get_create_sessions_table_sql()  # pyright: ignore[reportPrivateUsage]
+    ddl = psycopg_sync_store_with_fk._sessions_table_ddl()  # pyright: ignore[reportPrivateUsage]
 
     assert "account_id VARCHAR(64) NOT NULL" in ddl
     assert "test_sessions_sync_fk" in ddl

--- a/tests/unit/adapters/test_aiomysql/test_adk_store.py
+++ b/tests/unit/adapters/test_aiomysql/test_adk_store.py
@@ -47,8 +47,8 @@ def test_aiomysql_adk_tables_use_plain_mysql_schema_by_default() -> None:
     store = AiomysqlADKStore(_mock_config())
     memory_store = AiomysqlADKMemoryStore(_mock_config())
 
-    events_sql = asyncio.run(store._get_create_events_table_sql())
-    memory_sql = asyncio.run(memory_store._get_create_memory_table_sql())
+    events_sql = asyncio.run(store._events_table_ddl())
+    memory_sql = asyncio.run(memory_store._memory_table_ddl())
 
     assert "author_gc" not in events_sql
     assert "node_path_gc" not in events_sql
@@ -72,11 +72,11 @@ def test_aiomysql_adk_tables_apply_adapter_local_mysql_profile() -> None:
     )
     memory_store = AiomysqlADKMemoryStore(_mock_config({"memory_table_options": "COMMENT='adk-memory'"}))
 
-    session_sql = asyncio.run(store._get_create_sessions_table_sql())
-    events_sql = asyncio.run(store._get_create_events_table_sql())
-    app_state_sql = asyncio.run(store._get_create_app_states_table_sql())
-    user_state_sql = asyncio.run(store._get_create_user_states_table_sql())
-    memory_sql = asyncio.run(memory_store._get_create_memory_table_sql())
+    session_sql = asyncio.run(store._sessions_table_ddl())
+    events_sql = asyncio.run(store._events_table_ddl())
+    app_state_sql = asyncio.run(store._app_states_table_ddl())
+    user_state_sql = asyncio.run(store._user_states_table_ddl())
+    memory_sql = asyncio.run(memory_store._memory_table_ddl())
 
     assert (
         "author_gc VARCHAR(256) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.author'))) STORED"

--- a/tests/unit/adapters/test_aiosqlite/test_adk_config.py
+++ b/tests/unit/adapters/test_aiosqlite/test_adk_config.py
@@ -82,7 +82,7 @@ async def test_aiosqlite_adk_fts5_options_render_only_when_fts_enabled() -> None
         )
     )
 
-    assert "tokenize" not in await default_store._get_create_memory_table_sql()
-    sql = await configured_store._get_create_memory_table_sql()
+    assert "tokenize" not in await default_store._memory_table_ddl()
+    sql = await configured_store._memory_table_ddl()
     assert "tokenize = 'porter unicode61'" in sql
     assert "detail = column" in sql

--- a/tests/unit/adapters/test_asyncmy/test_adk_store.py
+++ b/tests/unit/adapters/test_asyncmy/test_adk_store.py
@@ -53,8 +53,8 @@ def test_asyncmy_adk_tables_use_plain_mysql_schema_by_default() -> None:
     store = AsyncmyADKStore(_mock_config())
     memory_store = AsyncmyADKMemoryStore(_mock_config())
 
-    events_sql = asyncio.run(store._get_create_events_table_sql())
-    memory_sql = asyncio.run(memory_store._get_create_memory_table_sql())
+    events_sql = asyncio.run(store._events_table_ddl())
+    memory_sql = asyncio.run(memory_store._memory_table_ddl())
 
     assert "author_gc" not in events_sql
     assert "node_path_gc" not in events_sql
@@ -78,11 +78,11 @@ def test_asyncmy_adk_tables_apply_adapter_local_mysql_profile() -> None:
     )
     memory_store = AsyncmyADKMemoryStore(_mock_config({"memory_table_options": "COMMENT='adk-memory'"}))
 
-    session_sql = asyncio.run(store._get_create_sessions_table_sql())
-    events_sql = asyncio.run(store._get_create_events_table_sql())
-    app_state_sql = asyncio.run(store._get_create_app_states_table_sql())
-    user_state_sql = asyncio.run(store._get_create_user_states_table_sql())
-    memory_sql = asyncio.run(memory_store._get_create_memory_table_sql())
+    session_sql = asyncio.run(store._sessions_table_ddl())
+    events_sql = asyncio.run(store._events_table_ddl())
+    app_state_sql = asyncio.run(store._app_states_table_ddl())
+    user_state_sql = asyncio.run(store._user_states_table_ddl())
+    memory_sql = asyncio.run(memory_store._memory_table_ddl())
 
     assert (
         "author_gc VARCHAR(256) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.author'))) STORED"

--- a/tests/unit/adapters/test_asyncpg/test_adk_store.py
+++ b/tests/unit/adapters/test_asyncpg/test_adk_store.py
@@ -36,7 +36,7 @@ async def test_asyncpg_adk_events_table_uses_plain_schema_by_default() -> None:
 
     store = AsyncpgADKStore(_mock_config())
 
-    sql = await store._get_create_events_table_sql()
+    sql = await store._events_table_ddl()
 
     assert "author_gc" not in sql
     assert "node_path_gc" not in sql
@@ -48,7 +48,7 @@ async def test_asyncpg_adk_events_table_applies_adapter_local_extension_config()
 
     store = AsyncpgADKStore(_mock_config({"enable_event_generated_columns": True, "enable_covering_indexes": True}))
 
-    sql = await store._get_create_events_table_sql()
+    sql = await store._events_table_ddl()
 
     assert "author_gc VARCHAR(256) GENERATED ALWAYS AS (event_data->>'author') STORED" in sql
     assert "node_path_gc TEXT GENERATED ALWAYS AS (event_data->'node_info'->>'path') STORED" in sql

--- a/tests/unit/adapters/test_bigquery/test_adk_store.py
+++ b/tests/unit/adapters/test_bigquery/test_adk_store.py
@@ -106,7 +106,7 @@ def test_bigquery_adk_session_ddl_is_partitioned_and_clustered_without_filter_by
 
     store = _make_store()
 
-    ddl = store._get_create_sessions_table_sql()
+    ddl = store._sessions_table_ddl()
 
     assert "PARTITION BY DATE(create_time)" in ddl
     assert "CLUSTER BY app_name, user_id, id" in ddl
@@ -119,8 +119,8 @@ def test_bigquery_adk_event_ddl_clusters_and_carries_event_ttl_only() -> None:
 
     store = _make_store({"retention": {"event_ttl_seconds": 86400 * 30}})
 
-    session_ddl = store._get_create_sessions_table_sql()
-    event_ddl = store._get_create_events_table_sql()
+    session_ddl = store._sessions_table_ddl()
+    event_ddl = store._events_table_ddl()
 
     assert "PARTITION BY DATE(timestamp)" in event_ddl
     assert "CLUSTER BY app_name, user_id, session_id" in event_ddl

--- a/tests/unit/adapters/test_cockroach_asyncpg/test_adk_store.py
+++ b/tests/unit/adapters/test_cockroach_asyncpg/test_adk_store.py
@@ -52,9 +52,9 @@ async def test_cockroach_asyncpg_adk_tables_use_plain_schema_by_default() -> Non
     store = CockroachAsyncpgADKStore(_mock_config())
     memory_store = CockroachAsyncpgADKMemoryStore(_mock_config())
 
-    session_sql = await store._get_create_sessions_table_sql()
-    events_sql = await store._get_create_events_table_sql()
-    memory_sql = await memory_store._get_create_memory_table_sql()
+    session_sql = await store._sessions_table_ddl()
+    events_sql = await store._events_table_ddl()
+    memory_sql = await memory_store._memory_table_ddl()
 
     assert "LOCALITY" not in session_sql
     assert "LOCALITY" not in events_sql
@@ -80,8 +80,8 @@ async def test_cockroach_asyncpg_adk_tables_apply_locality_hash_and_storing_inde
     })
     store = CockroachAsyncpgADKStore(config)
 
-    session_sql = await store._get_create_sessions_table_sql()
-    events_sql = await store._get_create_events_table_sql()
+    session_sql = await store._sessions_table_ddl()
+    events_sql = await store._events_table_ddl()
 
     assert 'LOCALITY REGIONAL BY TABLE IN "us-east1"' in session_sql
     assert "LOCALITY REGIONAL BY ROW" in events_sql
@@ -99,7 +99,7 @@ async def test_cockroach_asyncpg_memory_table_applies_trigram_index_and_locality
     config = _mock_config({"memory_table_locality": "LOCALITY GLOBAL", "enable_memory_trigram_index": True})
     memory_store = CockroachAsyncpgADKMemoryStore(config)
 
-    sql = await memory_store._get_create_memory_table_sql()
+    sql = await memory_store._memory_table_ddl()
 
     assert "LOCALITY GLOBAL" in sql
     assert "idx_adk_memory_content_trgm" in sql

--- a/tests/unit/adapters/test_cockroach_psycopg/test_adk_store.py
+++ b/tests/unit/adapters/test_cockroach_psycopg/test_adk_store.py
@@ -54,9 +54,9 @@ async def test_cockroach_psycopg_async_adk_tables_use_plain_schema_by_default() 
     store = CockroachPsycopgAsyncADKStore(_mock_config())
     memory_store = CockroachPsycopgAsyncADKMemoryStore(_mock_config())
 
-    session_sql = await store._get_create_sessions_table_sql()
-    events_sql = await store._get_create_events_table_sql()
-    memory_sql = await memory_store._get_create_memory_table_sql()
+    session_sql = await store._sessions_table_ddl()
+    events_sql = await store._events_table_ddl()
+    memory_sql = await memory_store._memory_table_ddl()
 
     assert "LOCALITY" not in session_sql
     assert "LOCALITY" not in events_sql
@@ -75,9 +75,9 @@ def test_cockroach_psycopg_sync_adk_tables_use_plain_schema_by_default() -> None
     store = CockroachPsycopgSyncADKStore(_mock_config())
     memory_store = CockroachPsycopgSyncADKMemoryStore(_mock_config())
 
-    session_sql = store._get_create_sessions_table_sql()
-    events_sql = store._get_create_events_table_sql()
-    memory_sql = memory_store._get_create_memory_table_sql()
+    session_sql = store._sessions_table_ddl()
+    events_sql = store._events_table_ddl()
+    memory_sql = memory_store._memory_table_ddl()
 
     assert "LOCALITY" not in session_sql
     assert "LOCALITY" not in events_sql
@@ -103,8 +103,8 @@ async def test_cockroach_psycopg_async_adk_tables_apply_locality_hash_and_storin
     })
     store = CockroachPsycopgAsyncADKStore(config)
 
-    session_sql = await store._get_create_sessions_table_sql()
-    events_sql = await store._get_create_events_table_sql()
+    session_sql = await store._sessions_table_ddl()
+    events_sql = await store._events_table_ddl()
 
     assert 'LOCALITY REGIONAL BY TABLE IN "us-east1"' in session_sql
     assert "LOCALITY REGIONAL BY ROW" in events_sql
@@ -126,8 +126,8 @@ def test_cockroach_psycopg_sync_adk_tables_apply_locality_hash_and_storing_index
     })
     store = CockroachPsycopgSyncADKStore(config)
 
-    session_sql = store._get_create_sessions_table_sql()
-    events_sql = store._get_create_events_table_sql()
+    session_sql = store._sessions_table_ddl()
+    events_sql = store._events_table_ddl()
 
     assert 'LOCALITY REGIONAL BY TABLE IN "us-east1"' in session_sql
     assert "LOCALITY REGIONAL BY ROW" in events_sql
@@ -144,7 +144,7 @@ async def test_cockroach_psycopg_async_memory_table_applies_trigram_index_and_lo
     config = _mock_config({"memory_table_locality": "LOCALITY GLOBAL", "enable_memory_trigram_index": True})
     memory_store = CockroachPsycopgAsyncADKMemoryStore(config)
 
-    sql = await memory_store._get_create_memory_table_sql()
+    sql = await memory_store._memory_table_ddl()
 
     assert "LOCALITY GLOBAL" in sql
     assert "idx_adk_memory_content_trgm" in sql
@@ -157,7 +157,7 @@ def test_cockroach_psycopg_sync_memory_table_applies_trigram_index_and_locality(
     config = _mock_config({"memory_table_locality": "LOCALITY GLOBAL", "enable_memory_trigram_index": True})
     memory_store = CockroachPsycopgSyncADKMemoryStore(config)
 
-    sql = memory_store._get_create_memory_table_sql()
+    sql = memory_store._memory_table_ddl()
 
     assert "LOCALITY GLOBAL" in sql
     assert "idx_adk_memory_content_trgm" in sql

--- a/tests/unit/adapters/test_duckdb/test_adk_store.py
+++ b/tests/unit/adapters/test_duckdb/test_adk_store.py
@@ -60,7 +60,7 @@ def test_duckdb_adk_events_table_uses_plain_schema_by_default() -> None:
 
     store = DuckdbADKStore(_mock_config())
 
-    sql = store._get_create_events_table_sql()
+    sql = store._events_table_ddl()
 
     assert _normalize_sql(sql) == _normalize_sql(
         """
@@ -86,7 +86,7 @@ def test_duckdb_adk_events_table_applies_adapter_local_generated_columns() -> No
         _mock_config({"enable_event_generated_columns": True, "enable_event_generated_column_indexes": True})
     )
 
-    sql = store._get_create_events_table_sql()
+    sql = store._events_table_ddl()
 
     assert (
         "author_gc VARCHAR GENERATED ALWAYS AS "
@@ -108,13 +108,11 @@ def test_duckdb_adk_memory_fts_pragmas_use_default_options() -> None:
     store = DuckdbADKMemoryStore(_mock_config({"memory_use_fts": True}))
 
     assert (
-        store._get_create_fts_index_sql(overwrite=False)
-        == "PRAGMA create_fts_index('adk_memory', 'id', 'content_text', "
+        store._fts_index_ddl(overwrite=False) == "PRAGMA create_fts_index('adk_memory', 'id', 'content_text', "
         "stemmer='porter', stopwords='english', strip_accents=1, lower=1)"
     )
     assert (
-        store._get_create_fts_index_sql(overwrite=True)
-        == "PRAGMA create_fts_index('adk_memory', 'id', 'content_text', "
+        store._fts_index_ddl(overwrite=True) == "PRAGMA create_fts_index('adk_memory', 'id', 'content_text', "
         "overwrite=1, stemmer='porter', stopwords='english', strip_accents=1, lower=1)"
     )
 
@@ -135,8 +133,8 @@ def test_duckdb_adk_memory_fts_pragmas_apply_adapter_local_options() -> None:
         })
     )
 
-    create_sql = store._get_create_fts_index_sql(overwrite=False)
-    refresh_sql = store._get_create_fts_index_sql(overwrite=True)
+    create_sql = store._fts_index_ddl(overwrite=False)
+    refresh_sql = store._fts_index_ddl(overwrite=True)
 
     assert create_sql == (
         "PRAGMA create_fts_index('adk_memory', 'id', 'content_text', "

--- a/tests/unit/adapters/test_mssql_python/test_adk_store.py
+++ b/tests/unit/adapters/test_mssql_python/test_adk_store.py
@@ -66,10 +66,10 @@ def test_sync_store_generates_tsql_idempotent_schema_with_conservative_json() ->
 
     store = MssqlPythonSyncADKStore(_mock_config())
 
-    sessions_sql = store._get_create_sessions_table_sql()
-    events_sql = store._get_create_events_table_sql()
-    app_state_sql = store._get_create_app_states_table_sql()
-    metadata_sql = store._get_seed_metadata_sql()
+    sessions_sql = store._sessions_table_ddl()
+    events_sql = store._events_table_ddl()
+    app_state_sql = store._app_states_table_ddl()
+    metadata_sql = store._metadata_seed_sql()
 
     assert "IF NOT EXISTS (SELECT 1 FROM sys.tables" in sessions_sql
     assert "schema_id = SCHEMA_ID(N'dbo')" in sessions_sql
@@ -91,8 +91,8 @@ def test_sync_store_can_force_native_json_from_extension_config() -> None:
 
     store = MssqlPythonSyncADKStore(_mock_config({"native_json": True}))
 
-    assert "state JSON NOT NULL" in store._get_create_sessions_table_sql()
-    assert "event_data JSON NOT NULL" in store._get_create_events_table_sql()
+    assert "state JSON NOT NULL" in store._sessions_table_ddl()
+    assert "event_data JSON NOT NULL" in store._events_table_ddl()
 
 
 def test_sync_store_uses_tsql_upsert_and_top_limit() -> None:
@@ -100,8 +100,8 @@ def test_sync_store_uses_tsql_upsert_and_top_limit() -> None:
 
     store = MssqlPythonSyncADKStore(_mock_config())
 
-    app_upsert = store._get_upsert_app_state_sql()
-    events_sql, params = store._get_events_query("app", "user", "session", limit=5)
+    app_upsert = store._upsert_app_state_sql()
+    events_sql, params = store._events_query("app", "user", "session", limit=5)
 
     assert "MERGE INTO [dbo].[adk_app_state]" in app_upsert
     assert "WITH (HOLDLOCK)" in app_upsert
@@ -116,8 +116,8 @@ async def test_async_store_generates_same_tsql_schema() -> None:
 
     store = MssqlPythonAsyncADKStore(_mock_config())
 
-    sessions_sql = await store._get_create_sessions_table_sql()
-    events_sql = await store._get_create_events_table_sql()
+    sessions_sql = await store._sessions_table_ddl()
+    events_sql = await store._events_table_ddl()
 
     assert "IF NOT EXISTS (SELECT 1 FROM sys.tables" in sessions_sql
     assert "row_id UNIQUEIDENTIFIER NOT NULL" in sessions_sql

--- a/tests/unit/adapters/test_mssql_python/test_litestar_store.py
+++ b/tests/unit/adapters/test_mssql_python/test_litestar_store.py
@@ -74,7 +74,7 @@ def test_mssql_python_store_create_table_uses_tsql_guards() -> None:
     """The store DDL should use SQL Server idempotent guards and binary payload storage."""
     store = MssqlPythonStore(cast("Any", FakeConfig(FakeSession())))
 
-    ddl = store._get_create_table_sql()
+    ddl = store._table_ddl()
 
     assert "IF NOT EXISTS" in ddl
     assert "sys.tables" in ddl

--- a/tests/unit/adapters/test_mysqlconnector/test_adk_store.py
+++ b/tests/unit/adapters/test_mysqlconnector/test_adk_store.py
@@ -49,8 +49,8 @@ def test_mysqlconnector_async_adk_tables_use_plain_mysql_schema_by_default() -> 
     store = MysqlConnectorAsyncADKStore(_mock_config())
     memory_store = MysqlConnectorAsyncADKMemoryStore(_mock_config())
 
-    events_sql = asyncio.run(store._get_create_events_table_sql())
-    memory_sql = asyncio.run(memory_store._get_create_memory_table_sql())
+    events_sql = asyncio.run(store._events_table_ddl())
+    memory_sql = asyncio.run(memory_store._memory_table_ddl())
 
     assert "author_gc" not in events_sql
     assert "node_path_gc" not in events_sql
@@ -74,11 +74,11 @@ def test_mysqlconnector_async_adk_tables_apply_adapter_local_mysql_profile() -> 
     )
     memory_store = MysqlConnectorAsyncADKMemoryStore(_mock_config({"memory_table_options": "COMMENT='adk-memory'"}))
 
-    session_sql = asyncio.run(store._get_create_sessions_table_sql())
-    events_sql = asyncio.run(store._get_create_events_table_sql())
-    app_state_sql = asyncio.run(store._get_create_app_states_table_sql())
-    user_state_sql = asyncio.run(store._get_create_user_states_table_sql())
-    memory_sql = asyncio.run(memory_store._get_create_memory_table_sql())
+    session_sql = asyncio.run(store._sessions_table_ddl())
+    events_sql = asyncio.run(store._events_table_ddl())
+    app_state_sql = asyncio.run(store._app_states_table_ddl())
+    user_state_sql = asyncio.run(store._user_states_table_ddl())
+    memory_sql = asyncio.run(memory_store._memory_table_ddl())
 
     assert (
         "author_gc VARCHAR(256) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.author'))) STORED"
@@ -107,8 +107,8 @@ def test_mysqlconnector_sync_adk_tables_apply_same_mysql_profile() -> None:
     )
     memory_store = MysqlConnectorSyncADKMemoryStore(_mock_config({"memory_table_options": "COMMENT='adk-memory'"}))
 
-    events_sql = store._get_create_events_table_sql()
-    memory_sql = memory_store._get_create_memory_table_sql()
+    events_sql = store._events_table_ddl()
+    memory_sql = memory_store._memory_table_ddl()
 
     assert (
         "author_gc VARCHAR(256) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.author'))) STORED"

--- a/tests/unit/adapters/test_oracledb/test_oracle_adk_store.py
+++ b/tests/unit/adapters/test_oracledb/test_oracle_adk_store.py
@@ -142,7 +142,7 @@ def test_oracle_adk_session_table_applies_partition_compression_and_inmemory_cla
     })
     store = OracleAsyncADKStore(config)
 
-    sql = store._get_create_sessions_table_sql_for_type(JSONStorageType.JSON_NATIVE)
+    sql = store._sessions_table_ddl_for_type(JSONStorageType.JSON_NATIVE)
 
     assert "COLUMN STORE COMPRESS FOR ARCHIVE HIGH" in sql
     assert "INMEMORY PRIORITY HIGH" in sql
@@ -157,7 +157,7 @@ def test_oracle_adk_events_table_applies_hash_partitioning_and_table_options() -
     })
     store = OracleSyncADKStore(config)
 
-    sql = store._get_create_events_table_sql_for_type(JSONStorageType.JSON_NATIVE)
+    sql = store._events_table_ddl_for_type(JSONStorageType.JSON_NATIVE)
 
     assert "TABLESPACE adk_data" in sql
     assert "PARTITION BY HASH (session_id) PARTITIONS 32" in sql
@@ -171,7 +171,7 @@ def test_oracle_adk_memory_table_applies_memory_specific_partition_key_and_compr
     })
     store = OracleAsyncADKMemoryStore(config)
 
-    sql = store._get_create_memory_table_sql_for_type(JSONStorageType.JSON_NATIVE)
+    sql = store._memory_table_ddl_for_type(JSONStorageType.JSON_NATIVE)
 
     assert "ROW STORE COMPRESS ADVANCED" in sql
     assert "TABLESPACE adk_memory" in sql
@@ -185,7 +185,7 @@ def test_oracle_adk_sync_memory_table_uses_same_lifecycle_clauses() -> None:
     })
     store = OracleSyncADKMemoryStore(config)
 
-    sql = store._get_create_memory_table_sql_for_type(JSONStorageType.JSON_NATIVE)
+    sql = store._memory_table_ddl_for_type(JSONStorageType.JSON_NATIVE)
 
     assert "COLUMN STORE COMPRESS FOR QUERY HIGH" in sql
     assert "PARTITION BY RANGE (inserted_at)" in sql

--- a/tests/unit/adapters/test_psqlpy/test_adk_store.py
+++ b/tests/unit/adapters/test_psqlpy/test_adk_store.py
@@ -36,7 +36,7 @@ async def test_psqlpy_adk_events_table_uses_plain_schema_by_default() -> None:
 
     store = PsqlpyADKStore(_mock_config())
 
-    sql = await store._get_create_events_table_sql()
+    sql = await store._events_table_ddl()
 
     assert "author_gc" not in sql
     assert "node_path_gc" not in sql
@@ -48,7 +48,7 @@ async def test_psqlpy_adk_events_table_applies_adapter_local_extension_config() 
 
     store = PsqlpyADKStore(_mock_config({"enable_event_generated_columns": True, "enable_covering_indexes": True}))
 
-    sql = await store._get_create_events_table_sql()
+    sql = await store._events_table_ddl()
 
     assert "author_gc VARCHAR(256) GENERATED ALWAYS AS (event_data->>'author') STORED" in sql
     assert "node_path_gc TEXT GENERATED ALWAYS AS (event_data->'node_info'->>'path') STORED" in sql

--- a/tests/unit/adapters/test_psycopg/test_adk_store.py
+++ b/tests/unit/adapters/test_psycopg/test_adk_store.py
@@ -102,7 +102,7 @@ async def test_psycopg_async_adk_events_table_uses_plain_schema_by_default() -> 
 
     store = PsycopgAsyncADKStore(_mock_config())
 
-    sql = await store._get_create_events_table_sql()
+    sql = await store._events_table_ddl()
 
     assert "author_gc" not in sql
     assert "node_path_gc" not in sql
@@ -116,7 +116,7 @@ async def test_psycopg_async_adk_events_table_applies_adapter_local_extension_co
         _mock_config({"enable_event_generated_columns": True, "enable_covering_indexes": True})
     )
 
-    sql = await store._get_create_events_table_sql()
+    sql = await store._events_table_ddl()
 
     assert "author_gc VARCHAR(256) GENERATED ALWAYS AS (event_data->>'author') STORED" in sql
     assert "node_path_gc TEXT GENERATED ALWAYS AS (event_data->'node_info'->>'path') STORED" in sql
@@ -130,7 +130,7 @@ def test_psycopg_sync_adk_events_table_uses_plain_schema_by_default() -> None:
 
     store = PsycopgSyncADKStore(_mock_config())
 
-    sql = store._get_create_events_table_sql()
+    sql = store._events_table_ddl()
 
     assert "author_gc" not in sql
     assert "node_path_gc" not in sql
@@ -142,7 +142,7 @@ def test_psycopg_sync_adk_events_table_applies_adapter_local_extension_config() 
 
     store = PsycopgSyncADKStore(_mock_config({"enable_event_generated_columns": True, "enable_covering_indexes": True}))
 
-    sql = store._get_create_events_table_sql()
+    sql = store._events_table_ddl()
 
     assert "author_gc VARCHAR(256) GENERATED ALWAYS AS (event_data->>'author') STORED" in sql
     assert "node_path_gc TEXT GENERATED ALWAYS AS (event_data->'node_info'->>'path') STORED" in sql

--- a/tests/unit/adapters/test_pymssql/test_extensions.py
+++ b/tests/unit/adapters/test_pymssql/test_extensions.py
@@ -22,7 +22,7 @@ def test_litestar_store_ddl_is_tsql_idempotent() -> None:
     from sqlspec.adapters.pymssql.litestar.store import PymssqlStore
 
     store = PymssqlStore(PymssqlConfig(extension_config={"litestar": {"session_table": "litestar_session"}}))
-    ddl = store._get_create_table_sql()
+    ddl = store._table_ddl()
 
     assert "IF NOT EXISTS" in ddl
     assert "CREATE TABLE litestar_session" in ddl
@@ -51,8 +51,8 @@ def test_adk_store_ddl_uses_tsql_tables_and_json_fallback() -> None:
 
     store = PymssqlADKStore(PymssqlConfig(extension_config={"adk": {}}))
 
-    sessions_ddl = store._get_create_sessions_table_sql()
-    events_ddl = store._get_create_events_table_sql()
+    sessions_ddl = store._sessions_table_ddl()
+    events_ddl = store._events_table_ddl()
 
     assert "CREATE TABLE" in sessions_ddl
     assert "NVARCHAR(MAX)" in sessions_ddl
@@ -67,4 +67,4 @@ def test_adk_store_can_force_native_json_column_type() -> None:
 
     store = PymssqlADKStore(PymssqlConfig(extension_config={"adk": {"native_json": True}}))
 
-    assert "state JSON NOT NULL" in store._get_create_sessions_table_sql()
+    assert "state JSON NOT NULL" in store._sessions_table_ddl()

--- a/tests/unit/adapters/test_pymysql/test_adk_store.py
+++ b/tests/unit/adapters/test_pymysql/test_adk_store.py
@@ -52,8 +52,8 @@ def test_pymysql_adk_tables_use_plain_mysql_schema_by_default() -> None:
     store = PyMysqlADKStore(_mock_config())
     memory_store = PyMysqlADKMemoryStore(_mock_config())
 
-    events_sql = store._get_create_events_table_sql()
-    memory_sql = memory_store._get_create_memory_table_sql()
+    events_sql = store._events_table_ddl()
+    memory_sql = memory_store._memory_table_ddl()
 
     assert "author_gc" not in events_sql
     assert "node_path_gc" not in events_sql
@@ -77,11 +77,11 @@ def test_pymysql_adk_tables_apply_adapter_local_mysql_profile() -> None:
     )
     memory_store = PyMysqlADKMemoryStore(_mock_config({"memory_table_options": "COMMENT='adk-memory'"}))
 
-    session_sql = store._get_create_sessions_table_sql()
-    events_sql = store._get_create_events_table_sql()
-    app_state_sql = store._get_create_app_states_table_sql()
-    user_state_sql = store._get_create_user_states_table_sql()
-    memory_sql = memory_store._get_create_memory_table_sql()
+    session_sql = store._sessions_table_ddl()
+    events_sql = store._events_table_ddl()
+    app_state_sql = store._app_states_table_ddl()
+    user_state_sql = store._user_states_table_ddl()
+    memory_sql = memory_store._memory_table_ddl()
 
     assert (
         "author_gc VARCHAR(256) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(event_data, '$.author'))) STORED"

--- a/tests/unit/adapters/test_spanner/test_adk_store.py
+++ b/tests/unit/adapters/test_spanner/test_adk_store.py
@@ -117,7 +117,7 @@ def test_append_event_and_update_state_preserves_event_record_timestamp() -> Non
 def test_spanner_session_table_generates_row_deletion_policy_from_retention() -> None:
     store = SpannerSyncADKStore(_mock_config({"retention": {"session_ttl_seconds": 86_400}}))
 
-    sql = store._get_create_sessions_table_sql()
+    sql = store._sessions_table_ddl()
 
     assert "ROW DELETION POLICY (OLDER_THAN(create_time, INTERVAL 1 DAY))" in sql
 
@@ -125,7 +125,7 @@ def test_spanner_session_table_generates_row_deletion_policy_from_retention() ->
 def test_spanner_events_table_rounds_retention_up_to_days() -> None:
     store = SpannerSyncADKStore(_mock_config({"retention": {"event_ttl_seconds": 86_401}}))
 
-    sql = store._get_create_events_table_sql()
+    sql = store._events_table_ddl()
 
     assert "ROW DELETION POLICY (OLDER_THAN(timestamp, INTERVAL 2 DAY))" in sql
 
@@ -135,7 +135,7 @@ def test_spanner_memory_table_generates_ttl_and_table_options() -> None:
         _mock_config({"memory_table_options": "locality_group = 'hot'", "retention": {"memory_ttl_seconds": 604_800}})
     )
 
-    statements = store._get_create_memory_table_sql()
+    statements = store._memory_table_ddl()
     table_sql = statements[0]
 
     assert "OPTIONS (locality_group = 'hot')" in table_sql
@@ -163,7 +163,7 @@ def test_spanner_session_store_emits_expiration_indexes_with_configured_options(
 def test_spanner_session_store_drops_expiration_indexes_before_tables() -> None:
     store = SpannerSyncADKStore(_mock_config())
 
-    statements = store._get_drop_tables_sql()
+    statements = store._drop_tables_sql()
 
     assert statements[:2] == ["DROP INDEX idx_adk_event_timestamp", "DROP INDEX idx_adk_session_update_time"]
     assert statements[-2:] == ["DROP TABLE adk_event", "DROP TABLE adk_session"]
@@ -228,7 +228,7 @@ def test_spanner_reset_drop_tables_filters_absent_tables() -> None:
     config.get_database.return_value.list_tables.return_value = [SimpleNamespace(table_id="adk_events")]
     store = SpannerSyncADKStore(config)
 
-    statements = store._get_reset_drop_tables_sql()
+    statements = store._reset_drop_tables_sql()
 
     assert statements == ["DROP INDEX idx_adk_events_timestamp", "DROP TABLE adk_events"]
 
@@ -238,7 +238,7 @@ def test_spanner_memory_reset_drop_tables_filters_absent_tables_and_indexes() ->
     config.get_database.return_value.list_tables.return_value = [SimpleNamespace(table_id="adk_memory_entries")]
     store = SpannerSyncADKMemoryStore(config)
 
-    statements = store._get_reset_drop_memory_table_sql()
+    statements = store._reset_drop_memory_table_sql()
 
     assert statements == [
         "DROP INDEX idx_adk_memory_entries_session",

--- a/tests/unit/adapters/test_spanner/test_events_store.py
+++ b/tests/unit/adapters/test_spanner/test_events_store.py
@@ -25,12 +25,12 @@ def test_column_types_returns_spanner_types() -> None:
     assert timestamp_type == "TIMESTAMP"
 
 
-def test_build_create_table_sql_uses_string_types() -> None:
+def test_table_ddl_uses_string_types() -> None:
     """Verify CREATE TABLE uses STRING instead of VARCHAR."""
     config = _mock_spanner_config()
     store = SpannerSyncEventQueueStore(config)
 
-    sql = store._build_create_table_sql()
+    sql = store._table_ddl()
 
     assert "STRING(64)" in sql
     assert "STRING(128)" in sql
@@ -38,43 +38,43 @@ def test_build_create_table_sql_uses_string_types() -> None:
     assert "VARCHAR" not in sql
 
 
-def test_build_create_table_sql_uses_int64() -> None:
+def test_table_ddl_uses_int64() -> None:
     """Verify CREATE TABLE uses INT64 instead of INTEGER."""
     config = _mock_spanner_config()
     store = SpannerSyncEventQueueStore(config)
 
-    sql = store._build_create_table_sql()
+    sql = store._table_ddl()
 
     assert "INT64" in sql
     assert "INTEGER" not in sql
 
 
-def test_build_create_table_sql_no_default_clauses() -> None:
+def test_table_ddl_no_default_clauses() -> None:
     """Verify CREATE TABLE has no DEFAULT clauses (Spanner restriction)."""
     config = _mock_spanner_config()
     store = SpannerSyncEventQueueStore(config)
 
-    sql = store._build_create_table_sql()
+    sql = store._table_ddl()
 
     assert "DEFAULT" not in sql
 
 
-def test_build_create_table_sql_inline_primary_key() -> None:
+def test_table_ddl_inline_primary_key() -> None:
     """Verify PRIMARY KEY is declared inline (Spanner requirement)."""
     config = _mock_spanner_config()
     store = SpannerSyncEventQueueStore(config)
 
-    sql = store._build_create_table_sql()
+    sql = store._table_ddl()
 
     assert sql.endswith(") PRIMARY KEY (event_id)")
 
 
-def test_build_index_sql_no_if_not_exists() -> None:
+def test_index_ddl_no_if_not_exists() -> None:
     """Verify index creation has no IF NOT EXISTS (Spanner restriction)."""
     config = _mock_spanner_config()
     store = SpannerSyncEventQueueStore(config)
 
-    sql = store._build_index_sql()
+    sql = store._index_ddl()
 
     assert sql is not None
     assert "IF NOT EXISTS" not in sql

--- a/tests/unit/adapters/test_sqlite/test_adk_config.py
+++ b/tests/unit/adapters/test_sqlite/test_adk_config.py
@@ -82,7 +82,7 @@ def test_sqlite_adk_fts5_options_render_only_when_fts_enabled() -> None:
         )
     )
 
-    assert "tokenize" not in default_store._get_create_memory_table_sql()
-    sql = configured_store._get_create_memory_table_sql()
+    assert "tokenize" not in default_store._memory_table_ddl()
+    sql = configured_store._memory_table_ddl()
     assert "tokenize = 'porter unicode61'" in sql
     assert "detail = column" in sql

--- a/tests/unit/core/test_statement.py
+++ b/tests/unit/core/test_statement.py
@@ -74,6 +74,11 @@ DEFAULT_PARAMETER_CONFIG = ParameterStyleConfig(
 TEST_CONFIG = StatementConfig(parameter_config=DEFAULT_PARAMETER_CONFIG)
 
 
+def test_sql_private_raw_sql_helper_uses_purpose_name() -> None:
+    assert hasattr(SQL, "_materialized_raw_sql")
+    assert not hasattr(SQL, "_get_raw_sql")
+
+
 @pytest.mark.parametrize(
     "config_kwargs,expected_values",
     [

--- a/tests/unit/extensions/test_adk/test_store_config.py
+++ b/tests/unit/extensions/test_adk/test_store_config.py
@@ -113,36 +113,36 @@ class _AsyncSessionStore(BaseAsyncADKStore[Any]):
     async def create_tables(self) -> None:
         return None
 
-    async def _get_create_sessions_table_sql(self) -> str:
+    async def _sessions_table_ddl(self) -> str:
         return ""
 
-    async def _get_create_events_table_sql(self) -> str:
+    async def _events_table_ddl(self) -> str:
         return ""
 
-    async def _get_create_app_states_table_sql(self) -> str:
+    async def _app_states_table_ddl(self) -> str:
         return ""
 
-    async def _get_create_user_states_table_sql(self) -> str:
+    async def _user_states_table_ddl(self) -> str:
         return ""
 
-    async def _get_create_metadata_table_sql(self) -> str:
+    async def _metadata_table_ddl(self) -> str:
         return ""
 
-    async def _get_seed_metadata_sql(self) -> str:
+    async def _metadata_seed_sql(self) -> str:
         return ""
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return ""
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return ""
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> list[str]:
+    def _drop_tables_sql(self) -> list[str]:
         return [
-            self._get_drop_metadata_table_sql(),
+            self._drop_metadata_table_sql(),
             f"DROP TABLE IF EXISTS {self._user_state_table}",
             f"DROP TABLE IF EXISTS {self._app_state_table}",
             f"DROP TABLE IF EXISTS {self._events_table}",
@@ -234,36 +234,36 @@ class _SyncSessionStore(BaseSyncADKStore[Any]):
     def create_tables(self) -> None:
         self.create_tables_called = True
 
-    def _get_create_sessions_table_sql(self) -> str:
+    def _sessions_table_ddl(self) -> str:
         return ""
 
-    def _get_create_events_table_sql(self) -> str:
+    def _events_table_ddl(self) -> str:
         return ""
 
-    def _get_create_app_states_table_sql(self) -> str:
+    def _app_states_table_ddl(self) -> str:
         return ""
 
-    def _get_create_user_states_table_sql(self) -> str:
+    def _user_states_table_ddl(self) -> str:
         return ""
 
-    def _get_create_metadata_table_sql(self) -> str:
+    def _metadata_table_ddl(self) -> str:
         return ""
 
-    def _get_seed_metadata_sql(self) -> str:
+    def _metadata_seed_sql(self) -> str:
         return ""
 
-    def _get_drop_app_states_table_sql(self) -> str:
+    def _drop_app_states_table_sql(self) -> str:
         return ""
 
-    def _get_drop_user_states_table_sql(self) -> str:
+    def _drop_user_states_table_sql(self) -> str:
         return ""
 
-    def _get_drop_metadata_table_sql(self) -> str:
+    def _drop_metadata_table_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self._metadata_table}"
 
-    def _get_drop_tables_sql(self) -> list[str]:
+    def _drop_tables_sql(self) -> list[str]:
         return [
-            self._get_drop_metadata_table_sql(),
+            self._drop_metadata_table_sql(),
             f"DROP TABLE IF EXISTS {self._user_state_table}",
             f"DROP TABLE IF EXISTS {self._app_state_table}",
             f"DROP TABLE IF EXISTS {self._events_table}",
@@ -291,11 +291,29 @@ class _SyncMemoryStore(BaseSyncADKMemoryStore[Any]):
     def delete_entries_older_than(self, days: int) -> int:
         return 0
 
-    def _get_create_memory_table_sql(self) -> str | list[str]:
+    def _memory_table_ddl(self) -> str | list[str]:
         return ""
 
-    def _get_drop_memory_table_sql(self) -> list[str]:
+    def _drop_memory_table_sql(self) -> list[str]:
         return [f"DROP TABLE IF EXISTS {self._memory_table}"]
+
+
+def test_adk_store_private_sql_helpers_use_purpose_names() -> None:
+    assert hasattr(_SyncSessionStore, "_sessions_table_ddl")
+    assert hasattr(_SyncSessionStore, "_events_table_ddl")
+    assert hasattr(_SyncSessionStore, "_metadata_seed_sql")
+    assert hasattr(_SyncSessionStore, "_drop_tables_sql")
+    assert not hasattr(_SyncSessionStore, "_get_create_sessions_table_sql")
+    assert not hasattr(_SyncSessionStore, "_get_create_events_table_sql")
+    assert not hasattr(_SyncSessionStore, "_get_seed_metadata_sql")
+    assert not hasattr(_SyncSessionStore, "_get_drop_tables_sql")
+
+
+def test_adk_memory_store_private_sql_helpers_use_purpose_names() -> None:
+    assert hasattr(_SyncMemoryStore, "_memory_table_ddl")
+    assert hasattr(_SyncMemoryStore, "_drop_memory_table_sql")
+    assert not hasattr(_SyncMemoryStore, "_get_create_memory_table_sql")
+    assert not hasattr(_SyncMemoryStore, "_get_drop_memory_table_sql")
 
 
 class _SyncArtifactStore(BaseSyncADKArtifactStore[Any]):
@@ -404,7 +422,7 @@ def test_sync_memory_store_logs_disabled_with_log_with_context(monkeypatch: pyte
 def test_session_store_reset_drop_tables_includes_legacy_metadata_table() -> None:
     store = _AsyncSessionStore(_Config())
 
-    statements = store._get_reset_drop_tables_sql()
+    statements = store._reset_drop_tables_sql()
 
     assert "DROP TABLE IF EXISTS adk_internal_metadata" in statements
     assert "DROP TABLE IF EXISTS adk_metadata" in statements
@@ -422,7 +440,7 @@ def test_session_store_reset_drop_tables_includes_legacy_metadata_table() -> Non
 def test_session_store_reset_drop_tables_does_not_duplicate_configured_legacy_metadata_table() -> None:
     store = _AsyncSessionStore(_Config({"metadata_table": "adk_metadata"}))
 
-    statements = store._get_reset_drop_tables_sql()
+    statements = store._reset_drop_tables_sql()
 
     assert statements.count("DROP TABLE IF EXISTS adk_metadata") == 1
     assert store.metadata_table == "adk_metadata"
@@ -444,7 +462,7 @@ async def test_reset_migration_accepts_sync_session_store(monkeypatch: pytest.Mo
 def test_sync_memory_store_reset_drop_tables_uses_drop_sql() -> None:
     store = _SyncMemoryStore(_Config({"memory_table": "agent_memory"}))
 
-    assert store._get_reset_drop_memory_table_sql() == [
+    assert store._reset_drop_memory_table_sql() == [
         "DROP TABLE IF EXISTS agent_memory",
         "DROP TABLE IF EXISTS adk_memory",
         "DROP TABLE IF EXISTS adk_memory_entries",

--- a/tests/unit/extensions/test_events/test_adapter_stores.py
+++ b/tests/unit/extensions/test_events/test_adapter_stores.py
@@ -39,7 +39,7 @@ def test_asyncmy_store_index_sql_dynamic_check() -> None:
 
     config = AsyncmyConfig(connection_config={"host": "localhost", "database": "test"})
     store = AsyncmyEventQueueStore(config)
-    index_sql = store._build_index_sql()
+    index_sql = store._index_ddl()
 
     assert index_sql is not None
     assert "information_schema.statistics" in index_sql.lower()
@@ -58,7 +58,7 @@ def test_asyncmy_store_schema_qualified_index() -> None:
         extension_config={"events": {"queue_table": "myschema.events"}},
     )
     store = AsyncmyEventQueueStore(config)
-    index_sql = store._build_index_sql()
+    index_sql = store._index_ddl()
     assert index_sql is not None
     assert "'myschema'" in index_sql
 
@@ -71,7 +71,7 @@ def test_asyncmy_store_unqualified_table_uses_database() -> None:
 
     config = AsyncmyConfig(connection_config={"host": "localhost", "database": "test"})
     store = AsyncmyEventQueueStore(config)
-    index_sql = store._build_index_sql()
+    index_sql = store._index_ddl()
     assert index_sql is not None
     assert "DATABASE()" in index_sql
 
@@ -99,7 +99,7 @@ def test_bigquery_store_create_table_uses_cluster_by() -> None:
 
     config = BigQueryConfig(connection_config={"project": "test-project"})
     store = BigQueryEventQueueStore(config)
-    create_sql = store._build_create_table_sql()
+    create_sql = store._table_ddl()
 
     assert "CREATE TABLE IF NOT EXISTS" in create_sql
     assert "STRING NOT NULL" in create_sql
@@ -115,7 +115,7 @@ def test_bigquery_store_create_table_has_defaults() -> None:
 
     config = BigQueryConfig(connection_config={"project": "test-project"})
     store = BigQueryEventQueueStore(config)
-    create_sql = store._build_create_table_sql()
+    create_sql = store._table_ddl()
 
     assert "DEFAULT 'pending'" in create_sql
     assert "DEFAULT 0" in create_sql
@@ -131,7 +131,7 @@ def test_bigquery_store_no_index() -> None:
     config = BigQueryConfig(connection_config={"project": "test-project"})
     store = BigQueryEventQueueStore(config)
 
-    assert store._build_index_sql() is None
+    assert store._index_ddl() is None
 
 
 def test_bigquery_store_create_statements_single() -> None:
@@ -176,7 +176,7 @@ def test_bigquery_store_custom_table_name() -> None:
     store = BigQueryEventQueueStore(config)
 
     assert store.table_name == "custom_events"
-    assert "custom_events" in store._build_create_table_sql()
+    assert "custom_events" in store._table_ddl()
     assert "custom_events" in store.drop_statements()[0]
 
 
@@ -363,7 +363,7 @@ def test_spanner_store_create_table_uses_string_types() -> None:
 
     config = SpannerSyncConfig(connection_config={"project": "test", "instance": "inst", "database": "db"})
     store = SpannerSyncEventQueueStore(config)
-    create_sql = store._build_create_table_sql()
+    create_sql = store._table_ddl()
 
     assert "STRING(64)" in create_sql
     assert "STRING(128)" in create_sql
@@ -379,7 +379,7 @@ def test_spanner_store_separate_index_statement() -> None:
 
     config = SpannerSyncConfig(connection_config={"project": "test", "instance": "inst", "database": "db"})
     store = SpannerSyncEventQueueStore(config)
-    index_sql = store._build_index_sql()
+    index_sql = store._index_ddl()
 
     assert index_sql is not None
     assert "CREATE INDEX" in index_sql
@@ -455,7 +455,7 @@ def test_adbc_store_snowflake_no_index() -> None:
     config = AdbcConfig(connection_config={"driver_name": "snowflake"})
     store = AdbcEventQueueStore(config)
 
-    assert store._build_index_sql() is None
+    assert store._index_ddl() is None
 
 
 def test_adbc_store_bigquery_dialect() -> None:
@@ -466,7 +466,7 @@ def test_adbc_store_bigquery_dialect() -> None:
 
     config = AdbcConfig(connection_config={"uri": "bigquery://project"})
     store = AdbcEventQueueStore(config)
-    create_sql = store._build_create_table_sql()
+    create_sql = store._table_ddl()
 
     assert "STRING NOT NULL" in create_sql
     assert "INT64 NOT NULL" in create_sql
@@ -482,7 +482,7 @@ def test_adbc_store_bigquery_no_index() -> None:
     config = AdbcConfig(connection_config={"uri": "bigquery://project"})
     store = AdbcEventQueueStore(config)
 
-    assert store._build_index_sql() is None
+    assert store._index_ddl() is None
 
 
 def test_adbc_store_flightsql_dialect() -> None:
@@ -538,7 +538,7 @@ def test_adbc_store_postgresql_partial_index() -> None:
 
     config = AdbcConfig(connection_config={"driver_name": "postgres"})
     store = AdbcEventQueueStore(config)
-    index_sql = store._build_index_sql()
+    index_sql = store._index_ddl()
 
     assert index_sql is not None
     assert "WHERE status = 'pending'" in index_sql
@@ -622,8 +622,8 @@ def test_adbc_store_dialect_caching() -> None:
     assert dialect1 is dialect2
 
     store._column_types()
-    store._build_create_table_sql()
-    store._build_index_sql()
+    store._table_ddl()
+    store._index_ddl()
     store.drop_statements()
     assert store._dialect == "postgres"
 

--- a/tests/unit/extensions/test_events/test_channel.py
+++ b/tests/unit/extensions/test_events/test_channel.py
@@ -157,7 +157,7 @@ def test_event_channel_runtime_hints_for_asyncmy(tmp_path) -> None:
     assert channel._adapter_name == "asyncmy"
     backend = channel._backend
     assert backend._lease_seconds == 5
-    assert "FOR UPDATE SKIP LOCKED" in backend._select_sql.upper()
+    assert "FOR UPDATE SKIP LOCKED" in backend._select_statement.upper()
 
 
 def test_event_channel_runtime_hints_for_duckdb(tmp_path) -> None:
@@ -185,7 +185,7 @@ def test_table_event_queue_locking_clause(tmp_path) -> None:
     """Locking hints are embedded when select_for_update/skip_locked are enabled."""
     config = SqliteConfig(connection_config={"database": str(tmp_path / "locks.db")})
     queue = SyncTableEventQueue(config, select_for_update=True, skip_locked=True)
-    assert "FOR UPDATE SKIP LOCKED" in queue._select_sql.upper()
+    assert "FOR UPDATE SKIP LOCKED" in queue._select_statement.upper()
 
 
 class _SyncBackend:

--- a/tests/unit/extensions/test_events/test_queue.py
+++ b/tests/unit/extensions/test_events/test_queue.py
@@ -84,38 +84,38 @@ def test_table_event_queue_select_for_update_disabled(tmp_path) -> None:
     """SELECT FOR UPDATE is disabled by default."""
     config = SqliteConfig(connection_config={"database": str(tmp_path / "test.db")})
     queue = SyncTableEventQueue(config)
-    assert "FOR UPDATE" not in queue._select_sql.upper()
+    assert "FOR UPDATE" not in queue._select_statement.upper()
 
 
 def test_table_event_queue_select_for_update_enabled(tmp_path) -> None:
     """SELECT FOR UPDATE clause is added when enabled."""
     config = SqliteConfig(connection_config={"database": str(tmp_path / "test.db")})
     queue = SyncTableEventQueue(config, select_for_update=True)
-    assert "FOR UPDATE" in queue._select_sql.upper()
+    assert "FOR UPDATE" in queue._select_statement.upper()
 
 
 def test_table_event_queue_skip_locked_requires_for_update(tmp_path) -> None:
     """SKIP LOCKED is only added when FOR UPDATE is enabled."""
     config = SqliteConfig(connection_config={"database": str(tmp_path / "test.db")})
     queue = SyncTableEventQueue(config, skip_locked=True)
-    assert "SKIP LOCKED" not in queue._select_sql.upper()
+    assert "SKIP LOCKED" not in queue._select_statement.upper()
 
     queue_with_both = SyncTableEventQueue(config, select_for_update=True, skip_locked=True)
-    assert "FOR UPDATE SKIP LOCKED" in queue_with_both._select_sql.upper()
+    assert "FOR UPDATE SKIP LOCKED" in queue_with_both._select_statement.upper()
 
 
 def test_table_event_queue_insert_sql_contains_table(tmp_path) -> None:
     """Insert SQL references the configured table name."""
     config = SqliteConfig(connection_config={"database": str(tmp_path / "test.db")})
     queue = SyncTableEventQueue(config, queue_table="my_events")
-    assert "my_events" in queue._upsert_sql
+    assert "my_events" in queue._insert_statement
 
 
 def test_table_event_queue_select_sql_contains_table(tmp_path) -> None:
     """Select SQL references the configured table name."""
     config = SqliteConfig(connection_config={"database": str(tmp_path / "test.db")})
     queue = SyncTableEventQueue(config, queue_table="my_events")
-    assert "my_events" in queue._select_sql
+    assert "my_events" in queue._select_statement
 
 
 def test_table_event_queue_oracle_dialect_uses_fetch_first(tmp_path) -> None:
@@ -125,8 +125,8 @@ def test_table_event_queue_oracle_dialect_uses_fetch_first(tmp_path) -> None:
         connection_config={"database": str(tmp_path / "test.db")}, statement_config=StatementConfig(dialect="oracle")
     )
     queue = SyncTableEventQueue(config)
-    assert "FETCH FIRST 1 ROWS ONLY" in queue._select_sql.upper()
-    assert "LIMIT" not in queue._select_sql.upper()
+    assert "FETCH FIRST 1 ROWS ONLY" in queue._select_statement.upper()
+    assert "LIMIT" not in queue._select_statement.upper()
 
 
 def test_table_event_queue_statement_config_property(tmp_path) -> None:

--- a/tests/unit/extensions/test_events/test_store_hooks.py
+++ b/tests/unit/extensions/test_events/test_store_hooks.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from sqlspec.extensions.events import BaseEventQueueStore
+from sqlspec.extensions.events._queue import _BaseTableEventQueue
 
 if TYPE_CHECKING:
     from sqlspec.adapters.sqlite import SqliteConfig
@@ -21,6 +22,30 @@ if TYPE_CHECKING:
     BaseEventQueueStoreBase = BaseEventQueueStore[SqliteConfig]
 else:
     BaseEventQueueStoreBase = BaseEventQueueStore
+
+
+def test_private_sql_helpers_use_purpose_names() -> None:
+    assert hasattr(BaseEventQueueStore, "_table_ddl")
+    assert hasattr(BaseEventQueueStore, "_index_ddl")
+    assert not hasattr(BaseEventQueueStore, "_build_create_table_sql")
+    assert not hasattr(BaseEventQueueStore, "_build_index_sql")
+
+
+def test_table_queue_private_sql_helpers_use_purpose_names() -> None:
+    assert hasattr(_BaseTableEventQueue, "_insert_sql")
+    assert hasattr(_BaseTableEventQueue, "_select_sql")
+    assert hasattr(_BaseTableEventQueue, "_select_by_id_sql")
+    assert hasattr(_BaseTableEventQueue, "_claim_sql")
+    assert hasattr(_BaseTableEventQueue, "_ack_sql")
+    assert hasattr(_BaseTableEventQueue, "_nack_sql")
+    assert hasattr(_BaseTableEventQueue, "_cleanup_sql")
+    assert not hasattr(_BaseTableEventQueue, "_build_insert_sql")
+    assert not hasattr(_BaseTableEventQueue, "_build_select_sql")
+    assert not hasattr(_BaseTableEventQueue, "_build_select_by_id_sql")
+    assert not hasattr(_BaseTableEventQueue, "_build_claim_sql")
+    assert not hasattr(_BaseTableEventQueue, "_build_ack_sql")
+    assert not hasattr(_BaseTableEventQueue, "_build_nack_sql")
+    assert not hasattr(_BaseTableEventQueue, "_build_cleanup_sql")
 
 
 def test_base_store_string_type_default() -> None:
@@ -110,8 +135,8 @@ def test_hook_override_string_type() -> None:
     store = CustomStore(config)
 
     assert store._string_type(64) == "STRING(64)"
-    assert "STRING(64)" in store._build_create_table_sql()
-    assert "STRING(128)" in store._build_create_table_sql()
+    assert "STRING(64)" in store._table_ddl()
+    assert "STRING(128)" in store._table_ddl()
 
 
 def test_hook_override_integer_type() -> None:
@@ -129,7 +154,7 @@ def test_hook_override_integer_type() -> None:
     store = CustomStore(config)
 
     assert store._integer_type() == "INT64"
-    assert "INT64 NOT NULL" in store._build_create_table_sql()
+    assert "INT64 NOT NULL" in store._table_ddl()
 
 
 def test_hook_override_timestamp_default() -> None:
@@ -147,7 +172,7 @@ def test_hook_override_timestamp_default() -> None:
     store = CustomStore(config)
 
     assert store._timestamp_default() == "CURRENT_TIMESTAMP(6)"
-    assert "DEFAULT CURRENT_TIMESTAMP(6)" in store._build_create_table_sql()
+    assert "DEFAULT CURRENT_TIMESTAMP(6)" in store._table_ddl()
 
 
 def test_hook_override_primary_key_syntax() -> None:
@@ -165,7 +190,7 @@ def test_hook_override_primary_key_syntax() -> None:
     store = CustomStore(config)
 
     assert store._primary_key_syntax() == " PRIMARY KEY (event_id)"
-    ddl = store._build_create_table_sql()
+    ddl = store._table_ddl()
     assert " PRIMARY KEY (event_id)" in ddl
     assert "event_id VARCHAR(64)," in ddl
 
@@ -185,7 +210,7 @@ def test_hook_override_table_clause() -> None:
     store = CustomStore(config)
 
     assert store._table_clause() == " CLUSTER BY channel, status"
-    assert " CLUSTER BY channel, status" in store._build_create_table_sql()
+    assert " CLUSTER BY channel, status" in store._table_ddl()
 
 
 def test_ddl_generation_uses_all_hooks() -> None:
@@ -213,7 +238,7 @@ def test_ddl_generation_uses_all_hooks() -> None:
 
     config = SqliteConfig(connection_config={"database": ":memory:"})
     store = FullCustomStore(config)
-    ddl = store._build_create_table_sql()
+    ddl = store._table_ddl()
 
     assert "STRING(64)" in ddl
     assert "STRING(128)" in ddl
@@ -347,7 +372,7 @@ def test_spanner_ddl_no_defaults() -> None:
 
     config = SpannerSyncConfig(connection_config={"project": "test", "instance": "inst", "database": "db"})
     store = SpannerSyncEventQueueStore(config)
-    ddl = store._build_create_table_sql()
+    ddl = store._table_ddl()
 
     assert "DEFAULT" not in ddl
 
@@ -443,7 +468,7 @@ def test_ddl_column_primary_key_without_inline_pk() -> None:
 
     config = SqliteConfig(connection_config={"database": ":memory:"})
     store = ColumnPKStore(config)
-    ddl = store._build_create_table_sql()
+    ddl = store._table_ddl()
 
     assert "event_id VARCHAR(64) PRIMARY KEY," in ddl
     assert not ddl.endswith(") PRIMARY KEY (event_id)")
@@ -462,7 +487,7 @@ def test_ddl_inline_primary_key_with_override() -> None:
 
     config = SqliteConfig(connection_config={"database": ":memory:"})
     store = InlinePKStore(config)
-    ddl = store._build_create_table_sql()
+    ddl = store._table_ddl()
 
     assert "event_id VARCHAR(64)," in ddl
     assert "event_id VARCHAR(64) PRIMARY KEY" not in ddl
@@ -479,7 +504,7 @@ def test_ddl_contains_all_required_columns() -> None:
 
     config = SqliteConfig(connection_config={"database": ":memory:"})
     store = FixtureStore(config)
-    ddl = store._build_create_table_sql()
+    ddl = store._table_ddl()
 
     required_columns = [
         "event_id",
@@ -508,7 +533,7 @@ def test_ddl_default_values() -> None:
 
     config = SqliteConfig(connection_config={"database": ":memory:"})
     store = FixtureStore(config)
-    ddl = store._build_create_table_sql()
+    ddl = store._table_ddl()
 
     assert "DEFAULT 'pending'" in ddl
     assert "DEFAULT 0" in ddl
@@ -525,7 +550,7 @@ def test_ddl_nullable_columns() -> None:
 
     config = SqliteConfig(connection_config={"database": ":memory:"})
     store = FixtureStore(config)
-    ddl = store._build_create_table_sql()
+    ddl = store._table_ddl()
 
     assert "metadata_json JSON," in ddl
     assert "lease_expires_at TIMESTAMP," in ddl
@@ -542,7 +567,7 @@ def test_ddl_not_null_columns() -> None:
 
     config = SqliteConfig(connection_config={"database": ":memory:"})
     store = FixtureStore(config)
-    ddl = store._build_create_table_sql()
+    ddl = store._table_ddl()
 
     assert "channel VARCHAR(128) NOT NULL" in ddl
     assert "payload_json JSON NOT NULL" in ddl
@@ -553,14 +578,14 @@ def test_ddl_not_null_columns() -> None:
 
 
 def test_create_statements_with_no_index() -> None:
-    """create_statements returns only table when _build_index_sql returns None."""
+    """create_statements returns only table when _index_ddl returns None."""
     from sqlspec.adapters.sqlite import SqliteConfig
 
     class NoIndexStore(BaseEventQueueStoreBase):
         def _column_types(self) -> tuple[str, str, str]:
             return "TEXT", "TEXT", "TIMESTAMP"
 
-        def _build_index_sql(self) -> str | None:
+        def _index_ddl(self) -> str | None:
             return None
 
     config = SqliteConfig(connection_config={"database": ":memory:"})
@@ -666,8 +691,8 @@ def test_index_name_with_schema_qualified_table() -> None:
     assert store._index_name() == "idx_myschema_events_channel_status"
 
 
-def test_build_index_sql() -> None:
-    """_build_index_sql generates correct CREATE INDEX statement."""
+def test_index_ddl() -> None:
+    """_index_ddl generates correct CREATE INDEX statement."""
     from sqlspec.adapters.sqlite import SqliteConfig
 
     class FixtureStore(BaseEventQueueStoreBase):
@@ -676,7 +701,7 @@ def test_build_index_sql() -> None:
 
     config = SqliteConfig(connection_config={"database": ":memory:"})
     store = FixtureStore(config)
-    index_sql = store._build_index_sql()
+    index_sql = store._index_ddl()
 
     assert index_sql is not None
     assert "CREATE INDEX idx_sqlspec_event_queue_channel_status" in index_sql

--- a/tests/unit/migrations/test_migration.py
+++ b/tests/unit/migrations/test_migration.py
@@ -594,7 +594,7 @@ def test_load_migration_metadata_invalid_version(tmp_path: Path) -> None:
     assert metadata["description"] == "name"
 
 
-def test_get_migration_sql_upgrade() -> None:
+def test_migration_sql_upgrade() -> None:
     """Test getting upgrade SQL from migration."""
     runner = MockMigrationRunner()
 
@@ -606,13 +606,13 @@ def test_get_migration_sql_upgrade() -> None:
         "loader": Mock(get_up_sql=Mock(return_value=["CREATE TABLE test (id INTEGER);"])),
     }
 
-    result = runner._get_migration_sql(migration, "up")
+    result = runner._migration_sql(migration, "up")
 
     assert isinstance(result, list)
     assert result == ["CREATE TABLE test (id INTEGER);"]
 
 
-def test_get_migration_sql_downgrade() -> None:
+def test_migration_sql_downgrade() -> None:
     """Test getting downgrade SQL from migration."""
     runner = MockMigrationRunner()
 
@@ -624,13 +624,13 @@ def test_get_migration_sql_downgrade() -> None:
         "loader": Mock(get_down_sql=Mock(return_value=["DROP TABLE test;"])),
     }
 
-    result = runner._get_migration_sql(migration, "down")
+    result = runner._migration_sql(migration, "down")
 
     assert isinstance(result, list)
     assert result == ["DROP TABLE test;"]
 
 
-def test_get_migration_sql_no_downgrade() -> None:
+def test_migration_sql_no_downgrade() -> None:
     """Test getting downgrade SQL when none available."""
     runner = MockMigrationRunner()
 
@@ -644,13 +644,13 @@ def test_get_migration_sql_no_downgrade() -> None:
 
     runner._log_migration_event = Mock()  # type: ignore[method-assign]
 
-    result = runner._get_migration_sql(migration, "down")
+    result = runner._migration_sql(migration, "down")
 
     assert result is None
     runner._log_migration_event.assert_called_once()  # type: ignore[attr-defined]
 
 
-def test_get_migration_sql_no_upgrade_error() -> None:
+def test_migration_sql_no_upgrade_error() -> None:
     """Test error when trying to get upgrade SQL but none available."""
     runner = MockMigrationRunner()
 
@@ -663,12 +663,12 @@ def test_get_migration_sql_no_upgrade_error() -> None:
     }
 
     with pytest.raises(ValueError) as exc_info:
-        runner._get_migration_sql(migration, "up")
+        runner._migration_sql(migration, "up")
 
     assert "has no upgrade query" in str(exc_info.value)
 
 
-def test_get_migration_sql_loader_error() -> None:
+def test_migration_sql_loader_error() -> None:
     """Test handling loader errors during SQL generation."""
     runner = MockMigrationRunner()
     loader = Mock()
@@ -684,17 +684,17 @@ def test_get_migration_sql_loader_error() -> None:
     }
 
     with pytest.raises(ValueError) as exc_info:
-        runner._get_migration_sql(migration, "up")
+        runner._migration_sql(migration, "up")
     assert "Failed to load upgrade" in str(exc_info.value)
 
     runner._log_migration_event = Mock()  # type: ignore[method-assign]
 
-    result = runner._get_migration_sql(migration, "down")
+    result = runner._migration_sql(migration, "down")
     assert result is None
     runner._log_migration_event.assert_called_once()  # type: ignore[attr-defined]
 
 
-def test_get_migration_sql_empty_statements() -> None:
+def test_migration_sql_empty_statements() -> None:
     """Test handling when loader returns empty statements."""
     runner = MockMigrationRunner()
 
@@ -706,5 +706,5 @@ def test_get_migration_sql_empty_statements() -> None:
         "loader": Mock(get_up_sql=Mock(return_value=[])),
     }
 
-    result = runner._get_migration_sql(migration, "up")
+    result = runner._migration_sql(migration, "up")
     assert result is None

--- a/tests/unit/migrations/test_migration.py
+++ b/tests/unit/migrations/test_migration.py
@@ -606,7 +606,7 @@ def test_migration_sql_upgrade() -> None:
         "loader": Mock(get_up_sql=Mock(return_value=["CREATE TABLE test (id INTEGER);"])),
     }
 
-    result = runner._migration_sql(migration, "up")
+    result = runner._migration_sql_sync(migration, "up")
 
     assert isinstance(result, list)
     assert result == ["CREATE TABLE test (id INTEGER);"]
@@ -624,7 +624,7 @@ def test_migration_sql_downgrade() -> None:
         "loader": Mock(get_down_sql=Mock(return_value=["DROP TABLE test;"])),
     }
 
-    result = runner._migration_sql(migration, "down")
+    result = runner._migration_sql_sync(migration, "down")
 
     assert isinstance(result, list)
     assert result == ["DROP TABLE test;"]
@@ -644,7 +644,7 @@ def test_migration_sql_no_downgrade() -> None:
 
     runner._log_migration_event = Mock()  # type: ignore[method-assign]
 
-    result = runner._migration_sql(migration, "down")
+    result = runner._migration_sql_sync(migration, "down")
 
     assert result is None
     runner._log_migration_event.assert_called_once()  # type: ignore[attr-defined]
@@ -663,7 +663,7 @@ def test_migration_sql_no_upgrade_error() -> None:
     }
 
     with pytest.raises(ValueError) as exc_info:
-        runner._migration_sql(migration, "up")
+        runner._migration_sql_sync(migration, "up")
 
     assert "has no upgrade query" in str(exc_info.value)
 
@@ -684,12 +684,12 @@ def test_migration_sql_loader_error() -> None:
     }
 
     with pytest.raises(ValueError) as exc_info:
-        runner._migration_sql(migration, "up")
+        runner._migration_sql_sync(migration, "up")
     assert "Failed to load upgrade" in str(exc_info.value)
 
     runner._log_migration_event = Mock()  # type: ignore[method-assign]
 
-    result = runner._migration_sql(migration, "down")
+    result = runner._migration_sql_sync(migration, "down")
     assert result is None
     runner._log_migration_event.assert_called_once()  # type: ignore[attr-defined]
 
@@ -706,5 +706,5 @@ def test_migration_sql_empty_statements() -> None:
         "loader": Mock(get_up_sql=Mock(return_value=[])),
     }
 
-    result = runner._migration_sql(migration, "up")
+    result = runner._migration_sql_sync(migration, "up")
     assert result is None

--- a/tests/unit/migrations/test_migration.py
+++ b/tests/unit/migrations/test_migration.py
@@ -606,7 +606,7 @@ def test_migration_sql_upgrade() -> None:
         "loader": Mock(get_up_sql=Mock(return_value=["CREATE TABLE test (id INTEGER);"])),
     }
 
-    result = runner._migration_sql_sync(migration, "up")
+    result = runner._migration_sql(migration, "up")
 
     assert isinstance(result, list)
     assert result == ["CREATE TABLE test (id INTEGER);"]
@@ -624,7 +624,7 @@ def test_migration_sql_downgrade() -> None:
         "loader": Mock(get_down_sql=Mock(return_value=["DROP TABLE test;"])),
     }
 
-    result = runner._migration_sql_sync(migration, "down")
+    result = runner._migration_sql(migration, "down")
 
     assert isinstance(result, list)
     assert result == ["DROP TABLE test;"]
@@ -644,7 +644,7 @@ def test_migration_sql_no_downgrade() -> None:
 
     runner._log_migration_event = Mock()  # type: ignore[method-assign]
 
-    result = runner._migration_sql_sync(migration, "down")
+    result = runner._migration_sql(migration, "down")
 
     assert result is None
     runner._log_migration_event.assert_called_once()  # type: ignore[attr-defined]
@@ -663,7 +663,7 @@ def test_migration_sql_no_upgrade_error() -> None:
     }
 
     with pytest.raises(ValueError) as exc_info:
-        runner._migration_sql_sync(migration, "up")
+        runner._migration_sql(migration, "up")
 
     assert "has no upgrade query" in str(exc_info.value)
 
@@ -684,12 +684,12 @@ def test_migration_sql_loader_error() -> None:
     }
 
     with pytest.raises(ValueError) as exc_info:
-        runner._migration_sql_sync(migration, "up")
+        runner._migration_sql(migration, "up")
     assert "Failed to load upgrade" in str(exc_info.value)
 
     runner._log_migration_event = Mock()  # type: ignore[method-assign]
 
-    result = runner._migration_sql_sync(migration, "down")
+    result = runner._migration_sql(migration, "down")
     assert result is None
     runner._log_migration_event.assert_called_once()  # type: ignore[attr-defined]
 
@@ -706,5 +706,5 @@ def test_migration_sql_empty_statements() -> None:
         "loader": Mock(get_up_sql=Mock(return_value=[])),
     }
 
-    result = runner._migration_sql_sync(migration, "up")
+    result = runner._migration_sql(migration, "up")
     assert result is None

--- a/tests/unit/migrations/test_migration_execution.py
+++ b/tests/unit/migrations/test_migration_execution.py
@@ -93,7 +93,7 @@ class MockMigrationRunner(SyncMigrationRunner):
     ) -> Any:
         """Mock execute upgrade."""
         _ = driver, use_transaction, on_success
-        sql = self._get_migration_sql(migration, "up")
+        sql = self._migration_sql(migration, "up")
         if sql:
             self._executed_migrations.append({"version": migration["version"], "direction": "up", "sql": sql})
             return Mock(spec=ExecutionResult)
@@ -109,7 +109,7 @@ class MockMigrationRunner(SyncMigrationRunner):
     ) -> Any:
         """Mock execute downgrade."""
         _ = driver, use_transaction, on_success
-        sql = self._get_migration_sql(migration, "down")
+        sql = self._migration_sql(migration, "down")
         if sql:
             self._executed_migrations.append({"version": migration["version"], "direction": "down", "sql": sql})
             return Mock(spec=ExecutionResult)
@@ -128,7 +128,7 @@ def test_tracking_table_sql_generation() -> None:
     """Test migration tracking table SQL generation."""
     tracker = MockMigrationTracker("test_migrations")
 
-    create_sql = tracker._get_create_table_sql()
+    create_sql = tracker._tracking_table_ddl()
 
     assert hasattr(create_sql, "to_statement")
     stmt = create_sql.to_statement()
@@ -146,7 +146,7 @@ def test_current_version_sql_generation() -> None:
     """Test current version query SQL generation."""
     tracker = MockMigrationTracker("test_migrations")
 
-    version_sql = tracker._get_current_version_sql()
+    version_sql = tracker._current_version_query()
 
     assert hasattr(version_sql, "to_statement")
     stmt = version_sql.to_statement()
@@ -161,7 +161,7 @@ def test_applied_migrations_sql_generation() -> None:
     """Test applied migrations query SQL generation."""
     tracker = MockMigrationTracker("test_migrations")
 
-    applied_sql = tracker._get_applied_migrations_sql()
+    applied_sql = tracker._applied_migrations_query()
 
     assert hasattr(applied_sql, "to_statement")
     stmt = applied_sql.to_statement()
@@ -176,7 +176,7 @@ def test_record_migration_sql_generation() -> None:
     """Test migration recording SQL generation."""
     tracker = MockMigrationTracker("test_migrations")
 
-    record_sql = tracker._get_record_migration_sql(
+    record_sql = tracker._record_migration_statement(
         version="0001",
         version_type="sequential",
         execution_sequence=1,
@@ -201,7 +201,7 @@ def test_remove_migration_sql_generation() -> None:
     """Test migration removal SQL generation."""
     tracker = MockMigrationTracker("test_migrations")
 
-    remove_sql = tracker._get_remove_migration_sql("0001")
+    remove_sql = tracker._remove_migration_statement("0001")
 
     assert hasattr(remove_sql, "to_statement")
     stmt = remove_sql.to_statement()

--- a/tests/unit/migrations/test_migration_execution.py
+++ b/tests/unit/migrations/test_migration_execution.py
@@ -93,7 +93,7 @@ class MockMigrationRunner(SyncMigrationRunner):
     ) -> Any:
         """Mock execute upgrade."""
         _ = driver, use_transaction, on_success
-        sql = self._migration_sql(migration, "up")
+        sql = self._migration_sql_sync(migration, "up")
         if sql:
             self._executed_migrations.append({"version": migration["version"], "direction": "up", "sql": sql})
             return Mock(spec=ExecutionResult)
@@ -109,7 +109,7 @@ class MockMigrationRunner(SyncMigrationRunner):
     ) -> Any:
         """Mock execute downgrade."""
         _ = driver, use_transaction, on_success
-        sql = self._migration_sql(migration, "down")
+        sql = self._migration_sql_sync(migration, "down")
         if sql:
             self._executed_migrations.append({"version": migration["version"], "direction": "down", "sql": sql})
             return Mock(spec=ExecutionResult)

--- a/tests/unit/migrations/test_migration_execution.py
+++ b/tests/unit/migrations/test_migration_execution.py
@@ -93,7 +93,7 @@ class MockMigrationRunner(SyncMigrationRunner):
     ) -> Any:
         """Mock execute upgrade."""
         _ = driver, use_transaction, on_success
-        sql = self._migration_sql_sync(migration, "up")
+        sql = self._migration_sql(migration, "up")
         if sql:
             self._executed_migrations.append({"version": migration["version"], "direction": "up", "sql": sql})
             return Mock(spec=ExecutionResult)
@@ -109,7 +109,7 @@ class MockMigrationRunner(SyncMigrationRunner):
     ) -> Any:
         """Mock execute downgrade."""
         _ = driver, use_transaction, on_success
-        sql = self._migration_sql_sync(migration, "down")
+        sql = self._migration_sql(migration, "down")
         if sql:
             self._executed_migrations.append({"version": migration["version"], "direction": "down", "sql": sql})
             return Mock(spec=ExecutionResult)

--- a/tests/unit/migrations/test_migration_runner.py
+++ b/tests/unit/migrations/test_migration_runner.py
@@ -703,7 +703,7 @@ def test_migration_sql_upgrade_success() -> None:
         "loader": Mock(get_up_sql=Mock(return_value=["CREATE TABLE test (id INTEGER PRIMARY KEY);"])),
     }
 
-    result = runner._migration_sql(migration, "up")
+    result = runner._migration_sql_sync(migration, "up")
 
     assert result is not None
     assert isinstance(result, list)
@@ -722,7 +722,7 @@ def test_migration_sql_downgrade_success() -> None:
         "loader": Mock(get_down_sql=Mock(return_value=["DROP TABLE test;"])),
     }
 
-    result = runner._migration_sql(migration, "down")
+    result = runner._migration_sql_sync(migration, "down")
 
     assert result is not None
     assert isinstance(result, list)
@@ -743,7 +743,7 @@ def test_migration_sql_no_downgrade_warning() -> None:
 
     runner._log_migration_event = Mock()  # type: ignore[method-assign]
 
-    result = runner._migration_sql(migration, "down")
+    result = runner._migration_sql_sync(migration, "down")
 
     assert result is None
     runner._log_migration_event.assert_called_once()  # type: ignore[attr-defined]
@@ -762,7 +762,7 @@ def test_migration_sql_no_upgrade_error() -> None:
     }
 
     with pytest.raises(ValueError) as exc_info:
-        runner._migration_sql(migration, "up")
+        runner._migration_sql_sync(migration, "up")
 
     assert "Migration 0001 has no upgrade query" in str(exc_info.value)
 
@@ -782,7 +782,7 @@ def test_migration_sql_loader_exception_upgrade() -> None:
     }
 
     with pytest.raises(ValueError) as exc_info:
-        runner._migration_sql(migration, "up")
+        runner._migration_sql_sync(migration, "up")
 
     assert "Failed to load upgrade for migration 0001" in str(exc_info.value)
 
@@ -803,7 +803,7 @@ def test_migration_sql_loader_exception_downgrade() -> None:
 
     runner._log_migration_event = Mock()  # type: ignore[method-assign]
 
-    result = runner._migration_sql(migration, "down")
+    result = runner._migration_sql_sync(migration, "down")
 
     assert result is None
     runner._log_migration_event.assert_called_once()  # type: ignore[attr-defined]
@@ -821,7 +821,7 @@ def test_migration_sql_empty_statements() -> None:
         "loader": Mock(get_up_sql=Mock(return_value=[])),
     }
 
-    result = runner._migration_sql(migration, "up")
+    result = runner._migration_sql_sync(migration, "up")
 
     assert result is None
 
@@ -838,7 +838,7 @@ def test_migration_sql_none_statements() -> None:
         "loader": Mock(get_up_sql=Mock(return_value=None)),
     }
 
-    result = runner._migration_sql(migration, "up")
+    result = runner._migration_sql_sync(migration, "up")
 
     assert result is None
 

--- a/tests/unit/migrations/test_migration_runner.py
+++ b/tests/unit/migrations/test_migration_runner.py
@@ -691,7 +691,7 @@ def down():
     assert metadata["has_downgrade"] is True
 
 
-def test_get_migration_sql_upgrade_success() -> None:
+def test_migration_sql_upgrade_success() -> None:
     """Test successful upgrade SQL generation."""
     runner = create_test_migration_runner()
 
@@ -703,14 +703,14 @@ def test_get_migration_sql_upgrade_success() -> None:
         "loader": Mock(get_up_sql=Mock(return_value=["CREATE TABLE test (id INTEGER PRIMARY KEY);"])),
     }
 
-    result = runner._get_migration_sql(migration, "up")
+    result = runner._migration_sql(migration, "up")
 
     assert result is not None
     assert isinstance(result, list)
     assert result == ["CREATE TABLE test (id INTEGER PRIMARY KEY);"]
 
 
-def test_get_migration_sql_downgrade_success() -> None:
+def test_migration_sql_downgrade_success() -> None:
     """Test successful downgrade SQL generation."""
     runner = create_test_migration_runner()
 
@@ -722,14 +722,14 @@ def test_get_migration_sql_downgrade_success() -> None:
         "loader": Mock(get_down_sql=Mock(return_value=["DROP TABLE test;"])),
     }
 
-    result = runner._get_migration_sql(migration, "down")
+    result = runner._migration_sql(migration, "down")
 
     assert result is not None
     assert isinstance(result, list)
     assert result == ["DROP TABLE test;"]
 
 
-def test_get_migration_sql_no_downgrade_warning() -> None:
+def test_migration_sql_no_downgrade_warning() -> None:
     """Test warning when no downgrade is available."""
     runner = create_test_migration_runner()
 
@@ -743,13 +743,13 @@ def test_get_migration_sql_no_downgrade_warning() -> None:
 
     runner._log_migration_event = Mock()  # type: ignore[method-assign]
 
-    result = runner._get_migration_sql(migration, "down")
+    result = runner._migration_sql(migration, "down")
 
     assert result is None
     runner._log_migration_event.assert_called_once()  # type: ignore[attr-defined]
 
 
-def test_get_migration_sql_no_upgrade_error() -> None:
+def test_migration_sql_no_upgrade_error() -> None:
     """Test error when no upgrade is available."""
     runner = create_test_migration_runner()
 
@@ -762,12 +762,12 @@ def test_get_migration_sql_no_upgrade_error() -> None:
     }
 
     with pytest.raises(ValueError) as exc_info:
-        runner._get_migration_sql(migration, "up")
+        runner._migration_sql(migration, "up")
 
     assert "Migration 0001 has no upgrade query" in str(exc_info.value)
 
 
-def test_get_migration_sql_loader_exception_upgrade() -> None:
+def test_migration_sql_loader_exception_upgrade() -> None:
     """Test handling of loader exceptions during upgrade SQL generation."""
     runner = create_test_migration_runner()
     loader = Mock()
@@ -782,12 +782,12 @@ def test_get_migration_sql_loader_exception_upgrade() -> None:
     }
 
     with pytest.raises(ValueError) as exc_info:
-        runner._get_migration_sql(migration, "up")
+        runner._migration_sql(migration, "up")
 
     assert "Failed to load upgrade for migration 0001" in str(exc_info.value)
 
 
-def test_get_migration_sql_loader_exception_downgrade() -> None:
+def test_migration_sql_loader_exception_downgrade() -> None:
     """Test handling of loader exceptions during downgrade SQL generation."""
     runner = create_test_migration_runner()
     loader = Mock()
@@ -803,13 +803,13 @@ def test_get_migration_sql_loader_exception_downgrade() -> None:
 
     runner._log_migration_event = Mock()  # type: ignore[method-assign]
 
-    result = runner._get_migration_sql(migration, "down")
+    result = runner._migration_sql(migration, "down")
 
     assert result is None
     runner._log_migration_event.assert_called_once()  # type: ignore[attr-defined]
 
 
-def test_get_migration_sql_empty_statements() -> None:
+def test_migration_sql_empty_statements() -> None:
     """Test handling when migration loader returns empty statements."""
     runner = create_test_migration_runner()
 
@@ -821,12 +821,12 @@ def test_get_migration_sql_empty_statements() -> None:
         "loader": Mock(get_up_sql=Mock(return_value=[])),
     }
 
-    result = runner._get_migration_sql(migration, "up")
+    result = runner._migration_sql(migration, "up")
 
     assert result is None
 
 
-def test_get_migration_sql_none_statements() -> None:
+def test_migration_sql_none_statements() -> None:
     """Test handling when migration loader returns None."""
     runner = create_test_migration_runner()
 
@@ -838,7 +838,7 @@ def test_get_migration_sql_none_statements() -> None:
         "loader": Mock(get_up_sql=Mock(return_value=None)),
     }
 
-    result = runner._get_migration_sql(migration, "up")
+    result = runner._migration_sql(migration, "up")
 
     assert result is None
 

--- a/tests/unit/migrations/test_migration_runner.py
+++ b/tests/unit/migrations/test_migration_runner.py
@@ -703,7 +703,7 @@ def test_migration_sql_upgrade_success() -> None:
         "loader": Mock(get_up_sql=Mock(return_value=["CREATE TABLE test (id INTEGER PRIMARY KEY);"])),
     }
 
-    result = runner._migration_sql_sync(migration, "up")
+    result = runner._migration_sql(migration, "up")
 
     assert result is not None
     assert isinstance(result, list)
@@ -722,7 +722,7 @@ def test_migration_sql_downgrade_success() -> None:
         "loader": Mock(get_down_sql=Mock(return_value=["DROP TABLE test;"])),
     }
 
-    result = runner._migration_sql_sync(migration, "down")
+    result = runner._migration_sql(migration, "down")
 
     assert result is not None
     assert isinstance(result, list)
@@ -743,7 +743,7 @@ def test_migration_sql_no_downgrade_warning() -> None:
 
     runner._log_migration_event = Mock()  # type: ignore[method-assign]
 
-    result = runner._migration_sql_sync(migration, "down")
+    result = runner._migration_sql(migration, "down")
 
     assert result is None
     runner._log_migration_event.assert_called_once()  # type: ignore[attr-defined]
@@ -762,7 +762,7 @@ def test_migration_sql_no_upgrade_error() -> None:
     }
 
     with pytest.raises(ValueError) as exc_info:
-        runner._migration_sql_sync(migration, "up")
+        runner._migration_sql(migration, "up")
 
     assert "Migration 0001 has no upgrade query" in str(exc_info.value)
 
@@ -782,7 +782,7 @@ def test_migration_sql_loader_exception_upgrade() -> None:
     }
 
     with pytest.raises(ValueError) as exc_info:
-        runner._migration_sql_sync(migration, "up")
+        runner._migration_sql(migration, "up")
 
     assert "Failed to load upgrade for migration 0001" in str(exc_info.value)
 
@@ -803,7 +803,7 @@ def test_migration_sql_loader_exception_downgrade() -> None:
 
     runner._log_migration_event = Mock()  # type: ignore[method-assign]
 
-    result = runner._migration_sql_sync(migration, "down")
+    result = runner._migration_sql(migration, "down")
 
     assert result is None
     runner._log_migration_event.assert_called_once()  # type: ignore[attr-defined]
@@ -821,7 +821,7 @@ def test_migration_sql_empty_statements() -> None:
         "loader": Mock(get_up_sql=Mock(return_value=[])),
     }
 
-    result = runner._migration_sql_sync(migration, "up")
+    result = runner._migration_sql(migration, "up")
 
     assert result is None
 
@@ -838,7 +838,7 @@ def test_migration_sql_none_statements() -> None:
         "loader": Mock(get_up_sql=Mock(return_value=None)),
     }
 
-    result = runner._migration_sql_sync(migration, "up")
+    result = runner._migration_sql(migration, "up")
 
     assert result is None
 

--- a/tests/unit/migrations/test_tracker_idempotency.py
+++ b/tests/unit/migrations/test_tracker_idempotency.py
@@ -12,6 +12,15 @@ from sqlspec.driver._sync import SyncDriverAdapterBase
 from sqlspec.migrations.tracker import AsyncMigrationTracker, SyncMigrationTracker
 
 
+def test_migration_tracker_private_sql_helpers_use_purpose_names() -> None:
+    assert hasattr(SyncMigrationTracker, "_tracking_table_ddl")
+    assert hasattr(SyncMigrationTracker, "_current_version_query")
+    assert hasattr(SyncMigrationTracker, "_record_migration_statement")
+    assert not hasattr(SyncMigrationTracker, "_get_create_table_sql")
+    assert not hasattr(SyncMigrationTracker, "_get_current_version_sql")
+    assert not hasattr(SyncMigrationTracker, "_get_record_migration_sql")
+
+
 def test_sync_update_version_record_success() -> None:
     """Test sync update succeeds when old version exists."""
     tracker = SyncMigrationTracker()
@@ -35,16 +44,18 @@ def test_sync_tracker_qualifies_table_sql_when_schema_is_configured() -> None:
 
     assert tracker.version_table == "history.ddl_migrations"
     rendered_statements = [
-        str(tracker._get_create_table_sql()),  # pyright: ignore[reportPrivateUsage]
-        str(tracker._get_current_version_sql()),  # pyright: ignore[reportPrivateUsage]
-        str(tracker._get_applied_migrations_sql()),  # pyright: ignore[reportPrivateUsage]
-        str(tracker._get_next_execution_sequence_sql()),  # pyright: ignore[reportPrivateUsage]
-        str(tracker._get_record_migration_sql("0001", "sequential", 1, "init", 10, "abc", "tester")),  # pyright: ignore[reportPrivateUsage]
-        str(tracker._get_remove_migration_sql("0001")),  # pyright: ignore[reportPrivateUsage]
-        str(tracker._get_update_version_sql("20250101000000", "0001", "sequential")),  # pyright: ignore[reportPrivateUsage]
-        str(tracker._get_delete_versions_sql(["0001"])),  # pyright: ignore[reportPrivateUsage]
-        str(tracker._get_record_squashed_migration_sql("0002", "sequential", 2, "squash", 0, "def", "tester", "0001")),  # pyright: ignore[reportPrivateUsage]
-        str(tracker._get_check_column_exists_sql()),  # pyright: ignore[reportPrivateUsage]
+        str(tracker._tracking_table_ddl()),  # pyright: ignore[reportPrivateUsage]
+        str(tracker._current_version_query()),  # pyright: ignore[reportPrivateUsage]
+        str(tracker._applied_migrations_query()),  # pyright: ignore[reportPrivateUsage]
+        str(tracker._next_execution_sequence_query()),  # pyright: ignore[reportPrivateUsage]
+        str(tracker._record_migration_statement("0001", "sequential", 1, "init", 10, "abc", "tester")),  # pyright: ignore[reportPrivateUsage]
+        str(tracker._remove_migration_statement("0001")),  # pyright: ignore[reportPrivateUsage]
+        str(tracker._update_version_statement("20250101000000", "0001", "sequential")),  # pyright: ignore[reportPrivateUsage]
+        str(tracker._delete_versions_statement(["0001"])),  # pyright: ignore[reportPrivateUsage]
+        str(
+            tracker._record_squashed_migration_statement("0002", "sequential", 2, "squash", 0, "def", "tester", "0001")
+        ),  # pyright: ignore[reportPrivateUsage]
+        str(tracker._column_exists_query()),  # pyright: ignore[reportPrivateUsage]
     ]
 
     assert all('"history"."ddl_migrations"' in statement for statement in rendered_statements)
@@ -55,7 +66,7 @@ def test_sync_tracker_keeps_bare_table_sql_without_schema() -> None:
     tracker = SyncMigrationTracker(version_table_name="ddl_migrations")
 
     assert tracker.version_table == "ddl_migrations"
-    assert "history.ddl_migrations" not in str(tracker._get_create_table_sql())  # pyright: ignore[reportPrivateUsage]
+    assert "history.ddl_migrations" not in str(tracker._tracking_table_ddl())  # pyright: ignore[reportPrivateUsage]
 
 
 def test_sync_tracker_introspects_bare_table_name_with_schema() -> None:
@@ -64,7 +75,7 @@ def test_sync_tracker_introspects_bare_table_name_with_schema() -> None:
     driver = Mock()
     driver.data_dictionary.get_columns.return_value = [
         {"column_name": column.name}
-        for column in tracker._get_create_table_sql().columns  # pyright: ignore[reportPrivateUsage]
+        for column in tracker._tracking_table_ddl().columns  # pyright: ignore[reportPrivateUsage]
     ]
 
     tracker._migrate_schema_if_needed(driver)  # pyright: ignore[reportPrivateUsage]
@@ -81,7 +92,7 @@ async def test_async_tracker_introspects_bare_table_name_with_schema() -> None:
     driver.data_dictionary.get_columns = AsyncMock(
         return_value=[
             {"column_name": column.name}
-            for column in tracker._get_create_table_sql().columns  # pyright: ignore[reportPrivateUsage]
+            for column in tracker._tracking_table_ddl().columns  # pyright: ignore[reportPrivateUsage]
         ]
     )
     driver.execute = AsyncMock()
@@ -116,7 +127,7 @@ def test_oracle_sync_tracker_introspects_unmodified_table_name_with_schema() -> 
     driver = Mock()
     driver.data_dictionary.get_columns.return_value = [
         {"column_name": column.name}
-        for column in tracker._get_create_table_sql().columns  # pyright: ignore[reportPrivateUsage]
+        for column in tracker._tracking_table_ddl().columns  # pyright: ignore[reportPrivateUsage]
     ]
 
     tracker._migrate_schema_if_needed(driver)  # pyright: ignore[reportPrivateUsage]
@@ -133,7 +144,7 @@ async def test_oracle_async_tracker_introspects_unmodified_table_name_with_schem
     driver.data_dictionary.get_columns = AsyncMock(
         return_value=[
             {"column_name": column.name}
-            for column in tracker._get_create_table_sql().columns  # pyright: ignore[reportPrivateUsage]
+            for column in tracker._tracking_table_ddl().columns  # pyright: ignore[reportPrivateUsage]
         ]
     )
     driver.execute = AsyncMock()

--- a/tests/unit/migrations/test_tracker_squash.py
+++ b/tests/unit/migrations/test_tracker_squash.py
@@ -20,11 +20,11 @@ def _mock_result(**kwargs: Any) -> Mock:
 
 
 def test_tracker_schema_squash_create_table_sql_includes_replaces_column() -> None:
-    """Test that _get_create_table_sql includes replaces column."""
+    """Test that _tracking_table_ddl includes replaces column."""
     from sqlspec.migrations.tracker import SyncMigrationTracker
 
     tracker = SyncMigrationTracker()
-    create_sql = tracker._get_create_table_sql()
+    create_sql = tracker._tracking_table_ddl()
     column_names = [col.name.lower() for col in create_sql.columns]
     assert "replaces" in column_names
 
@@ -34,7 +34,7 @@ def test_tracker_schema_squash_replaces_column_is_nullable() -> None:
     from sqlspec.migrations.tracker import SyncMigrationTracker
 
     tracker = SyncMigrationTracker()
-    create_sql = tracker._get_create_table_sql()
+    create_sql = tracker._tracking_table_ddl()
     replaces_col = next((col for col in create_sql.columns if col.name.lower() == "replaces"), None)
     assert replaces_col is not None
     assert not replaces_col.not_null
@@ -186,7 +186,7 @@ def test_check_versions_exist_sql_uses_where_in_clause() -> None:
     from sqlspec.migrations.tracker import SyncMigrationTracker
 
     tracker = SyncMigrationTracker()
-    query = str(tracker._get_check_versions_exist_sql(["0001", "0002"])).upper()
+    query = str(tracker._check_versions_query(["0001", "0002"])).upper()
     assert "WHERE" in query
     assert "IN" in query
     assert "SELECT *" not in query


### PR DESCRIPTION
## Summary

This follows #597 by renaming private SQL, DDL, query, and statement helpers so their names describe the statement they return instead of the action used to produce it. The change covers ADK stores, event queues, Litestar stores, migration helpers, the core `SQL` materialization helper, and the DuckDB secret helper.

The SQL emitted by these helpers is unchanged; this is a private implementation cleanup with updated tests for the renamed surfaces.

## Rename Map

| Area | Old | New |
| --- | --- | --- |
| ADK stores | `_get_create_sessions_table_sql` | `_sessions_table_ddl` |
| ADK stores | `_get_create_events_table_sql` | `_events_table_ddl` |
| ADK stores | `_get_create_app_states_table_sql` | `_app_states_table_ddl` |
| ADK stores | `_get_create_user_states_table_sql` | `_user_states_table_ddl` |
| ADK stores | `_get_create_metadata_table_sql` | `_metadata_table_ddl` |
| ADK stores | `_get_seed_metadata_sql` | `_metadata_seed_sql` |
| ADK stores | `_get_drop_app_states_table_sql` | `_drop_app_states_table_sql` |
| ADK stores | `_get_drop_user_states_table_sql` | `_drop_user_states_table_sql` |
| ADK stores | `_get_drop_metadata_table_sql` | `_drop_metadata_table_sql` |
| ADK stores | `_get_drop_tables_sql` | `_drop_tables_sql` |
| ADK stores | `_get_reset_drop_tables_sql` | `_reset_drop_tables_sql` |
| ADK stores | `_get_drop_tables_sql_for_table_profile` | `_drop_sql_for_table_profile` |
| ADK memory stores | `_get_create_memory_table_sql` | `_memory_table_ddl` |
| ADK memory stores | `_get_drop_memory_table_sql` | `_drop_memory_table_sql` |
| ADK memory stores | `_get_reset_drop_memory_table_sql` | `_reset_drop_memory_table_sql` |
| ADK memory stores | `_get_drop_memory_table_sql_for_table` | `_drop_memory_sql_for_table` |
| ADBC ADK stores | `_get_sessions_ddl_postgresql` | `_sessions_ddl_postgresql` |
| ADBC ADK stores | `_get_sessions_ddl_sqlite` | `_sessions_ddl_sqlite` |
| ADBC ADK stores | `_get_sessions_ddl_duckdb` | `_sessions_ddl_duckdb` |
| ADBC ADK stores | `_get_sessions_ddl_snowflake` | `_sessions_ddl_snowflake` |
| ADBC ADK stores | `_get_sessions_ddl_generic` | `_sessions_ddl_generic` |
| ADBC ADK stores | `_get_events_ddl_postgresql` | `_events_ddl_postgresql` |
| ADBC ADK stores | `_get_events_ddl_sqlite` | `_events_ddl_sqlite` |
| ADBC ADK stores | `_get_events_ddl_duckdb` | `_events_ddl_duckdb` |
| ADBC ADK stores | `_get_events_ddl_snowflake` | `_events_ddl_snowflake` |
| ADBC ADK stores | `_get_events_ddl_generic` | `_events_ddl_generic` |
| ADBC ADK stores | `_get_memory_ddl_postgresql` | `_memory_ddl_postgresql` |
| ADBC ADK stores | `_get_memory_ddl_sqlite` | `_memory_ddl_sqlite` |
| ADBC ADK stores | `_get_memory_ddl_duckdb` | `_memory_ddl_duckdb` |
| ADBC ADK stores | `_get_memory_ddl_snowflake` | `_memory_ddl_snowflake` |
| ADBC ADK stores | `_get_memory_ddl_generic` | `_memory_ddl_generic` |
| DuckDB ADK stores | `_get_event_generated_columns_sql` | `_event_generated_columns_sql` |
| DuckDB ADK stores | `_get_event_generated_column_indexes_sql` | `_event_generated_column_indexes_sql` |
| DuckDB ADK stores | `__get_create_sessions_table_sql_sync` | `_sync_sessions_table_ddl` |
| DuckDB ADK stores | `__get_create_events_table_sql_sync` | `_sync_events_table_ddl` |
| DuckDB ADK stores | `__get_create_memory_table_sql_sync` | `_sync_memory_table_ddl` |
| DuckDB ADK stores | `_get_create_fts_index_sql` | `_fts_index_ddl` |
| Oracle ADK stores | `_get_sessions_table_sql_for_type` | `_sessions_table_ddl_for_type` |
| Oracle ADK stores | `_get_events_table_sql_for_type` | `_events_table_ddl_for_type` |
| Oracle ADK stores | `_get_app_states_table_sql_for_type` | `_app_states_table_ddl_for_type` |
| Oracle ADK stores | `_get_user_states_table_sql_for_type` | `_user_states_table_ddl_for_type` |
| Oracle ADK stores | `_get_memory_table_sql_for_type` | `_memory_table_ddl_for_type` |
| T-SQL and ODBC ADK stores | `_get_events_query` | `_events_query` |
| Events stores | `_build_create_table_sql` | `_table_ddl` |
| Events stores | `_build_index_sql` | `_index_ddl` |
| Events stores | `_mysql_build_index_sql` | `_mysql_index_ddl` |
| Oracle events stores | `_build_oracle_create_table_sql` | `_oracle_table_ddl` |
| Oracle events stores | `_build_oracle_drop_sql` | `_oracle_drop_sql` |
| Event queues | `_build_insert_sql` | `_insert_sql` |
| Event queues | `_build_select_sql` | `_select_sql` |
| Event queues | `_build_select_by_id_sql` | `_select_by_id_sql` |
| Event queues | `_build_claim_sql` | `_claim_sql` |
| Event queues | `_build_ack_sql` | `_ack_sql` |
| Event queues | `_build_nack_sql` | `_nack_sql` |
| Event queues | `_build_cleanup_sql` | `_cleanup_sql` |
| Event queues | `_upsert_sql` | `_insert_statement` |
| Event queues | `_select_sql` cached attribute | `_select_statement` |
| Event queues | `_select_by_id_sql` cached attribute | `_select_by_id_statement` |
| Event queues | `_claim_sql` cached attribute | `_claim_statement` |
| Event queues | `_ack_sql` cached attribute | `_ack_statement` |
| Event queues | `_nack_sql` cached attribute | `_nack_statement` |
| Event queues | `_acked_cleanup_sql` cached attribute | `_acked_cleanup_statement` |
| Litestar stores | `_get_drop_table_sql` | `_drop_table_sql` |
| Migration trackers | `_get_create_table_sql` | `_tracking_table_ddl` |
| Migration trackers | `_get_current_version_sql` | `_current_version_query` |
| Migration trackers | `_get_applied_migrations_sql` | `_applied_migrations_query` |
| Migration trackers | `_get_next_execution_sequence_sql` | `_next_execution_sequence_query` |
| Migration trackers | `_get_record_migration_sql` | `_record_migration_statement` |
| Migration trackers | `_get_remove_migration_sql` | `_remove_migration_statement` |
| Migration trackers | `_get_update_version_sql` | `_update_version_statement` |
| Migration trackers | `_get_delete_versions_sql` | `_delete_versions_statement` |
| Migration trackers | `_get_check_versions_exist_sql` | `_check_versions_query` |
| Migration trackers | `_get_record_squashed_migration_sql` | `_record_squashed_migration_statement` |
| Migration trackers | `_get_check_column_exists_sql` | `_column_exists_query` |
| MSSQL migration trackers | `_get_idempotent_create_table_sql_text` | `_idempotent_tracking_table_ddl_text` |
| MSSQL migration trackers | `_get_create_table_sql_text` | `_tracking_table_ddl_text` |
| MSSQL migration trackers | `_get_existing_columns_sql` | `_existing_columns_query` |
| MSSQL migration trackers | `_get_add_column_sql_text` | `_add_column_statement_text` |
| MSSQL migration trackers | `_get_create_table_builder` | `_tracking_table_builder` |
| Sync migration runner | `_get_migration_sql` | `_migration_sql` |
| Async migration runner | `_get_migration_sql_async` | `_migration_sql` |
| Core SQL | `_get_raw_sql` | `_materialized_raw_sql` |
| DuckDB pool | `_build_secret_sql` | `_secret_sql` |
