### PR TITLE
docs: prefer direct bind arguments in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 SQLSpec is a SQL execution layer for Python. You write the SQL -- as strings, through a builder API, or loaded from files -- and SQLSpec handles connections, parameter binding, SQL injection prevention, dialect translation, and mapping results back to typed Python objects. It uses [sqlglot](https://github.com/tobymao/sqlglot) under the hood to parse, validate, and optimize your queries before they hit the database.
 
-It works with PostgreSQL (asyncpg, psycopg, psqlpy), SQLite (sqlite3, aiosqlite), DuckDB, MySQL (asyncmy, mysql-connector, pymysql), Oracle (oracledb), CockroachDB, BigQuery, Spanner, and anything ADBC-compatible. Sync or async, same API. It also includes a built-in storage layer, native and bridged Arrow support for all drivers, and integrations for Litestar, FastAPI, Flask, Sanic, and Starlette.
+It works with PostgreSQL (asyncpg, psycopg, psqlpy), SQLite (sqlite3, aiosqlite), DuckDB, MySQL (asyncmy, aiomysql, mysql-connector, pymysql), SQL Server (mssql-python, pymssql, arrow-odbc), Oracle (oracledb), CockroachDB, BigQuery, Spanner, and supported ADBC backends including Snowflake, Flight SQL, and GizmoSQL. Sync or async, same API. It also includes a built-in storage layer, Arrow export through native paths or conversion fallbacks, storage-bridge bulk ingest for adapters with native ingest support, and integrations for Litestar, FastAPI, Flask, Sanic, and Starlette.
 
 ## Quick Start
 
@@ -16,11 +16,13 @@ pip install sqlspec
 ```
 
 ```python
-from pydantic import BaseModel
+from dataclasses import dataclass
+
 from sqlspec import SQLSpec
 from sqlspec.adapters.sqlite import SqliteConfig
 
-class Greeting(BaseModel):
+@dataclass
+class Greeting:
     message: str
 
 spec = SQLSpec()
@@ -46,21 +48,22 @@ users = session.select(
        .where("active = :active")
        .order_by("name")
        .limit(10),
-    {"active": True},
+    active=True,
     schema_type=User,
 )
 ```
 
 ## Features
 
-- **Connection pooling** -- sync and async adapters with a unified API across all supported drivers
+- **Session lifecycle** -- sync and async sessions with pooling where the adapter supports it
 - **Parameter binding and dialect translation** -- powered by sqlglot, with a fluent query builder and `.sql` file loader
 - **Result mapping** -- map rows to Pydantic, msgspec, attrs, or dataclass models, or export to Arrow tables for pandas and Polars
 - **Storage layer** -- read and write Arrow tables to local files, fsspec, or object stores
 - **Framework integrations** -- Litestar plugin with DI, Starlette/FastAPI/Sanic middleware, Flask extension
+- **Google ADK** -- SQLSpec-backed session, event, memory, and artifact services
 - **Observability** -- OpenTelemetry and Prometheus instrumentation, structured logging with correlation IDs
-- **Event channels** -- LISTEN/NOTIFY, Oracle AQ, and a portable polling fallback
-- **Migrations** -- schema versioning CLI built on Alembic
+- **Event channels** -- LISTEN/NOTIFY, Oracle AQ/TxEventQ, and durable table-backed queues with polling fallback
+- **Migrations** -- native schema migration CLI backed by SQLSpec's SQL file loader
 
 ## Documentation
 

--- a/docs/PYPI_README.md
+++ b/docs/PYPI_README.md
@@ -7,7 +7,7 @@
 
 SQLSpec is a SQL execution layer for Python. You write the SQL -- as strings, through a builder API, or loaded from files -- and SQLSpec handles connections, parameter binding, SQL injection prevention, dialect translation, and mapping results back to typed Python objects. It uses [sqlglot](https://github.com/tobymao/sqlglot) under the hood to parse, validate, and optimize your queries before they hit the database.
 
-It works with PostgreSQL (asyncpg, psycopg, psqlpy), SQLite (sqlite3, aiosqlite), DuckDB, MySQL (asyncmy, mysql-connector, pymysql), Oracle (oracledb), CockroachDB, BigQuery, Spanner, and anything ADBC-compatible. Sync or async, same API. It also includes a built-in storage layer, native and bridged Arrow support for all drivers, and integrations for Litestar, FastAPI, Flask, Sanic, and Starlette.
+It works with PostgreSQL (asyncpg, psycopg, psqlpy), SQLite (sqlite3, aiosqlite), DuckDB, MySQL (asyncmy, aiomysql, mysql-connector, pymysql), SQL Server (mssql-python, pymssql, arrow-odbc), Oracle (oracledb), CockroachDB, BigQuery, Spanner, and supported ADBC backends including Snowflake, Flight SQL, and GizmoSQL. Sync or async, same API. It also includes a built-in storage layer, Arrow export through native paths or conversion fallbacks, storage-bridge bulk ingest for adapters with native ingest support, and integrations for Litestar, FastAPI, Flask, Sanic, and Starlette.
 
 ## Quick Start
 
@@ -16,11 +16,13 @@ pip install sqlspec
 ```
 
 ```python
-from pydantic import BaseModel
+from dataclasses import dataclass
+
 from sqlspec import SQLSpec
 from sqlspec.adapters.sqlite import SqliteConfig
 
-class Greeting(BaseModel):
+@dataclass
+class Greeting:
     message: str
 
 spec = SQLSpec()
@@ -46,21 +48,22 @@ users = session.select(
        .where("active = :active")
        .order_by("name")
        .limit(10),
-    {"active": True},
+    active=True,
     schema_type=User,
 )
 ```
 
 ## Features
 
-- **Connection pooling** -- sync and async adapters with a unified API across all supported drivers
+- **Session lifecycle** -- sync and async sessions with pooling where the adapter supports it
 - **Parameter binding and dialect translation** -- powered by sqlglot, with a fluent query builder and `.sql` file loader
 - **Result mapping** -- map rows to Pydantic, msgspec, attrs, or dataclass models, or export to Arrow tables for pandas and Polars
 - **Storage layer** -- read and write Arrow tables to local files, fsspec, or object stores
 - **Framework integrations** -- Litestar plugin with DI, Starlette/FastAPI/Sanic middleware, Flask extension
+- **Google ADK** -- SQLSpec-backed session, event, memory, and artifact services
 - **Observability** -- OpenTelemetry and Prometheus instrumentation, structured logging with correlation IDs
-- **Event channels** -- LISTEN/NOTIFY, Oracle AQ, and a portable polling fallback
-- **Migrations** -- schema versioning CLI built on Alembic
+- **Event channels** -- LISTEN/NOTIFY, Oracle AQ/TxEventQ, and durable table-backed queues with polling fallback
+- **Migrations** -- native schema migration CLI backed by SQLSpec's SQL file loader
 
 ## Documentation
 

--- a/docs/examples/drivers/parameter_binding.py
+++ b/docs/examples/drivers/parameter_binding.py
@@ -15,8 +15,8 @@ def test_parameter_binding(tmp_path: Path) -> None:
     config = spec.add_config(SqliteConfig(connection_config={"database": str(db_path)}))
 
     with spec.provide_session(config) as session:
-        session.execute("select :status as status, :status as status_copy", {"status": "active"})
-        result = session.execute("select ? as value", (42,))
+        session.execute("select :status as status, :status as status_copy", status="active")
+        result = session.execute("select ? as value", 42)
         print(result.one())
     # end-example
 

--- a/docs/examples/frameworks/sanic/commit_modes.py
+++ b/docs/examples/frameworks/sanic/commit_modes.py
@@ -30,7 +30,7 @@ def test_sanic_commit_modes() -> None:
     @app.post("/users")
     async def create_user(request: Request) -> HTTPResponse:
         db = db_plugin.get_session(request, "db")
-        await db.execute("insert into users (name) values (:name)", {"name": request.json["name"]})
+        await db.execute("insert into users (name) values (:name)", name=request.json["name"])
         return response.json({"created": True}, status=201)
 
     db_plugin.init_app(app)

--- a/docs/examples/patterns/migrations_with_schema.py
+++ b/docs/examples/patterns/migrations_with_schema.py
@@ -53,7 +53,8 @@ def down():
                 FROM information_schema.tables
                 WHERE table_schema = ? AND table_name = ?
                 """,
-                ("app_schema", "users"),
+                "app_schema",
+                "users",
             )
             tracker_table = session.select_value(
                 """
@@ -61,7 +62,8 @@ def down():
                 FROM information_schema.tables
                 WHERE table_schema = ? AND table_name = ?
                 """,
-                ("admin_schema", "schema_versions"),
+                "admin_schema",
+                "schema_versions",
             )
 
         assert users_table == "users"

--- a/docs/examples/quickstart/basic_connection.py
+++ b/docs/examples/quickstart/basic_connection.py
@@ -16,7 +16,7 @@ def test_basic_connection(tmp_path: Path) -> None:
 
     with spec.provide_session(config) as session:
         session.execute("create table if not exists notes (id integer primary key, body text)")
-        session.execute("insert into notes (body) values (?)", ("Hello, SQLSpec!",))
+        session.execute("insert into notes (body) values (?)", "Hello, SQLSpec!")
         result = session.execute("select id, body from notes")
         print(result.all())
     # end-example

--- a/docs/examples/quickstart/first_query.py
+++ b/docs/examples/quickstart/first_query.py
@@ -16,8 +16,8 @@ def test_first_query(tmp_path: Path) -> None:
 
     with spec.provide_session(config) as session:
         session.execute("create table if not exists users (id integer primary key, name text)")
-        session.execute("insert into users (name) values (?)", ("Ada",))
-        result = session.execute("select id, name from users where name = ?", ("Ada",))
+        session.execute("insert into users (name) values (?)", "Ada")
+        result = session.execute("select id, name from users where name = ?", "Ada")
         print(result.one())
     # end-example
 

--- a/docs/examples/reference/core_api.py
+++ b/docs/examples/reference/core_api.py
@@ -19,7 +19,7 @@ def test_core_api(tmp_path: Path) -> None:
         session.execute("create table if not exists notes (id integer primary key, body text)")
         session.execute("insert into notes (body) values ('Note')")
         query = SQL("select id, body from notes where id = :note_id or id = :note_id").select_only("body")
-        result = session.execute(query, {"note_id": 1})
+        result = session.execute(query, note_id=1)
         print(result.one_or_none())
     # end-example
 

--- a/docs/examples/reference/driver_api.py
+++ b/docs/examples/reference/driver_api.py
@@ -17,7 +17,7 @@ def test_driver_api(tmp_path: Path) -> None:
     with spec.provide_session(config) as session:
         session.execute("create table if not exists users (id integer primary key, name text)")
         session.execute("insert into users (name) values ('Ada')")
-        row = session.select_one_or_none("select name from users where id = ?", (1,))
+        row = session.select_one_or_none("select name from users where id = ?", 1)
         print(row)
     # end-example
 

--- a/docs/examples/sql_files/declared_params.py
+++ b/docs/examples/sql_files/declared_params.py
@@ -39,14 +39,14 @@ def test_declared_params(tmp_path: "Path") -> None:
         session.execute("insert into teams (name) values ('Litestar'), ('SQLSpec')")
 
         # A declared query validates supplied parameters automatically.
-        row = session.execute(query, {"name": "SQLSpec"}).one()
+        row = session.execute(query, name="SQLSpec").one()
 
         # Optional named parameters are bound as NULL when omitted.
         optional_rows = session.execute(spec.get_sql("list_teams")).all()
 
         # Omitting a declared parameter raises before the query reaches the driver.
         try:
-            session.execute(spec.get_sql("get_team_by_name"), {})
+            session.execute(spec.get_sql("get_team_by_name"))
         except SQLSpecError as exc:
             missing_error = str(exc)
     # end-example

--- a/docs/examples/sql_files/named_queries.py
+++ b/docs/examples/sql_files/named_queries.py
@@ -15,7 +15,7 @@ def test_named_queries() -> None:
     with spec.provide_session(config) as session:
         session.execute("create table teams (id integer primary key, name text)")
         session.execute("insert into teams (name) values ('Litestar'), ('SQLSpec')")
-        result = session.execute(spec.get_sql("find_team"), {"name": "SQLSpec"})
+        result = session.execute(spec.get_sql("find_team"), name="SQLSpec")
         row = result.one()
     # end-example
 

--- a/docs/recipes/dishka.rst
+++ b/docs/recipes/dishka.rst
@@ -69,7 +69,7 @@ Inject drivers into service classes via Dishka:
        async def get_user(self, user_id: str):
            return await self.driver.select_one(
                "SELECT * FROM users WHERE id = :id",
-               {"id": user_id},
+               id=user_id,
            )
 
 .. seealso::

--- a/docs/reference/adapters/spanner.rst
+++ b/docs/reference/adapters/spanner.rst
@@ -34,7 +34,7 @@ Per-call overrides use the existing ``execute()``, ``execute_many()``, and
 
    result = driver.execute(
        "SELECT id FROM users WHERE id = @id",
-       {"id": "u-1"},
+       id="u-1",
        request_options={"request_tag": "users.lookup"},
        directed_read_options=directed_read_options,
        timeout=10.0,
@@ -58,7 +58,7 @@ for the returned session context:
        retry=retry,
        timeout=20.0,
    ) as driver:
-       driver.execute("UPDATE orders SET status = @status WHERE id = @id", params)
+       driver.execute("UPDATE orders SET status = @status WHERE id = @id", status="paid", id="o-1")
 
 The explicit ``provide_session()`` arguments are copied into the returned
 driver's feature set and do not mutate ``config.driver_features``. They also do

--- a/docs/usage/etl.rst
+++ b/docs/usage/etl.rst
@@ -31,7 +31,7 @@ transfers between databases that support native Arrow (ADBC, DuckDB, BigQuery).
     # Extract as Arrow table
     arrow_result = await source_session.select_to_arrow(
         "SELECT * FROM large_table WHERE updated > :since",
-        {"since": last_sync},
+        since=last_sync,
     )
 
     # Arrow table can be converted to pandas, polars, or written to Parquet

--- a/docs/usage/frameworks/litestar/transactions.rst
+++ b/docs/usage/frameworks/litestar/transactions.rst
@@ -34,10 +34,16 @@ is sent. This keeps your database consistent when handlers fail.
 
    @post("/transfer")
    async def transfer(db: AsyncSession, data: TransferRequest) -> dict:
-       await db.execute("UPDATE accounts SET balance = balance - :amount WHERE id = :from_id",
-                        {"amount": data.amount, "from_id": data.from_account})
-       await db.execute("UPDATE accounts SET balance = balance + :amount WHERE id = :to_id",
-                        {"amount": data.amount, "to_id": data.to_account})
+       await db.execute(
+           "UPDATE accounts SET balance = balance - :amount WHERE id = :from_id",
+           amount=data.amount,
+           from_id=data.from_account,
+       )
+       await db.execute(
+           "UPDATE accounts SET balance = balance + :amount WHERE id = :to_id",
+           amount=data.amount,
+           to_id=data.to_account,
+       )
        await db.commit()  # Both updates succeed or both rollback
        return {"status": "transferred"}
 


### PR DESCRIPTION
## What changed

- Updates README and PyPI README feature wording to reflect current adapter, Arrow/storage, Google ADK, event channel, and migration support.
- Switches the quick start model example to a stdlib dataclass so the base install command is accurate.
- Updates docs and examples to prefer keyword bind arguments for named placeholders and bare positional bind arguments for positional placeholders.