### PR TITLE
feat(data-dictionary): add PostgreSQL and Cockroach metadata packs

### DIFF
--- a/sqlspec/adapters/asyncpg/data_dictionary.py
+++ b/sqlspec/adapters/asyncpg/data_dictionary.py
@@ -1,21 +1,192 @@
 """PostgreSQL-specific data dictionary for metadata queries via asyncpg."""
 
-from typing import TYPE_CHECKING, ClassVar
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, ClassVar
 
-from sqlspec.data_dictionary import ColumnMetadata, ForeignKeyMetadata, IndexMetadata, TableMetadata, VersionInfo
+from sqlspec.data_dictionary import (
+    ColumnMetadata,
+    ForeignKeyMetadata,
+    IndexMetadata,
+    MetadataCapability,
+    MetadataCapabilityProfile,
+    MetadataFidelity,
+    MetadataResult,
+    MetadataRisk,
+    MetadataSource,
+    MetadataSupport,
+    TableMetadata,
+    VersionInfo,
+    get_data_dictionary_loader,
+)
 from sqlspec.data_dictionary.dialects.postgres import resolve_postgres_json_type
 from sqlspec.driver import AsyncDataDictionaryBase
 
 if TYPE_CHECKING:
     from sqlspec.adapters.asyncpg.driver import AsyncpgDriver
+    from sqlspec.core import SQL
 
 __all__ = ("AsyncpgDataDictionary",)
+
+
+_POSTGRES_METADATA_DOMAINS = (
+    "schemas",
+    "objects",
+    "tables",
+    "columns",
+    "constraints",
+    "indexes",
+    "views",
+    "materialized_views",
+    "sequences",
+    "routines",
+    "triggers",
+    "comments",
+    "privileges",
+    "dependencies",
+    "extensions",
+    "partitions",
+    "ddl",
+    "system",
+)
+_POSTGRES_SUPPORTED_DOMAINS = frozenset(_POSTGRES_METADATA_DOMAINS) - {"system"}
+
+
+def _postgres_metadata_capability(domain: str) -> MetadataCapability:
+    if domain == "system":
+        return MetadataCapability(
+            domain=domain,
+            support=MetadataSupport.UNSUPPORTED,
+            fidelity=MetadataFidelity.UNSUPPORTED,
+            source=MetadataSource.SYSTEM_VIEW,
+            risks=(MetadataRisk.EXPENSIVE, MetadataRisk.PRIVILEGED),
+            warnings=("System metadata is opt-in and disabled by default.",),
+        )
+    if domain in _POSTGRES_SUPPORTED_DOMAINS:
+        return MetadataCapability(
+            domain=domain,
+            support=MetadataSupport.SUPPORTED,
+            fidelity=MetadataFidelity.NATIVE,
+            source=MetadataSource.CATALOG,
+        )
+    return MetadataCapability.unsupported(domain)
+
+
+def _postgres_metadata_profile(adapter: str, domains: Sequence[str] | None) -> MetadataCapabilityProfile:
+    requested_domains = _POSTGRES_METADATA_DOMAINS if domains is None else tuple(domains)
+    return MetadataCapabilityProfile(
+        "postgres",
+        adapter=adapter,
+        capabilities=tuple(_postgres_metadata_capability(domain) for domain in requested_domains),
+    )
+
+
+def _metadata_result(
+    domain: str, capability: MetadataCapability, rows: list[Any] | tuple[Any, ...] = ()
+) -> MetadataResult:
+    return MetadataResult(domain, capability=capability, items=tuple(rows), warnings=capability.warnings)
+
+
+def _postgres_domain_sql(domain: str, query_name: str) -> "SQL":
+    query = get_data_dictionary_loader().get_domain_query("postgres", domain, query_name)
+    if query.sql is None:
+        msg = f"Missing PostgreSQL data-dictionary query: {domain}/{query_name}"
+        raise RuntimeError(msg)
+    return query.sql
 
 
 class AsyncpgDataDictionary(AsyncDataDictionaryBase):
     """PostgreSQL-specific async data dictionary."""
 
     dialect: ClassVar[str] = "postgres"
+
+    async def get_metadata_capabilities(
+        self, driver: "AsyncpgDriver", domains: Sequence[str] | None = None
+    ) -> MetadataCapabilityProfile:
+        """Get PostgreSQL replacement data-dictionary capability profile."""
+        return _postgres_metadata_profile(type(self).__name__, domains)
+
+    async def _select_domain(
+        self, driver: "AsyncpgDriver", domain: str, query_name: str, **parameters: Any
+    ) -> MetadataResult:
+        query = get_data_dictionary_loader().get_domain_query(type(self).dialect, domain, query_name)
+        if not query.is_supported or query.sql is None:
+            return MetadataResult(domain, capability=query.capability, warnings=query.warnings)
+        rows = await driver.select(query.sql, **parameters)
+        return _metadata_result(domain, _postgres_metadata_capability(domain), rows)
+
+    async def get_schemas(self, driver: "AsyncpgDriver") -> MetadataResult:
+        """Get schema metadata."""
+        return await self._select_domain(driver, "schemas", "list")
+
+    async def get_objects(self, driver: "AsyncpgDriver", schema: str | None = None) -> MetadataResult:
+        """Get database object metadata."""
+        return await self._select_domain(driver, "objects", "by_schema", schema_name=self.resolve_schema(schema))
+
+    async def get_table_details(self, driver: "AsyncpgDriver", table: str, schema: str | None = None) -> MetadataResult:
+        """Get rich table metadata."""
+        return await self._select_domain(
+            driver,
+            "tables",
+            "by_schema",
+            schema_name=self.resolve_schema(schema),
+            table_name=self.resolve_identifier(table),
+        )
+
+    async def get_constraints(
+        self, driver: "AsyncpgDriver", table: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get constraint metadata."""
+        table_name = self.resolve_identifier(table) if table is not None else None
+        return await self._select_domain(
+            driver, "constraints", "by_schema", schema_name=self.resolve_schema(schema), table_name=table_name
+        )
+
+    async def get_views(self, driver: "AsyncpgDriver", schema: str | None = None) -> MetadataResult:
+        """Get view metadata."""
+        return await self._select_domain(driver, "views", "by_schema", schema_name=self.resolve_schema(schema))
+
+    async def get_routines(self, driver: "AsyncpgDriver", schema: str | None = None) -> MetadataResult:
+        """Get routine metadata."""
+        return await self._select_domain(driver, "routines", "by_schema", schema_name=self.resolve_schema(schema))
+
+    async def get_privileges(
+        self, driver: "AsyncpgDriver", object_name: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get privilege metadata."""
+        resolved_object = self.resolve_identifier(object_name) if object_name is not None else None
+        return await self._select_domain(
+            driver, "privileges", "by_schema", schema_name=self.resolve_schema(schema), object_name=resolved_object
+        )
+
+    async def get_dependencies(
+        self, driver: "AsyncpgDriver", object_name: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get dependency metadata."""
+        resolved_object = self.resolve_identifier(object_name) if object_name is not None else None
+        return await self._select_domain(
+            driver, "dependencies", "by_schema", schema_name=self.resolve_schema(schema), object_name=resolved_object
+        )
+
+    async def get_ddl(
+        self, driver: "AsyncpgDriver", object_name: str, schema: str | None = None, object_type: str | None = None
+    ) -> MetadataResult:
+        """Get object DDL where PostgreSQL exposes native definition helpers."""
+        return await self._select_domain(
+            driver,
+            "ddl",
+            "by_object",
+            schema_name=self.resolve_schema(schema),
+            object_name=self.resolve_identifier(object_name),
+            object_type=object_type,
+        )
+
+    async def get_system_metadata(
+        self, driver: "AsyncpgDriver", domain: str, *, include_sensitive: bool = False
+    ) -> MetadataResult:
+        """Get opt-in PostgreSQL system metadata."""
+        if not include_sensitive:
+            return _metadata_result("system", _postgres_metadata_capability("system"))
+        return await self._select_domain(driver, "system", domain, schema_name=None, table_name=None, limit=100)
 
     async def get_version(self, driver: "AsyncpgDriver") -> "VersionInfo | None":
         """Get PostgreSQL database version information.
@@ -85,7 +256,10 @@ class AsyncpgDataDictionary(AsyncDataDictionaryBase):
         schema_name = self.resolve_schema(schema)
         self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="tables")
         return await driver.select(
-            self.get_query("tables_by_schema"), schema_name=schema_name, schema_type=TableMetadata
+            _postgres_domain_sql("tables", "by_schema"),
+            schema_name=schema_name,
+            table_name=None,
+            schema_type=TableMetadata,
         )
 
     async def get_columns(
@@ -96,13 +270,16 @@ class AsyncpgDataDictionary(AsyncDataDictionaryBase):
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="columns")
             return await driver.select(
-                self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
+                _postgres_domain_sql("columns", "by_schema"),
+                schema_name=schema_name,
+                table_name=None,
+                schema_type=ColumnMetadata,
             )
 
         table_name = self.resolve_identifier(table)
         self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="columns")
         return await driver.select(
-            self.get_query("columns_by_table"),
+            _postgres_domain_sql("columns", "by_schema"),
             schema_name=schema_name,
             table_name=table_name,
             schema_type=ColumnMetadata,
@@ -116,13 +293,16 @@ class AsyncpgDataDictionary(AsyncDataDictionaryBase):
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="indexes")
             return await driver.select(
-                self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
+                _postgres_domain_sql("indexes", "by_schema"),
+                schema_name=schema_name,
+                table_name=None,
+                schema_type=IndexMetadata,
             )
 
         table_name = self.resolve_identifier(table)
         self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="indexes")
         return await driver.select(
-            self.get_query("indexes_by_table"),
+            _postgres_domain_sql("indexes", "by_schema"),
             schema_name=schema_name,
             table_name=table_name,
             schema_type=IndexMetadata,

--- a/sqlspec/adapters/asyncpg/data_dictionary.py
+++ b/sqlspec/adapters/asyncpg/data_dictionary.py
@@ -1,10 +1,11 @@
 """PostgreSQL-specific data dictionary for metadata queries via asyncpg."""
 
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, ClassVar
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from sqlspec.data_dictionary import (
     ColumnMetadata,
+    DDLResult,
     ForeignKeyMetadata,
     IndexMetadata,
     MetadataCapability,
@@ -14,9 +15,16 @@ from sqlspec.data_dictionary import (
     MetadataRisk,
     MetadataSource,
     MetadataSupport,
+    ObjectIdentity,
+    SystemMetadataCapability,
+    SystemMetadataRequest,
+    SystemMetadataResult,
     TableMetadata,
     VersionInfo,
+    ensure_system_metadata_request,
     get_data_dictionary_loader,
+    system_metadata_gated_result,
+    unsupported_system_metadata_capability,
 )
 from sqlspec.data_dictionary.dialects.postgres import resolve_postgres_json_type
 from sqlspec.driver import AsyncDataDictionaryBase
@@ -49,6 +57,13 @@ _POSTGRES_METADATA_DOMAINS = (
     "system",
 )
 _POSTGRES_SUPPORTED_DOMAINS = frozenset(_POSTGRES_METADATA_DOMAINS) - {"system"}
+_POSTGRES_SYSTEM_METADATA_QUERIES = {
+    "settings": "settings",
+    "statement_history": "pg_stat_statements",
+    "pg_stat_statements": "pg_stat_statements",
+    "table_statistics": "table_stats",
+    "table_stats": "table_stats",
+}
 
 
 def _postgres_metadata_capability(domain: str) -> MetadataCapability:
@@ -86,6 +101,63 @@ def _metadata_result(
     return MetadataResult(domain, capability=capability, items=tuple(rows), warnings=capability.warnings)
 
 
+def _row_value(row: object, key: str) -> object | None:
+    if isinstance(row, Mapping):
+        return row.get(key)
+    return getattr(row, key, None)
+
+
+def _rows_as_mappings(rows: list[Any] | tuple[Any, ...]) -> tuple[Mapping[str, object], ...]:
+    return tuple(cast("Mapping[str, object]", row) for row in rows if isinstance(row, Mapping))
+
+
+def _ddl_result_from_rows(
+    *,
+    dialect: str,
+    object_name: str,
+    object_type: str,
+    schema: str | None,
+    rows: list[Any] | tuple[Any, ...],
+    warnings: tuple[str, ...] = (),
+) -> DDLResult:
+    row = rows[0] if rows else None
+    resolved_schema = _row_value(row, "schema_name") if row is not None else schema
+    ddl = _row_value(row, "ddl") if row is not None else None
+    fidelity = _row_value(row, "fidelity") if row is not None else MetadataFidelity.UNSUPPORTED
+    row_warning = _row_value(row, "warning") if row is not None else None
+    result_warnings = warnings + ((str(row_warning),) if row_warning else ())
+    identity = ObjectIdentity(
+        name=object_name,
+        object_type=object_type,
+        schema=str(resolved_schema) if resolved_schema is not None else None,
+        dialect=dialect,
+        source=MetadataSource.CATALOG,
+    )
+    if ddl is None:
+        return DDLResult.unsupported(identity, source=MetadataSource.CATALOG, warnings=result_warnings)
+    return DDLResult(
+        identity=identity,
+        status=MetadataSupport.SUPPORTED,
+        fidelity=str(fidelity),
+        source=MetadataSource.CATALOG,
+        ddl=str(ddl),
+        warnings=result_warnings,
+    )
+
+
+def _postgres_system_metadata_capability(domain: str) -> SystemMetadataCapability:
+    if domain not in _POSTGRES_SYSTEM_METADATA_QUERIES:
+        return unsupported_system_metadata_capability(domain)
+    return SystemMetadataCapability(
+        domain,
+        MetadataSupport.SUPPORTED,
+        fidelity=MetadataFidelity.NATIVE,
+        source=MetadataSource.SYSTEM_VIEW,
+        risks=(MetadataRisk.PRIVILEGED, MetadataRisk.REDACTED),
+        redaction_fields=("query_text", "setting_value", "user_oid"),
+    )
+
+
 def _postgres_domain_sql(domain: str, query_name: str) -> "SQL":
     query = get_data_dictionary_loader().get_domain_query("postgres", domain, query_name)
     if query.sql is None:
@@ -104,6 +176,14 @@ class AsyncpgDataDictionary(AsyncDataDictionaryBase):
     ) -> MetadataCapabilityProfile:
         """Get PostgreSQL replacement data-dictionary capability profile."""
         return _postgres_metadata_profile(type(self).__name__, domains)
+
+    async def get_system_metadata_capabilities(
+        self, driver: "AsyncpgDriver", domains: Sequence[str] | None = None
+    ) -> tuple[SystemMetadataCapability, ...]:
+        """Get PostgreSQL opt-in system metadata capability disclosures."""
+        _ = driver
+        requested_domains = tuple(_POSTGRES_SYSTEM_METADATA_QUERIES) if domains is None else tuple(domains)
+        return tuple(_postgres_system_metadata_capability(domain) for domain in requested_domains)
 
     async def _select_domain(
         self, driver: "AsyncpgDriver", domain: str, query_name: str, **parameters: Any
@@ -168,25 +248,57 @@ class AsyncpgDataDictionary(AsyncDataDictionaryBase):
         )
 
     async def get_ddl(
-        self, driver: "AsyncpgDriver", object_name: str, schema: str | None = None, object_type: str | None = None
-    ) -> MetadataResult:
+        self,
+        driver: "AsyncpgDriver",
+        object_name: str,
+        schema: str | None = None,
+        *,
+        object_type: str = "table",
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> DDLResult:
         """Get object DDL where PostgreSQL exposes native definition helpers."""
-        return await self._select_domain(
-            driver,
-            "ddl",
-            "by_object",
-            schema_name=self.resolve_schema(schema),
-            object_name=self.resolve_identifier(object_name),
+        _ = include_dependencies, prefer_native, redact
+        schema_name = self.resolve_schema(schema)
+        resolved_object = self.resolve_identifier(object_name)
+        result = await self._select_domain(
+            driver, "ddl", "by_object", schema_name=schema_name, object_name=resolved_object, object_type=object_type
+        )
+        return _ddl_result_from_rows(
+            dialect=type(self).dialect,
+            object_name=resolved_object,
             object_type=object_type,
+            schema=schema_name,
+            rows=result.items,
+            warnings=result.warnings,
         )
 
     async def get_system_metadata(
-        self, driver: "AsyncpgDriver", domain: str, *, include_sensitive: bool = False
-    ) -> MetadataResult:
+        self, driver: "AsyncpgDriver", request: SystemMetadataRequest | str | None = None, **kwargs: Any
+    ) -> SystemMetadataResult:
         """Get opt-in PostgreSQL system metadata."""
-        if not include_sensitive:
-            return _metadata_result("system", _postgres_metadata_capability("system"))
-        return await self._select_domain(driver, "system", domain, schema_name=None, table_name=None, limit=100)
+        metadata_request = ensure_system_metadata_request(request, **kwargs)
+        capability = _postgres_system_metadata_capability(metadata_request.domain)
+        gate_result = system_metadata_gated_result(metadata_request, capability)
+        if gate_result.capability.support != MetadataSupport.SUPPORTED:
+            return gate_result
+
+        query_name = _POSTGRES_SYSTEM_METADATA_QUERIES.get(metadata_request.domain)
+        if query_name is None:
+            return gate_result
+        parameters: dict[str, object] = {}
+        if query_name == "pg_stat_statements":
+            parameters["limit"] = 100
+        elif query_name == "table_stats":
+            parameters["schema_name"] = self.resolve_schema(metadata_request.schema)
+            parameters["table_name"] = (
+                self.resolve_identifier(metadata_request.table) if metadata_request.table is not None else None
+            )
+        result = await self._select_domain(driver, "system", query_name, **parameters)
+        return SystemMetadataResult.from_rows(
+            metadata_request, capability, rows=_rows_as_mappings(result.items), source=MetadataSource.SYSTEM_VIEW
+        )
 
     async def get_version(self, driver: "AsyncpgDriver") -> "VersionInfo | None":
         """Get PostgreSQL database version information.

--- a/sqlspec/adapters/cockroach_asyncpg/data_dictionary.py
+++ b/sqlspec/adapters/cockroach_asyncpg/data_dictionary.py
@@ -1,21 +1,211 @@
 """CockroachDB AsyncPG data dictionary."""
 
-from typing import TYPE_CHECKING, ClassVar
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, ClassVar
 
-from sqlspec.data_dictionary import ColumnMetadata, ForeignKeyMetadata, IndexMetadata, TableMetadata, VersionInfo
+from sqlspec.data_dictionary import (
+    ColumnMetadata,
+    ForeignKeyMetadata,
+    IndexMetadata,
+    MetadataCapability,
+    MetadataCapabilityProfile,
+    MetadataFidelity,
+    MetadataResult,
+    MetadataRisk,
+    MetadataSource,
+    MetadataSupport,
+    TableMetadata,
+    VersionInfo,
+    get_data_dictionary_loader,
+)
 from sqlspec.data_dictionary.dialects.cockroachdb import resolve_cockroachdb_json_type
 from sqlspec.driver import AsyncDataDictionaryBase
 
 if TYPE_CHECKING:
     from sqlspec.adapters.cockroach_asyncpg.driver import CockroachAsyncpgDriver
+    from sqlspec.core import SQL
 
 __all__ = ("CockroachAsyncpgDataDictionary",)
+
+
+_COCKROACH_METADATA_DOMAINS = (
+    "schemas",
+    "objects",
+    "tables",
+    "columns",
+    "constraints",
+    "indexes",
+    "views",
+    "sequences",
+    "comments",
+    "privileges",
+    "dependencies",
+    "ddl",
+    "crdb_internal",
+    "system",
+)
+_COCKROACH_SUPPORTED_DOMAINS = frozenset(_COCKROACH_METADATA_DOMAINS) - {"crdb_internal", "system"}
+
+
+def _cockroach_metadata_capability(domain: str) -> MetadataCapability:
+    if domain == "ddl":
+        return MetadataCapability(
+            domain=domain,
+            support=MetadataSupport.SUPPORTED,
+            fidelity=MetadataFidelity.LOSSY,
+            source=MetadataSource.INFORMATION_SCHEMA,
+            warnings=(
+                "CockroachDB DDL metadata is lossy unless SHOW-derived SQL is requested with quoted identifiers.",
+            ),
+        )
+    if domain == "crdb_internal":
+        return MetadataCapability(
+            domain=domain,
+            support=MetadataSupport.UNSUPPORTED,
+            fidelity=MetadataFidelity.UNSUPPORTED,
+            source=MetadataSource.SYSTEM_VIEW,
+            risks=(MetadataRisk.VERSION_GATED, MetadataRisk.PRIVILEGED),
+            warnings=("crdb_internal metadata is disabled by default.",),
+        )
+    if domain == "system":
+        return MetadataCapability(
+            domain=domain,
+            support=MetadataSupport.UNSUPPORTED,
+            fidelity=MetadataFidelity.UNSUPPORTED,
+            source=MetadataSource.SYSTEM_VIEW,
+            risks=(MetadataRisk.EXPENSIVE, MetadataRisk.PRIVILEGED),
+            warnings=("System metadata is opt-in and disabled by default.",),
+        )
+    if domain in _COCKROACH_SUPPORTED_DOMAINS:
+        return MetadataCapability(
+            domain=domain,
+            support=MetadataSupport.SUPPORTED,
+            fidelity=MetadataFidelity.PARTIAL,
+            source=MetadataSource.INFORMATION_SCHEMA,
+        )
+    return MetadataCapability.unsupported(domain)
+
+
+def _cockroach_metadata_profile(adapter: str, domains: Sequence[str] | None) -> MetadataCapabilityProfile:
+    requested_domains = _COCKROACH_METADATA_DOMAINS if domains is None else tuple(domains)
+    return MetadataCapabilityProfile(
+        "cockroachdb",
+        adapter=adapter,
+        capabilities=tuple(_cockroach_metadata_capability(domain) for domain in requested_domains),
+    )
+
+
+def _metadata_result(
+    domain: str, capability: MetadataCapability, rows: list[Any] | tuple[Any, ...] = ()
+) -> MetadataResult:
+    return MetadataResult(domain, capability=capability, items=tuple(rows), warnings=capability.warnings)
+
+
+def _cockroach_domain_sql(domain: str, query_name: str) -> "SQL":
+    query = get_data_dictionary_loader().get_domain_query("cockroachdb", domain, query_name)
+    if query.sql is None:
+        msg = f"Missing CockroachDB data-dictionary query: {domain}/{query_name}"
+        raise RuntimeError(msg)
+    return query.sql
 
 
 class CockroachAsyncpgDataDictionary(AsyncDataDictionaryBase):
     """CockroachDB async data dictionary (AsyncPG)."""
 
     dialect: ClassVar[str] = "cockroachdb"
+
+    async def get_metadata_capabilities(
+        self, driver: "CockroachAsyncpgDriver", domains: Sequence[str] | None = None
+    ) -> MetadataCapabilityProfile:
+        """Get CockroachDB replacement data-dictionary capability profile."""
+        return _cockroach_metadata_profile(type(self).__name__, domains)
+
+    async def _select_domain(
+        self, driver: "CockroachAsyncpgDriver", domain: str, query_name: str, **parameters: Any
+    ) -> MetadataResult:
+        query = get_data_dictionary_loader().get_domain_query(type(self).dialect, domain, query_name)
+        if not query.is_supported or query.sql is None:
+            return MetadataResult(domain, capability=query.capability, warnings=query.warnings)
+        rows = await driver.select(query.sql, **parameters)
+        return _metadata_result(domain, _cockroach_metadata_capability(domain), rows)
+
+    async def get_schemas(self, driver: "CockroachAsyncpgDriver") -> MetadataResult:
+        """Get schema metadata."""
+        return await self._select_domain(driver, "schemas", "list")
+
+    async def get_objects(self, driver: "CockroachAsyncpgDriver", schema: str | None = None) -> MetadataResult:
+        """Get database object metadata."""
+        return await self._select_domain(driver, "objects", "by_schema", schema_name=self.resolve_schema(schema))
+
+    async def get_table_details(
+        self, driver: "CockroachAsyncpgDriver", table: str, schema: str | None = None
+    ) -> MetadataResult:
+        """Get rich table metadata."""
+        return await self._select_domain(
+            driver,
+            "tables",
+            "by_schema",
+            schema_name=self.resolve_schema(schema),
+            table_name=self.resolve_identifier(table),
+        )
+
+    async def get_constraints(
+        self, driver: "CockroachAsyncpgDriver", table: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get constraint metadata."""
+        table_name = self.resolve_identifier(table) if table is not None else None
+        return await self._select_domain(
+            driver, "constraints", "by_schema", schema_name=self.resolve_schema(schema), table_name=table_name
+        )
+
+    async def get_views(self, driver: "CockroachAsyncpgDriver", schema: str | None = None) -> MetadataResult:
+        """Get view metadata."""
+        return await self._select_domain(driver, "views", "by_schema", schema_name=self.resolve_schema(schema))
+
+    async def get_routines(self, driver: "CockroachAsyncpgDriver", schema: str | None = None) -> MetadataResult:
+        """Get routine metadata."""
+        return _metadata_result("routines", MetadataCapability.unsupported("routines"))
+
+    async def get_privileges(
+        self, driver: "CockroachAsyncpgDriver", object_name: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get privilege metadata."""
+        resolved_object = self.resolve_identifier(object_name) if object_name is not None else None
+        return await self._select_domain(
+            driver, "privileges", "by_schema", schema_name=self.resolve_schema(schema), object_name=resolved_object
+        )
+
+    async def get_dependencies(
+        self, driver: "CockroachAsyncpgDriver", object_name: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get stable dependency metadata."""
+        resolved_object = self.resolve_identifier(object_name) if object_name is not None else None
+        return await self._select_domain(
+            driver, "dependencies", "by_schema", schema_name=self.resolve_schema(schema), object_name=resolved_object
+        )
+
+    async def get_ddl(
+        self,
+        driver: "CockroachAsyncpgDriver",
+        object_name: str,
+        schema: str | None = None,
+        object_type: str | None = None,
+    ) -> MetadataResult:
+        """Get lossy CockroachDB DDL status without parameterized identifiers."""
+        return await self._select_domain(
+            driver,
+            "ddl",
+            "by_object",
+            schema_name=self.resolve_schema(schema),
+            object_name=self.resolve_identifier(object_name),
+            object_type=object_type,
+        )
+
+    async def get_system_metadata(
+        self, driver: "CockroachAsyncpgDriver", domain: str, *, include_sensitive: bool = False
+    ) -> MetadataResult:
+        """Get opt-in CockroachDB system metadata."""
+        return _metadata_result("system", _cockroach_metadata_capability("system"))
 
     async def get_version(self, driver: "CockroachAsyncpgDriver") -> "VersionInfo | None":
         driver_id = id(driver)
@@ -52,7 +242,10 @@ class CockroachAsyncpgDataDictionary(AsyncDataDictionaryBase):
         schema_name = self.resolve_schema(schema)
         self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="tables")
         return await driver.select(
-            self.get_query("tables_by_schema"), schema_name=schema_name, schema_type=TableMetadata
+            _cockroach_domain_sql("tables", "by_schema"),
+            schema_name=schema_name,
+            table_name=None,
+            schema_type=TableMetadata,
         )
 
     async def get_columns(
@@ -62,13 +255,16 @@ class CockroachAsyncpgDataDictionary(AsyncDataDictionaryBase):
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="columns")
             return await driver.select(
-                self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
+                _cockroach_domain_sql("columns", "by_schema"),
+                schema_name=schema_name,
+                table_name=None,
+                schema_type=ColumnMetadata,
             )
 
         table_name = self.resolve_identifier(table)
         self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="columns")
         return await driver.select(
-            self.get_query("columns_by_table"),
+            _cockroach_domain_sql("columns", "by_schema"),
             schema_name=schema_name,
             table_name=table_name,
             schema_type=ColumnMetadata,
@@ -81,13 +277,16 @@ class CockroachAsyncpgDataDictionary(AsyncDataDictionaryBase):
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="indexes")
             return await driver.select(
-                self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
+                _cockroach_domain_sql("indexes", "by_schema"),
+                schema_name=schema_name,
+                table_name=None,
+                schema_type=IndexMetadata,
             )
 
         table_name = self.resolve_identifier(table)
         self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="indexes")
         return await driver.select(
-            self.get_query("indexes_by_table"),
+            _cockroach_domain_sql("indexes", "by_schema"),
             schema_name=schema_name,
             table_name=table_name,
             schema_type=IndexMetadata,

--- a/sqlspec/adapters/cockroach_asyncpg/data_dictionary.py
+++ b/sqlspec/adapters/cockroach_asyncpg/data_dictionary.py
@@ -1,10 +1,11 @@
 """CockroachDB AsyncPG data dictionary."""
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from sqlspec.data_dictionary import (
     ColumnMetadata,
+    DDLResult,
     ForeignKeyMetadata,
     IndexMetadata,
     MetadataCapability,
@@ -14,9 +15,16 @@ from sqlspec.data_dictionary import (
     MetadataRisk,
     MetadataSource,
     MetadataSupport,
+    ObjectIdentity,
+    SystemMetadataCapability,
+    SystemMetadataRequest,
+    SystemMetadataResult,
     TableMetadata,
     VersionInfo,
+    ensure_system_metadata_request,
     get_data_dictionary_loader,
+    system_metadata_gated_result,
+    unsupported_system_metadata_capability,
 )
 from sqlspec.data_dictionary.dialects.cockroachdb import resolve_cockroachdb_json_type
 from sqlspec.driver import AsyncDataDictionaryBase
@@ -101,6 +109,41 @@ def _metadata_result(
     return MetadataResult(domain, capability=capability, items=tuple(rows), warnings=capability.warnings)
 
 
+def _row_value(row: object, key: str) -> object | None:
+    if isinstance(row, Mapping):
+        return row.get(key)
+    return getattr(row, key, None)
+
+
+def _cockroach_ddl_result_from_rows(
+    *,
+    dialect: str,
+    object_name: str,
+    object_type: str,
+    schema: str | None,
+    rows: tuple[object, ...],
+    warnings: tuple[str, ...] = (),
+) -> DDLResult:
+    row = rows[0] if rows else None
+    resolved_schema = _row_value(row, "schema_name") if row is not None else schema
+    ddl = _row_value(row, "ddl") if row is not None else None
+    row_warning = _row_value(row, "warning") if row is not None else None
+    result_warnings = warnings + ((str(row_warning),) if row_warning else ())
+    identity = ObjectIdentity(
+        name=object_name,
+        object_type=object_type,
+        schema=str(resolved_schema) if resolved_schema is not None else None,
+        dialect=dialect,
+        source=MetadataSource.INFORMATION_SCHEMA,
+    )
+    return DDLResult.lossy(
+        identity,
+        ddl=str(ddl) if ddl is not None else None,
+        source=MetadataSource.INFORMATION_SCHEMA,
+        warnings=result_warnings,
+    )
+
+
 def _cockroach_domain_sql(domain: str, query_name: str) -> "SQL":
     query = get_data_dictionary_loader().get_domain_query("cockroachdb", domain, query_name)
     if query.sql is None:
@@ -119,6 +162,14 @@ class CockroachAsyncpgDataDictionary(AsyncDataDictionaryBase):
     ) -> MetadataCapabilityProfile:
         """Get CockroachDB replacement data-dictionary capability profile."""
         return _cockroach_metadata_profile(type(self).__name__, domains)
+
+    async def get_system_metadata_capabilities(
+        self, driver: "CockroachAsyncpgDriver", domains: Sequence[str] | None = None
+    ) -> tuple[SystemMetadataCapability, ...]:
+        """Get CockroachDB opt-in system metadata capability disclosures."""
+        _ = driver
+        requested_domains = ("system",) if domains is None else tuple(domains)
+        return tuple(unsupported_system_metadata_capability(domain) for domain in requested_domains)
 
     async def _select_domain(
         self, driver: "CockroachAsyncpgDriver", domain: str, query_name: str, **parameters: Any
@@ -189,23 +240,36 @@ class CockroachAsyncpgDataDictionary(AsyncDataDictionaryBase):
         driver: "CockroachAsyncpgDriver",
         object_name: str,
         schema: str | None = None,
-        object_type: str | None = None,
-    ) -> MetadataResult:
+        *,
+        object_type: str = "table",
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> DDLResult:
         """Get lossy CockroachDB DDL status without parameterized identifiers."""
-        return await self._select_domain(
-            driver,
-            "ddl",
-            "by_object",
-            schema_name=self.resolve_schema(schema),
-            object_name=self.resolve_identifier(object_name),
+        _ = include_dependencies, prefer_native, redact
+        schema_name = self.resolve_schema(schema)
+        resolved_object = self.resolve_identifier(object_name)
+        result = await self._select_domain(
+            driver, "ddl", "by_object", schema_name=schema_name, object_name=resolved_object, object_type=object_type
+        )
+        return _cockroach_ddl_result_from_rows(
+            dialect=type(self).dialect,
+            object_name=resolved_object,
             object_type=object_type,
+            schema=schema_name,
+            rows=result.items,
+            warnings=result.warnings,
         )
 
     async def get_system_metadata(
-        self, driver: "CockroachAsyncpgDriver", domain: str, *, include_sensitive: bool = False
-    ) -> MetadataResult:
+        self, driver: "CockroachAsyncpgDriver", request: SystemMetadataRequest | str | None = None, **kwargs: Any
+    ) -> SystemMetadataResult:
         """Get opt-in CockroachDB system metadata."""
-        return _metadata_result("system", _cockroach_metadata_capability("system"))
+        _ = driver
+        metadata_request = ensure_system_metadata_request(request, **kwargs)
+        capability = unsupported_system_metadata_capability(metadata_request.domain)
+        return system_metadata_gated_result(metadata_request, capability)
 
     async def get_version(self, driver: "CockroachAsyncpgDriver") -> "VersionInfo | None":
         driver_id = id(driver)

--- a/sqlspec/adapters/cockroach_psycopg/data_dictionary.py
+++ b/sqlspec/adapters/cockroach_psycopg/data_dictionary.py
@@ -1,12 +1,13 @@
 """CockroachDB-specific data dictionary for metadata queries."""
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from mypy_extensions import mypyc_attr
 
 from sqlspec.data_dictionary import (
     ColumnMetadata,
+    DDLResult,
     ForeignKeyMetadata,
     IndexMetadata,
     MetadataCapability,
@@ -16,9 +17,16 @@ from sqlspec.data_dictionary import (
     MetadataRisk,
     MetadataSource,
     MetadataSupport,
+    ObjectIdentity,
+    SystemMetadataCapability,
+    SystemMetadataRequest,
+    SystemMetadataResult,
     TableMetadata,
     VersionInfo,
+    ensure_system_metadata_request,
     get_data_dictionary_loader,
+    system_metadata_gated_result,
+    unsupported_system_metadata_capability,
 )
 from sqlspec.data_dictionary.dialects.cockroachdb import resolve_cockroachdb_json_type
 from sqlspec.driver import AsyncDataDictionaryBase, SyncDataDictionaryBase
@@ -103,6 +111,41 @@ def _metadata_result(
     return MetadataResult(domain, capability=capability, items=tuple(rows), warnings=capability.warnings)
 
 
+def _row_value(row: object, key: str) -> object | None:
+    if isinstance(row, Mapping):
+        return row.get(key)
+    return getattr(row, key, None)
+
+
+def _cockroach_ddl_result_from_rows(
+    *,
+    dialect: str,
+    object_name: str,
+    object_type: str,
+    schema: str | None,
+    rows: tuple[object, ...],
+    warnings: tuple[str, ...] = (),
+) -> DDLResult:
+    row = rows[0] if rows else None
+    resolved_schema = _row_value(row, "schema_name") if row is not None else schema
+    ddl = _row_value(row, "ddl") if row is not None else None
+    row_warning = _row_value(row, "warning") if row is not None else None
+    result_warnings = warnings + ((str(row_warning),) if row_warning else ())
+    identity = ObjectIdentity(
+        name=object_name,
+        object_type=object_type,
+        schema=str(resolved_schema) if resolved_schema is not None else None,
+        dialect=dialect,
+        source=MetadataSource.INFORMATION_SCHEMA,
+    )
+    return DDLResult.lossy(
+        identity,
+        ddl=str(ddl) if ddl is not None else None,
+        source=MetadataSource.INFORMATION_SCHEMA,
+        warnings=result_warnings,
+    )
+
+
 def _cockroach_domain_sql(domain: str, query_name: str) -> "SQL":
     query = get_data_dictionary_loader().get_domain_query("cockroachdb", domain, query_name)
     if query.sql is None:
@@ -125,6 +168,14 @@ class CockroachPsycopgSyncDataDictionary(SyncDataDictionaryBase):
     ) -> MetadataCapabilityProfile:
         """Get CockroachDB replacement data-dictionary capability profile."""
         return _cockroach_metadata_profile(type(self).__name__, domains)
+
+    def get_system_metadata_capabilities(
+        self, driver: "CockroachPsycopgSyncDriver", domains: Sequence[str] | None = None
+    ) -> tuple[SystemMetadataCapability, ...]:
+        """Get CockroachDB opt-in system metadata capability disclosures."""
+        _ = driver
+        requested_domains = ("system",) if domains is None else tuple(domains)
+        return tuple(unsupported_system_metadata_capability(domain) for domain in requested_domains)
 
     def _select_domain(
         self, driver: "CockroachPsycopgSyncDriver", domain: str, query_name: str, **parameters: Any
@@ -195,23 +246,36 @@ class CockroachPsycopgSyncDataDictionary(SyncDataDictionaryBase):
         driver: "CockroachPsycopgSyncDriver",
         object_name: str,
         schema: str | None = None,
-        object_type: str | None = None,
-    ) -> MetadataResult:
+        *,
+        object_type: str = "table",
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> DDLResult:
         """Get lossy CockroachDB DDL status without parameterized identifiers."""
-        return self._select_domain(
-            driver,
-            "ddl",
-            "by_object",
-            schema_name=self.resolve_schema(schema),
-            object_name=self.resolve_identifier(object_name),
+        _ = include_dependencies, prefer_native, redact
+        schema_name = self.resolve_schema(schema)
+        resolved_object = self.resolve_identifier(object_name)
+        result = self._select_domain(
+            driver, "ddl", "by_object", schema_name=schema_name, object_name=resolved_object, object_type=object_type
+        )
+        return _cockroach_ddl_result_from_rows(
+            dialect=type(self).dialect,
+            object_name=resolved_object,
             object_type=object_type,
+            schema=schema_name,
+            rows=result.items,
+            warnings=result.warnings,
         )
 
     def get_system_metadata(
-        self, driver: "CockroachPsycopgSyncDriver", domain: str, *, include_sensitive: bool = False
-    ) -> MetadataResult:
+        self, driver: "CockroachPsycopgSyncDriver", request: SystemMetadataRequest | str | None = None, **kwargs: Any
+    ) -> SystemMetadataResult:
         """Get opt-in CockroachDB system metadata."""
-        return _metadata_result("system", _cockroach_metadata_capability("system"))
+        _ = driver
+        metadata_request = ensure_system_metadata_request(request, **kwargs)
+        capability = unsupported_system_metadata_capability(metadata_request.domain)
+        return system_metadata_gated_result(metadata_request, capability)
 
     def get_version(self, driver: "CockroachPsycopgSyncDriver") -> "VersionInfo | None":
         """Get CockroachDB version information."""
@@ -340,6 +404,14 @@ class CockroachPsycopgAsyncDataDictionary(AsyncDataDictionaryBase):
         """Get CockroachDB replacement data-dictionary capability profile."""
         return _cockroach_metadata_profile(type(self).__name__, domains)
 
+    async def get_system_metadata_capabilities(
+        self, driver: "CockroachPsycopgAsyncDriver", domains: Sequence[str] | None = None
+    ) -> tuple[SystemMetadataCapability, ...]:
+        """Get CockroachDB opt-in system metadata capability disclosures."""
+        _ = driver
+        requested_domains = ("system",) if domains is None else tuple(domains)
+        return tuple(unsupported_system_metadata_capability(domain) for domain in requested_domains)
+
     async def _select_domain(
         self, driver: "CockroachPsycopgAsyncDriver", domain: str, query_name: str, **parameters: Any
     ) -> MetadataResult:
@@ -409,23 +481,36 @@ class CockroachPsycopgAsyncDataDictionary(AsyncDataDictionaryBase):
         driver: "CockroachPsycopgAsyncDriver",
         object_name: str,
         schema: str | None = None,
-        object_type: str | None = None,
-    ) -> MetadataResult:
+        *,
+        object_type: str = "table",
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> DDLResult:
         """Get lossy CockroachDB DDL status without parameterized identifiers."""
-        return await self._select_domain(
-            driver,
-            "ddl",
-            "by_object",
-            schema_name=self.resolve_schema(schema),
-            object_name=self.resolve_identifier(object_name),
+        _ = include_dependencies, prefer_native, redact
+        schema_name = self.resolve_schema(schema)
+        resolved_object = self.resolve_identifier(object_name)
+        result = await self._select_domain(
+            driver, "ddl", "by_object", schema_name=schema_name, object_name=resolved_object, object_type=object_type
+        )
+        return _cockroach_ddl_result_from_rows(
+            dialect=type(self).dialect,
+            object_name=resolved_object,
             object_type=object_type,
+            schema=schema_name,
+            rows=result.items,
+            warnings=result.warnings,
         )
 
     async def get_system_metadata(
-        self, driver: "CockroachPsycopgAsyncDriver", domain: str, *, include_sensitive: bool = False
-    ) -> MetadataResult:
+        self, driver: "CockroachPsycopgAsyncDriver", request: SystemMetadataRequest | str | None = None, **kwargs: Any
+    ) -> SystemMetadataResult:
         """Get opt-in CockroachDB system metadata."""
-        return _metadata_result("system", _cockroach_metadata_capability("system"))
+        _ = driver
+        metadata_request = ensure_system_metadata_request(request, **kwargs)
+        capability = unsupported_system_metadata_capability(metadata_request.domain)
+        return system_metadata_gated_result(metadata_request, capability)
 
     async def get_version(self, driver: "CockroachPsycopgAsyncDriver") -> "VersionInfo | None":
         """Get CockroachDB version information."""

--- a/sqlspec/adapters/cockroach_psycopg/data_dictionary.py
+++ b/sqlspec/adapters/cockroach_psycopg/data_dictionary.py
@@ -1,17 +1,114 @@
 """CockroachDB-specific data dictionary for metadata queries."""
 
-from typing import TYPE_CHECKING, ClassVar
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from mypy_extensions import mypyc_attr
 
-from sqlspec.data_dictionary import ColumnMetadata, ForeignKeyMetadata, IndexMetadata, TableMetadata, VersionInfo
+from sqlspec.data_dictionary import (
+    ColumnMetadata,
+    ForeignKeyMetadata,
+    IndexMetadata,
+    MetadataCapability,
+    MetadataCapabilityProfile,
+    MetadataFidelity,
+    MetadataResult,
+    MetadataRisk,
+    MetadataSource,
+    MetadataSupport,
+    TableMetadata,
+    VersionInfo,
+    get_data_dictionary_loader,
+)
 from sqlspec.data_dictionary.dialects.cockroachdb import resolve_cockroachdb_json_type
 from sqlspec.driver import AsyncDataDictionaryBase, SyncDataDictionaryBase
 
 if TYPE_CHECKING:
     from sqlspec.adapters.cockroach_psycopg.driver import CockroachPsycopgAsyncDriver, CockroachPsycopgSyncDriver
+    from sqlspec.core import SQL
 
 __all__ = ("CockroachPsycopgAsyncDataDictionary", "CockroachPsycopgSyncDataDictionary")
+
+
+_COCKROACH_METADATA_DOMAINS = (
+    "schemas",
+    "objects",
+    "tables",
+    "columns",
+    "constraints",
+    "indexes",
+    "views",
+    "sequences",
+    "comments",
+    "privileges",
+    "dependencies",
+    "ddl",
+    "crdb_internal",
+    "system",
+)
+_COCKROACH_SUPPORTED_DOMAINS = frozenset(_COCKROACH_METADATA_DOMAINS) - {"crdb_internal", "system"}
+
+
+def _cockroach_metadata_capability(domain: str) -> MetadataCapability:
+    if domain == "ddl":
+        return MetadataCapability(
+            domain=domain,
+            support=MetadataSupport.SUPPORTED,
+            fidelity=MetadataFidelity.LOSSY,
+            source=MetadataSource.INFORMATION_SCHEMA,
+            warnings=(
+                "CockroachDB DDL metadata is lossy unless SHOW-derived SQL is requested with quoted identifiers.",
+            ),
+        )
+    if domain == "crdb_internal":
+        return MetadataCapability(
+            domain=domain,
+            support=MetadataSupport.UNSUPPORTED,
+            fidelity=MetadataFidelity.UNSUPPORTED,
+            source=MetadataSource.SYSTEM_VIEW,
+            risks=(MetadataRisk.VERSION_GATED, MetadataRisk.PRIVILEGED),
+            warnings=("crdb_internal metadata is disabled by default.",),
+        )
+    if domain == "system":
+        return MetadataCapability(
+            domain=domain,
+            support=MetadataSupport.UNSUPPORTED,
+            fidelity=MetadataFidelity.UNSUPPORTED,
+            source=MetadataSource.SYSTEM_VIEW,
+            risks=(MetadataRisk.EXPENSIVE, MetadataRisk.PRIVILEGED),
+            warnings=("System metadata is opt-in and disabled by default.",),
+        )
+    if domain in _COCKROACH_SUPPORTED_DOMAINS:
+        return MetadataCapability(
+            domain=domain,
+            support=MetadataSupport.SUPPORTED,
+            fidelity=MetadataFidelity.PARTIAL,
+            source=MetadataSource.INFORMATION_SCHEMA,
+        )
+    return MetadataCapability.unsupported(domain)
+
+
+def _cockroach_metadata_profile(adapter: str, domains: Sequence[str] | None) -> MetadataCapabilityProfile:
+    requested_domains = _COCKROACH_METADATA_DOMAINS if domains is None else tuple(domains)
+    return MetadataCapabilityProfile(
+        "cockroachdb",
+        adapter=adapter,
+        capabilities=tuple(_cockroach_metadata_capability(domain) for domain in requested_domains),
+    )
+
+
+def _metadata_result(
+    domain: str, capability: MetadataCapability, rows: list[Any] | tuple[Any, ...] = ()
+) -> MetadataResult:
+    return MetadataResult(domain, capability=capability, items=tuple(rows), warnings=capability.warnings)
+
+
+def _cockroach_domain_sql(domain: str, query_name: str) -> "SQL":
+    query = get_data_dictionary_loader().get_domain_query("cockroachdb", domain, query_name)
+    if query.sql is None:
+        msg = f"Missing CockroachDB data-dictionary query: {domain}/{query_name}"
+        raise RuntimeError(msg)
+    return query.sql
 
 
 @mypyc_attr(allow_interpreted_subclasses=True, native_class=False)
@@ -22,6 +119,99 @@ class CockroachPsycopgSyncDataDictionary(SyncDataDictionaryBase):
 
     def __init__(self) -> None:
         super().__init__()
+
+    def get_metadata_capabilities(
+        self, driver: "CockroachPsycopgSyncDriver", domains: Sequence[str] | None = None
+    ) -> MetadataCapabilityProfile:
+        """Get CockroachDB replacement data-dictionary capability profile."""
+        return _cockroach_metadata_profile(type(self).__name__, domains)
+
+    def _select_domain(
+        self, driver: "CockroachPsycopgSyncDriver", domain: str, query_name: str, **parameters: Any
+    ) -> MetadataResult:
+        query = get_data_dictionary_loader().get_domain_query(type(self).dialect, domain, query_name)
+        if not query.is_supported or query.sql is None:
+            return MetadataResult(domain, capability=query.capability, warnings=query.warnings)
+        rows = driver.select(query.sql, **parameters)
+        return _metadata_result(domain, _cockroach_metadata_capability(domain), rows)
+
+    def get_schemas(self, driver: "CockroachPsycopgSyncDriver") -> MetadataResult:
+        """Get schema metadata."""
+        return self._select_domain(driver, "schemas", "list")
+
+    def get_objects(self, driver: "CockroachPsycopgSyncDriver", schema: str | None = None) -> MetadataResult:
+        """Get database object metadata."""
+        return self._select_domain(driver, "objects", "by_schema", schema_name=self.resolve_schema(schema))
+
+    def get_table_details(
+        self, driver: "CockroachPsycopgSyncDriver", table: str, schema: str | None = None
+    ) -> MetadataResult:
+        """Get rich table metadata."""
+        return self._select_domain(
+            driver,
+            "tables",
+            "by_schema",
+            schema_name=self.resolve_schema(schema),
+            table_name=self.resolve_identifier(table),
+        )
+
+    def get_constraints(
+        self, driver: "CockroachPsycopgSyncDriver", table: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get constraint metadata."""
+        table_name = self.resolve_identifier(table) if table is not None else None
+        return self._select_domain(
+            driver, "constraints", "by_schema", schema_name=self.resolve_schema(schema), table_name=table_name
+        )
+
+    def get_views(self, driver: "CockroachPsycopgSyncDriver", schema: str | None = None) -> MetadataResult:
+        """Get view metadata."""
+        return self._select_domain(driver, "views", "by_schema", schema_name=self.resolve_schema(schema))
+
+    def get_routines(self, driver: "CockroachPsycopgSyncDriver", schema: str | None = None) -> MetadataResult:
+        """Get routine metadata."""
+        return _metadata_result("routines", MetadataCapability.unsupported("routines"))
+
+    def get_privileges(
+        self, driver: "CockroachPsycopgSyncDriver", object_name: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get privilege metadata."""
+        resolved_object = self.resolve_identifier(object_name) if object_name is not None else None
+        return self._select_domain(
+            driver, "privileges", "by_schema", schema_name=self.resolve_schema(schema), object_name=resolved_object
+        )
+
+    def get_dependencies(
+        self, driver: "CockroachPsycopgSyncDriver", object_name: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get stable dependency metadata."""
+        resolved_object = self.resolve_identifier(object_name) if object_name is not None else None
+        return self._select_domain(
+            driver, "dependencies", "by_schema", schema_name=self.resolve_schema(schema), object_name=resolved_object
+        )
+
+    def get_ddl(
+        self,
+        driver: "CockroachPsycopgSyncDriver",
+        object_name: str,
+        schema: str | None = None,
+        object_type: str | None = None,
+    ) -> MetadataResult:
+        """Get lossy CockroachDB DDL status without parameterized identifiers."""
+        return self._select_domain(
+            driver,
+            "ddl",
+            "by_object",
+            schema_name=self.resolve_schema(schema),
+            object_name=self.resolve_identifier(object_name),
+            object_type=object_type,
+        )
+
+    def get_system_metadata(
+        self, driver: "CockroachPsycopgSyncDriver", domain: str, *, include_sensitive: bool = False
+    ) -> MetadataResult:
+        """Get opt-in CockroachDB system metadata."""
+        return _metadata_result("system", _cockroach_metadata_capability("system"))
 
     def get_version(self, driver: "CockroachPsycopgSyncDriver") -> "VersionInfo | None":
         """Get CockroachDB version information."""
@@ -61,7 +251,12 @@ class CockroachPsycopgSyncDataDictionary(SyncDataDictionaryBase):
         """Get tables sorted by dependency order."""
         schema_name = self.resolve_schema(schema)
         self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="tables")
-        return driver.select(self.get_query("tables_by_schema"), schema_name=schema_name, schema_type=TableMetadata)
+        return driver.select(
+            _cockroach_domain_sql("tables", "by_schema"),
+            schema_name=schema_name,
+            table_name=None,
+            schema_type=TableMetadata,
+        )
 
     def get_columns(
         self, driver: "CockroachPsycopgSyncDriver", table: "str | None" = None, schema: "str | None" = None
@@ -71,13 +266,16 @@ class CockroachPsycopgSyncDataDictionary(SyncDataDictionaryBase):
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="columns")
             return driver.select(
-                self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
+                _cockroach_domain_sql("columns", "by_schema"),
+                schema_name=schema_name,
+                table_name=None,
+                schema_type=ColumnMetadata,
             )
 
         table_name = self.resolve_identifier(table)
         self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="columns")
         return driver.select(
-            self.get_query("columns_by_table"),
+            _cockroach_domain_sql("columns", "by_schema"),
             schema_name=schema_name,
             table_name=table_name,
             schema_type=ColumnMetadata,
@@ -91,13 +289,16 @@ class CockroachPsycopgSyncDataDictionary(SyncDataDictionaryBase):
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="indexes")
             return driver.select(
-                self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
+                _cockroach_domain_sql("indexes", "by_schema"),
+                schema_name=schema_name,
+                table_name=None,
+                schema_type=IndexMetadata,
             )
 
         table_name = self.resolve_identifier(table)
         self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="indexes")
         return driver.select(
-            self.get_query("indexes_by_table"),
+            _cockroach_domain_sql("indexes", "by_schema"),
             schema_name=schema_name,
             table_name=table_name,
             schema_type=IndexMetadata,
@@ -132,6 +333,99 @@ class CockroachPsycopgAsyncDataDictionary(AsyncDataDictionaryBase):
 
     def __init__(self) -> None:
         super().__init__()
+
+    async def get_metadata_capabilities(
+        self, driver: "CockroachPsycopgAsyncDriver", domains: Sequence[str] | None = None
+    ) -> MetadataCapabilityProfile:
+        """Get CockroachDB replacement data-dictionary capability profile."""
+        return _cockroach_metadata_profile(type(self).__name__, domains)
+
+    async def _select_domain(
+        self, driver: "CockroachPsycopgAsyncDriver", domain: str, query_name: str, **parameters: Any
+    ) -> MetadataResult:
+        query = get_data_dictionary_loader().get_domain_query(type(self).dialect, domain, query_name)
+        if not query.is_supported or query.sql is None:
+            return MetadataResult(domain, capability=query.capability, warnings=query.warnings)
+        rows = await driver.select(query.sql, **parameters)
+        return _metadata_result(domain, _cockroach_metadata_capability(domain), rows)
+
+    async def get_schemas(self, driver: "CockroachPsycopgAsyncDriver") -> MetadataResult:
+        """Get schema metadata."""
+        return await self._select_domain(driver, "schemas", "list")
+
+    async def get_objects(self, driver: "CockroachPsycopgAsyncDriver", schema: str | None = None) -> MetadataResult:
+        """Get database object metadata."""
+        return await self._select_domain(driver, "objects", "by_schema", schema_name=self.resolve_schema(schema))
+
+    async def get_table_details(
+        self, driver: "CockroachPsycopgAsyncDriver", table: str, schema: str | None = None
+    ) -> MetadataResult:
+        """Get rich table metadata."""
+        return await self._select_domain(
+            driver,
+            "tables",
+            "by_schema",
+            schema_name=self.resolve_schema(schema),
+            table_name=self.resolve_identifier(table),
+        )
+
+    async def get_constraints(
+        self, driver: "CockroachPsycopgAsyncDriver", table: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get constraint metadata."""
+        table_name = self.resolve_identifier(table) if table is not None else None
+        return await self._select_domain(
+            driver, "constraints", "by_schema", schema_name=self.resolve_schema(schema), table_name=table_name
+        )
+
+    async def get_views(self, driver: "CockroachPsycopgAsyncDriver", schema: str | None = None) -> MetadataResult:
+        """Get view metadata."""
+        return await self._select_domain(driver, "views", "by_schema", schema_name=self.resolve_schema(schema))
+
+    async def get_routines(self, driver: "CockroachPsycopgAsyncDriver", schema: str | None = None) -> MetadataResult:
+        """Get routine metadata."""
+        return _metadata_result("routines", MetadataCapability.unsupported("routines"))
+
+    async def get_privileges(
+        self, driver: "CockroachPsycopgAsyncDriver", object_name: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get privilege metadata."""
+        resolved_object = self.resolve_identifier(object_name) if object_name is not None else None
+        return await self._select_domain(
+            driver, "privileges", "by_schema", schema_name=self.resolve_schema(schema), object_name=resolved_object
+        )
+
+    async def get_dependencies(
+        self, driver: "CockroachPsycopgAsyncDriver", object_name: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get stable dependency metadata."""
+        resolved_object = self.resolve_identifier(object_name) if object_name is not None else None
+        return await self._select_domain(
+            driver, "dependencies", "by_schema", schema_name=self.resolve_schema(schema), object_name=resolved_object
+        )
+
+    async def get_ddl(
+        self,
+        driver: "CockroachPsycopgAsyncDriver",
+        object_name: str,
+        schema: str | None = None,
+        object_type: str | None = None,
+    ) -> MetadataResult:
+        """Get lossy CockroachDB DDL status without parameterized identifiers."""
+        return await self._select_domain(
+            driver,
+            "ddl",
+            "by_object",
+            schema_name=self.resolve_schema(schema),
+            object_name=self.resolve_identifier(object_name),
+            object_type=object_type,
+        )
+
+    async def get_system_metadata(
+        self, driver: "CockroachPsycopgAsyncDriver", domain: str, *, include_sensitive: bool = False
+    ) -> MetadataResult:
+        """Get opt-in CockroachDB system metadata."""
+        return _metadata_result("system", _cockroach_metadata_capability("system"))
 
     async def get_version(self, driver: "CockroachPsycopgAsyncDriver") -> "VersionInfo | None":
         """Get CockroachDB version information."""
@@ -174,7 +468,10 @@ class CockroachPsycopgAsyncDataDictionary(AsyncDataDictionaryBase):
         schema_name = self.resolve_schema(schema)
         self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="tables")
         return await driver.select(
-            self.get_query("tables_by_schema"), schema_name=schema_name, schema_type=TableMetadata
+            _cockroach_domain_sql("tables", "by_schema"),
+            schema_name=schema_name,
+            table_name=None,
+            schema_type=TableMetadata,
         )
 
     async def get_columns(
@@ -185,13 +482,16 @@ class CockroachPsycopgAsyncDataDictionary(AsyncDataDictionaryBase):
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="columns")
             return await driver.select(
-                self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
+                _cockroach_domain_sql("columns", "by_schema"),
+                schema_name=schema_name,
+                table_name=None,
+                schema_type=ColumnMetadata,
             )
 
         table_name = self.resolve_identifier(table)
         self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="columns")
         return await driver.select(
-            self.get_query("columns_by_table"),
+            _cockroach_domain_sql("columns", "by_schema"),
             schema_name=schema_name,
             table_name=table_name,
             schema_type=ColumnMetadata,
@@ -205,13 +505,16 @@ class CockroachPsycopgAsyncDataDictionary(AsyncDataDictionaryBase):
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="indexes")
             return await driver.select(
-                self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
+                _cockroach_domain_sql("indexes", "by_schema"),
+                schema_name=schema_name,
+                table_name=None,
+                schema_type=IndexMetadata,
             )
 
         table_name = self.resolve_identifier(table)
         self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="indexes")
         return await driver.select(
-            self.get_query("indexes_by_table"),
+            _cockroach_domain_sql("indexes", "by_schema"),
             schema_name=schema_name,
             table_name=table_name,
             schema_type=IndexMetadata,

--- a/sqlspec/adapters/psqlpy/data_dictionary.py
+++ b/sqlspec/adapters/psqlpy/data_dictionary.py
@@ -1,12 +1,13 @@
 """PostgreSQL-specific data dictionary for metadata queries via psqlpy."""
 
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, ClassVar
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from mypy_extensions import mypyc_attr
 
 from sqlspec.data_dictionary import (
     ColumnMetadata,
+    DDLResult,
     ForeignKeyMetadata,
     IndexMetadata,
     MetadataCapability,
@@ -16,9 +17,16 @@ from sqlspec.data_dictionary import (
     MetadataRisk,
     MetadataSource,
     MetadataSupport,
+    ObjectIdentity,
+    SystemMetadataCapability,
+    SystemMetadataRequest,
+    SystemMetadataResult,
     TableMetadata,
     VersionInfo,
+    ensure_system_metadata_request,
     get_data_dictionary_loader,
+    system_metadata_gated_result,
+    unsupported_system_metadata_capability,
 )
 from sqlspec.data_dictionary.dialects.postgres import resolve_postgres_json_type
 from sqlspec.driver import AsyncDataDictionaryBase
@@ -51,6 +59,13 @@ _POSTGRES_METADATA_DOMAINS = (
     "system",
 )
 _POSTGRES_SUPPORTED_DOMAINS = frozenset(_POSTGRES_METADATA_DOMAINS) - {"system"}
+_POSTGRES_SYSTEM_METADATA_QUERIES = {
+    "settings": "settings",
+    "statement_history": "pg_stat_statements",
+    "pg_stat_statements": "pg_stat_statements",
+    "table_statistics": "table_stats",
+    "table_stats": "table_stats",
+}
 
 
 def _postgres_metadata_capability(domain: str) -> MetadataCapability:
@@ -88,6 +103,63 @@ def _metadata_result(
     return MetadataResult(domain, capability=capability, items=tuple(rows), warnings=capability.warnings)
 
 
+def _row_value(row: object, key: str) -> object | None:
+    if isinstance(row, Mapping):
+        return row.get(key)
+    return getattr(row, key, None)
+
+
+def _rows_as_mappings(rows: list[Any] | tuple[Any, ...]) -> tuple[Mapping[str, object], ...]:
+    return tuple(cast("Mapping[str, object]", row) for row in rows if isinstance(row, Mapping))
+
+
+def _ddl_result_from_rows(
+    *,
+    dialect: str,
+    object_name: str,
+    object_type: str,
+    schema: str | None,
+    rows: list[Any] | tuple[Any, ...],
+    warnings: tuple[str, ...] = (),
+) -> DDLResult:
+    row = rows[0] if rows else None
+    resolved_schema = _row_value(row, "schema_name") if row is not None else schema
+    ddl = _row_value(row, "ddl") if row is not None else None
+    fidelity = _row_value(row, "fidelity") if row is not None else MetadataFidelity.UNSUPPORTED
+    row_warning = _row_value(row, "warning") if row is not None else None
+    result_warnings = warnings + ((str(row_warning),) if row_warning else ())
+    identity = ObjectIdentity(
+        name=object_name,
+        object_type=object_type,
+        schema=str(resolved_schema) if resolved_schema is not None else None,
+        dialect=dialect,
+        source=MetadataSource.CATALOG,
+    )
+    if ddl is None:
+        return DDLResult.unsupported(identity, source=MetadataSource.CATALOG, warnings=result_warnings)
+    return DDLResult(
+        identity=identity,
+        status=MetadataSupport.SUPPORTED,
+        fidelity=str(fidelity),
+        source=MetadataSource.CATALOG,
+        ddl=str(ddl),
+        warnings=result_warnings,
+    )
+
+
+def _postgres_system_metadata_capability(domain: str) -> SystemMetadataCapability:
+    if domain not in _POSTGRES_SYSTEM_METADATA_QUERIES:
+        return unsupported_system_metadata_capability(domain)
+    return SystemMetadataCapability(
+        domain,
+        MetadataSupport.SUPPORTED,
+        fidelity=MetadataFidelity.NATIVE,
+        source=MetadataSource.SYSTEM_VIEW,
+        risks=(MetadataRisk.PRIVILEGED, MetadataRisk.REDACTED),
+        redaction_fields=("query_text", "setting_value", "user_oid"),
+    )
+
+
 def _postgres_domain_sql(domain: str, query_name: str) -> "SQL":
     query = get_data_dictionary_loader().get_domain_query("postgres", domain, query_name)
     if query.sql is None:
@@ -110,6 +182,14 @@ class PsqlpyDataDictionary(AsyncDataDictionaryBase):
     ) -> MetadataCapabilityProfile:
         """Get PostgreSQL replacement data-dictionary capability profile."""
         return _postgres_metadata_profile(type(self).__name__, domains)
+
+    async def get_system_metadata_capabilities(
+        self, driver: "PsqlpyDriver", domains: Sequence[str] | None = None
+    ) -> tuple[SystemMetadataCapability, ...]:
+        """Get PostgreSQL opt-in system metadata capability disclosures."""
+        _ = driver
+        requested_domains = tuple(_POSTGRES_SYSTEM_METADATA_QUERIES) if domains is None else tuple(domains)
+        return tuple(_postgres_system_metadata_capability(domain) for domain in requested_domains)
 
     async def _select_domain(
         self, driver: "PsqlpyDriver", domain: str, query_name: str, **parameters: Any
@@ -174,25 +254,57 @@ class PsqlpyDataDictionary(AsyncDataDictionaryBase):
         )
 
     async def get_ddl(
-        self, driver: "PsqlpyDriver", object_name: str, schema: str | None = None, object_type: str | None = None
-    ) -> MetadataResult:
+        self,
+        driver: "PsqlpyDriver",
+        object_name: str,
+        schema: str | None = None,
+        *,
+        object_type: str = "table",
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> DDLResult:
         """Get object DDL where PostgreSQL exposes native definition helpers."""
-        return await self._select_domain(
-            driver,
-            "ddl",
-            "by_object",
-            schema_name=self.resolve_schema(schema),
-            object_name=self.resolve_identifier(object_name),
+        _ = include_dependencies, prefer_native, redact
+        schema_name = self.resolve_schema(schema)
+        resolved_object = self.resolve_identifier(object_name)
+        result = await self._select_domain(
+            driver, "ddl", "by_object", schema_name=schema_name, object_name=resolved_object, object_type=object_type
+        )
+        return _ddl_result_from_rows(
+            dialect=type(self).dialect,
+            object_name=resolved_object,
             object_type=object_type,
+            schema=schema_name,
+            rows=result.items,
+            warnings=result.warnings,
         )
 
     async def get_system_metadata(
-        self, driver: "PsqlpyDriver", domain: str, *, include_sensitive: bool = False
-    ) -> MetadataResult:
+        self, driver: "PsqlpyDriver", request: SystemMetadataRequest | str | None = None, **kwargs: Any
+    ) -> SystemMetadataResult:
         """Get opt-in PostgreSQL system metadata."""
-        if not include_sensitive:
-            return _metadata_result("system", _postgres_metadata_capability("system"))
-        return await self._select_domain(driver, "system", domain, schema_name=None, table_name=None, limit=100)
+        metadata_request = ensure_system_metadata_request(request, **kwargs)
+        capability = _postgres_system_metadata_capability(metadata_request.domain)
+        gate_result = system_metadata_gated_result(metadata_request, capability)
+        if gate_result.capability.support != MetadataSupport.SUPPORTED:
+            return gate_result
+
+        query_name = _POSTGRES_SYSTEM_METADATA_QUERIES.get(metadata_request.domain)
+        if query_name is None:
+            return gate_result
+        parameters: dict[str, object] = {}
+        if query_name == "pg_stat_statements":
+            parameters["limit"] = 100
+        elif query_name == "table_stats":
+            parameters["schema_name"] = self.resolve_schema(metadata_request.schema)
+            parameters["table_name"] = (
+                self.resolve_identifier(metadata_request.table) if metadata_request.table is not None else None
+            )
+        result = await self._select_domain(driver, "system", query_name, **parameters)
+        return SystemMetadataResult.from_rows(
+            metadata_request, capability, rows=_rows_as_mappings(result.items), source=MetadataSource.SYSTEM_VIEW
+        )
 
     async def get_version(self, driver: "PsqlpyDriver") -> "VersionInfo | None":
         """Get PostgreSQL database version information.

--- a/sqlspec/adapters/psqlpy/data_dictionary.py
+++ b/sqlspec/adapters/psqlpy/data_dictionary.py
@@ -1,17 +1,99 @@
 """PostgreSQL-specific data dictionary for metadata queries via psqlpy."""
 
-from typing import TYPE_CHECKING, ClassVar
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from mypy_extensions import mypyc_attr
 
-from sqlspec.data_dictionary import ColumnMetadata, ForeignKeyMetadata, IndexMetadata, TableMetadata, VersionInfo
+from sqlspec.data_dictionary import (
+    ColumnMetadata,
+    ForeignKeyMetadata,
+    IndexMetadata,
+    MetadataCapability,
+    MetadataCapabilityProfile,
+    MetadataFidelity,
+    MetadataResult,
+    MetadataRisk,
+    MetadataSource,
+    MetadataSupport,
+    TableMetadata,
+    VersionInfo,
+    get_data_dictionary_loader,
+)
 from sqlspec.data_dictionary.dialects.postgres import resolve_postgres_json_type
 from sqlspec.driver import AsyncDataDictionaryBase
 
 if TYPE_CHECKING:
     from sqlspec.adapters.psqlpy.driver import PsqlpyDriver
+    from sqlspec.core import SQL
 
 __all__ = ("PsqlpyDataDictionary",)
+
+
+_POSTGRES_METADATA_DOMAINS = (
+    "schemas",
+    "objects",
+    "tables",
+    "columns",
+    "constraints",
+    "indexes",
+    "views",
+    "materialized_views",
+    "sequences",
+    "routines",
+    "triggers",
+    "comments",
+    "privileges",
+    "dependencies",
+    "extensions",
+    "partitions",
+    "ddl",
+    "system",
+)
+_POSTGRES_SUPPORTED_DOMAINS = frozenset(_POSTGRES_METADATA_DOMAINS) - {"system"}
+
+
+def _postgres_metadata_capability(domain: str) -> MetadataCapability:
+    if domain == "system":
+        return MetadataCapability(
+            domain=domain,
+            support=MetadataSupport.UNSUPPORTED,
+            fidelity=MetadataFidelity.UNSUPPORTED,
+            source=MetadataSource.SYSTEM_VIEW,
+            risks=(MetadataRisk.EXPENSIVE, MetadataRisk.PRIVILEGED),
+            warnings=("System metadata is opt-in and disabled by default.",),
+        )
+    if domain in _POSTGRES_SUPPORTED_DOMAINS:
+        return MetadataCapability(
+            domain=domain,
+            support=MetadataSupport.SUPPORTED,
+            fidelity=MetadataFidelity.NATIVE,
+            source=MetadataSource.CATALOG,
+        )
+    return MetadataCapability.unsupported(domain)
+
+
+def _postgres_metadata_profile(adapter: str, domains: Sequence[str] | None) -> MetadataCapabilityProfile:
+    requested_domains = _POSTGRES_METADATA_DOMAINS if domains is None else tuple(domains)
+    return MetadataCapabilityProfile(
+        "postgres",
+        adapter=adapter,
+        capabilities=tuple(_postgres_metadata_capability(domain) for domain in requested_domains),
+    )
+
+
+def _metadata_result(
+    domain: str, capability: MetadataCapability, rows: list[Any] | tuple[Any, ...] = ()
+) -> MetadataResult:
+    return MetadataResult(domain, capability=capability, items=tuple(rows), warnings=capability.warnings)
+
+
+def _postgres_domain_sql(domain: str, query_name: str) -> "SQL":
+    query = get_data_dictionary_loader().get_domain_query("postgres", domain, query_name)
+    if query.sql is None:
+        msg = f"Missing PostgreSQL data-dictionary query: {domain}/{query_name}"
+        raise RuntimeError(msg)
+    return query.sql
 
 
 @mypyc_attr(allow_interpreted_subclasses=True, native_class=False)
@@ -22,6 +104,95 @@ class PsqlpyDataDictionary(AsyncDataDictionaryBase):
 
     def __init__(self) -> None:
         super().__init__()
+
+    async def get_metadata_capabilities(
+        self, driver: "PsqlpyDriver", domains: Sequence[str] | None = None
+    ) -> MetadataCapabilityProfile:
+        """Get PostgreSQL replacement data-dictionary capability profile."""
+        return _postgres_metadata_profile(type(self).__name__, domains)
+
+    async def _select_domain(
+        self, driver: "PsqlpyDriver", domain: str, query_name: str, **parameters: Any
+    ) -> MetadataResult:
+        query = get_data_dictionary_loader().get_domain_query(type(self).dialect, domain, query_name)
+        if not query.is_supported or query.sql is None:
+            return MetadataResult(domain, capability=query.capability, warnings=query.warnings)
+        rows = await driver.select(query.sql, **parameters)
+        return _metadata_result(domain, _postgres_metadata_capability(domain), rows)
+
+    async def get_schemas(self, driver: "PsqlpyDriver") -> MetadataResult:
+        """Get schema metadata."""
+        return await self._select_domain(driver, "schemas", "list")
+
+    async def get_objects(self, driver: "PsqlpyDriver", schema: str | None = None) -> MetadataResult:
+        """Get database object metadata."""
+        return await self._select_domain(driver, "objects", "by_schema", schema_name=self.resolve_schema(schema))
+
+    async def get_table_details(self, driver: "PsqlpyDriver", table: str, schema: str | None = None) -> MetadataResult:
+        """Get rich table metadata."""
+        return await self._select_domain(
+            driver,
+            "tables",
+            "by_schema",
+            schema_name=self.resolve_schema(schema),
+            table_name=self.resolve_identifier(table),
+        )
+
+    async def get_constraints(
+        self, driver: "PsqlpyDriver", table: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get constraint metadata."""
+        table_name = self.resolve_identifier(table) if table is not None else None
+        return await self._select_domain(
+            driver, "constraints", "by_schema", schema_name=self.resolve_schema(schema), table_name=table_name
+        )
+
+    async def get_views(self, driver: "PsqlpyDriver", schema: str | None = None) -> MetadataResult:
+        """Get view metadata."""
+        return await self._select_domain(driver, "views", "by_schema", schema_name=self.resolve_schema(schema))
+
+    async def get_routines(self, driver: "PsqlpyDriver", schema: str | None = None) -> MetadataResult:
+        """Get routine metadata."""
+        return await self._select_domain(driver, "routines", "by_schema", schema_name=self.resolve_schema(schema))
+
+    async def get_privileges(
+        self, driver: "PsqlpyDriver", object_name: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get privilege metadata."""
+        resolved_object = self.resolve_identifier(object_name) if object_name is not None else None
+        return await self._select_domain(
+            driver, "privileges", "by_schema", schema_name=self.resolve_schema(schema), object_name=resolved_object
+        )
+
+    async def get_dependencies(
+        self, driver: "PsqlpyDriver", object_name: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get dependency metadata."""
+        resolved_object = self.resolve_identifier(object_name) if object_name is not None else None
+        return await self._select_domain(
+            driver, "dependencies", "by_schema", schema_name=self.resolve_schema(schema), object_name=resolved_object
+        )
+
+    async def get_ddl(
+        self, driver: "PsqlpyDriver", object_name: str, schema: str | None = None, object_type: str | None = None
+    ) -> MetadataResult:
+        """Get object DDL where PostgreSQL exposes native definition helpers."""
+        return await self._select_domain(
+            driver,
+            "ddl",
+            "by_object",
+            schema_name=self.resolve_schema(schema),
+            object_name=self.resolve_identifier(object_name),
+            object_type=object_type,
+        )
+
+    async def get_system_metadata(
+        self, driver: "PsqlpyDriver", domain: str, *, include_sensitive: bool = False
+    ) -> MetadataResult:
+        """Get opt-in PostgreSQL system metadata."""
+        if not include_sensitive:
+            return _metadata_result("system", _postgres_metadata_capability("system"))
+        return await self._select_domain(driver, "system", domain, schema_name=None, table_name=None, limit=100)
 
     async def get_version(self, driver: "PsqlpyDriver") -> "VersionInfo | None":
         """Get PostgreSQL database version information.
@@ -69,7 +240,10 @@ class PsqlpyDataDictionary(AsyncDataDictionaryBase):
         schema_name = self.resolve_schema(schema)
         self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="tables")
         return await driver.select(
-            self.get_query("tables_by_schema"), schema_name=schema_name, schema_type=TableMetadata
+            _postgres_domain_sql("tables", "by_schema"),
+            schema_name=schema_name,
+            table_name=None,
+            schema_type=TableMetadata,
         )
 
     async def get_columns(
@@ -80,13 +254,16 @@ class PsqlpyDataDictionary(AsyncDataDictionaryBase):
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="columns")
             return await driver.select(
-                self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
+                _postgres_domain_sql("columns", "by_schema"),
+                schema_name=schema_name,
+                table_name=None,
+                schema_type=ColumnMetadata,
             )
 
         table_name = self.resolve_identifier(table)
         self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="columns")
         return await driver.select(
-            self.get_query("columns_by_table"),
+            _postgres_domain_sql("columns", "by_schema"),
             schema_name=schema_name,
             table_name=table_name,
             schema_type=ColumnMetadata,
@@ -100,13 +277,16 @@ class PsqlpyDataDictionary(AsyncDataDictionaryBase):
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="indexes")
             return await driver.select(
-                self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
+                _postgres_domain_sql("indexes", "by_schema"),
+                schema_name=schema_name,
+                table_name=None,
+                schema_type=IndexMetadata,
             )
 
         table_name = self.resolve_identifier(table)
         self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="indexes")
         return await driver.select(
-            self.get_query("indexes_by_table"),
+            _postgres_domain_sql("indexes", "by_schema"),
             schema_name=schema_name,
             table_name=table_name,
             schema_type=IndexMetadata,

--- a/sqlspec/adapters/psycopg/data_dictionary.py
+++ b/sqlspec/adapters/psycopg/data_dictionary.py
@@ -1,17 +1,99 @@
 """PostgreSQL-specific data dictionary for metadata queries via psycopg."""
 
-from typing import TYPE_CHECKING, ClassVar
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from mypy_extensions import mypyc_attr
 
-from sqlspec.data_dictionary import ColumnMetadata, ForeignKeyMetadata, IndexMetadata, TableMetadata, VersionInfo
+from sqlspec.data_dictionary import (
+    ColumnMetadata,
+    ForeignKeyMetadata,
+    IndexMetadata,
+    MetadataCapability,
+    MetadataCapabilityProfile,
+    MetadataFidelity,
+    MetadataResult,
+    MetadataRisk,
+    MetadataSource,
+    MetadataSupport,
+    TableMetadata,
+    VersionInfo,
+    get_data_dictionary_loader,
+)
 from sqlspec.data_dictionary.dialects.postgres import resolve_postgres_json_type
 from sqlspec.driver import AsyncDataDictionaryBase, SyncDataDictionaryBase
 
 if TYPE_CHECKING:
     from sqlspec.adapters.psycopg.driver import PsycopgAsyncDriver, PsycopgSyncDriver
+    from sqlspec.core import SQL
 
 __all__ = ("PsycopgAsyncDataDictionary", "PsycopgSyncDataDictionary")
+
+
+_POSTGRES_METADATA_DOMAINS = (
+    "schemas",
+    "objects",
+    "tables",
+    "columns",
+    "constraints",
+    "indexes",
+    "views",
+    "materialized_views",
+    "sequences",
+    "routines",
+    "triggers",
+    "comments",
+    "privileges",
+    "dependencies",
+    "extensions",
+    "partitions",
+    "ddl",
+    "system",
+)
+_POSTGRES_SUPPORTED_DOMAINS = frozenset(_POSTGRES_METADATA_DOMAINS) - {"system"}
+
+
+def _postgres_metadata_capability(domain: str) -> MetadataCapability:
+    if domain == "system":
+        return MetadataCapability(
+            domain=domain,
+            support=MetadataSupport.UNSUPPORTED,
+            fidelity=MetadataFidelity.UNSUPPORTED,
+            source=MetadataSource.SYSTEM_VIEW,
+            risks=(MetadataRisk.EXPENSIVE, MetadataRisk.PRIVILEGED),
+            warnings=("System metadata is opt-in and disabled by default.",),
+        )
+    if domain in _POSTGRES_SUPPORTED_DOMAINS:
+        return MetadataCapability(
+            domain=domain,
+            support=MetadataSupport.SUPPORTED,
+            fidelity=MetadataFidelity.NATIVE,
+            source=MetadataSource.CATALOG,
+        )
+    return MetadataCapability.unsupported(domain)
+
+
+def _postgres_metadata_profile(adapter: str, domains: Sequence[str] | None) -> MetadataCapabilityProfile:
+    requested_domains = _POSTGRES_METADATA_DOMAINS if domains is None else tuple(domains)
+    return MetadataCapabilityProfile(
+        "postgres",
+        adapter=adapter,
+        capabilities=tuple(_postgres_metadata_capability(domain) for domain in requested_domains),
+    )
+
+
+def _metadata_result(
+    domain: str, capability: MetadataCapability, rows: list[Any] | tuple[Any, ...] = ()
+) -> MetadataResult:
+    return MetadataResult(domain, capability=capability, items=tuple(rows), warnings=capability.warnings)
+
+
+def _postgres_domain_sql(domain: str, query_name: str) -> "SQL":
+    query = get_data_dictionary_loader().get_domain_query("postgres", domain, query_name)
+    if query.sql is None:
+        msg = f"Missing PostgreSQL data-dictionary query: {domain}/{query_name}"
+        raise RuntimeError(msg)
+    return query.sql
 
 
 @mypyc_attr(allow_interpreted_subclasses=True, native_class=False)
@@ -22,6 +104,95 @@ class PsycopgSyncDataDictionary(SyncDataDictionaryBase):
 
     def __init__(self) -> None:
         super().__init__()
+
+    def get_metadata_capabilities(
+        self, driver: "PsycopgSyncDriver", domains: Sequence[str] | None = None
+    ) -> MetadataCapabilityProfile:
+        """Get PostgreSQL replacement data-dictionary capability profile."""
+        return _postgres_metadata_profile(type(self).__name__, domains)
+
+    def _select_domain(
+        self, driver: "PsycopgSyncDriver", domain: str, query_name: str, **parameters: Any
+    ) -> MetadataResult:
+        query = get_data_dictionary_loader().get_domain_query(type(self).dialect, domain, query_name)
+        if not query.is_supported or query.sql is None:
+            return MetadataResult(domain, capability=query.capability, warnings=query.warnings)
+        rows = driver.select(query.sql, **parameters)
+        return _metadata_result(domain, _postgres_metadata_capability(domain), rows)
+
+    def get_schemas(self, driver: "PsycopgSyncDriver") -> MetadataResult:
+        """Get schema metadata."""
+        return self._select_domain(driver, "schemas", "list")
+
+    def get_objects(self, driver: "PsycopgSyncDriver", schema: str | None = None) -> MetadataResult:
+        """Get database object metadata."""
+        return self._select_domain(driver, "objects", "by_schema", schema_name=self.resolve_schema(schema))
+
+    def get_table_details(self, driver: "PsycopgSyncDriver", table: str, schema: str | None = None) -> MetadataResult:
+        """Get rich table metadata."""
+        return self._select_domain(
+            driver,
+            "tables",
+            "by_schema",
+            schema_name=self.resolve_schema(schema),
+            table_name=self.resolve_identifier(table),
+        )
+
+    def get_constraints(
+        self, driver: "PsycopgSyncDriver", table: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get constraint metadata."""
+        table_name = self.resolve_identifier(table) if table is not None else None
+        return self._select_domain(
+            driver, "constraints", "by_schema", schema_name=self.resolve_schema(schema), table_name=table_name
+        )
+
+    def get_views(self, driver: "PsycopgSyncDriver", schema: str | None = None) -> MetadataResult:
+        """Get view metadata."""
+        return self._select_domain(driver, "views", "by_schema", schema_name=self.resolve_schema(schema))
+
+    def get_routines(self, driver: "PsycopgSyncDriver", schema: str | None = None) -> MetadataResult:
+        """Get routine metadata."""
+        return self._select_domain(driver, "routines", "by_schema", schema_name=self.resolve_schema(schema))
+
+    def get_privileges(
+        self, driver: "PsycopgSyncDriver", object_name: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get privilege metadata."""
+        resolved_object = self.resolve_identifier(object_name) if object_name is not None else None
+        return self._select_domain(
+            driver, "privileges", "by_schema", schema_name=self.resolve_schema(schema), object_name=resolved_object
+        )
+
+    def get_dependencies(
+        self, driver: "PsycopgSyncDriver", object_name: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get dependency metadata."""
+        resolved_object = self.resolve_identifier(object_name) if object_name is not None else None
+        return self._select_domain(
+            driver, "dependencies", "by_schema", schema_name=self.resolve_schema(schema), object_name=resolved_object
+        )
+
+    def get_ddl(
+        self, driver: "PsycopgSyncDriver", object_name: str, schema: str | None = None, object_type: str | None = None
+    ) -> MetadataResult:
+        """Get object DDL where PostgreSQL exposes native definition helpers."""
+        return self._select_domain(
+            driver,
+            "ddl",
+            "by_object",
+            schema_name=self.resolve_schema(schema),
+            object_name=self.resolve_identifier(object_name),
+            object_type=object_type,
+        )
+
+    def get_system_metadata(
+        self, driver: "PsycopgSyncDriver", domain: str, *, include_sensitive: bool = False
+    ) -> MetadataResult:
+        """Get opt-in PostgreSQL system metadata."""
+        if not include_sensitive:
+            return _metadata_result("system", _postgres_metadata_capability("system"))
+        return self._select_domain(driver, "system", domain, schema_name=None, table_name=None, limit=100)
 
     def get_version(self, driver: "PsycopgSyncDriver") -> "VersionInfo | None":
         """Get PostgreSQL database version information.
@@ -89,7 +260,12 @@ class PsycopgSyncDataDictionary(SyncDataDictionaryBase):
         """Get tables sorted by topological dependency order using Recursive CTE."""
         schema_name = self.resolve_schema(schema)
         self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="tables")
-        return driver.select(self.get_query("tables_by_schema"), schema_name=schema_name, schema_type=TableMetadata)
+        return driver.select(
+            _postgres_domain_sql("tables", "by_schema"),
+            schema_name=schema_name,
+            table_name=None,
+            schema_type=TableMetadata,
+        )
 
     def get_columns(
         self, driver: "PsycopgSyncDriver", table: "str | None" = None, schema: "str | None" = None
@@ -99,13 +275,16 @@ class PsycopgSyncDataDictionary(SyncDataDictionaryBase):
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="columns")
             return driver.select(
-                self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
+                _postgres_domain_sql("columns", "by_schema"),
+                schema_name=schema_name,
+                table_name=None,
+                schema_type=ColumnMetadata,
             )
 
         table_name = self.resolve_identifier(table)
         self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="columns")
         return driver.select(
-            self.get_query("columns_by_table"),
+            _postgres_domain_sql("columns", "by_schema"),
             schema_name=schema_name,
             table_name=table_name,
             schema_type=ColumnMetadata,
@@ -119,13 +298,16 @@ class PsycopgSyncDataDictionary(SyncDataDictionaryBase):
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="indexes")
             return driver.select(
-                self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
+                _postgres_domain_sql("indexes", "by_schema"),
+                schema_name=schema_name,
+                table_name=None,
+                schema_type=IndexMetadata,
             )
 
         table_name = self.resolve_identifier(table)
         self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="indexes")
         return driver.select(
-            self.get_query("indexes_by_table"),
+            _postgres_domain_sql("indexes", "by_schema"),
             schema_name=schema_name,
             table_name=table_name,
             schema_type=IndexMetadata,
@@ -159,6 +341,97 @@ class PsycopgAsyncDataDictionary(AsyncDataDictionaryBase):
 
     def __init__(self) -> None:
         super().__init__()
+
+    async def get_metadata_capabilities(
+        self, driver: "PsycopgAsyncDriver", domains: Sequence[str] | None = None
+    ) -> MetadataCapabilityProfile:
+        """Get PostgreSQL replacement data-dictionary capability profile."""
+        return _postgres_metadata_profile(type(self).__name__, domains)
+
+    async def _select_domain(
+        self, driver: "PsycopgAsyncDriver", domain: str, query_name: str, **parameters: Any
+    ) -> MetadataResult:
+        query = get_data_dictionary_loader().get_domain_query(type(self).dialect, domain, query_name)
+        if not query.is_supported or query.sql is None:
+            return MetadataResult(domain, capability=query.capability, warnings=query.warnings)
+        rows = await driver.select(query.sql, **parameters)
+        return _metadata_result(domain, _postgres_metadata_capability(domain), rows)
+
+    async def get_schemas(self, driver: "PsycopgAsyncDriver") -> MetadataResult:
+        """Get schema metadata."""
+        return await self._select_domain(driver, "schemas", "list")
+
+    async def get_objects(self, driver: "PsycopgAsyncDriver", schema: str | None = None) -> MetadataResult:
+        """Get database object metadata."""
+        return await self._select_domain(driver, "objects", "by_schema", schema_name=self.resolve_schema(schema))
+
+    async def get_table_details(
+        self, driver: "PsycopgAsyncDriver", table: str, schema: str | None = None
+    ) -> MetadataResult:
+        """Get rich table metadata."""
+        return await self._select_domain(
+            driver,
+            "tables",
+            "by_schema",
+            schema_name=self.resolve_schema(schema),
+            table_name=self.resolve_identifier(table),
+        )
+
+    async def get_constraints(
+        self, driver: "PsycopgAsyncDriver", table: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get constraint metadata."""
+        table_name = self.resolve_identifier(table) if table is not None else None
+        return await self._select_domain(
+            driver, "constraints", "by_schema", schema_name=self.resolve_schema(schema), table_name=table_name
+        )
+
+    async def get_views(self, driver: "PsycopgAsyncDriver", schema: str | None = None) -> MetadataResult:
+        """Get view metadata."""
+        return await self._select_domain(driver, "views", "by_schema", schema_name=self.resolve_schema(schema))
+
+    async def get_routines(self, driver: "PsycopgAsyncDriver", schema: str | None = None) -> MetadataResult:
+        """Get routine metadata."""
+        return await self._select_domain(driver, "routines", "by_schema", schema_name=self.resolve_schema(schema))
+
+    async def get_privileges(
+        self, driver: "PsycopgAsyncDriver", object_name: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get privilege metadata."""
+        resolved_object = self.resolve_identifier(object_name) if object_name is not None else None
+        return await self._select_domain(
+            driver, "privileges", "by_schema", schema_name=self.resolve_schema(schema), object_name=resolved_object
+        )
+
+    async def get_dependencies(
+        self, driver: "PsycopgAsyncDriver", object_name: str | None = None, schema: str | None = None
+    ) -> MetadataResult:
+        """Get dependency metadata."""
+        resolved_object = self.resolve_identifier(object_name) if object_name is not None else None
+        return await self._select_domain(
+            driver, "dependencies", "by_schema", schema_name=self.resolve_schema(schema), object_name=resolved_object
+        )
+
+    async def get_ddl(
+        self, driver: "PsycopgAsyncDriver", object_name: str, schema: str | None = None, object_type: str | None = None
+    ) -> MetadataResult:
+        """Get object DDL where PostgreSQL exposes native definition helpers."""
+        return await self._select_domain(
+            driver,
+            "ddl",
+            "by_object",
+            schema_name=self.resolve_schema(schema),
+            object_name=self.resolve_identifier(object_name),
+            object_type=object_type,
+        )
+
+    async def get_system_metadata(
+        self, driver: "PsycopgAsyncDriver", domain: str, *, include_sensitive: bool = False
+    ) -> MetadataResult:
+        """Get opt-in PostgreSQL system metadata."""
+        if not include_sensitive:
+            return _metadata_result("system", _postgres_metadata_capability("system"))
+        return await self._select_domain(driver, "system", domain, schema_name=None, table_name=None, limit=100)
 
     async def get_version(self, driver: "PsycopgAsyncDriver") -> "VersionInfo | None":
         """Get PostgreSQL database version information.
@@ -227,7 +500,10 @@ class PsycopgAsyncDataDictionary(AsyncDataDictionaryBase):
         schema_name = self.resolve_schema(schema)
         self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="tables")
         return await driver.select(
-            self.get_query("tables_by_schema"), schema_name=schema_name, schema_type=TableMetadata
+            _postgres_domain_sql("tables", "by_schema"),
+            schema_name=schema_name,
+            table_name=None,
+            schema_type=TableMetadata,
         )
 
     async def get_columns(
@@ -238,13 +514,16 @@ class PsycopgAsyncDataDictionary(AsyncDataDictionaryBase):
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="columns")
             return await driver.select(
-                self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
+                _postgres_domain_sql("columns", "by_schema"),
+                schema_name=schema_name,
+                table_name=None,
+                schema_type=ColumnMetadata,
             )
 
         table_name = self.resolve_identifier(table)
         self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="columns")
         return await driver.select(
-            self.get_query("columns_by_table"),
+            _postgres_domain_sql("columns", "by_schema"),
             schema_name=schema_name,
             table_name=table_name,
             schema_type=ColumnMetadata,
@@ -258,13 +537,16 @@ class PsycopgAsyncDataDictionary(AsyncDataDictionaryBase):
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="indexes")
             return await driver.select(
-                self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
+                _postgres_domain_sql("indexes", "by_schema"),
+                schema_name=schema_name,
+                table_name=None,
+                schema_type=IndexMetadata,
             )
 
         table_name = self.resolve_identifier(table)
         self._log_table_describe(driver, schema_name=schema_name, table_name=table_name, operation="indexes")
         return await driver.select(
-            self.get_query("indexes_by_table"),
+            _postgres_domain_sql("indexes", "by_schema"),
             schema_name=schema_name,
             table_name=table_name,
             schema_type=IndexMetadata,

--- a/sqlspec/adapters/psycopg/data_dictionary.py
+++ b/sqlspec/adapters/psycopg/data_dictionary.py
@@ -1,12 +1,13 @@
 """PostgreSQL-specific data dictionary for metadata queries via psycopg."""
 
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, ClassVar
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from mypy_extensions import mypyc_attr
 
 from sqlspec.data_dictionary import (
     ColumnMetadata,
+    DDLResult,
     ForeignKeyMetadata,
     IndexMetadata,
     MetadataCapability,
@@ -16,9 +17,16 @@ from sqlspec.data_dictionary import (
     MetadataRisk,
     MetadataSource,
     MetadataSupport,
+    ObjectIdentity,
+    SystemMetadataCapability,
+    SystemMetadataRequest,
+    SystemMetadataResult,
     TableMetadata,
     VersionInfo,
+    ensure_system_metadata_request,
     get_data_dictionary_loader,
+    system_metadata_gated_result,
+    unsupported_system_metadata_capability,
 )
 from sqlspec.data_dictionary.dialects.postgres import resolve_postgres_json_type
 from sqlspec.driver import AsyncDataDictionaryBase, SyncDataDictionaryBase
@@ -51,6 +59,13 @@ _POSTGRES_METADATA_DOMAINS = (
     "system",
 )
 _POSTGRES_SUPPORTED_DOMAINS = frozenset(_POSTGRES_METADATA_DOMAINS) - {"system"}
+_POSTGRES_SYSTEM_METADATA_QUERIES = {
+    "settings": "settings",
+    "statement_history": "pg_stat_statements",
+    "pg_stat_statements": "pg_stat_statements",
+    "table_statistics": "table_stats",
+    "table_stats": "table_stats",
+}
 
 
 def _postgres_metadata_capability(domain: str) -> MetadataCapability:
@@ -88,6 +103,63 @@ def _metadata_result(
     return MetadataResult(domain, capability=capability, items=tuple(rows), warnings=capability.warnings)
 
 
+def _row_value(row: object, key: str) -> object | None:
+    if isinstance(row, Mapping):
+        return row.get(key)
+    return getattr(row, key, None)
+
+
+def _rows_as_mappings(rows: list[Any] | tuple[Any, ...]) -> tuple[Mapping[str, object], ...]:
+    return tuple(cast("Mapping[str, object]", row) for row in rows if isinstance(row, Mapping))
+
+
+def _ddl_result_from_rows(
+    *,
+    dialect: str,
+    object_name: str,
+    object_type: str,
+    schema: str | None,
+    rows: list[Any] | tuple[Any, ...],
+    warnings: tuple[str, ...] = (),
+) -> DDLResult:
+    row = rows[0] if rows else None
+    resolved_schema = _row_value(row, "schema_name") if row is not None else schema
+    ddl = _row_value(row, "ddl") if row is not None else None
+    fidelity = _row_value(row, "fidelity") if row is not None else MetadataFidelity.UNSUPPORTED
+    row_warning = _row_value(row, "warning") if row is not None else None
+    result_warnings = warnings + ((str(row_warning),) if row_warning else ())
+    identity = ObjectIdentity(
+        name=object_name,
+        object_type=object_type,
+        schema=str(resolved_schema) if resolved_schema is not None else None,
+        dialect=dialect,
+        source=MetadataSource.CATALOG,
+    )
+    if ddl is None:
+        return DDLResult.unsupported(identity, source=MetadataSource.CATALOG, warnings=result_warnings)
+    return DDLResult(
+        identity=identity,
+        status=MetadataSupport.SUPPORTED,
+        fidelity=str(fidelity),
+        source=MetadataSource.CATALOG,
+        ddl=str(ddl),
+        warnings=result_warnings,
+    )
+
+
+def _postgres_system_metadata_capability(domain: str) -> SystemMetadataCapability:
+    if domain not in _POSTGRES_SYSTEM_METADATA_QUERIES:
+        return unsupported_system_metadata_capability(domain)
+    return SystemMetadataCapability(
+        domain,
+        MetadataSupport.SUPPORTED,
+        fidelity=MetadataFidelity.NATIVE,
+        source=MetadataSource.SYSTEM_VIEW,
+        risks=(MetadataRisk.PRIVILEGED, MetadataRisk.REDACTED),
+        redaction_fields=("query_text", "setting_value", "user_oid"),
+    )
+
+
 def _postgres_domain_sql(domain: str, query_name: str) -> "SQL":
     query = get_data_dictionary_loader().get_domain_query("postgres", domain, query_name)
     if query.sql is None:
@@ -110,6 +182,14 @@ class PsycopgSyncDataDictionary(SyncDataDictionaryBase):
     ) -> MetadataCapabilityProfile:
         """Get PostgreSQL replacement data-dictionary capability profile."""
         return _postgres_metadata_profile(type(self).__name__, domains)
+
+    def get_system_metadata_capabilities(
+        self, driver: "PsycopgSyncDriver", domains: Sequence[str] | None = None
+    ) -> tuple[SystemMetadataCapability, ...]:
+        """Get PostgreSQL opt-in system metadata capability disclosures."""
+        _ = driver
+        requested_domains = tuple(_POSTGRES_SYSTEM_METADATA_QUERIES) if domains is None else tuple(domains)
+        return tuple(_postgres_system_metadata_capability(domain) for domain in requested_domains)
 
     def _select_domain(
         self, driver: "PsycopgSyncDriver", domain: str, query_name: str, **parameters: Any
@@ -174,25 +254,57 @@ class PsycopgSyncDataDictionary(SyncDataDictionaryBase):
         )
 
     def get_ddl(
-        self, driver: "PsycopgSyncDriver", object_name: str, schema: str | None = None, object_type: str | None = None
-    ) -> MetadataResult:
+        self,
+        driver: "PsycopgSyncDriver",
+        object_name: str,
+        schema: str | None = None,
+        *,
+        object_type: str = "table",
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> DDLResult:
         """Get object DDL where PostgreSQL exposes native definition helpers."""
-        return self._select_domain(
-            driver,
-            "ddl",
-            "by_object",
-            schema_name=self.resolve_schema(schema),
-            object_name=self.resolve_identifier(object_name),
+        _ = include_dependencies, prefer_native, redact
+        schema_name = self.resolve_schema(schema)
+        resolved_object = self.resolve_identifier(object_name)
+        result = self._select_domain(
+            driver, "ddl", "by_object", schema_name=schema_name, object_name=resolved_object, object_type=object_type
+        )
+        return _ddl_result_from_rows(
+            dialect=type(self).dialect,
+            object_name=resolved_object,
             object_type=object_type,
+            schema=schema_name,
+            rows=result.items,
+            warnings=result.warnings,
         )
 
     def get_system_metadata(
-        self, driver: "PsycopgSyncDriver", domain: str, *, include_sensitive: bool = False
-    ) -> MetadataResult:
+        self, driver: "PsycopgSyncDriver", request: SystemMetadataRequest | str | None = None, **kwargs: Any
+    ) -> SystemMetadataResult:
         """Get opt-in PostgreSQL system metadata."""
-        if not include_sensitive:
-            return _metadata_result("system", _postgres_metadata_capability("system"))
-        return self._select_domain(driver, "system", domain, schema_name=None, table_name=None, limit=100)
+        metadata_request = ensure_system_metadata_request(request, **kwargs)
+        capability = _postgres_system_metadata_capability(metadata_request.domain)
+        gate_result = system_metadata_gated_result(metadata_request, capability)
+        if gate_result.capability.support != MetadataSupport.SUPPORTED:
+            return gate_result
+
+        query_name = _POSTGRES_SYSTEM_METADATA_QUERIES.get(metadata_request.domain)
+        if query_name is None:
+            return gate_result
+        parameters: dict[str, object] = {}
+        if query_name == "pg_stat_statements":
+            parameters["limit"] = 100
+        elif query_name == "table_stats":
+            parameters["schema_name"] = self.resolve_schema(metadata_request.schema)
+            parameters["table_name"] = (
+                self.resolve_identifier(metadata_request.table) if metadata_request.table is not None else None
+            )
+        result = self._select_domain(driver, "system", query_name, **parameters)
+        return SystemMetadataResult.from_rows(
+            metadata_request, capability, rows=_rows_as_mappings(result.items), source=MetadataSource.SYSTEM_VIEW
+        )
 
     def get_version(self, driver: "PsycopgSyncDriver") -> "VersionInfo | None":
         """Get PostgreSQL database version information.
@@ -348,6 +460,14 @@ class PsycopgAsyncDataDictionary(AsyncDataDictionaryBase):
         """Get PostgreSQL replacement data-dictionary capability profile."""
         return _postgres_metadata_profile(type(self).__name__, domains)
 
+    async def get_system_metadata_capabilities(
+        self, driver: "PsycopgAsyncDriver", domains: Sequence[str] | None = None
+    ) -> tuple[SystemMetadataCapability, ...]:
+        """Get PostgreSQL opt-in system metadata capability disclosures."""
+        _ = driver
+        requested_domains = tuple(_POSTGRES_SYSTEM_METADATA_QUERIES) if domains is None else tuple(domains)
+        return tuple(_postgres_system_metadata_capability(domain) for domain in requested_domains)
+
     async def _select_domain(
         self, driver: "PsycopgAsyncDriver", domain: str, query_name: str, **parameters: Any
     ) -> MetadataResult:
@@ -413,25 +533,57 @@ class PsycopgAsyncDataDictionary(AsyncDataDictionaryBase):
         )
 
     async def get_ddl(
-        self, driver: "PsycopgAsyncDriver", object_name: str, schema: str | None = None, object_type: str | None = None
-    ) -> MetadataResult:
+        self,
+        driver: "PsycopgAsyncDriver",
+        object_name: str,
+        schema: str | None = None,
+        *,
+        object_type: str = "table",
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> DDLResult:
         """Get object DDL where PostgreSQL exposes native definition helpers."""
-        return await self._select_domain(
-            driver,
-            "ddl",
-            "by_object",
-            schema_name=self.resolve_schema(schema),
-            object_name=self.resolve_identifier(object_name),
+        _ = include_dependencies, prefer_native, redact
+        schema_name = self.resolve_schema(schema)
+        resolved_object = self.resolve_identifier(object_name)
+        result = await self._select_domain(
+            driver, "ddl", "by_object", schema_name=schema_name, object_name=resolved_object, object_type=object_type
+        )
+        return _ddl_result_from_rows(
+            dialect=type(self).dialect,
+            object_name=resolved_object,
             object_type=object_type,
+            schema=schema_name,
+            rows=result.items,
+            warnings=result.warnings,
         )
 
     async def get_system_metadata(
-        self, driver: "PsycopgAsyncDriver", domain: str, *, include_sensitive: bool = False
-    ) -> MetadataResult:
+        self, driver: "PsycopgAsyncDriver", request: SystemMetadataRequest | str | None = None, **kwargs: Any
+    ) -> SystemMetadataResult:
         """Get opt-in PostgreSQL system metadata."""
-        if not include_sensitive:
-            return _metadata_result("system", _postgres_metadata_capability("system"))
-        return await self._select_domain(driver, "system", domain, schema_name=None, table_name=None, limit=100)
+        metadata_request = ensure_system_metadata_request(request, **kwargs)
+        capability = _postgres_system_metadata_capability(metadata_request.domain)
+        gate_result = system_metadata_gated_result(metadata_request, capability)
+        if gate_result.capability.support != MetadataSupport.SUPPORTED:
+            return gate_result
+
+        query_name = _POSTGRES_SYSTEM_METADATA_QUERIES.get(metadata_request.domain)
+        if query_name is None:
+            return gate_result
+        parameters: dict[str, object] = {}
+        if query_name == "pg_stat_statements":
+            parameters["limit"] = 100
+        elif query_name == "table_stats":
+            parameters["schema_name"] = self.resolve_schema(metadata_request.schema)
+            parameters["table_name"] = (
+                self.resolve_identifier(metadata_request.table) if metadata_request.table is not None else None
+            )
+        result = await self._select_domain(driver, "system", query_name, **parameters)
+        return SystemMetadataResult.from_rows(
+            metadata_request, capability, rows=_rows_as_mappings(result.items), source=MetadataSource.SYSTEM_VIEW
+        )
 
     async def get_version(self, driver: "PsycopgAsyncDriver") -> "VersionInfo | None":
         """Get PostgreSQL database version information.

--- a/sqlspec/data_dictionary/_types.py
+++ b/sqlspec/data_dictionary/_types.py
@@ -1382,6 +1382,7 @@ class FeatureFlags(TypedDict, total=False):
 
     supports_arrays: bool
     supports_clustering: bool
+    supports_crdb_internal_metadata: bool
     supports_cte: bool
     supports_generators: bool
     supports_for_update: bool

--- a/sqlspec/data_dictionary/dialects/cockroachdb.py
+++ b/sqlspec/data_dictionary/dialects/cockroachdb.py
@@ -23,6 +23,7 @@ COCKROACHDB_FEATURE_FLAGS: "FeatureFlags" = {
     "supports_schemas": True,
     "supports_for_update": True,
     "supports_skip_locked": True,
+    "supports_crdb_internal_metadata": False,
 }
 
 COCKROACHDB_TYPE_MAPPINGS: dict[str, str] = {

--- a/sqlspec/data_dictionary/sql/cockroachdb/columns/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/cockroachdb/columns/by_schema.sql
@@ -1,0 +1,18 @@
+-- name: by_schema
+-- dialect: cockroachdb
+SELECT
+    table_catalog::text AS table_catalog,
+    table_schema::text AS table_schema,
+    table_schema::text AS schema_name,
+    table_name::text AS table_name,
+    column_name::text AS column_name,
+    ordinal_position,
+    data_type::text AS data_type,
+    is_nullable::text AS is_nullable,
+    column_default::text AS column_default,
+    generation_expression::text AS generation_expression,
+    is_hidden::text AS is_hidden
+FROM information_schema.columns
+WHERE table_schema = :schema_name
+  AND (:table_name::text IS NULL OR table_name = :table_name)
+ORDER BY table_schema, table_name, ordinal_position;

--- a/sqlspec/data_dictionary/sql/cockroachdb/comments/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/cockroachdb/comments/by_schema.sql
@@ -1,0 +1,10 @@
+-- name: by_schema
+-- dialect: cockroachdb
+SELECT
+    table_schema::text AS schema_name,
+    table_name::text AS object_name,
+    'table'::text AS object_type,
+    NULL::text AS comment
+FROM information_schema.tables
+WHERE table_schema = :schema_name
+ORDER BY table_schema, table_name;

--- a/sqlspec/data_dictionary/sql/cockroachdb/constraints/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/cockroachdb/constraints/by_schema.sql
@@ -1,0 +1,43 @@
+-- name: by_schema
+-- dialect: cockroachdb
+SELECT
+    tc.constraint_catalog::text AS constraint_catalog,
+    tc.constraint_schema::text AS constraint_schema,
+    tc.table_schema::text AS schema_name,
+    tc.table_name::text AS table_name,
+    tc.constraint_name::text AS constraint_name,
+    tc.constraint_type::text AS constraint_type,
+    tc.is_deferrable::text AS is_deferrable,
+    tc.initially_deferred::text AS initially_deferred,
+    ARRAY(
+        SELECT kcu.column_name::text
+        FROM information_schema.key_column_usage kcu
+        WHERE kcu.constraint_catalog = tc.constraint_catalog
+          AND kcu.constraint_schema = tc.constraint_schema
+          AND kcu.constraint_name = tc.constraint_name
+          AND kcu.table_schema = tc.table_schema
+          AND kcu.table_name = tc.table_name
+        ORDER BY kcu.ordinal_position
+    )::text[] AS columns,
+    rc.unique_constraint_schema::text AS referenced_schema,
+    ccu.table_name::text AS referenced_table,
+    ARRAY(
+        SELECT ccu_inner.column_name::text
+        FROM information_schema.constraint_column_usage ccu_inner
+        WHERE ccu_inner.constraint_catalog = tc.constraint_catalog
+          AND ccu_inner.constraint_schema = tc.constraint_schema
+          AND ccu_inner.constraint_name = tc.constraint_name
+        ORDER BY ccu_inner.column_name
+    )::text[] AS referenced_columns
+FROM information_schema.table_constraints tc
+LEFT JOIN information_schema.referential_constraints rc
+  ON rc.constraint_catalog = tc.constraint_catalog
+ AND rc.constraint_schema = tc.constraint_schema
+ AND rc.constraint_name = tc.constraint_name
+LEFT JOIN information_schema.constraint_column_usage ccu
+  ON ccu.constraint_catalog = tc.constraint_catalog
+ AND ccu.constraint_schema = tc.constraint_schema
+ AND ccu.constraint_name = tc.constraint_name
+WHERE tc.table_schema = :schema_name
+  AND (:table_name::text IS NULL OR tc.table_name = :table_name)
+ORDER BY tc.table_schema, tc.table_name, tc.constraint_name;

--- a/sqlspec/data_dictionary/sql/cockroachdb/crdb_internal/ranges.sql
+++ b/sqlspec/data_dictionary/sql/cockroachdb/crdb_internal/ranges.sql
@@ -1,0 +1,11 @@
+-- name: ranges
+-- dialect: cockroachdb
+SELECT
+    database_name::text AS database_name,
+    schema_name::text AS schema_name,
+    table_name::text AS table_name,
+    range_id::text AS range_id
+FROM crdb_internal.ranges
+WHERE (:schema_name::text IS NULL OR schema_name = :schema_name)
+  AND (:table_name::text IS NULL OR table_name = :table_name)
+ORDER BY database_name, schema_name, table_name, range_id;

--- a/sqlspec/data_dictionary/sql/cockroachdb/ddl/by_object.sql
+++ b/sqlspec/data_dictionary/sql/cockroachdb/ddl/by_object.sql
@@ -1,0 +1,10 @@
+-- name: by_object
+-- dialect: cockroachdb
+SELECT
+    :schema_name::text AS schema_name,
+    :object_name::text AS object_name,
+    :object_type::text AS object_type,
+    NULL::text AS ddl,
+    'lossy'::text AS fidelity,
+    'SHOW CREATE requires a safely quoted identifier and is not emitted by the bind-only query pack'::text AS warning
+WHERE :object_name::text IS NOT NULL;

--- a/sqlspec/data_dictionary/sql/cockroachdb/dependencies/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/cockroachdb/dependencies/by_schema.sql
@@ -1,0 +1,20 @@
+-- name: by_schema
+-- dialect: cockroachdb
+SELECT
+    tc.table_schema::text AS schema_name,
+    tc.table_name::text AS object_name,
+    'table'::text AS object_type,
+    ccu.table_schema::text AS referenced_schema,
+    ccu.table_name::text AS referenced_object,
+    'table'::text AS referenced_object_type,
+    'foreign_key'::text AS dependency_type,
+    tc.constraint_name::text AS constraint_name
+FROM information_schema.table_constraints tc
+JOIN information_schema.constraint_column_usage ccu
+  ON ccu.constraint_catalog = tc.constraint_catalog
+ AND ccu.constraint_schema = tc.constraint_schema
+ AND ccu.constraint_name = tc.constraint_name
+WHERE tc.constraint_type = 'FOREIGN KEY'
+  AND tc.table_schema = :schema_name
+  AND (:object_name::text IS NULL OR tc.table_name = :object_name)
+ORDER BY tc.table_schema, tc.table_name, tc.constraint_name;

--- a/sqlspec/data_dictionary/sql/cockroachdb/indexes/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/cockroachdb/indexes/by_schema.sql
@@ -1,0 +1,15 @@
+-- name: by_schema
+-- dialect: cockroachdb
+SELECT
+    table_schema::text AS schema_name,
+    table_name::text AS table_name,
+    index_name::text AS index_name,
+    column_name::text AS column_name,
+    non_unique = false AS is_unique,
+    index_name = 'primary' AS is_primary,
+    direction::text AS direction,
+    storing::text AS storing
+FROM information_schema.statistics
+WHERE table_schema = :schema_name
+  AND (:table_name::text IS NULL OR table_name = :table_name)
+ORDER BY table_schema, table_name, index_name, seq_in_index;

--- a/sqlspec/data_dictionary/sql/cockroachdb/objects/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/cockroachdb/objects/by_schema.sql
@@ -1,0 +1,15 @@
+-- name: by_schema
+-- dialect: cockroachdb
+SELECT
+    table_catalog::text AS catalog_name,
+    table_schema::text AS schema_name,
+    table_name::text AS object_name,
+    CASE table_type
+        WHEN 'BASE TABLE' THEN 'table'
+        WHEN 'VIEW' THEN 'view'
+        ELSE table_type::text
+    END AS object_type,
+    table_type::text AS native_object_type
+FROM information_schema.tables
+WHERE table_schema = :schema_name
+ORDER BY table_schema, table_name;

--- a/sqlspec/data_dictionary/sql/cockroachdb/privileges/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/cockroachdb/privileges/by_schema.sql
@@ -1,0 +1,13 @@
+-- name: by_schema
+-- dialect: cockroachdb
+SELECT
+    table_schema::text AS schema_name,
+    table_name::text AS object_name,
+    grantee::text AS grantee,
+    privilege_type::text AS privilege_type,
+    is_grantable::text AS is_grantable,
+    with_hierarchy::text AS with_hierarchy
+FROM information_schema.table_privileges
+WHERE table_schema = :schema_name
+  AND (:object_name::text IS NULL OR table_name = :object_name)
+ORDER BY table_schema, table_name, grantee, privilege_type;

--- a/sqlspec/data_dictionary/sql/cockroachdb/schemas/list.sql
+++ b/sqlspec/data_dictionary/sql/cockroachdb/schemas/list.sql
@@ -1,0 +1,10 @@
+-- name: list
+-- dialect: cockroachdb
+SELECT
+    catalog_name::text AS catalog_name,
+    schema_name::text AS schema_name,
+    schema_owner::text AS owner_name
+FROM information_schema.schemata
+WHERE schema_name NOT LIKE 'pg\_%'
+  AND schema_name <> 'information_schema'
+ORDER BY schema_name;

--- a/sqlspec/data_dictionary/sql/cockroachdb/sequences/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/cockroachdb/sequences/by_schema.sql
@@ -1,0 +1,14 @@
+-- name: by_schema
+-- dialect: cockroachdb
+SELECT
+    sequence_schema::text AS schema_name,
+    sequence_name::text AS sequence_name,
+    data_type::text AS data_type,
+    start_value::text AS start_value,
+    minimum_value::text AS minimum_value,
+    maximum_value::text AS maximum_value,
+    increment::text AS increment,
+    cycle_option::text AS cycle_option
+FROM information_schema.sequences
+WHERE sequence_schema = :schema_name
+ORDER BY sequence_schema, sequence_name;

--- a/sqlspec/data_dictionary/sql/cockroachdb/tables/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/cockroachdb/tables/by_schema.sql
@@ -1,0 +1,15 @@
+-- name: by_schema
+-- dialect: cockroachdb
+SELECT
+    table_catalog::text AS table_catalog,
+    table_schema::text AS table_schema,
+    table_schema::text AS schema_name,
+    table_name::text AS table_name,
+    table_type::text AS table_type,
+    NULL::int AS dependency_level,
+    NULL::int AS level
+FROM information_schema.tables
+WHERE table_schema = :schema_name
+  AND (:table_name::text IS NULL OR table_name = :table_name)
+  AND table_type = 'BASE TABLE'
+ORDER BY table_schema, table_name;

--- a/sqlspec/data_dictionary/sql/cockroachdb/views/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/cockroachdb/views/by_schema.sql
@@ -1,0 +1,11 @@
+-- name: by_schema
+-- dialect: cockroachdb
+SELECT
+    table_schema::text AS schema_name,
+    table_name::text AS view_name,
+    view_definition::text AS definition,
+    check_option::text AS check_option,
+    is_updatable::text AS is_updatable
+FROM information_schema.views
+WHERE table_schema = :schema_name
+ORDER BY table_schema, table_name;

--- a/sqlspec/data_dictionary/sql/postgres/columns/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/postgres/columns/by_schema.sql
@@ -1,0 +1,41 @@
+-- name: by_schema
+-- dialect: postgres
+SELECT
+    current_database()::text AS table_catalog,
+    n.nspname::text AS table_schema,
+    n.nspname::text AS schema_name,
+    c.relname::text AS table_name,
+    a.attname::text AS column_name,
+    a.attnum::integer AS ordinal_position,
+    pg_catalog.format_type(a.atttypid, a.atttypmod)::text AS data_type,
+    t.typname::text AS type_name,
+    CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END AS is_nullable,
+    pg_catalog.pg_get_expr(d.adbin, d.adrelid)::text AS column_default,
+    a.attidentity::text AS identity_generation,
+    a.attgenerated::text AS generated_kind,
+    col_description(c.oid, a.attnum)::text AS comment,
+    EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_constraint pk
+        WHERE pk.conrelid = c.oid
+          AND pk.contype = 'p'
+          AND a.attnum = ANY(pk.conkey)
+    ) AS is_primary,
+    EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_constraint uq
+        WHERE uq.conrelid = c.oid
+          AND uq.contype = 'u'
+          AND a.attnum = ANY(uq.conkey)
+    ) AS is_unique
+FROM pg_catalog.pg_attribute a
+JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+JOIN pg_catalog.pg_type t ON t.oid = a.atttypid
+LEFT JOIN pg_catalog.pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+WHERE n.nspname = :schema_name
+  AND (:table_name::text IS NULL OR c.relname = :table_name)
+  AND c.relkind IN ('r', 'p', 'v', 'm', 'f')
+  AND a.attnum > 0
+  AND NOT a.attisdropped
+ORDER BY n.nspname, c.relname, a.attnum;

--- a/sqlspec/data_dictionary/sql/postgres/comments/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/postgres/comments/by_schema.sql
@@ -1,0 +1,27 @@
+-- name: by_schema
+-- dialect: postgres
+SELECT
+    n.nspname::text AS schema_name,
+    c.relname::text AS object_name,
+    'table'::text AS object_type,
+    d.description::text AS comment,
+    c.oid::text AS object_oid
+FROM pg_catalog.pg_description d
+JOIN pg_catalog.pg_class c ON c.oid = d.objoid
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname = :schema_name
+  AND d.objsubid = 0
+UNION ALL
+SELECT
+    n.nspname::text AS schema_name,
+    c.relname::text || '.' || a.attname::text AS object_name,
+    'column'::text AS object_type,
+    d.description::text AS comment,
+    c.oid::text AS object_oid
+FROM pg_catalog.pg_description d
+JOIN pg_catalog.pg_class c ON c.oid = d.objoid
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid AND a.attnum = d.objsubid
+WHERE n.nspname = :schema_name
+  AND d.objsubid > 0
+ORDER BY schema_name, object_type, object_name;

--- a/sqlspec/data_dictionary/sql/postgres/constraints/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/postgres/constraints/by_schema.sql
@@ -1,0 +1,43 @@
+-- name: by_schema
+-- dialect: postgres
+SELECT
+    current_database()::text AS constraint_catalog,
+    n.nspname::text AS constraint_schema,
+    n.nspname::text AS schema_name,
+    c.relname::text AS table_name,
+    con.conname::text AS constraint_name,
+    CASE con.contype
+        WHEN 'c' THEN 'CHECK'
+        WHEN 'f' THEN 'FOREIGN KEY'
+        WHEN 'p' THEN 'PRIMARY KEY'
+        WHEN 'u' THEN 'UNIQUE'
+        WHEN 'x' THEN 'EXCLUDE'
+        ELSE con.contype::text
+    END AS constraint_type,
+    pg_catalog.pg_get_constraintdef(con.oid, true)::text AS definition,
+    ARRAY(
+        SELECT att.attname::text
+        FROM unnest(con.conkey) WITH ORDINALITY AS keys(attnum, ord)
+        JOIN pg_catalog.pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = keys.attnum
+        ORDER BY keys.ord
+    )::text[] AS columns,
+    ref_ns.nspname::text AS referenced_schema,
+    ref.relname::text AS referenced_table,
+    ARRAY(
+        SELECT att.attname::text
+        FROM unnest(con.confkey) WITH ORDINALITY AS keys(attnum, ord)
+        JOIN pg_catalog.pg_attribute att ON att.attrelid = con.confrelid AND att.attnum = keys.attnum
+        ORDER BY keys.ord
+    )::text[] AS referenced_columns,
+    con.condeferrable AS is_deferrable,
+    con.condeferred AS initially_deferred,
+    dep.refobjid IS NOT NULL AS is_extension_owned
+FROM pg_catalog.pg_constraint con
+JOIN pg_catalog.pg_namespace n ON n.oid = con.connamespace
+LEFT JOIN pg_catalog.pg_class c ON c.oid = con.conrelid
+LEFT JOIN pg_catalog.pg_class ref ON ref.oid = con.confrelid
+LEFT JOIN pg_catalog.pg_namespace ref_ns ON ref_ns.oid = ref.relnamespace
+LEFT JOIN pg_catalog.pg_depend dep ON dep.objid = con.oid AND dep.deptype = 'e'
+WHERE n.nspname = :schema_name
+  AND (:table_name::text IS NULL OR c.relname = :table_name)
+ORDER BY n.nspname, c.relname, con.conname;

--- a/sqlspec/data_dictionary/sql/postgres/ddl/by_object.sql
+++ b/sqlspec/data_dictionary/sql/postgres/ddl/by_object.sql
@@ -1,0 +1,44 @@
+-- name: by_object
+-- dialect: postgres
+SELECT
+    n.nspname::text AS schema_name,
+    c.relname::text AS object_name,
+    CASE c.relkind
+        WHEN 'v' THEN pg_catalog.pg_get_viewdef(c.oid, true)::text
+        WHEN 'm' THEN pg_catalog.pg_get_viewdef(c.oid, true)::text
+        WHEN 'S' THEN 'CREATE SEQUENCE ' || pg_catalog.quote_ident(n.nspname) || '.' || pg_catalog.quote_ident(c.relname)
+        ELSE NULL::text
+    END AS ddl,
+    CASE c.relkind
+        WHEN 'v' THEN 'native'
+        WHEN 'm' THEN 'native'
+        WHEN 'S' THEN 'generated'
+        ELSE 'unsupported'
+    END AS fidelity,
+    dep.refobjid IS NOT NULL AS is_extension_owned
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+LEFT JOIN pg_catalog.pg_depend dep ON dep.objid = c.oid AND dep.deptype = 'e'
+WHERE n.nspname = :schema_name
+  AND c.relname = :object_name
+  AND (:object_type::text IS NULL OR c.relkind = CASE :object_type
+      WHEN 'view' THEN 'v'
+      WHEN 'materialized_view' THEN 'm'
+      WHEN 'sequence' THEN 'S'
+      WHEN 'table' THEN 'r'
+      ELSE c.relkind
+  END)
+UNION ALL
+SELECT
+    n.nspname::text AS schema_name,
+    p.proname::text AS object_name,
+    pg_catalog.pg_get_functiondef(p.oid)::text AS ddl,
+    'native'::text AS fidelity,
+    dep.refobjid IS NOT NULL AS is_extension_owned
+FROM pg_catalog.pg_proc p
+JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+LEFT JOIN pg_catalog.pg_depend dep ON dep.objid = p.oid AND dep.deptype = 'e'
+WHERE n.nspname = :schema_name
+  AND p.proname = :object_name
+  AND (:object_type::text IS NULL OR :object_type IN ('routine', 'function', 'procedure'))
+ORDER BY schema_name, object_name;

--- a/sqlspec/data_dictionary/sql/postgres/dependencies/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/postgres/dependencies/by_schema.sql
@@ -1,0 +1,42 @@
+-- name: by_schema
+-- dialect: postgres
+SELECT
+    src_ns.nspname::text AS schema_name,
+    src.relname::text AS object_name,
+    src.relkind::text AS object_type,
+    target_ns.nspname::text AS referenced_schema,
+    target.relname::text AS referenced_object,
+    target.relkind::text AS referenced_object_type,
+    dep.deptype::text AS dependency_type,
+    ext.extname::text AS extension_name,
+    dep.objid::text AS object_oid,
+    dep.refobjid::text AS referenced_oid
+FROM pg_catalog.pg_depend dep
+JOIN pg_catalog.pg_class src ON src.oid = dep.objid
+JOIN pg_catalog.pg_namespace src_ns ON src_ns.oid = src.relnamespace
+LEFT JOIN pg_catalog.pg_class target ON target.oid = dep.refobjid
+LEFT JOIN pg_catalog.pg_namespace target_ns ON target_ns.oid = target.relnamespace
+LEFT JOIN pg_catalog.pg_extension ext ON ext.oid = dep.refobjid AND dep.deptype = 'e'
+WHERE src_ns.nspname = :schema_name
+  AND (:object_name::text IS NULL OR src.relname = :object_name)
+UNION ALL
+SELECT
+    src_ns.nspname::text AS schema_name,
+    src.relname::text AS object_name,
+    'table'::text AS object_type,
+    target_ns.nspname::text AS referenced_schema,
+    target.relname::text AS referenced_object,
+    'table'::text AS referenced_object_type,
+    'foreign_key'::text AS dependency_type,
+    NULL::text AS extension_name,
+    fk.oid::text AS object_oid,
+    fk.confrelid::text AS referenced_oid
+FROM pg_catalog.pg_constraint fk
+JOIN pg_catalog.pg_class src ON src.oid = fk.conrelid
+JOIN pg_catalog.pg_namespace src_ns ON src_ns.oid = src.relnamespace
+JOIN pg_catalog.pg_class target ON target.oid = fk.confrelid
+JOIN pg_catalog.pg_namespace target_ns ON target_ns.oid = target.relnamespace
+WHERE fk.contype = 'f'
+  AND src_ns.nspname = :schema_name
+  AND (:object_name::text IS NULL OR src.relname = :object_name)
+ORDER BY schema_name, object_name, dependency_type, referenced_object;

--- a/sqlspec/data_dictionary/sql/postgres/extensions/list.sql
+++ b/sqlspec/data_dictionary/sql/postgres/extensions/list.sql
@@ -1,0 +1,11 @@
+-- name: list
+-- dialect: postgres
+SELECT
+    ext.extname::text AS extension_name,
+    ext.extversion::text AS extension_version,
+    n.nspname::text AS schema_name,
+    ext.oid::text AS extension_oid,
+    pg_catalog.obj_description(ext.oid, 'pg_extension')::text AS comment
+FROM pg_catalog.pg_extension ext
+JOIN pg_catalog.pg_namespace n ON n.oid = ext.extnamespace
+ORDER BY ext.extname;

--- a/sqlspec/data_dictionary/sql/postgres/indexes/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/postgres/indexes/by_schema.sql
@@ -9,7 +9,7 @@ SELECT
     ix.indisprimary AS is_primary,
     ix.indisexclusion AS is_exclusion,
     ix.indisvalid AS is_valid,
-    ix.indispartial AS is_partial,
+    pg_catalog.pg_get_expr(ix.indpred, ix.indrelid)::text IS NOT NULL AS is_partial,
     pg_catalog.pg_get_expr(ix.indpred, ix.indrelid)::text AS predicate,
     pg_catalog.pg_get_indexdef(idx.oid)::text AS definition,
     ARRAY(

--- a/sqlspec/data_dictionary/sql/postgres/indexes/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/postgres/indexes/by_schema.sql
@@ -1,0 +1,43 @@
+-- name: by_schema
+-- dialect: postgres
+SELECT
+    tn.nspname::text AS schema_name,
+    tbl.relname::text AS table_name,
+    idx.relname::text AS index_name,
+    am.amname::text AS access_method,
+    ix.indisunique AS is_unique,
+    ix.indisprimary AS is_primary,
+    ix.indisexclusion AS is_exclusion,
+    ix.indisvalid AS is_valid,
+    ix.indispartial AS is_partial,
+    pg_catalog.pg_get_expr(ix.indpred, ix.indrelid)::text AS predicate,
+    pg_catalog.pg_get_indexdef(idx.oid)::text AS definition,
+    ARRAY(
+        SELECT COALESCE(att.attname::text, pg_catalog.pg_get_indexdef(idx.oid, keys.ord::integer, true)::text)
+        FROM unnest(ix.indkey) WITH ORDINALITY AS keys(attnum, ord)
+        LEFT JOIN pg_catalog.pg_attribute att ON att.attrelid = tbl.oid AND att.attnum = keys.attnum
+        WHERE keys.ord <= ix.indnkeyatts
+        ORDER BY keys.ord
+    )::text[] AS columns,
+    ARRAY(
+        SELECT pg_catalog.pg_get_indexdef(idx.oid, keys.ord::integer, true)::text
+        FROM unnest(ix.indkey) WITH ORDINALITY AS keys(attnum, ord)
+        WHERE keys.ord > ix.indnkeyatts
+        ORDER BY keys.ord
+    )::text[] AS included_columns,
+    ARRAY(
+        SELECT opc.opcname::text
+        FROM unnest(ix.indclass) WITH ORDINALITY AS classes(opclass_oid, ord)
+        JOIN pg_catalog.pg_opclass opc ON opc.oid = classes.opclass_oid
+        ORDER BY classes.ord
+    )::text[] AS opclasses,
+    dep.refobjid IS NOT NULL AS is_extension_owned
+FROM pg_catalog.pg_index ix
+JOIN pg_catalog.pg_class tbl ON tbl.oid = ix.indrelid
+JOIN pg_catalog.pg_namespace tn ON tn.oid = tbl.relnamespace
+JOIN pg_catalog.pg_class idx ON idx.oid = ix.indexrelid
+JOIN pg_catalog.pg_am am ON am.oid = idx.relam
+LEFT JOIN pg_catalog.pg_depend dep ON dep.objid = idx.oid AND dep.deptype = 'e'
+WHERE tn.nspname = :schema_name
+  AND (:table_name::text IS NULL OR tbl.relname = :table_name)
+ORDER BY tn.nspname, tbl.relname, idx.relname;

--- a/sqlspec/data_dictionary/sql/postgres/materialized_views/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/postgres/materialized_views/by_schema.sql
@@ -1,0 +1,17 @@
+-- name: by_schema
+-- dialect: postgres
+SELECT
+    n.nspname::text AS schema_name,
+    c.relname::text AS view_name,
+    c.oid::text AS object_oid,
+    pg_catalog.pg_get_viewdef(c.oid, true)::text AS definition,
+    r.rolname::text AS owner_name,
+    pg_catalog.obj_description(c.oid, 'pg_class')::text AS comment,
+    dep.refobjid IS NOT NULL AS is_extension_owned
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+LEFT JOIN pg_catalog.pg_roles r ON r.oid = c.relowner
+LEFT JOIN pg_catalog.pg_depend dep ON dep.objid = c.oid AND dep.deptype = 'e'
+WHERE n.nspname = :schema_name
+  AND c.relkind = 'm'
+ORDER BY n.nspname, c.relname;

--- a/sqlspec/data_dictionary/sql/postgres/objects/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/postgres/objects/by_schema.sql
@@ -1,10 +1,25 @@
 -- name: by_schema
 -- dialect: postgres
 SELECT
-    table_catalog,
-    table_schema,
-    table_name,
-    table_type
-FROM information_schema.tables
-WHERE table_schema = :schema_name
-ORDER BY table_schema, table_name;
+    current_database()::text AS catalog_name,
+    n.nspname::text AS schema_name,
+    c.relname::text AS object_name,
+    CASE c.relkind
+        WHEN 'r' THEN 'table'
+        WHEN 'p' THEN 'partitioned_table'
+        WHEN 'v' THEN 'view'
+        WHEN 'm' THEN 'materialized_view'
+        WHEN 'S' THEN 'sequence'
+        WHEN 'f' THEN 'foreign_table'
+        ELSE c.relkind::text
+    END AS object_type,
+    c.oid::text AS object_oid,
+    r.rolname::text AS owner_name,
+    c.relispartition AS is_partition,
+    pg_catalog.obj_description(c.oid, 'pg_class')::text AS comment
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+LEFT JOIN pg_catalog.pg_roles r ON r.oid = c.relowner
+WHERE n.nspname = :schema_name
+  AND c.relkind IN ('r', 'p', 'v', 'm', 'S', 'f')
+ORDER BY n.nspname, object_type, c.relname;

--- a/sqlspec/data_dictionary/sql/postgres/partitions/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/postgres/partitions/by_schema.sql
@@ -7,13 +7,13 @@ SELECT
     child.relname::text AS partition_name,
     pg_catalog.pg_get_expr(child.relpartbound, child.oid, true)::text AS partition_bound,
     pt.partstrat::text AS partition_strategy,
-    inh.inhseqno AS inherit_sequence
-FROM pg_catalog.pg_inherits inh
-JOIN pg_catalog.pg_class parent ON parent.oid = inh.inhparent
+    inherit.inhseqno AS inherit_sequence
+FROM pg_catalog.pg_inherits inherit
+JOIN pg_catalog.pg_class parent ON parent.oid = inherit.inhparent
 JOIN pg_catalog.pg_namespace parent_ns ON parent_ns.oid = parent.relnamespace
-JOIN pg_catalog.pg_class child ON child.oid = inh.inhrelid
+JOIN pg_catalog.pg_class child ON child.oid = inherit.inhrelid
 JOIN pg_catalog.pg_namespace child_ns ON child_ns.oid = child.relnamespace
 LEFT JOIN pg_catalog.pg_partitioned_table pt ON pt.partrelid = parent.oid
 WHERE parent_ns.nspname = :schema_name
   AND (:table_name::text IS NULL OR parent.relname = :table_name OR child.relname = :table_name)
-ORDER BY parent_ns.nspname, parent.relname, inh.inhseqno, child.relname;
+ORDER BY parent_ns.nspname, parent.relname, inherit.inhseqno, child.relname;

--- a/sqlspec/data_dictionary/sql/postgres/partitions/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/postgres/partitions/by_schema.sql
@@ -1,0 +1,19 @@
+-- name: by_schema
+-- dialect: postgres
+SELECT
+    parent_ns.nspname::text AS schema_name,
+    parent.relname::text AS parent_table,
+    child_ns.nspname::text AS partition_schema,
+    child.relname::text AS partition_name,
+    pg_catalog.pg_get_expr(child.relpartbound, child.oid, true)::text AS partition_bound,
+    pt.partstrat::text AS partition_strategy,
+    inh.inhseqno AS inherit_sequence
+FROM pg_catalog.pg_inherits inh
+JOIN pg_catalog.pg_class parent ON parent.oid = inh.inhparent
+JOIN pg_catalog.pg_namespace parent_ns ON parent_ns.oid = parent.relnamespace
+JOIN pg_catalog.pg_class child ON child.oid = inh.inhrelid
+JOIN pg_catalog.pg_namespace child_ns ON child_ns.oid = child.relnamespace
+LEFT JOIN pg_catalog.pg_partitioned_table pt ON pt.partrelid = parent.oid
+WHERE parent_ns.nspname = :schema_name
+  AND (:table_name::text IS NULL OR parent.relname = :table_name OR child.relname = :table_name)
+ORDER BY parent_ns.nspname, parent.relname, inh.inhseqno, child.relname;

--- a/sqlspec/data_dictionary/sql/postgres/privileges/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/postgres/privileges/by_schema.sql
@@ -1,0 +1,29 @@
+-- name: by_schema
+-- dialect: postgres
+SELECT
+    n.nspname::text AS schema_name,
+    c.relname::text AS object_name,
+    CASE c.relkind
+        WHEN 'r' THEN 'table'
+        WHEN 'p' THEN 'partitioned_table'
+        WHEN 'v' THEN 'view'
+        WHEN 'm' THEN 'materialized_view'
+        WHEN 'S' THEN 'sequence'
+        ELSE c.relkind::text
+    END AS object_type,
+    grant_row.grantee::text AS grantee,
+    grant_row.privilege_type::text AS privilege_type,
+    grant_row.is_grantable AS is_grantable
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+CROSS JOIN LATERAL pg_catalog.aclexplode(COALESCE(c.relacl, pg_catalog.acldefault('r', c.relowner))) AS acl
+LEFT JOIN pg_catalog.pg_roles grantee ON grantee.oid = acl.grantee
+CROSS JOIN LATERAL (
+    SELECT
+        COALESCE(grantee.rolname, 'PUBLIC') AS grantee,
+        acl.privilege_type,
+        acl.is_grantable
+) AS grant_row
+WHERE n.nspname = :schema_name
+  AND (:object_name::text IS NULL OR c.relname = :object_name)
+ORDER BY n.nspname, c.relname, grant_row.grantee, grant_row.privilege_type;

--- a/sqlspec/data_dictionary/sql/postgres/routines/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/postgres/routines/by_schema.sql
@@ -1,0 +1,25 @@
+-- name: by_schema
+-- dialect: postgres
+SELECT
+    n.nspname::text AS schema_name,
+    p.proname::text AS routine_name,
+    p.oid::text AS routine_oid,
+    CASE p.prokind
+        WHEN 'f' THEN 'function'
+        WHEN 'p' THEN 'procedure'
+        WHEN 'a' THEN 'aggregate'
+        WHEN 'w' THEN 'window'
+        ELSE p.prokind::text
+    END AS routine_type,
+    pg_catalog.pg_get_function_arguments(p.oid)::text AS arguments,
+    pg_catalog.pg_get_function_result(p.oid)::text AS result_type,
+    lang.lanname::text AS language_name,
+    pg_catalog.pg_get_functiondef(p.oid)::text AS definition,
+    pg_catalog.obj_description(p.oid, 'pg_proc')::text AS comment,
+    dep.refobjid IS NOT NULL AS is_extension_owned
+FROM pg_catalog.pg_proc p
+JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+JOIN pg_catalog.pg_language lang ON lang.oid = p.prolang
+LEFT JOIN pg_catalog.pg_depend dep ON dep.objid = p.oid AND dep.deptype = 'e'
+WHERE n.nspname = :schema_name
+ORDER BY n.nspname, p.proname, p.oid;

--- a/sqlspec/data_dictionary/sql/postgres/schemas/list.sql
+++ b/sqlspec/data_dictionary/sql/postgres/schemas/list.sql
@@ -1,0 +1,13 @@
+-- name: list
+-- dialect: postgres
+SELECT
+    current_database()::text AS catalog_name,
+    n.oid::text AS schema_oid,
+    n.nspname::text AS schema_name,
+    r.rolname::text AS owner_name,
+    pg_catalog.obj_description(n.oid, 'pg_namespace')::text AS comment
+FROM pg_catalog.pg_namespace n
+LEFT JOIN pg_catalog.pg_roles r ON r.oid = n.nspowner
+WHERE n.nspname NOT LIKE 'pg\_%'
+  AND n.nspname <> 'information_schema'
+ORDER BY n.nspname;

--- a/sqlspec/data_dictionary/sql/postgres/sequences/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/postgres/sequences/by_schema.sql
@@ -1,0 +1,18 @@
+-- name: by_schema
+-- dialect: postgres
+SELECT
+    n.nspname::text AS schema_name,
+    c.relname::text AS sequence_name,
+    s.seqstart AS start_value,
+    s.seqmin AS minimum_value,
+    s.seqmax AS maximum_value,
+    s.seqincrement AS increment,
+    s.seqcycle AS cycles,
+    pg_catalog.obj_description(c.oid, 'pg_class')::text AS comment,
+    dep.refobjid IS NOT NULL AS is_extension_owned
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+JOIN pg_catalog.pg_sequence s ON s.seqrelid = c.oid
+LEFT JOIN pg_catalog.pg_depend dep ON dep.objid = c.oid AND dep.deptype = 'e'
+WHERE n.nspname = :schema_name
+ORDER BY n.nspname, c.relname;

--- a/sqlspec/data_dictionary/sql/postgres/system/pg_stat_statements.sql
+++ b/sqlspec/data_dictionary/sql/postgres/system/pg_stat_statements.sql
@@ -1,0 +1,14 @@
+-- name: pg_stat_statements
+-- dialect: postgres
+SELECT
+    userid::text AS user_oid,
+    dbid::text AS database_oid,
+    queryid::text AS query_id,
+    query::text AS query_text,
+    calls,
+    total_exec_time,
+    mean_exec_time,
+    rows
+FROM pg_catalog.pg_stat_statements
+ORDER BY total_exec_time DESC
+LIMIT :limit;

--- a/sqlspec/data_dictionary/sql/postgres/system/settings.sql
+++ b/sqlspec/data_dictionary/sql/postgres/system/settings.sql
@@ -1,0 +1,15 @@
+-- name: settings
+-- dialect: postgres
+SELECT
+    name::text AS setting_name,
+    setting::text AS setting_value,
+    unit::text AS unit,
+    category::text AS category,
+    context::text AS context,
+    vartype::text AS value_type,
+    source::text AS source,
+    boot_val::text AS boot_value,
+    reset_val::text AS reset_value,
+    pending_restart
+FROM pg_catalog.pg_settings
+ORDER BY name;

--- a/sqlspec/data_dictionary/sql/postgres/system/table_stats.sql
+++ b/sqlspec/data_dictionary/sql/postgres/system/table_stats.sql
@@ -1,0 +1,22 @@
+-- name: table_stats
+-- dialect: postgres
+SELECT
+    schemaname::text AS schema_name,
+    relname::text AS table_name,
+    seq_scan,
+    seq_tup_read,
+    idx_scan,
+    idx_tup_fetch,
+    n_tup_ins,
+    n_tup_upd,
+    n_tup_del,
+    n_live_tup,
+    n_dead_tup,
+    vacuum_count,
+    autovacuum_count,
+    analyze_count,
+    autoanalyze_count
+FROM pg_catalog.pg_stat_user_tables
+WHERE (:schema_name::text IS NULL OR schemaname = :schema_name)
+  AND (:table_name::text IS NULL OR relname = :table_name)
+ORDER BY schemaname, relname;

--- a/sqlspec/data_dictionary/sql/postgres/tables/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/postgres/tables/by_schema.sql
@@ -1,0 +1,58 @@
+-- name: by_schema
+-- dialect: postgres
+WITH RECURSIVE dependency_tree AS (
+    SELECT
+        c.oid,
+        n.nspname::text AS schema_name,
+        c.relname::text AS table_name,
+        0 AS dependency_level,
+        ARRAY[c.oid] AS path
+    FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = :schema_name
+      AND (:table_name::text IS NULL OR c.relname = :table_name)
+      AND c.relkind IN ('r', 'p')
+      AND NOT EXISTS (
+          SELECT 1
+          FROM pg_catalog.pg_constraint fk
+          WHERE fk.conrelid = c.oid
+            AND fk.contype = 'f'
+      )
+
+    UNION ALL
+
+    SELECT
+        child.oid,
+        child_ns.nspname::text AS schema_name,
+        child.relname::text AS table_name,
+        parent.dependency_level + 1,
+        parent.path || child.oid
+    FROM pg_catalog.pg_constraint fk
+    JOIN pg_catalog.pg_class child ON child.oid = fk.conrelid
+    JOIN pg_catalog.pg_namespace child_ns ON child_ns.oid = child.relnamespace
+    JOIN dependency_tree parent ON parent.oid = fk.confrelid
+    WHERE fk.contype = 'f'
+      AND child_ns.nspname = :schema_name
+      AND (:table_name::text IS NULL OR child.relname = :table_name)
+      AND NOT child.oid = ANY(parent.path)
+)
+SELECT DISTINCT ON (t.oid)
+    current_database()::text AS table_catalog,
+    n.nspname::text AS table_schema,
+    n.nspname::text AS schema_name,
+    c.relname::text AS table_name,
+    CASE c.relkind WHEN 'p' THEN 'PARTITIONED TABLE' ELSE 'BASE TABLE' END AS table_type,
+    COALESCE(t.dependency_level, 0) AS dependency_level,
+    COALESCE(t.dependency_level, 0) AS level,
+    c.reltuples::bigint AS estimated_row_count,
+    c.relispartition AS is_partition,
+    r.rolname::text AS owner_name,
+    pg_catalog.obj_description(c.oid, 'pg_class')::text AS comment
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+LEFT JOIN pg_catalog.pg_roles r ON r.oid = c.relowner
+LEFT JOIN dependency_tree t ON t.oid = c.oid
+WHERE n.nspname = :schema_name
+  AND (:table_name::text IS NULL OR c.relname = :table_name)
+  AND c.relkind IN ('r', 'p')
+ORDER BY t.oid, dependency_level, c.relname;

--- a/sqlspec/data_dictionary/sql/postgres/triggers/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/postgres/triggers/by_schema.sql
@@ -1,0 +1,20 @@
+-- name: by_schema
+-- dialect: postgres
+SELECT
+    n.nspname::text AS schema_name,
+    c.relname::text AS table_name,
+    tg.tgname::text AS trigger_name,
+    p.proname::text AS function_name,
+    pg_catalog.pg_get_triggerdef(tg.oid, true)::text AS definition,
+    NOT tg.tgenabled = 'D' AS is_enabled,
+    pg_catalog.obj_description(tg.oid, 'pg_trigger')::text AS comment,
+    dep.refobjid IS NOT NULL AS is_extension_owned
+FROM pg_catalog.pg_trigger tg
+JOIN pg_catalog.pg_class c ON c.oid = tg.tgrelid
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+JOIN pg_catalog.pg_proc p ON p.oid = tg.tgfoid
+LEFT JOIN pg_catalog.pg_depend dep ON dep.objid = tg.oid AND dep.deptype = 'e'
+WHERE n.nspname = :schema_name
+  AND (:table_name::text IS NULL OR c.relname = :table_name)
+  AND NOT tg.tgisinternal
+ORDER BY n.nspname, c.relname, tg.tgname;

--- a/sqlspec/data_dictionary/sql/postgres/views/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/postgres/views/by_schema.sql
@@ -1,0 +1,17 @@
+-- name: by_schema
+-- dialect: postgres
+SELECT
+    n.nspname::text AS schema_name,
+    c.relname::text AS view_name,
+    c.oid::text AS object_oid,
+    pg_catalog.pg_get_viewdef(c.oid, true)::text AS definition,
+    r.rolname::text AS owner_name,
+    pg_catalog.obj_description(c.oid, 'pg_class')::text AS comment,
+    dep.refobjid IS NOT NULL AS is_extension_owned
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+LEFT JOIN pg_catalog.pg_roles r ON r.oid = c.relowner
+LEFT JOIN pg_catalog.pg_depend dep ON dep.objid = c.oid AND dep.deptype = 'e'
+WHERE n.nspname = :schema_name
+  AND c.relkind = 'v'
+ORDER BY n.nspname, c.relname;

--- a/tests/unit/adapters/test_postgres_data_dictionary.py
+++ b/tests/unit/adapters/test_postgres_data_dictionary.py
@@ -1,0 +1,140 @@
+"""PostgreSQL-family replacement data-dictionary adapter contracts."""
+
+from typing import Any, cast
+
+import pytest
+
+from sqlspec.adapters.asyncpg.data_dictionary import AsyncpgDataDictionary
+from sqlspec.adapters.cockroach_asyncpg.data_dictionary import CockroachAsyncpgDataDictionary
+from sqlspec.adapters.cockroach_psycopg.data_dictionary import (
+    CockroachPsycopgAsyncDataDictionary,
+    CockroachPsycopgSyncDataDictionary,
+)
+from sqlspec.adapters.psqlpy.data_dictionary import PsqlpyDataDictionary
+from sqlspec.adapters.psycopg.data_dictionary import PsycopgAsyncDataDictionary, PsycopgSyncDataDictionary
+from sqlspec.data_dictionary import MetadataFidelity, MetadataSource, MetadataSupport
+
+
+class FakeSyncDriver:
+    """Minimal sync driver recording metadata calls."""
+
+    def __init__(self) -> None:
+        self.select_calls: list[tuple[Any, dict[str, Any]]] = []
+
+    def select(self, statement: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        self.select_calls.append((statement, kwargs))
+        return [{"schema_name": kwargs.get("schema_name"), "table_name": kwargs.get("table_name", "app")}]
+
+
+class FakeAsyncDriver:
+    """Minimal async driver recording metadata calls."""
+
+    def __init__(self) -> None:
+        self.select_calls: list[tuple[Any, dict[str, Any]]] = []
+
+    async def select(self, statement: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        self.select_calls.append((statement, kwargs))
+        return [{"schema_name": kwargs.get("schema_name"), "table_name": kwargs.get("table_name", "app")}]
+
+
+@pytest.mark.parametrize("data_dictionary", [PsycopgSyncDataDictionary()])
+def test_postgres_sync_metadata_capabilities_report_supported_replacement_domains(data_dictionary: Any) -> None:
+    """PostgreSQL sync adapters report rich domains as supported and system metadata as gated."""
+    profile = data_dictionary.get_metadata_capabilities(cast(Any, FakeSyncDriver()))
+
+    assert profile.dialect == "postgres"
+    assert profile.get("schemas").support == MetadataSupport.SUPPORTED
+    assert profile.get("constraints").fidelity == MetadataFidelity.NATIVE
+    assert profile.get("dependencies").source == MetadataSource.CATALOG
+    assert profile.get("ddl").support == MetadataSupport.SUPPORTED
+    assert profile.get("system").support == MetadataSupport.UNSUPPORTED
+
+
+@pytest.mark.parametrize(
+    "data_dictionary", [AsyncpgDataDictionary(), PsqlpyDataDictionary(), PsycopgAsyncDataDictionary()]
+)
+async def test_postgres_async_metadata_capabilities_report_supported_replacement_domains(data_dictionary: Any) -> None:
+    """PostgreSQL async adapters report rich domains as supported and system metadata as gated."""
+    profile = await data_dictionary.get_metadata_capabilities(cast(Any, FakeAsyncDriver()))
+
+    assert profile.dialect == "postgres"
+    assert profile.get("schemas").support == MetadataSupport.SUPPORTED
+    assert profile.get("constraints").fidelity == MetadataFidelity.NATIVE
+    assert profile.get("dependencies").source == MetadataSource.CATALOG
+    assert profile.get("ddl").support == MetadataSupport.SUPPORTED
+    assert profile.get("system").support == MetadataSupport.UNSUPPORTED
+
+
+def test_postgres_sync_domain_methods_delegate_to_direct_query_packs() -> None:
+    """Sync replacement methods execute direct domain-pack SQL with schema/table binds."""
+    driver = FakeSyncDriver()
+    data_dictionary = PsycopgSyncDataDictionary()
+
+    result = data_dictionary.get_constraints(cast(Any, driver), table="orders", schema="Reporting")
+
+    assert result.domain == "constraints"
+    assert result.capability.support == MetadataSupport.SUPPORTED
+    assert result.items == ({"schema_name": "reporting", "table_name": "orders"},)
+    statement, kwargs = driver.select_calls[0]
+    assert "pg_catalog.pg_constraint" in statement.raw_sql
+    assert kwargs["schema_name"] == "reporting"
+    assert kwargs["table_name"] == "orders"
+
+
+@pytest.mark.parametrize(
+    "data_dictionary", [AsyncpgDataDictionary(), PsqlpyDataDictionary(), PsycopgAsyncDataDictionary()]
+)
+async def test_postgres_async_domain_methods_delegate_to_direct_query_packs(data_dictionary: Any) -> None:
+    """Async replacement methods execute direct domain-pack SQL with schema/table binds."""
+    driver = FakeAsyncDriver()
+
+    result = await data_dictionary.get_constraints(cast(Any, driver), table="orders", schema="Reporting")
+
+    assert result.domain == "constraints"
+    assert result.capability.support == MetadataSupport.SUPPORTED
+    assert result.items == ({"schema_name": "reporting", "table_name": "orders"},)
+    statement, kwargs = driver.select_calls[0]
+    assert "pg_catalog.pg_constraint" in statement.raw_sql
+    assert kwargs["schema_name"] == "reporting"
+    assert kwargs["table_name"] == "orders"
+
+
+@pytest.mark.parametrize("data_dictionary", [CockroachPsycopgSyncDataDictionary()])
+def test_cockroach_sync_capabilities_are_truthful_without_internal_metadata(data_dictionary: Any) -> None:
+    """Cockroach sync adapters report stable-core support and no crdb_internal by default."""
+    profile = data_dictionary.get_metadata_capabilities(
+        cast(Any, FakeSyncDriver()), domains=("schemas", "ddl", "crdb_internal")
+    )
+
+    assert profile.dialect == "cockroachdb"
+    assert profile.get("schemas").support == MetadataSupport.SUPPORTED
+    assert profile.get("ddl").fidelity == MetadataFidelity.LOSSY
+    assert profile.get("crdb_internal").support == MetadataSupport.UNSUPPORTED
+
+
+@pytest.mark.parametrize("data_dictionary", [CockroachAsyncpgDataDictionary(), CockroachPsycopgAsyncDataDictionary()])
+async def test_cockroach_async_capabilities_are_truthful_without_internal_metadata(data_dictionary: Any) -> None:
+    """Cockroach async adapters report stable-core support and no crdb_internal by default."""
+    profile = await data_dictionary.get_metadata_capabilities(
+        cast(Any, FakeAsyncDriver()), domains=("schemas", "ddl", "crdb_internal")
+    )
+
+    assert profile.dialect == "cockroachdb"
+    assert profile.get("schemas").support == MetadataSupport.SUPPORTED
+    assert profile.get("ddl").fidelity == MetadataFidelity.LOSSY
+    assert profile.get("crdb_internal").support == MetadataSupport.UNSUPPORTED
+
+
+async def test_cockroach_async_domain_methods_use_stable_query_packs() -> None:
+    """Cockroach async replacement methods use stable metadata query packs."""
+    driver = FakeAsyncDriver()
+    data_dictionary = CockroachAsyncpgDataDictionary()
+
+    result = await data_dictionary.get_dependencies(cast(Any, driver), schema="Public")
+
+    assert result.domain == "dependencies"
+    assert result.capability.support == MetadataSupport.SUPPORTED
+    statement, kwargs = driver.select_calls[0]
+    assert "information_schema" in statement.raw_sql
+    assert "crdb_internal" not in statement.raw_sql
+    assert kwargs["schema_name"] == "public"

--- a/tests/unit/adapters/test_postgres_data_dictionary.py
+++ b/tests/unit/adapters/test_postgres_data_dictionary.py
@@ -12,7 +12,14 @@ from sqlspec.adapters.cockroach_psycopg.data_dictionary import (
 )
 from sqlspec.adapters.psqlpy.data_dictionary import PsqlpyDataDictionary
 from sqlspec.adapters.psycopg.data_dictionary import PsycopgAsyncDataDictionary, PsycopgSyncDataDictionary
-from sqlspec.data_dictionary import MetadataFidelity, MetadataSource, MetadataSupport
+from sqlspec.data_dictionary import (
+    DDLResult,
+    MetadataFidelity,
+    MetadataSource,
+    MetadataSupport,
+    SystemMetadataRequest,
+    SystemMetadataResult,
+)
 
 
 class FakeSyncDriver:
@@ -35,6 +42,36 @@ class FakeAsyncDriver:
     async def select(self, statement: Any, **kwargs: Any) -> list[dict[str, Any]]:
         self.select_calls.append((statement, kwargs))
         return [{"schema_name": kwargs.get("schema_name"), "table_name": kwargs.get("table_name", "app")}]
+
+
+class FakeDdlSyncDriver(FakeSyncDriver):
+    """Sync driver returning DDL-shaped metadata rows."""
+
+    def select(self, statement: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        self.select_calls.append((statement, kwargs))
+        return [
+            {
+                "schema_name": kwargs.get("schema_name"),
+                "object_name": kwargs.get("object_name"),
+                "ddl": "CREATE VIEW public.active_orders AS SELECT 1",
+                "fidelity": "native",
+            }
+        ]
+
+
+class FakeDdlAsyncDriver(FakeAsyncDriver):
+    """Async driver returning DDL-shaped metadata rows."""
+
+    async def select(self, statement: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        self.select_calls.append((statement, kwargs))
+        return [
+            {
+                "schema_name": kwargs.get("schema_name"),
+                "object_name": kwargs.get("object_name"),
+                "ddl": "CREATE VIEW public.active_orders AS SELECT 1",
+                "fidelity": "native",
+            }
+        ]
 
 
 @pytest.mark.parametrize("data_dictionary", [PsycopgSyncDataDictionary()])
@@ -97,6 +134,68 @@ async def test_postgres_async_domain_methods_delegate_to_direct_query_packs(data
     assert "pg_catalog.pg_constraint" in statement.raw_sql
     assert kwargs["schema_name"] == "reporting"
     assert kwargs["table_name"] == "orders"
+
+
+def test_postgres_sync_ddl_returns_contract_result() -> None:
+    """Sync PostgreSQL DDL lookup returns the typed DDL envelope."""
+    driver = FakeDdlSyncDriver()
+    data_dictionary = PsycopgSyncDataDictionary()
+
+    result = data_dictionary.get_ddl(cast(Any, driver), "active_orders", schema="Public", object_type="view")
+
+    assert isinstance(result, DDLResult)
+    assert result.identity.schema == "public"
+    assert result.identity.name == "active_orders"
+    assert result.fidelity == MetadataFidelity.NATIVE
+    assert result.ddl == "CREATE VIEW public.active_orders AS SELECT 1"
+
+
+@pytest.mark.parametrize(
+    "data_dictionary", [AsyncpgDataDictionary(), PsqlpyDataDictionary(), PsycopgAsyncDataDictionary()]
+)
+async def test_postgres_async_ddl_returns_contract_result(data_dictionary: Any) -> None:
+    """Async PostgreSQL DDL lookup returns the typed DDL envelope."""
+    driver = FakeDdlAsyncDriver()
+
+    result = await data_dictionary.get_ddl(cast(Any, driver), "active_orders", schema="Public", object_type="view")
+
+    assert isinstance(result, DDLResult)
+    assert result.identity.schema == "public"
+    assert result.identity.name == "active_orders"
+    assert result.fidelity == MetadataFidelity.NATIVE
+    assert result.ddl == "CREATE VIEW public.active_orders AS SELECT 1"
+
+
+def test_postgres_sync_system_metadata_returns_contract_result() -> None:
+    """Sync PostgreSQL system metadata returns the typed opt-in envelope."""
+    driver = FakeSyncDriver()
+    data_dictionary = PsycopgSyncDataDictionary()
+
+    result = data_dictionary.get_system_metadata(
+        cast(Any, driver), SystemMetadataRequest("settings", include_system=True)
+    )
+
+    assert isinstance(result, SystemMetadataResult)
+    assert result.capability.support == MetadataSupport.SUPPORTED
+    assert result.source == MetadataSource.SYSTEM_VIEW
+    assert result.rows == ({"schema_name": None, "table_name": "app"},)
+
+
+@pytest.mark.parametrize(
+    "data_dictionary", [AsyncpgDataDictionary(), PsqlpyDataDictionary(), PsycopgAsyncDataDictionary()]
+)
+async def test_postgres_async_system_metadata_returns_contract_result(data_dictionary: Any) -> None:
+    """Async PostgreSQL system metadata returns the typed opt-in envelope."""
+    driver = FakeAsyncDriver()
+
+    result = await data_dictionary.get_system_metadata(
+        cast(Any, driver), SystemMetadataRequest("settings", include_system=True)
+    )
+
+    assert isinstance(result, SystemMetadataResult)
+    assert result.capability.support == MetadataSupport.SUPPORTED
+    assert result.source == MetadataSource.SYSTEM_VIEW
+    assert result.rows == ({"schema_name": None, "table_name": "app"},)
 
 
 @pytest.mark.parametrize("data_dictionary", [CockroachPsycopgSyncDataDictionary()])

--- a/tests/unit/data_dictionary/test_loader_domains.py
+++ b/tests/unit/data_dictionary/test_loader_domains.py
@@ -79,7 +79,9 @@ def test_version_and_feature_gates_return_unsupported_status() -> None:
     assert query.sql is None
     assert query.capability.support == MetadataSupport.UNSUPPORTED
     assert query.capability.risks == (MetadataRisk.VERSION_GATED,)
-    assert query.capability.warnings == ("postgres/objects/by_schema requires supports_window_functions >= 8.4.0",)
+    assert query.capability.warnings == (
+        "postgres/objects/by_schema requires supports_window_functions >= 8.4.0",
+    )
 
 
 def test_domain_query_batch_lookup_reuses_domain_results() -> None:

--- a/tests/unit/data_dictionary/test_loader_domains.py
+++ b/tests/unit/data_dictionary/test_loader_domains.py
@@ -26,7 +26,7 @@ def test_domain_query_lookup() -> None:
     assert query.capability.support == MetadataSupport.SUPPORTED
     assert isinstance(query.sql, SQL)
     assert query.query_text is not None
-    assert "information_schema.tables" in query.query_text
+    assert "pg_catalog.pg_class" in query.query_text
     assert loader.get_domain_query_text("postgres", "objects", "by_schema") == query.query_text
 
 
@@ -34,14 +34,14 @@ def test_missing_domain_returns_unsupported_status() -> None:
     """Missing domain query files report unsupported instead of false-empty metadata."""
     loader = DataDictionaryLoader()
 
-    query = loader.get_domain_query("postgres", "privileges", "by_schema")
+    query = loader.get_domain_query("postgres", "policies", "by_schema")
 
     assert query.is_supported is False
     assert query.sql is None
     assert query.query_text is None
     assert query.capability.support == MetadataSupport.UNSUPPORTED
     assert query.capability.source == MetadataSource.UNKNOWN
-    assert query.capability.warnings == ("No data-dictionary query found for postgres/privileges/by_schema",)
+    assert query.capability.warnings == ("No data-dictionary query found for postgres/policies/by_schema",)
 
 
 def test_dialect_mode_dispatch() -> None:

--- a/tests/unit/data_dictionary/test_loader_domains.py
+++ b/tests/unit/data_dictionary/test_loader_domains.py
@@ -79,9 +79,7 @@ def test_version_and_feature_gates_return_unsupported_status() -> None:
     assert query.sql is None
     assert query.capability.support == MetadataSupport.UNSUPPORTED
     assert query.capability.risks == (MetadataRisk.VERSION_GATED,)
-    assert query.capability.warnings == (
-        "postgres/objects/by_schema requires supports_window_functions >= 8.4.0",
-    )
+    assert query.capability.warnings == ("postgres/objects/by_schema requires supports_window_functions >= 8.4.0",)
 
 
 def test_domain_query_batch_lookup_reuses_domain_results() -> None:

--- a/tests/unit/data_dictionary/test_postgres_cockroach_query_packs.py
+++ b/tests/unit/data_dictionary/test_postgres_cockroach_query_packs.py
@@ -1,0 +1,103 @@
+"""PostgreSQL-family replacement data-dictionary query-pack contracts."""
+
+import pytest
+
+from sqlspec.data_dictionary import DataDictionaryLoader, MetadataRisk, MetadataSource, MetadataSupport
+
+POSTGRES_DOMAIN_QUERIES = (
+    ("schemas", "list"),
+    ("objects", "by_schema"),
+    ("tables", "by_schema"),
+    ("columns", "by_schema"),
+    ("constraints", "by_schema"),
+    ("indexes", "by_schema"),
+    ("views", "by_schema"),
+    ("materialized_views", "by_schema"),
+    ("sequences", "by_schema"),
+    ("routines", "by_schema"),
+    ("triggers", "by_schema"),
+    ("comments", "by_schema"),
+    ("privileges", "by_schema"),
+    ("dependencies", "by_schema"),
+    ("extensions", "list"),
+    ("partitions", "by_schema"),
+    ("ddl", "by_object"),
+    ("system", "settings"),
+    ("system", "table_stats"),
+    ("system", "pg_stat_statements"),
+)
+
+COCKROACH_STABLE_DOMAIN_QUERIES = (
+    ("schemas", "list"),
+    ("objects", "by_schema"),
+    ("tables", "by_schema"),
+    ("columns", "by_schema"),
+    ("constraints", "by_schema"),
+    ("indexes", "by_schema"),
+    ("views", "by_schema"),
+    ("sequences", "by_schema"),
+    ("comments", "by_schema"),
+    ("privileges", "by_schema"),
+    ("dependencies", "by_schema"),
+    ("ddl", "by_object"),
+)
+
+
+@pytest.mark.parametrize(("domain", "query_name"), POSTGRES_DOMAIN_QUERIES)
+def test_postgres_replacement_domain_query_pack_is_available(domain: str, query_name: str) -> None:
+    """PostgreSQL exposes every C3 metadata domain through direct domain paths."""
+    query = DataDictionaryLoader().get_domain_query("postgresql", domain, query_name)
+
+    assert query.is_supported is True
+    assert query.dialect == "postgres"
+    assert query.domain == domain
+    assert query.name == query_name
+    assert query.capability.source == MetadataSource.CATALOG
+    assert query.query_text is not None
+    assert "pg_catalog" in query.query_text or domain == "system"
+
+
+def test_postgres_query_pack_uses_catalogs_needed_for_ddl_grade_metadata() -> None:
+    """DDL-grade PostgreSQL domains use pg_catalog objects, not information_schema-only queries."""
+    loader = DataDictionaryLoader()
+
+    columns = loader.get_domain_query_text("postgres", "columns", "by_schema")
+    constraints = loader.get_domain_query_text("postgres", "constraints", "by_schema")
+    indexes = loader.get_domain_query_text("postgres", "indexes", "by_schema")
+    dependencies = loader.get_domain_query_text("postgres", "dependencies", "by_schema")
+    ddl = loader.get_domain_query_text("postgres", "ddl", "by_object")
+
+    assert columns is not None and "pg_catalog.pg_attribute" in columns
+    assert columns is not None and "pg_catalog.format_type" in columns
+    assert constraints is not None and "pg_catalog.pg_constraint" in constraints
+    assert constraints is not None and "pg_catalog.pg_get_constraintdef" in constraints
+    assert indexes is not None and "pg_catalog.pg_index" in indexes
+    assert indexes is not None and "pg_catalog.pg_get_indexdef" in indexes
+    assert indexes is not None and "::text" in indexes
+    assert dependencies is not None and "pg_catalog.pg_depend" in dependencies
+    assert ddl is not None and "pg_catalog.pg_get_" in ddl
+
+
+@pytest.mark.parametrize(("domain", "query_name"), COCKROACH_STABLE_DOMAIN_QUERIES)
+def test_cockroach_replacement_stable_query_pack_is_available(domain: str, query_name: str) -> None:
+    """CockroachDB default metadata uses stable information_schema/pg_catalog surfaces."""
+    query = DataDictionaryLoader().get_domain_query("cockroach", domain, query_name)
+
+    assert query.is_supported is True
+    assert query.dialect == "cockroachdb"
+    assert query.domain == domain
+    assert query.query_text is not None
+    assert "crdb_internal" not in query.query_text
+
+
+def test_cockroach_crdb_internal_query_is_feature_gated_by_default() -> None:
+    """CockroachDB internal metadata must be explicit opt-in, not default metadata."""
+    query = DataDictionaryLoader().get_domain_query(
+        "cockroachdb", "crdb_internal", "ranges", required_features=("supports_crdb_internal_metadata",)
+    )
+
+    assert query.is_supported is False
+    assert query.sql is None
+    assert query.capability.support == MetadataSupport.UNSUPPORTED
+    assert query.capability.risks == (MetadataRisk.VERSION_GATED,)
+    assert query.capability.warnings == ("cockroachdb/crdb_internal/ranges requires supports_crdb_internal_metadata",)

--- a/tests/unit/data_dictionary/test_postgres_cockroach_query_packs.py
+++ b/tests/unit/data_dictionary/test_postgres_cockroach_query_packs.py
@@ -73,6 +73,11 @@ def test_postgres_query_pack_uses_catalogs_needed_for_ddl_grade_metadata() -> No
     assert constraints is not None and "pg_catalog.pg_get_constraintdef" in constraints
     assert indexes is not None and "pg_catalog.pg_index" in indexes
     assert indexes is not None and "pg_catalog.pg_get_indexdef" in indexes
+    assert indexes is not None and "ix.indispartial" not in indexes
+    assert (
+        indexes is not None
+        and "pg_catalog.pg_get_expr(ix.indpred, ix.indrelid)::text IS NOT NULL AS is_partial" in indexes
+    )
     assert indexes is not None and "::text" in indexes
     assert dependencies is not None and "pg_catalog.pg_depend" in dependencies
     assert ddl is not None and "pg_catalog.pg_get_" in ddl


### PR DESCRIPTION
## Summary

- add PostgreSQL pg_catalog metadata domains and CockroachDB stable metadata packs
- wire PostgreSQL-family adapters to replacement capability and domain methods
- keep CockroachDB internal metadata gated by default