### PR TITLE
docs(data-dictionary): add support matrix and migration guide

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,10 +17,15 @@ Unreleased
 * Began replacing the old narrow data-dictionary interface with a consistent
   metadata contract based on ``MetadataCapabilityProfile``,
   ``MetadataCapability``, ``MetadataResult``, ``ObjectIdentity``, and
-  ``DDLResult``. This is a pre-1.0 breaking change: adapter metadata
-  capabilities are preserved, but callers should migrate to the domain result
-  envelope and inspect capability status instead of treating empty lists as
-  unsupported metadata.
+  ``DDLResult``. This is a pre-1.0 breaking change: structural domain lookups
+  return result envelopes, object DDL lookups return ``DDLResult`` directly, and
+  callers should inspect capability or DDL status instead of treating empty
+  lists as unsupported metadata.
+
+**Docs:**
+
+* Expanded the data dictionary guide with capability vocabulary, support
+  matrix, DDL/dependency guidance, and safe system-metadata opt-in behavior.
 
 v0.54.0 - SQL processing correctness and cleanup
 ------------------------------------------------------------------------------

--- a/docs/reference/adapters/adbc.rst
+++ b/docs/reference/adapters/adbc.rst
@@ -248,6 +248,11 @@ SQLSpec does not define a portable SQL statistics contract. It wraps
 ``adbc_get_statistics`` directly; unsupported drivers raise
 :exc:`sqlspec.exceptions.OperationalError`.
 
+In the replacement data dictionary, ADBC statistics are also exposed through the
+opt-in system metadata namespace as transport metadata. This does not make ADBC
+a lossless DDL or dependency source; dialect query packs remain canonical for
+DDL-grade metadata.
+
 .. list-table:: ADBC native metadata support (driver manager 1.11.0)
    :header-rows: 1
 

--- a/docs/reference/driver.rst
+++ b/docs/reference/driver.rst
@@ -40,6 +40,16 @@ Asynchronous Driver
 Data Dictionary
 ===============
 
+The shared data dictionary base classes define the replacement metadata
+contract used by adapter-local dictionaries. User-facing examples and the
+support matrix live in :doc:`../usage/data_dictionary`. In short:
+
+- Structural metadata returns ``MetadataResult`` envelopes.
+- DDL lookups return ``DDLResult`` objects with fidelity and warning metadata.
+- Dependency ordering uses typed dependency edges rather than only table names.
+- System and performance metadata uses ``SystemMetadataRequest`` and
+  ``SystemMetadataResult`` in a separate opt-in namespace.
+
 .. autoclass:: DataDictionaryMixin
    :members:
    :undoc-members:

--- a/docs/usage/data_dictionary.rst
+++ b/docs/usage/data_dictionary.rst
@@ -2,74 +2,293 @@
 Data Dictionary
 ===============
 
-SQLSpec's data dictionary provides structured database metadata discovery
-across supported adapters. It reports what each adapter can inspect, returns
-capability details with every metadata lookup, and represents database objects
-with typed result models.
+The data dictionary is SQLSpec's database-introspection interface. Use it to ask
+a driver what metadata it can provide, then fetch schemas, objects, table
+details, constraints, indexes, DDL, dependencies, and opt-in system metadata
+through structured result objects.
 
 Metadata Contract
 =================
 
-The data dictionary uses structured metadata envelopes:
+The data dictionary uses these public shapes:
 
 - ``MetadataCapabilityProfile`` reports support by domain and adapter.
-- ``MetadataCapability`` distinguishes supported, unsupported, unknown, and
-  not implemented domains.
-- ``MetadataResult`` wraps every domain lookup, including unsupported domains,
-  so callers never need to guess whether an empty list means "nothing exists" or
-  "the database cannot answer this".
-- Object detail models carry an ``ObjectIdentity`` with catalog, schema,
-  object name, object type, dialect, quoted name, and source.
-- DDL lookups return a ``DDLResult`` with native/generated/hybrid/lossy status.
+- ``MetadataCapability`` distinguishes ``supported``, ``unsupported``,
+  ``unknown``, and ``not_implemented`` domains.
+- ``MetadataResult`` wraps domain lookups, including unsupported domains.
+- ``ObjectIdentity`` carries catalog, schema, object name, object type, dialect,
+  quoted name, and metadata source.
+- ``DDLResult`` carries DDL text plus ``native``, ``generated``, ``hybrid``,
+  ``lossy``, or ``unsupported`` fidelity.
+- ``SystemMetadataCapability``, ``SystemMetadataRequest``, and
+  ``SystemMetadataResult`` keep operational metadata separate from structural
+  metadata.
+- Dependency graph helpers model typed edges such as foreign keys, views,
+  sequence use, triggers, routines, partitions, grants, and extension-owned
+  objects.
+- System and performance metadata stays separate from structural metadata and
+  is exposed only by adapters that report support for those domains.
 
-Applications should inspect ``MetadataResult.capability`` before using
-``MetadataResult.items``.
+For ``MetadataResult`` and ``SystemMetadataResult`` responses, inspect
+``result.capability`` before using ``result.items`` or ``result.rows``. For
+``DDLResult`` responses, inspect ``result.status`` and ``result.fidelity``.
+That makes unsupported metadata distinct from an empty result set.
 
 Capability Vocabulary
 =====================
 
-The stable support values are:
+Support values:
 
-- ``supported``
-- ``unsupported``
-- ``unknown``
-- ``not_implemented``
+- ``supported``: the adapter implements the domain.
+- ``gated``: the domain exists but requires an explicit opt-in flag before it
+  can run.
+- ``unsupported``: the database or adapter cannot provide the domain.
+- ``unknown``: no capability has been declared for the domain.
+- ``not_implemented``: SQLSpec has a contract but no implementation yet.
 
-The stable fidelity values are:
+Fidelity values:
 
-- ``native``
-- ``generated``
-- ``hybrid``
-- ``lossy``
-- ``partial``
-- ``transport_fallback``
+- ``native``: returned by a database catalog, native API, or exact stored
+  definition.
+- ``generated``: reconstructed by SQLSpec from catalog metadata.
+- ``hybrid``: combines native fragments and generated structure.
+- ``lossy``: useful but incomplete; replay or export output may need review.
+- ``partial``: only part of the domain is available.
+- ``transport_fallback``: provided by a driver transport API such as ADBC.
+- ``unsupported``: no reliable metadata is available.
 
 Risk gates describe why metadata may be hidden, expensive, or unavailable:
 ``privileged``, ``billed``, ``expensive``, ``license_gated``, ``redacted``,
 ``managed_service_limited``, ``extension_required``, and ``version_gated``.
 
-Usage
-=====
+Capability-First Usage
+======================
 
-Use capabilities first:
+Ask for capabilities before assuming a domain exists:
 
 .. code-block:: python
 
    profile = db.data_dictionary.get_metadata_capabilities(db)
-   tables = profile.get("tables")
+   table_capability = profile.get("tables")
 
-   if tables.support == "supported":
-       result = db.data_dictionary.get_table_details(db, "users")
+   if table_capability.support == "supported":
+       result = db.data_dictionary.get_table_details(db, "orders", schema="public")
        for item in result.items:
            ...
 
-For unsupported domains, SQLSpec returns a structured result:
+Unsupported metadata is explicit:
 
 .. code-block:: python
 
-   result = db.data_dictionary.get_privileges(db, "users")
+   result = db.data_dictionary.get_privileges(db, "orders", schema="public")
+
    if result.capability.support == "unsupported":
+       # The adapter cannot answer this domain. This is not an empty grant list.
+       ...
+   elif not result.items:
+       # The domain is supported, but no privileges matched.
        ...
 
-System and performance metadata is disabled by default unless the adapter
-chapter explicitly opts into a safe, redacted, privilege-aware implementation.
+Support Matrix
+==============
+
+The exact answer for a driver is always its runtime capability profile. This
+matrix summarizes the implemented support families and the expected fidelity
+terms callers should branch on.
+
+.. list-table:: Metadata domain support by family
+   :header-rows: 1
+   :widths: 18 20 18 18 18 18
+
+   * - Family
+     - Core objects
+     - Constraints/indexes
+     - DDL
+     - Dependencies
+     - System/performance
+   * - PostgreSQL
+     - Native ``pg_catalog`` structural metadata.
+     - Native constraints and indexes with catalog definitions.
+     - Native or hybrid, depending on object type.
+     - Native catalog edges.
+     - Gated by default; settings and ``pg_stat`` domains require explicit
+       opt-in.
+   * - CockroachDB
+     - Stable ``information_schema`` and compatible catalog metadata.
+     - Stable-core support; internal metadata is opt-in.
+     - Lossy or generated where exact DDL is unavailable.
+     - Stable metadata only by default.
+     - ``crdb_internal`` domains are disabled unless explicitly requested.
+   * - MySQL and MariaDB
+     - Native ``information_schema`` metadata with separate MariaDB handling.
+     - Native constraints and indexes where exposed by the server.
+     - Native ``SHOW CREATE`` output with session context.
+     - Partial; sequence and event behavior differs by engine.
+     - Performance Schema, ``sys``, plugins, and status domains are opt-in.
+   * - Oracle
+     - Native dictionary views.
+     - Native constraints and indexes.
+     - Native ``DBMS_METADATA`` where privileges allow it.
+     - Native dictionary edges where available.
+     - Diagnostics views are gated and may require license acknowledgement.
+   * - SQL Server
+     - Native catalog and ``INFORMATION_SCHEMA`` metadata.
+     - Native constraints and indexes.
+     - Generated or hybrid DDL with explicit fidelity.
+     - Native catalog edges where available.
+     - DMVs and Query Store are gated and redacted by default.
+   * - SQLite
+     - Native schema tables and PRAGMAs.
+     - Native indexes and foreign keys; checks can be partial.
+     - Native schema SQL when stored; parsed dependencies may be lossy.
+     - Parsed/native edges for tables, views, and triggers.
+     - Safe PRAGMAs are opt-in; integrity checks are explicit.
+   * - DuckDB
+     - Native ``duckdb_*`` catalog functions.
+     - Native constraints and indexes where exposed.
+     - Native or generated from catalog SQL.
+     - Native ``duckdb_dependencies()`` where available.
+     - Settings, memory, logs, and extensions are opt-in.
+   * - BigQuery
+     - ``INFORMATION_SCHEMA`` by project, dataset, and region.
+     - Partial; constraints depend on BigQuery metadata availability.
+     - Native table DDL where ``INFORMATION_SCHEMA.TABLES.ddl`` is available.
+     - Partial and dataset-scoped.
+     - Jobs, reservations, timelines, and sessions are risk-disclosed; check
+       domain-level system capabilities before execution.
+   * - Spanner
+     - GoogleSQL and PostgreSQL dialect query packs.
+     - Dialect-specific catalog support.
+     - Admin API or catalog DDL depending on driver path.
+     - Partial.
+     - ``SPANNER_SYS`` and optimizer stats are operational metadata; check
+       domain-level system capabilities before execution.
+   * - ADBC
+     - Transport fallback through driver metadata APIs when available.
+     - Lossy constraints from ``GetObjects``; indexes use dialect packs.
+     - Unsupported as a lossless source.
+     - Not portable as a complete dependency source.
+     - Table statistics are opt-in transport metadata.
+   * - arrow-odbc
+     - Dialect SQL packs and Arrow schema probes.
+     - Dialect SQL packs where available.
+     - Unsupported as a lossless source.
+     - Unsupported until a raw ODBC catalog bridge exists.
+     - Raw ODBC catalog APIs are explicitly unavailable in Python today.
+
+Result Envelopes And DDL
+========================
+
+Some convenience methods return plain lists:
+
+.. code-block:: python
+
+   tables = db.data_dictionary.get_tables(db, schema="public")
+   for table in tables:
+       ...
+
+Table, column, index, and foreign-key convenience calls can use that shape.
+Domain lookups return result envelopes:
+
+.. code-block:: python
+
+   result = db.data_dictionary.get_objects(db, schema="public")
+
+   if result.capability.support == "supported":
+       for object_metadata in result.items:
+           ...
+   else:
+       log.warning("object metadata unavailable: %s", result.warnings)
+
+Use DDL fidelity instead of assuming a returned string is replayable. Object DDL
+lookups return a ``DDLResult`` directly:
+
+.. code-block:: python
+
+   ddl = db.data_dictionary.get_ddl(db, "orders", schema="public")
+
+   if ddl.status == "supported" and ddl.fidelity in {"native", "hybrid"}:
+       apply_to_review_buffer(ddl.ddl)
+   elif ddl.fidelity == "lossy":
+       request_manual_review(ddl)
+   else:
+       skip_export(ddl.warnings)
+
+Use ``get_schema_ddl()`` when you need a collection of DDL items. That method
+returns a ``MetadataResult`` whose items are ``DDLResult`` instances.
+
+Sort DDL by typed dependencies before replay. Dependency-capable adapters should
+return enough edge metadata for callers to order objects before exporting or
+replaying them:
+
+.. code-block:: python
+
+   dependencies = db.data_dictionary.get_dependencies(db, schema="public")
+   ddl = db.data_dictionary.get_ddl(db, "orders", schema="public")
+
+   if dependencies.capability.support == "supported":
+       ordered_items = order_for_replay((ddl,), dependencies.items)
+
+System And Performance Metadata
+===============================
+
+System metadata is disabled by default because it can expose SQL text, users,
+hosts, settings, grants, connection strings, operational topology, billing data,
+or license-gated diagnostics.
+
+Use system metadata capability disclosures and explicit request flags before
+requesting these domains:
+
+.. code-block:: python
+
+   from sqlspec.data_dictionary import SystemMetadataRequest
+
+   profile = db.data_dictionary.get_metadata_capabilities(db)
+
+   if profile.get("system").support == "supported":
+       request = SystemMetadataRequest(
+           "table_statistics",
+           include_performance=True,
+           schema="public",
+           table="orders",
+       )
+       result = db.data_dictionary.get_system_metadata(db, request)
+
+       if result.capability.support == "supported":
+           for row in result.rows:
+               ...
+
+When an adapter exposes domain-level disclosures through
+``get_system_metadata_capabilities()``, use that method to inspect the exact
+system metadata domain before constructing a request. The returned
+``SystemMetadataResult.capability`` is still the final execution status for the
+specific request.
+
+Rows should be redacted by default. Include sensitive values only for trusted
+diagnostics workflows.
+
+Cloud Notes
+===========
+
+BigQuery metadata must be scoped carefully. ``INFORMATION_SCHEMA`` views are
+qualified by dataset, project, or region. Job, timeline, reservation, and
+session-style metadata can be region-bound or billed. Structural capability
+profiles disclose those risks; direct system metadata calls should still branch
+on ``get_system_metadata_capabilities()`` before calling
+``get_system_metadata()``.
+
+Spanner has separate GoogleSQL and PostgreSQL dialect metadata shapes. Select the
+driver dialect mode explicitly and treat ``SPANNER_SYS`` statistics as
+performance metadata, not structural metadata. As with BigQuery, branch on the
+system metadata capability API before attempting operational statistics queries.
+
+Transport Fallback Notes
+========================
+
+ADBC and ODBC are transport layers, not database catalogs. They can expose
+portable discovery metadata, but dialect query packs remain the source for
+DDL-grade output. Treat ``transport_fallback`` and ``lossy`` fidelity as
+inspection metadata unless the target workflow explicitly accepts those limits.
+
+SQLSpec's bundled dialect query packs are maintained SQLSpec query packs based
+on public catalog behavior.


### PR DESCRIPTION
## Summary

- expand the data dictionary usage guide with breaking-change migration guidance
- add capability vocabulary, support matrix, DDL/dependency examples, and safe system metadata opt-in guidance
- add reference notes for driver data dictionary contracts and ADBC transport metadata