### PR TITLE
feat(data-dictionary): add SQLite and DuckDB metadata packs

### DIFF
--- a/sqlspec/adapters/aiosqlite/data_dictionary.py
+++ b/sqlspec/adapters/aiosqlite/data_dictionary.py
@@ -1,6 +1,6 @@
 """SQLite-specific data dictionary for metadata queries via aiosqlite."""
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from mypy_extensions import mypyc_attr
 
@@ -11,6 +11,7 @@ from sqlspec.data_dictionary import (
     IndexMetadata,
     TableMetadata,
     VersionInfo,
+    get_data_dictionary_loader,
     get_dialect_config,
 )
 from sqlspec.data_dictionary.dialects.sqlite import list_sqlite_available_features, resolve_sqlite_json_type
@@ -21,6 +22,8 @@ if TYPE_CHECKING:
     from sqlspec.data_dictionary._types import DialectConfig
 
 __all__ = ("AiosqliteDataDictionary",)
+
+SQLITE_INDEX_EXPRESSION_COLUMN_ID = -2
 
 
 @mypyc_attr(allow_interpreted_subclasses=True, native_class=False)
@@ -112,9 +115,8 @@ class AiosqliteDataDictionary(AsyncDataDictionaryBase):
         """Get tables sorted by topological dependency order using SQLite catalog."""
         schema_name = self.resolve_schema(schema)
         self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="tables")
-        schema_prefix = f"{format_identifier(schema_name)}." if schema_name else ""
-        query_text = self.get_query_text("tables_by_schema").format(schema_prefix=schema_prefix)
-        return await driver.select(query_text, schema_type=TableMetadata)
+        query_text = self._get_domain_query_text("tables", "by_schema")
+        return await driver.select(query_text, schema_name=schema_name, schema_type=TableMetadata)
 
     async def get_columns(
         self, driver: "AiosqliteDriver", table: "str | None" = None, schema: "str | None" = None
@@ -124,80 +126,100 @@ class AiosqliteDataDictionary(AsyncDataDictionaryBase):
         schema_prefix = f"{format_identifier(schema_name)}." if schema_name else ""
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="columns")
-            query_text = self.get_query_text("columns_by_schema").format(schema_prefix=schema_prefix)
-            return await driver.select(query_text, schema_type=ColumnMetadata)
+            query_text = self._get_domain_query_text("columns", "by_schema").format(schema_prefix=schema_prefix)
+            return await driver.select(query_text, schema_name=schema_name, schema_type=ColumnMetadata)
 
         self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="columns")
-        table_name = table
-        table_identifier = f"{schema_name}.{table_name}" if schema_name else table_name
-        query_text = self.get_query_text("columns_by_table").format(table_name=format_identifier(table_identifier))
-        return await driver.select(query_text, schema_type=ColumnMetadata)
+        query_text = self._get_domain_query_text("columns", "by_table").format(schema_prefix=schema_prefix)
+        return await driver.select(query_text, table_name=table, schema_name=schema_name, schema_type=ColumnMetadata)
 
     async def get_indexes(
         self, driver: "AiosqliteDriver", table: "str | None" = None, schema: "str | None" = None
     ) -> "list[IndexMetadata]":
         """Get index metadata for a table or schema."""
         schema_name = self.resolve_schema(schema)
-        indexes: list[IndexMetadata] = []
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="indexes")
-            for table_info in await self.get_tables(driver, schema=schema_name):
-                table_name = table_info.get("table_name")
-                if not table_name:
-                    continue
-                indexes.extend(await self.get_indexes(driver, table=table_name, schema=schema_name))
-            return indexes
+            schema_prefix = f"{format_identifier(schema_name)}." if schema_name else ""
+            query_text = self._get_domain_query_text("indexes", "by_schema").format(schema_prefix=schema_prefix)
+            rows = await driver.select(query_text, schema_name=schema_name)
+            return _sqlite_index_rows_to_metadata(rows, schema_name)
 
         self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="indexes")
-        table_name = table
-        table_identifier = f"{schema_name}.{table_name}" if schema_name else table_name
-        index_list_sql = self.get_query_text("indexes_by_table").format(table_name=format_identifier(table_identifier))
-        index_rows = await driver.select(index_list_sql)
-        for row in index_rows:
-            index_name = row.get("name")
-            if not index_name:
-                continue
-            index_identifier = f"{schema_name}.{index_name}" if schema_name else index_name
-            columns_sql = self.get_query_text("index_columns_by_index").format(
-                index_name=format_identifier(index_identifier)
-            )
-            columns_rows = await driver.select(columns_sql)
-            columns: list[str] = []
-            for col in columns_rows:
-                column_name = col.get("name")
-                if column_name is None:
-                    continue
-                columns.append(str(column_name))
-            is_primary = row.get("origin") == "pk"
-            index_metadata: IndexMetadata = {
-                "index_name": index_name,
-                "table_name": table_name,
-                "columns": columns,
-                "is_primary": is_primary,
-            }
-            if schema_name is not None:
-                index_metadata["schema_name"] = schema_name
-            unique_value = row.get("unique")
-            if unique_value is not None:
-                index_metadata["is_unique"] = unique_value
-            indexes.append(index_metadata)
-        return indexes
+        schema_prefix = f"{format_identifier(schema_name)}." if schema_name else ""
+        query_text = self._get_domain_query_text("indexes", "by_table").format(schema_prefix=schema_prefix)
+        rows = await driver.select(query_text, table_name=table, schema_name=schema_name)
+        return _sqlite_index_rows_to_metadata(rows, schema_name)
 
     async def get_foreign_keys(
         self, driver: "AiosqliteDriver", table: "str | None" = None, schema: "str | None" = None
     ) -> "list[ForeignKeyMetadata]":
         """Get foreign key metadata."""
         schema_name = self.resolve_schema(schema)
-        schema_prefix = f"{format_identifier(schema_name)}." if schema_name else ""
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="foreign_keys")
-            query_text = self.get_query_text("foreign_keys_by_schema").format(schema_prefix=schema_prefix)
-            return await driver.select(query_text, schema_type=ForeignKeyMetadata)
+            query_text = self._get_domain_query_text("constraints", "foreign_keys_by_schema")
+            return await driver.select(query_text, schema_name=schema_name, schema_type=ForeignKeyMetadata)
 
         self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="foreign_keys")
-        table_label = table.replace("'", "''")
-        table_identifier = f"{schema_name}.{table}" if schema_name else table
-        query_text = self.get_query_text("foreign_keys_by_table").format(
-            table_name=format_identifier(table_identifier), table_label=table_label
+        query_text = self._get_domain_query_text("constraints", "foreign_keys_by_table")
+        return await driver.select(
+            query_text, table_name=table, schema_name=schema_name, schema_type=ForeignKeyMetadata
         )
-        return await driver.select(query_text, schema_type=ForeignKeyMetadata)
+
+    def _get_domain_query_text(self, domain: str, query_name: str) -> str:
+        """Return a required direct-domain query for SQLite."""
+        query_text = get_data_dictionary_loader().get_domain_query_text(type(self).dialect, domain, query_name)
+        if query_text is None:
+            msg = f"Missing SQLite data-dictionary query: {domain}/{query_name}"
+            raise RuntimeError(msg)
+        return query_text
+
+
+def _sqlite_index_rows_to_metadata(rows: "list[dict[str, Any]]", schema_name: "str | None") -> "list[IndexMetadata]":
+    """Group SQLite index_xinfo rows into the public index metadata shape."""
+    if not rows:
+        return []
+    first_row = rows[0]
+    if "columns" in first_row:
+        return cast("list[IndexMetadata]", rows)
+
+    grouped: dict[tuple[str | None, str, str], dict[str, Any]] = {}
+    for row in rows:
+        table_name_value = row.get("table_name")
+        index_name_value = row.get("index_name")
+        if table_name_value is None or index_name_value is None:
+            continue
+        row_schema = cast("str | None", row.get("schema_name", schema_name))
+        table_name = str(table_name_value)
+        index_name = str(index_name_value)
+        key = (row_schema, table_name, index_name)
+        index_metadata = grouped.get(key)
+        if index_metadata is None:
+            index_metadata = {
+                "index_name": index_name,
+                "table_name": table_name,
+                "columns": [],
+                "is_primary": bool(row.get("is_primary")),
+            }
+            if row_schema is not None:
+                index_metadata["schema_name"] = row_schema
+            unique_value = row.get("is_unique")
+            if unique_value is not None:
+                index_metadata["is_unique"] = unique_value
+            if row.get("is_partial") is not None:
+                index_metadata["is_partial"] = row.get("is_partial")
+            if row.get("index_sql") is not None:
+                index_metadata["native_sql"] = row.get("index_sql")
+            grouped[key] = index_metadata
+
+        if row.get("is_key_column") in (0, False):
+            continue
+        columns = cast("list[str]", index_metadata["columns"])
+        column_name = row.get("column_name")
+        if column_name is not None:
+            columns.append(str(column_name))
+        elif row.get("column_id") == SQLITE_INDEX_EXPRESSION_COLUMN_ID:
+            columns.append("<expression>")
+
+    return [cast("IndexMetadata", metadata) for metadata in grouped.values()]

--- a/sqlspec/adapters/duckdb/data_dictionary.py
+++ b/sqlspec/adapters/duckdb/data_dictionary.py
@@ -1,10 +1,21 @@
 """DuckDB-specific data dictionary for metadata queries."""
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from mypy_extensions import mypyc_attr
 
-from sqlspec.data_dictionary import ColumnMetadata, ForeignKeyMetadata, IndexMetadata, TableMetadata, VersionInfo
+from sqlspec.data_dictionary import (
+    ColumnMetadata,
+    DependencyMetadata,
+    ForeignKeyMetadata,
+    IndexMetadata,
+    MetadataResult,
+    MetadataSource,
+    ObjectIdentity,
+    TableMetadata,
+    VersionInfo,
+    get_data_dictionary_loader,
+)
 from sqlspec.driver import SyncDataDictionaryBase
 
 if TYPE_CHECKING:
@@ -91,12 +102,15 @@ class DuckDBDataDictionary(SyncDataDictionaryBase):
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="columns")
             return driver.select(
-                self.get_query("columns_by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
+                self._get_domain_query_text("columns", "by_schema"), schema_name=schema_name, schema_type=ColumnMetadata
             )
 
         self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="columns")
         return driver.select(
-            self.get_query("columns_by_table"), table_name=table, schema_name=schema_name, schema_type=ColumnMetadata
+            self._get_domain_query_text("columns", "by_table"),
+            table_name=table,
+            schema_name=schema_name,
+            schema_type=ColumnMetadata,
         )
 
     def get_indexes(
@@ -106,14 +120,14 @@ class DuckDBDataDictionary(SyncDataDictionaryBase):
         schema_name = self.resolve_schema(schema)
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="indexes")
-            return driver.select(
-                self.get_query("indexes_by_schema"), schema_name=schema_name, schema_type=IndexMetadata
-            )
+            rows = driver.select(self._get_domain_query_text("indexes", "by_schema"), schema_name=schema_name)
+            return _duckdb_index_rows_to_metadata(rows)
 
         self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="indexes")
-        return driver.select(
-            self.get_query("indexes_by_table"), table_name=table, schema_name=schema_name, schema_type=IndexMetadata
+        rows = driver.select(
+            self._get_domain_query_text("indexes", "by_table"), table_name=table, schema_name=schema_name
         )
+        return _duckdb_index_rows_to_metadata(rows)
 
     def get_foreign_keys(
         self, driver: "DuckDBDriver", table: "str | None" = None, schema: "str | None" = None
@@ -133,3 +147,81 @@ class DuckDBDataDictionary(SyncDataDictionaryBase):
             schema_name=schema_name,
             schema_type=ForeignKeyMetadata,
         )
+
+    def get_dependencies(
+        self, driver: "DuckDBDriver", object_name: "str | None" = None, schema: "str | None" = None
+    ) -> "MetadataResult":
+        """Get DuckDB object dependency metadata from duckdb_dependencies()."""
+        schema_name = self.resolve_schema(schema)
+        self._log_schema_introspect(driver, schema_name=schema_name, table_name=object_name, operation="dependencies")
+        rows = driver.select(self._get_domain_query_text("dependencies", "by_schema"), schema_name=schema_name)
+        items: list[DependencyMetadata] = []
+        for row in rows:
+            if (
+                object_name is not None
+                and row.get("object_name") != object_name
+                and row.get("referenced_object_name") != object_name
+            ):
+                continue
+            name = str(row.get("object_name") or row.get("objid") or "dependency")
+            object_type = str(row.get("object_type") or "dependency")
+            identity = ObjectIdentity(
+                name=name,
+                object_type=object_type,
+                schema=cast("str | None", row.get("schema_name", schema_name)),
+                dialect=type(self).dialect,
+                source=MetadataSource.CATALOG,
+            )
+            items.append(DependencyMetadata(identity, attributes=dict(row)))
+        return MetadataResult("dependencies", items=tuple(items))
+
+    def _get_domain_query_text(self, domain: str, query_name: str) -> str:
+        """Return a required direct-domain query for DuckDB."""
+        query_text = get_data_dictionary_loader().get_domain_query_text(type(self).dialect, domain, query_name)
+        if query_text is None:
+            msg = f"Missing DuckDB data-dictionary query: {domain}/{query_name}"
+            raise RuntimeError(msg)
+        return query_text
+
+
+def _duckdb_index_rows_to_metadata(rows: "list[dict[str, Any]]") -> "list[IndexMetadata]":
+    """Normalize duckdb_indexes() rows into the public index metadata shape."""
+    indexes: list[IndexMetadata] = []
+    for row in rows:
+        index_name = row.get("index_name")
+        table_name = row.get("table_name")
+        if index_name is None or table_name is None:
+            continue
+        index_metadata: dict[str, Any] = {
+            "index_name": str(index_name),
+            "table_name": str(table_name),
+            "columns": _duckdb_index_columns(row.get("columns")),
+            "is_unique": bool(row.get("is_unique")),
+            "is_primary": bool(row.get("is_primary")),
+        }
+        schema_name = row.get("schema_name")
+        if schema_name is not None:
+            index_metadata["schema_name"] = str(schema_name)
+        native_sql = row.get("native_sql")
+        if native_sql is not None:
+            index_metadata["native_sql"] = native_sql
+        indexes.append(cast("IndexMetadata", index_metadata))
+    return indexes
+
+
+def _duckdb_index_columns(value: Any) -> list[str]:
+    """Return a stable list from duckdb_indexes().expressions."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    if isinstance(value, tuple):
+        return [str(item) for item in value]
+    if not isinstance(value, str):
+        return [str(value)]
+    cleaned = value.strip()
+    if cleaned.startswith("[") and cleaned.endswith("]"):
+        cleaned = cleaned[1:-1].strip()
+    if not cleaned:
+        return []
+    return [part.strip().strip('"') for part in cleaned.split(",")]

--- a/sqlspec/adapters/sqlite/data_dictionary.py
+++ b/sqlspec/adapters/sqlite/data_dictionary.py
@@ -1,6 +1,6 @@
 """SQLite-specific data dictionary for metadata queries."""
 
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from mypy_extensions import mypyc_attr
 
@@ -11,6 +11,7 @@ from sqlspec.data_dictionary import (
     IndexMetadata,
     TableMetadata,
     VersionInfo,
+    get_data_dictionary_loader,
     get_dialect_config,
 )
 from sqlspec.data_dictionary.dialects.sqlite import list_sqlite_available_features, resolve_sqlite_json_type
@@ -20,6 +21,8 @@ if TYPE_CHECKING:
     from sqlspec.adapters.sqlite.driver import SqliteDriver
 
 __all__ = ("SqliteDataDictionary",)
+
+SQLITE_INDEX_EXPRESSION_COLUMN_ID = -2
 
 
 @mypyc_attr(allow_interpreted_subclasses=True, native_class=False)
@@ -108,9 +111,8 @@ class SqliteDataDictionary(SyncDataDictionaryBase):
         """Get tables sorted by topological dependency order using SQLite catalog."""
         schema_name = self.resolve_schema(schema)
         self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="tables")
-        schema_prefix = f"{format_identifier(schema_name)}." if schema_name else ""
-        query_text = self.get_query_text("tables_by_schema").format(schema_prefix=schema_prefix)
-        return driver.select(query_text, schema_type=TableMetadata)
+        query_text = self._get_domain_query_text("tables", "by_schema")
+        return driver.select(query_text, schema_name=schema_name, schema_type=TableMetadata)
 
     def get_columns(
         self, driver: "SqliteDriver", table: "str | None" = None, schema: "str | None" = None
@@ -120,80 +122,98 @@ class SqliteDataDictionary(SyncDataDictionaryBase):
         schema_prefix = f"{format_identifier(schema_name)}." if schema_name else ""
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="columns")
-            query_text = self.get_query_text("columns_by_schema").format(schema_prefix=schema_prefix)
-            return driver.select(query_text, schema_type=ColumnMetadata)
+            query_text = self._get_domain_query_text("columns", "by_schema").format(schema_prefix=schema_prefix)
+            return driver.select(query_text, schema_name=schema_name, schema_type=ColumnMetadata)
 
         self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="columns")
-        table_name = table
-        table_identifier = f"{schema_name}.{table_name}" if schema_name else table_name
-        query_text = self.get_query_text("columns_by_table").format(table_name=format_identifier(table_identifier))
-        return driver.select(query_text, schema_type=ColumnMetadata)
+        query_text = self._get_domain_query_text("columns", "by_table").format(schema_prefix=schema_prefix)
+        return driver.select(query_text, table_name=table, schema_name=schema_name, schema_type=ColumnMetadata)
 
     def get_indexes(
         self, driver: "SqliteDriver", table: "str | None" = None, schema: "str | None" = None
     ) -> "list[IndexMetadata]":
         """Get index metadata for a table or schema."""
         schema_name = self.resolve_schema(schema)
-        indexes: list[IndexMetadata] = []
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="indexes")
-            for table_info in self.get_tables(driver, schema=schema_name):
-                table_name = table_info.get("table_name")
-                if not table_name:
-                    continue
-                indexes.extend(self.get_indexes(driver, table=table_name, schema=schema_name))
-            return indexes
+            schema_prefix = f"{format_identifier(schema_name)}." if schema_name else ""
+            query_text = self._get_domain_query_text("indexes", "by_schema").format(schema_prefix=schema_prefix)
+            rows = driver.select(query_text, schema_name=schema_name)
+            return _sqlite_index_rows_to_metadata(rows, schema_name)
 
         self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="indexes")
-        table_name = table
-        table_identifier = f"{schema_name}.{table_name}" if schema_name else table_name
-        index_list_sql = self.get_query_text("indexes_by_table").format(table_name=format_identifier(table_identifier))
-        index_rows = driver.select(index_list_sql)
-        for row in index_rows:
-            index_name = row.get("name")
-            if not index_name:
-                continue
-            index_identifier = f"{schema_name}.{index_name}" if schema_name else index_name
-            columns_sql = self.get_query_text("index_columns_by_index").format(
-                index_name=format_identifier(index_identifier)
-            )
-            columns_rows = driver.select(columns_sql)
-            columns: list[str] = []
-            for col in columns_rows:
-                column_name = col.get("name")
-                if column_name is None:
-                    continue
-                columns.append(str(column_name))
-            is_primary = row.get("origin") == "pk"
-            index_metadata: IndexMetadata = {
-                "index_name": index_name,
-                "table_name": table_name,
-                "columns": columns,
-                "is_primary": is_primary,
-            }
-            if schema_name is not None:
-                index_metadata["schema_name"] = schema_name
-            unique_value = row.get("unique")
-            if unique_value is not None:
-                index_metadata["is_unique"] = unique_value
-            indexes.append(index_metadata)
-        return indexes
+        schema_prefix = f"{format_identifier(schema_name)}." if schema_name else ""
+        query_text = self._get_domain_query_text("indexes", "by_table").format(schema_prefix=schema_prefix)
+        rows = driver.select(query_text, table_name=table, schema_name=schema_name)
+        return _sqlite_index_rows_to_metadata(rows, schema_name)
 
     def get_foreign_keys(
         self, driver: "SqliteDriver", table: "str | None" = None, schema: "str | None" = None
     ) -> "list[ForeignKeyMetadata]":
         """Get foreign key metadata."""
         schema_name = self.resolve_schema(schema)
-        schema_prefix = f"{format_identifier(schema_name)}." if schema_name else ""
         if table is None:
             self._log_schema_introspect(driver, schema_name=schema_name, table_name=None, operation="foreign_keys")
-            query_text = self.get_query_text("foreign_keys_by_schema").format(schema_prefix=schema_prefix)
-            return driver.select(query_text, schema_type=ForeignKeyMetadata)
+            query_text = self._get_domain_query_text("constraints", "foreign_keys_by_schema")
+            return driver.select(query_text, schema_name=schema_name, schema_type=ForeignKeyMetadata)
 
         self._log_table_describe(driver, schema_name=schema_name, table_name=table, operation="foreign_keys")
-        table_label = table.replace("'", "''")
-        table_identifier = f"{schema_name}.{table}" if schema_name else table
-        query_text = self.get_query_text("foreign_keys_by_table").format(
-            table_name=format_identifier(table_identifier), table_label=table_label
-        )
-        return driver.select(query_text, schema_type=ForeignKeyMetadata)
+        query_text = self._get_domain_query_text("constraints", "foreign_keys_by_table")
+        return driver.select(query_text, table_name=table, schema_name=schema_name, schema_type=ForeignKeyMetadata)
+
+    def _get_domain_query_text(self, domain: str, query_name: str) -> str:
+        """Return a required direct-domain query for SQLite."""
+        query_text = get_data_dictionary_loader().get_domain_query_text(type(self).dialect, domain, query_name)
+        if query_text is None:
+            msg = f"Missing SQLite data-dictionary query: {domain}/{query_name}"
+            raise RuntimeError(msg)
+        return query_text
+
+
+def _sqlite_index_rows_to_metadata(rows: "list[dict[str, Any]]", schema_name: "str | None") -> "list[IndexMetadata]":
+    """Group SQLite index_xinfo rows into the public index metadata shape."""
+    if not rows:
+        return []
+    first_row = rows[0]
+    if "columns" in first_row:
+        return cast("list[IndexMetadata]", rows)
+
+    grouped: dict[tuple[str | None, str, str], dict[str, Any]] = {}
+    for row in rows:
+        table_name_value = row.get("table_name")
+        index_name_value = row.get("index_name")
+        if table_name_value is None or index_name_value is None:
+            continue
+        row_schema = cast("str | None", row.get("schema_name", schema_name))
+        table_name = str(table_name_value)
+        index_name = str(index_name_value)
+        key = (row_schema, table_name, index_name)
+        index_metadata = grouped.get(key)
+        if index_metadata is None:
+            index_metadata = {
+                "index_name": index_name,
+                "table_name": table_name,
+                "columns": [],
+                "is_primary": bool(row.get("is_primary")),
+            }
+            if row_schema is not None:
+                index_metadata["schema_name"] = row_schema
+            unique_value = row.get("is_unique")
+            if unique_value is not None:
+                index_metadata["is_unique"] = unique_value
+            if row.get("is_partial") is not None:
+                index_metadata["is_partial"] = row.get("is_partial")
+            if row.get("index_sql") is not None:
+                index_metadata["native_sql"] = row.get("index_sql")
+            grouped[key] = index_metadata
+
+        if row.get("is_key_column") in (0, False):
+            continue
+        columns = cast("list[str]", index_metadata["columns"])
+        column_name = row.get("column_name")
+        if column_name is not None:
+            columns.append(str(column_name))
+        elif row.get("column_id") == SQLITE_INDEX_EXPRESSION_COLUMN_ID:
+            columns.append("<expression>")
+
+    return [cast("IndexMetadata", metadata) for metadata in grouped.values()]

--- a/sqlspec/data_dictionary/sql/duckdb/columns/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/duckdb/columns/by_schema.sql
@@ -1,0 +1,20 @@
+-- name: by_schema
+-- dialect: duckdb
+SELECT
+    database_name,
+    schema_name,
+    table_name,
+    column_name,
+    column_index AS ordinal_position,
+    data_type,
+    is_nullable,
+    column_default,
+    character_maximum_length AS max_length,
+    numeric_precision,
+    numeric_scale,
+    comment,
+    internal
+FROM duckdb_columns()
+WHERE schema_name = COALESCE(:schema_name, current_schema())
+  AND NOT internal
+ORDER BY table_name, column_index;

--- a/sqlspec/data_dictionary/sql/duckdb/columns/by_table.sql
+++ b/sqlspec/data_dictionary/sql/duckdb/columns/by_table.sql
@@ -1,0 +1,21 @@
+-- name: by_table
+-- dialect: duckdb
+SELECT
+    database_name,
+    schema_name,
+    table_name,
+    column_name,
+    column_index AS ordinal_position,
+    data_type,
+    is_nullable,
+    column_default,
+    character_maximum_length AS max_length,
+    numeric_precision,
+    numeric_scale,
+    comment,
+    internal
+FROM duckdb_columns()
+WHERE schema_name = COALESCE(:schema_name, current_schema())
+  AND table_name = :table_name
+  AND NOT internal
+ORDER BY column_index;

--- a/sqlspec/data_dictionary/sql/duckdb/constraints/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/duckdb/constraints/by_schema.sql
@@ -1,0 +1,16 @@
+-- name: by_schema
+-- dialect: duckdb
+SELECT
+    database_name,
+    schema_name,
+    table_name,
+    constraint_name,
+    constraint_type,
+    constraint_text,
+    expression,
+    constraint_column_names,
+    referenced_table,
+    referenced_column_names
+FROM duckdb_constraints()
+WHERE schema_name = COALESCE(:schema_name, current_schema())
+ORDER BY table_name, constraint_index;

--- a/sqlspec/data_dictionary/sql/duckdb/constraints/by_table.sql
+++ b/sqlspec/data_dictionary/sql/duckdb/constraints/by_table.sql
@@ -1,0 +1,17 @@
+-- name: by_table
+-- dialect: duckdb
+SELECT
+    database_name,
+    schema_name,
+    table_name,
+    constraint_name,
+    constraint_type,
+    constraint_text,
+    expression,
+    constraint_column_names,
+    referenced_table,
+    referenced_column_names
+FROM duckdb_constraints()
+WHERE schema_name = COALESCE(:schema_name, current_schema())
+  AND table_name = :table_name
+ORDER BY constraint_index;

--- a/sqlspec/data_dictionary/sql/duckdb/databases/list.sql
+++ b/sqlspec/data_dictionary/sql/duckdb/databases/list.sql
@@ -1,0 +1,11 @@
+-- name: list
+-- dialect: duckdb
+SELECT
+    database_name,
+    path,
+    type,
+    readonly,
+    internal
+FROM duckdb_databases()
+WHERE NOT internal
+ORDER BY database_name;

--- a/sqlspec/data_dictionary/sql/duckdb/dependencies/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/duckdb/dependencies/by_schema.sql
@@ -1,0 +1,50 @@
+-- name: by_schema
+-- dialect: duckdb
+WITH object_inventory AS (
+    SELECT
+        database_name,
+        schema_name,
+        table_oid AS object_oid,
+        table_name AS object_name,
+        'table' AS object_type
+    FROM duckdb_tables()
+    WHERE schema_name = COALESCE(:schema_name, current_schema())
+    UNION ALL
+    SELECT
+        database_name,
+        schema_name,
+        index_oid AS object_oid,
+        index_name AS object_name,
+        'index' AS object_type
+    FROM duckdb_indexes()
+    WHERE schema_name = COALESCE(:schema_name, current_schema())
+    UNION ALL
+    SELECT
+        database_name,
+        schema_name,
+        view_oid AS object_oid,
+        view_name AS object_name,
+        'view' AS object_type
+    FROM duckdb_views()
+    WHERE schema_name = COALESCE(:schema_name, current_schema())
+)
+SELECT
+    dependent.database_name,
+    dependent.schema_name,
+    dependent.object_name,
+    dependent.object_type,
+    referenced.object_name AS referenced_object_name,
+    referenced.object_type AS referenced_object_type,
+    dep.classid,
+    dep.objid,
+    dep.objsubid,
+    dep.refclassid,
+    dep.refobjid,
+    dep.refobjsubid,
+    dep.deptype
+FROM duckdb_dependencies() AS dep
+LEFT JOIN object_inventory AS dependent ON dependent.object_oid = dep.objid
+LEFT JOIN object_inventory AS referenced ON referenced.object_oid = dep.refobjid
+WHERE dependent.object_oid IS NOT NULL
+   OR referenced.object_oid IS NOT NULL
+ORDER BY dependent.object_type, dependent.object_name, referenced.object_type, referenced.object_name;

--- a/sqlspec/data_dictionary/sql/duckdb/extensions/list.sql
+++ b/sqlspec/data_dictionary/sql/duckdb/extensions/list.sql
@@ -1,0 +1,14 @@
+-- name: list
+-- dialect: duckdb
+SELECT
+    extension_name,
+    loaded,
+    installed,
+    install_path,
+    description,
+    aliases,
+    extension_version,
+    install_mode,
+    installed_from
+FROM duckdb_extensions()
+ORDER BY extension_name;

--- a/sqlspec/data_dictionary/sql/duckdb/functions/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/duckdb/functions/by_schema.sql
@@ -1,0 +1,18 @@
+-- name: by_schema
+-- dialect: duckdb
+SELECT
+    database_name,
+    schema_name,
+    function_name,
+    function_type,
+    return_type,
+    parameters,
+    parameter_types,
+    macro_definition,
+    has_side_effects,
+    internal,
+    comment,
+    tags
+FROM duckdb_functions()
+WHERE schema_name = COALESCE(:schema_name, current_schema())
+ORDER BY function_type, function_name;

--- a/sqlspec/data_dictionary/sql/duckdb/indexes/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/duckdb/indexes/by_schema.sql
@@ -1,0 +1,16 @@
+-- name: by_schema
+-- dialect: duckdb
+SELECT
+    database_name,
+    schema_name,
+    table_name,
+    index_name,
+    is_unique,
+    is_primary,
+    expressions AS columns,
+    comment,
+    tags,
+    sql AS native_sql
+FROM duckdb_indexes()
+WHERE schema_name = COALESCE(:schema_name, current_schema())
+ORDER BY table_name, index_name;

--- a/sqlspec/data_dictionary/sql/duckdb/indexes/by_table.sql
+++ b/sqlspec/data_dictionary/sql/duckdb/indexes/by_table.sql
@@ -1,0 +1,17 @@
+-- name: by_table
+-- dialect: duckdb
+SELECT
+    database_name,
+    schema_name,
+    table_name,
+    index_name,
+    is_unique,
+    is_primary,
+    expressions AS columns,
+    comment,
+    tags,
+    sql AS native_sql
+FROM duckdb_indexes()
+WHERE schema_name = COALESCE(:schema_name, current_schema())
+  AND table_name = :table_name
+ORDER BY index_name;

--- a/sqlspec/data_dictionary/sql/duckdb/objects/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/duckdb/objects/by_schema.sql
@@ -1,0 +1,30 @@
+-- name: by_schema
+-- dialect: duckdb
+SELECT
+    database_name,
+    schema_name,
+    table_name AS object_name,
+    'table' AS object_type,
+    comment,
+    tags,
+    internal,
+    temporary,
+    sql AS native_sql
+FROM duckdb_tables()
+WHERE schema_name = COALESCE(:schema_name, current_schema())
+  AND NOT internal
+UNION ALL
+SELECT
+    database_name,
+    schema_name,
+    view_name AS object_name,
+    'view' AS object_type,
+    comment,
+    tags,
+    internal,
+    temporary,
+    sql AS native_sql
+FROM duckdb_views()
+WHERE schema_name = COALESCE(:schema_name, current_schema())
+  AND NOT internal
+ORDER BY object_type, object_name;

--- a/sqlspec/data_dictionary/sql/duckdb/schemas/list.sql
+++ b/sqlspec/data_dictionary/sql/duckdb/schemas/list.sql
@@ -1,0 +1,10 @@
+-- name: list
+-- dialect: duckdb
+SELECT
+    database_name,
+    schema_name,
+    internal,
+    sql AS native_sql
+FROM duckdb_schemas()
+WHERE NOT internal
+ORDER BY database_name, schema_name;

--- a/sqlspec/data_dictionary/sql/duckdb/sequences/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/duckdb/sequences/by_schema.sql
@@ -1,0 +1,19 @@
+-- name: by_schema
+-- dialect: duckdb
+SELECT
+    database_name,
+    schema_name,
+    sequence_name,
+    temporary,
+    start_value,
+    min_value,
+    max_value,
+    increment_by,
+    cycle,
+    last_value,
+    comment,
+    tags,
+    sql AS native_sql
+FROM duckdb_sequences()
+WHERE schema_name = COALESCE(:schema_name, current_schema())
+ORDER BY sequence_name;

--- a/sqlspec/data_dictionary/sql/duckdb/system/logs.sql
+++ b/sqlspec/data_dictionary/sql/duckdb/system/logs.sql
@@ -1,0 +1,4 @@
+-- name: logs
+-- dialect: duckdb
+SELECT *
+FROM duckdb_logs();

--- a/sqlspec/data_dictionary/sql/duckdb/system/memory.sql
+++ b/sqlspec/data_dictionary/sql/duckdb/system/memory.sql
@@ -1,0 +1,4 @@
+-- name: memory
+-- dialect: duckdb
+SELECT *
+FROM duckdb_memory();

--- a/sqlspec/data_dictionary/sql/duckdb/system/settings.sql
+++ b/sqlspec/data_dictionary/sql/duckdb/system/settings.sql
@@ -1,0 +1,11 @@
+-- name: settings
+-- dialect: duckdb
+SELECT
+    name,
+    value,
+    description,
+    input_type,
+    scope,
+    aliases
+FROM duckdb_settings()
+ORDER BY name;

--- a/sqlspec/data_dictionary/sql/duckdb/views/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/duckdb/views/by_schema.sql
@@ -1,0 +1,15 @@
+-- name: by_schema
+-- dialect: duckdb
+SELECT
+    database_name,
+    schema_name,
+    view_name,
+    comment,
+    tags,
+    internal,
+    temporary,
+    sql AS native_sql
+FROM duckdb_views()
+WHERE schema_name = COALESCE(:schema_name, current_schema())
+  AND NOT internal
+ORDER BY view_name;

--- a/sqlspec/data_dictionary/sql/sqlite/columns/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/sqlite/columns/by_schema.sql
@@ -1,0 +1,22 @@
+-- name: by_schema
+-- dialect: sqlite
+SELECT
+    tl.schema AS schema_name,
+    tl.name AS table_name,
+    ti.name AS column_name,
+    ti.type AS data_type,
+    CASE WHEN ti."notnull" THEN 'NO' ELSE 'YES' END AS is_nullable,
+    ti.dflt_value AS column_default,
+    ti.cid + 1 AS ordinal_position,
+    ti.pk AS is_primary,
+    CASE
+        WHEN ti.hidden = 1 THEN 'hidden'
+        WHEN ti.hidden IN (2, 3) THEN 'generated'
+        ELSE NULL
+    END AS extra
+FROM pragma_table_list AS tl
+JOIN pragma_table_xinfo(tl.name, COALESCE(:schema_name, 'main')) AS ti
+WHERE tl.schema = COALESCE(:schema_name, 'main')
+  AND tl.type IN ('table', 'virtual')
+  AND tl.name NOT LIKE 'sqlite_%'
+ORDER BY tl.name, ti.cid;

--- a/sqlspec/data_dictionary/sql/sqlite/columns/by_table.sql
+++ b/sqlspec/data_dictionary/sql/sqlite/columns/by_table.sql
@@ -1,0 +1,18 @@
+-- name: by_table
+-- dialect: sqlite
+SELECT
+    :schema_name AS schema_name,
+    :table_name AS table_name,
+    ti.name AS column_name,
+    ti.type AS data_type,
+    CASE WHEN ti."notnull" THEN 'NO' ELSE 'YES' END AS is_nullable,
+    ti.dflt_value AS column_default,
+    ti.cid + 1 AS ordinal_position,
+    ti.pk AS is_primary,
+    CASE
+        WHEN ti.hidden = 1 THEN 'hidden'
+        WHEN ti.hidden IN (2, 3) THEN 'generated'
+        ELSE NULL
+    END AS extra
+FROM pragma_table_xinfo(:table_name, :schema_name) AS ti
+ORDER BY ti.cid;

--- a/sqlspec/data_dictionary/sql/sqlite/compile_options/list.sql
+++ b/sqlspec/data_dictionary/sql/sqlite/compile_options/list.sql
@@ -1,0 +1,3 @@
+-- name: list
+-- dialect: sqlite
+PRAGMA compile_options;

--- a/sqlspec/data_dictionary/sql/sqlite/constraints/foreign_keys_by_schema.sql
+++ b/sqlspec/data_dictionary/sql/sqlite/constraints/foreign_keys_by_schema.sql
@@ -1,0 +1,19 @@
+-- name: foreign_keys_by_schema
+-- dialect: sqlite
+SELECT
+    tl.schema AS schema_name,
+    tl.name AS table_name,
+    fk."from" AS column_name,
+    fk."table" AS referenced_table_name,
+    fk."to" AS referenced_column_name,
+    fk.id AS constraint_name,
+    fk.seq AS ordinal_position,
+    fk.on_update,
+    fk.on_delete,
+    fk.match
+FROM pragma_table_list AS tl
+JOIN pragma_foreign_key_list(tl.name, COALESCE(:schema_name, 'main')) AS fk
+WHERE tl.schema = COALESCE(:schema_name, 'main')
+  AND tl.type IN ('table', 'virtual')
+  AND tl.name NOT LIKE 'sqlite_%'
+ORDER BY tl.name, fk.id, fk.seq;

--- a/sqlspec/data_dictionary/sql/sqlite/constraints/foreign_keys_by_table.sql
+++ b/sqlspec/data_dictionary/sql/sqlite/constraints/foreign_keys_by_table.sql
@@ -1,0 +1,15 @@
+-- name: foreign_keys_by_table
+-- dialect: sqlite
+SELECT
+    :schema_name AS schema_name,
+    :table_name AS table_name,
+    fk."from" AS column_name,
+    fk."table" AS referenced_table_name,
+    fk."to" AS referenced_column_name,
+    fk.id AS constraint_name,
+    fk.seq AS ordinal_position,
+    fk.on_update,
+    fk.on_delete,
+    fk.match
+FROM pragma_foreign_key_list(:table_name, :schema_name) AS fk
+ORDER BY fk.id, fk.seq;

--- a/sqlspec/data_dictionary/sql/sqlite/functions/list.sql
+++ b/sqlspec/data_dictionary/sql/sqlite/functions/list.sql
@@ -1,0 +1,3 @@
+-- name: list
+-- dialect: sqlite
+PRAGMA function_list;

--- a/sqlspec/data_dictionary/sql/sqlite/indexes/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/sqlite/indexes/by_schema.sql
@@ -1,0 +1,28 @@
+-- name: by_schema
+-- dialect: sqlite
+SELECT
+    tl.schema AS schema_name,
+    tl.name AS table_name,
+    il.name AS index_name,
+    il."unique" AS is_unique,
+    CASE WHEN il.origin = 'pk' THEN 1 ELSE 0 END AS is_primary,
+    il.origin,
+    il.partial AS is_partial,
+    ix.seqno,
+    ix.cid AS column_id,
+    ix.name AS column_name,
+    ix.desc AS is_descending,
+    ix.coll AS collation,
+    ix.key AS is_key_column,
+    sm.sql AS index_sql
+FROM pragma_table_list AS tl
+JOIN pragma_index_list(tl.name, COALESCE(:schema_name, 'main')) AS il
+JOIN pragma_index_xinfo(il.name, COALESCE(:schema_name, 'main')) AS ix
+LEFT JOIN {schema_prefix}sqlite_schema AS sm
+  ON sm.type = 'index'
+ AND sm.name = il.name
+WHERE tl.schema = COALESCE(:schema_name, 'main')
+  AND tl.type IN ('table', 'virtual')
+  AND tl.name NOT LIKE 'sqlite_%'
+  AND il.name NOT LIKE 'sqlite_%'
+ORDER BY tl.name, il.seq, ix.seqno;

--- a/sqlspec/data_dictionary/sql/sqlite/indexes/by_table.sql
+++ b/sqlspec/data_dictionary/sql/sqlite/indexes/by_table.sql
@@ -1,0 +1,24 @@
+-- name: by_table
+-- dialect: sqlite
+SELECT
+    :schema_name AS schema_name,
+    :table_name AS table_name,
+    il.name AS index_name,
+    il."unique" AS is_unique,
+    CASE WHEN il.origin = 'pk' THEN 1 ELSE 0 END AS is_primary,
+    il.origin,
+    il.partial AS is_partial,
+    ix.seqno,
+    ix.cid AS column_id,
+    ix.name AS column_name,
+    ix.desc AS is_descending,
+    ix.coll AS collation,
+    ix.key AS is_key_column,
+    sm.sql AS index_sql
+FROM pragma_index_list(:table_name, :schema_name) AS il
+JOIN pragma_index_xinfo(il.name, :schema_name) AS ix
+LEFT JOIN {schema_prefix}sqlite_schema AS sm
+  ON sm.type = 'index'
+ AND sm.name = il.name
+WHERE il.name NOT LIKE 'sqlite_%'
+ORDER BY il.seq, ix.seqno;

--- a/sqlspec/data_dictionary/sql/sqlite/indexes/columns_by_index.sql
+++ b/sqlspec/data_dictionary/sql/sqlite/indexes/columns_by_index.sql
@@ -1,0 +1,13 @@
+-- name: columns_by_index
+-- dialect: sqlite
+SELECT
+    :schema_name AS schema_name,
+    :index_name AS index_name,
+    ix.seqno,
+    ix.cid AS column_id,
+    ix.name AS column_name,
+    ix.desc AS is_descending,
+    ix.coll AS collation,
+    ix.key AS is_key_column
+FROM pragma_index_xinfo(:index_name, :schema_name) AS ix
+ORDER BY ix.seqno;

--- a/sqlspec/data_dictionary/sql/sqlite/modules/list.sql
+++ b/sqlspec/data_dictionary/sql/sqlite/modules/list.sql
@@ -1,0 +1,3 @@
+-- name: list
+-- dialect: sqlite
+PRAGMA module_list;

--- a/sqlspec/data_dictionary/sql/sqlite/native_sql/by_object.sql
+++ b/sqlspec/data_dictionary/sql/sqlite/native_sql/by_object.sql
@@ -1,0 +1,10 @@
+-- name: by_object
+-- dialect: sqlite
+SELECT
+    :schema_name AS schema_name,
+    name AS object_name,
+    type AS object_type,
+    sql AS native_sql
+FROM {schema_prefix}sqlite_schema
+WHERE name = :object_name
+  AND (:object_type IS NULL OR type = :object_type);

--- a/sqlspec/data_dictionary/sql/sqlite/objects/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/sqlite/objects/by_schema.sql
@@ -1,0 +1,13 @@
+-- name: by_schema
+-- dialect: sqlite
+SELECT
+    :schema_name AS schema_name,
+    name AS object_name,
+    type AS object_type,
+    tbl_name AS table_name,
+    rootpage,
+    sql AS native_sql
+FROM {schema_prefix}sqlite_schema
+WHERE type IN ('table', 'index', 'view', 'trigger')
+  AND name NOT LIKE 'sqlite_%'
+ORDER BY type, name;

--- a/sqlspec/data_dictionary/sql/sqlite/schemas/database_list.sql
+++ b/sqlspec/data_dictionary/sql/sqlite/schemas/database_list.sql
@@ -1,0 +1,3 @@
+-- name: database_list
+-- dialect: sqlite
+PRAGMA database_list;

--- a/sqlspec/data_dictionary/sql/sqlite/system/foreign_key_check.sql
+++ b/sqlspec/data_dictionary/sql/sqlite/system/foreign_key_check.sql
@@ -1,0 +1,3 @@
+-- name: foreign_key_check
+-- dialect: sqlite
+PRAGMA foreign_key_check;

--- a/sqlspec/data_dictionary/sql/sqlite/system/integrity_check.sql
+++ b/sqlspec/data_dictionary/sql/sqlite/system/integrity_check.sql
@@ -1,0 +1,3 @@
+-- name: integrity_check
+-- dialect: sqlite
+PRAGMA integrity_check;

--- a/sqlspec/data_dictionary/sql/sqlite/tables/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/sqlite/tables/by_schema.sql
@@ -1,0 +1,49 @@
+-- name: by_schema
+-- dialect: sqlite
+WITH table_inventory AS (
+    SELECT
+        tl.schema AS schema_name,
+        tl.name AS table_name,
+        tl.type AS table_type,
+        tl.ncol,
+        tl.wr,
+        tl.strict
+    FROM pragma_table_list AS tl
+    WHERE tl.schema = COALESCE(:schema_name, 'main')
+      AND tl.type IN ('table', 'virtual')
+      AND tl.name NOT LIKE 'sqlite_%'
+),
+dependency_tree AS (
+    SELECT
+        ti.table_name,
+        0 AS level,
+        '/' || ti.table_name || '/' AS path
+    FROM table_inventory AS ti
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM pragma_foreign_key_list(ti.table_name, COALESCE(:schema_name, 'main'))
+    )
+
+    UNION ALL
+
+    SELECT
+        ti.table_name,
+        dt.level + 1,
+        dt.path || ti.table_name || '/'
+    FROM table_inventory AS ti
+    JOIN pragma_foreign_key_list(ti.table_name, COALESCE(:schema_name, 'main')) AS fk
+    JOIN dependency_tree AS dt ON fk."table" = dt.table_name
+    WHERE instr(dt.path, '/' || ti.table_name || '/') = 0
+)
+SELECT DISTINCT
+    ti.schema_name,
+    ti.table_name,
+    ti.table_type,
+    COALESCE(dt.level, 0) AS dependency_level,
+    COALESCE(dt.level, 0) AS level,
+    ti.ncol,
+    ti.wr,
+    ti.strict
+FROM table_inventory AS ti
+LEFT JOIN dependency_tree AS dt ON dt.table_name = ti.table_name
+ORDER BY COALESCE(dt.level, 0), ti.table_name;

--- a/sqlspec/data_dictionary/sql/sqlite/triggers/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/sqlite/triggers/by_schema.sql
@@ -1,0 +1,10 @@
+-- name: by_schema
+-- dialect: sqlite
+SELECT
+    :schema_name AS schema_name,
+    name AS trigger_name,
+    tbl_name AS table_name,
+    sql AS native_sql
+FROM {schema_prefix}sqlite_schema
+WHERE type = 'trigger'
+ORDER BY name;

--- a/sqlspec/data_dictionary/sql/sqlite/views/by_schema.sql
+++ b/sqlspec/data_dictionary/sql/sqlite/views/by_schema.sql
@@ -1,0 +1,10 @@
+-- name: by_schema
+-- dialect: sqlite
+SELECT
+    :schema_name AS schema_name,
+    name AS view_name,
+    tbl_name AS table_name,
+    sql AS native_sql
+FROM {schema_prefix}sqlite_schema
+WHERE type = 'view'
+ORDER BY name;

--- a/tests/unit/data_dictionary/test_sqlite_duckdb_metadata.py
+++ b/tests/unit/data_dictionary/test_sqlite_duckdb_metadata.py
@@ -1,0 +1,206 @@
+"""SQLite and DuckDB data-dictionary replacement metadata tests."""
+
+import sqlite3
+from typing import cast
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from sqlspec.adapters.aiosqlite.data_dictionary import AiosqliteDataDictionary
+from sqlspec.adapters.duckdb import DuckDBDriver
+from sqlspec.adapters.sqlite import SqliteDriver
+from sqlspec.adapters.sqlite.data_dictionary import SqliteDataDictionary
+from sqlspec.data_dictionary import DataDictionaryLoader, DependencyMetadata, MetadataSupport
+from tests.conftest import requires_interpreted
+
+pytestmark = requires_interpreted
+
+
+def test_direct_sqlite_duckdb_domain_query_packs_cover_c7_domains() -> None:
+    """C7 query packs should use direct dialect/domain paths without v2 namespaces."""
+    loader = DataDictionaryLoader()
+    expected_queries = (
+        ("sqlite", "schemas", "database_list"),
+        ("sqlite", "objects", "by_schema"),
+        ("sqlite", "tables", "by_schema"),
+        ("sqlite", "columns", "by_table"),
+        ("sqlite", "constraints", "foreign_keys_by_table"),
+        ("sqlite", "indexes", "by_schema"),
+        ("sqlite", "views", "by_schema"),
+        ("sqlite", "triggers", "by_schema"),
+        ("sqlite", "native_sql", "by_object"),
+        ("sqlite", "functions", "list"),
+        ("sqlite", "modules", "list"),
+        ("sqlite", "compile_options", "list"),
+        ("sqlite", "system", "integrity_check"),
+        ("duckdb", "schemas", "list"),
+        ("duckdb", "databases", "list"),
+        ("duckdb", "objects", "by_schema"),
+        ("duckdb", "columns", "by_schema"),
+        ("duckdb", "constraints", "by_schema"),
+        ("duckdb", "indexes", "by_schema"),
+        ("duckdb", "views", "by_schema"),
+        ("duckdb", "sequences", "by_schema"),
+        ("duckdb", "functions", "by_schema"),
+        ("duckdb", "dependencies", "by_schema"),
+        ("duckdb", "extensions", "list"),
+        ("duckdb", "system", "settings"),
+    )
+
+    for dialect, domain, name in expected_queries:
+        query = loader.get_domain_query(dialect, domain, name)
+        assert query.is_supported, f"{dialect}/{domain}/{name} should be present"
+        assert query.query_text is not None
+
+    assert loader.get_domain_query("sqlite", "comments", "by_schema").capability.support == MetadataSupport.UNSUPPORTED
+    assert (
+        loader.get_domain_query("sqlite", "privileges", "by_schema").capability.support == MetadataSupport.UNSUPPORTED
+    )
+    assert loader.get_domain_query("sqlite", "routines", "by_schema").capability.support == MetadataSupport.UNSUPPORTED
+    assert loader.get_domain_query("duckdb", "triggers", "by_schema").capability.support == MetadataSupport.UNSUPPORTED
+    assert (
+        loader.get_domain_query("duckdb", "privileges", "by_schema").capability.support == MetadataSupport.UNSUPPORTED
+    )
+
+
+def test_sqlite_table_xinfo_includes_generated_columns() -> None:
+    """SQLite column introspection should use table_xinfo, not table_info."""
+    connection = sqlite3.connect(":memory:")
+    connection.row_factory = sqlite3.Row
+    driver = SqliteDriver(connection)
+    try:
+        driver.execute_script("""
+            CREATE TABLE products (
+                id INTEGER PRIMARY KEY,
+                price INTEGER NOT NULL,
+                quantity INTEGER NOT NULL,
+                total INTEGER GENERATED ALWAYS AS (price * quantity) VIRTUAL
+            );
+        """)
+
+        columns = driver.data_dictionary.get_columns(driver, table="products")
+
+        columns_by_name = {column["column_name"]: column for column in columns}
+        assert {"id", "price", "quantity", "total"} <= set(columns_by_name)
+        assert columns_by_name["total"]["extra"] == "generated"
+    finally:
+        connection.close()
+
+
+def test_sqlite_schema_wide_index_lookup_is_batched() -> None:
+    """SQLite schema-wide index lookup should not recurse table-by-table."""
+    driver = Mock()
+    driver.select.return_value = [
+        {
+            "index_name": "idx_users_email",
+            "table_name": "users",
+            "columns": ["email"],
+            "is_primary": False,
+            "is_unique": 1,
+        }
+    ]
+
+    indexes = SqliteDataDictionary().get_indexes(driver)
+
+    assert indexes == driver.select.return_value
+    assert driver.select.call_count == 1
+    query_text = driver.select.call_args.args[0]
+    assert "pragma_index_xinfo" in query_text.lower()
+
+
+def test_sqlite_indexes_include_expression_partial_metadata() -> None:
+    """SQLite index introspection should preserve expression and partial-index metadata."""
+    connection = sqlite3.connect(":memory:")
+    connection.row_factory = sqlite3.Row
+    driver = SqliteDriver(connection)
+    try:
+        driver.execute_script("""
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY,
+                email TEXT
+            );
+            CREATE INDEX idx_users_email_expr
+                ON users((lower(email)) COLLATE NOCASE DESC)
+                WHERE email IS NOT NULL;
+        """)
+
+        indexes = driver.data_dictionary.get_indexes(driver, table="users")
+
+        index = next(index for index in indexes if index["index_name"] == "idx_users_email_expr")
+        index_details = cast("dict[str, object]", index)
+        assert index["columns"] == ["<expression>"]
+        assert index_details["is_partial"] == 1
+        assert "WHERE email IS NOT NULL" in str(index_details["native_sql"])
+    finally:
+        connection.close()
+
+
+async def test_aiosqlite_schema_wide_index_lookup_is_batched() -> None:
+    """aiosqlite should match SQLite schema-wide index batching."""
+    expected_indexes = [
+        {
+            "index_name": "idx_users_email",
+            "table_name": "users",
+            "columns": ["email"],
+            "is_primary": False,
+            "is_unique": 1,
+        }
+    ]
+    driver = Mock()
+    driver.select = AsyncMock(return_value=expected_indexes)
+
+    indexes = await AiosqliteDataDictionary().get_indexes(driver)
+
+    assert indexes == expected_indexes
+    assert driver.select.await_count == 1
+    query_text = driver.select.call_args.args[0]
+    assert "pragma_index_xinfo" in query_text.lower()
+
+
+def test_duckdb_explicit_indexes_not_empty() -> None:
+    """DuckDB should expose explicit indexes through duckdb_indexes()."""
+    duckdb = pytest.importorskip("duckdb")
+    connection = duckdb.connect(":memory:")
+    driver = DuckDBDriver(connection)
+    try:
+        driver.execute_script("""
+            CREATE SCHEMA app;
+            CREATE TABLE app.events (
+                id INTEGER PRIMARY KEY,
+                tenant_id INTEGER NOT NULL,
+                payload VARCHAR
+            );
+            CREATE INDEX idx_events_tenant ON app.events(tenant_id);
+        """)
+
+        indexes = driver.data_dictionary.get_indexes(driver, table="events", schema="app")
+
+        assert any(index["index_name"] == "idx_events_tenant" for index in indexes)
+        index = next(index for index in indexes if index["index_name"] == "idx_events_tenant")
+        assert index["table_name"] == "events"
+        assert index["columns"] == ["tenant_id"]
+        assert index["is_primary"] is False
+    finally:
+        connection.close()
+
+
+def test_duckdb_dependencies_from_duckdb_dependencies() -> None:
+    """DuckDB dependency metadata should be backed by duckdb_dependencies()."""
+    duckdb = pytest.importorskip("duckdb")
+    connection = duckdb.connect(":memory:")
+    driver = DuckDBDriver(connection)
+    try:
+        driver.execute_script("""
+            CREATE SCHEMA app;
+            CREATE TABLE app.parent (id INTEGER PRIMARY KEY);
+            CREATE TABLE app.child (id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES app.parent(id));
+            CREATE INDEX idx_child_parent ON app.child(parent_id);
+        """)
+
+        result = driver.data_dictionary.get_dependencies(driver, schema="app")
+
+        assert result.capability.support == MetadataSupport.SUPPORTED
+        assert result.items
+        assert any(isinstance(item, DependencyMetadata) and "deptype" in item.attributes for item in result.items)
+    finally:
+        connection.close()


### PR DESCRIPTION
## Summary

- add SQLite and DuckDB metadata query packs and adapter domain methods
- add DuckDB dependency metadata through duckdb_dependencies()
- add embedded database unit and contract coverage