### PR TITLE
feat(data-dictionary): add system metadata policy

### DIFF
--- a/sqlspec/adapters/adbc/data_dictionary.py
+++ b/sqlspec/adapters/adbc/data_dictionary.py
@@ -11,13 +11,23 @@ from sqlspec.data_dictionary import (
     ColumnMetadata,
     ForeignKeyMetadata,
     IndexMetadata,
+    MetadataFidelity,
+    MetadataRisk,
+    MetadataSource,
+    MetadataSupport,
+    SystemMetadataCapability,
+    SystemMetadataRequest,
+    SystemMetadataResult,
     TableMetadata,
     TableStatisticsMetadata,
     VersionInfo,
+    ensure_system_metadata_request,
     get_data_dictionary_loader,
     get_dialect_config,
     list_registered_dialects,
     normalize_dialect_name,
+    system_metadata_gated_result,
+    unsupported_system_metadata_capability,
 )
 from sqlspec.data_dictionary.dialects.bigquery import (
     format_bigquery_information_schema_tables,
@@ -33,6 +43,8 @@ from sqlspec.utils.logging import get_logger
 from sqlspec.utils.text import normalize_identifier
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from sqlspec.adapters.adbc.driver import AdbcDriver
     from sqlspec.core import SQL
 
@@ -541,6 +553,59 @@ class AdbcDataDictionary(SyncDataDictionaryBase):
             raise OperationalError(msg) from exc
         rows = reader.read_all().to_pylist()
         return [entry for entry in _normalize_native_statistics(rows) if entry["table_name"] == table_name]
+
+    def get_system_metadata_capabilities(
+        self, driver: Any, domains: "Sequence[str] | None" = None
+    ) -> "tuple[SystemMetadataCapability, ...]":
+        """Get ADBC system metadata capability disclosures."""
+        requested_domains = ("table_statistics",) if domains is None else tuple(domains)
+        return tuple(self._system_metadata_capability(domain) for domain in requested_domains)
+
+    def get_system_metadata(
+        self, driver: "AdbcDriver", request: "SystemMetadataRequest | str | None" = None, **kwargs: Any
+    ) -> "SystemMetadataResult":
+        """Get ADBC transport metadata through the opt-in system namespace."""
+        metadata_request = ensure_system_metadata_request(request, **kwargs)
+        capability = self._system_metadata_capability(metadata_request.domain)
+        gate_result = system_metadata_gated_result(metadata_request, capability)
+        if gate_result.capability.support != MetadataSupport.SUPPORTED:
+            return gate_result
+        if metadata_request.domain != "table_statistics":
+            return gate_result
+        if metadata_request.table is None:
+            missing_table_capability = capability.with_support(
+                MetadataSupport.GATED,
+                fidelity=MetadataFidelity.UNSUPPORTED,
+                warnings=("ADBC table_statistics system metadata requires request.table.",),
+            )
+            return SystemMetadataResult(
+                metadata_request, missing_table_capability, source=MetadataSource.DRIVER_METADATA
+            )
+        try:
+            statistics = self.get_statistics(driver, metadata_request.table, metadata_request.schema)
+        except OperationalError as exc:
+            unsupported_capability = SystemMetadataCapability.unsupported(
+                "table_statistics", source=MetadataSource.DRIVER_METADATA
+            ).with_support(MetadataSupport.UNSUPPORTED, fidelity=MetadataFidelity.UNSUPPORTED, warnings=(str(exc),))
+            return SystemMetadataResult(metadata_request, unsupported_capability, source=MetadataSource.DRIVER_METADATA)
+        rows = tuple(cast("dict[str, object]", entry) for entry in statistics)
+        return SystemMetadataResult.from_rows(
+            metadata_request, capability, rows=rows, source=MetadataSource.DRIVER_METADATA
+        )
+
+    def _system_metadata_capability(self, domain: str) -> "SystemMetadataCapability":
+        if domain != "table_statistics":
+            return unsupported_system_metadata_capability(domain)
+        return SystemMetadataCapability(
+            "table_statistics",
+            MetadataSupport.SUPPORTED,
+            fidelity=MetadataFidelity.TRANSPORT_FALLBACK,
+            source=MetadataSource.DRIVER_METADATA,
+            risks=(MetadataRisk.PRIVILEGED, MetadataRisk.EXPENSIVE, MetadataRisk.REDACTED),
+            required_privileges=("ADBC GetStatistics support",),
+            redaction_fields=("catalog_name", "schema_name", "table_name", "column_name"),
+            warnings=("ADBC statistics are driver-reported transport metadata, not a full system query namespace.",),
+        )
 
     def _normalize_dialect(self, driver: "AdbcDriver") -> str:
         dialect_value = str(driver.dialect)

--- a/sqlspec/data_dictionary/__init__.py
+++ b/sqlspec/data_dictionary/__init__.py
@@ -2,6 +2,13 @@
 
 from typing import TYPE_CHECKING, Any
 
+from sqlspec.data_dictionary._capabilities import (
+    DEFAULT_SYSTEM_METADATA_DOMAINS,
+    ensure_system_metadata_request,
+    system_metadata_capabilities_from_domains,
+    system_metadata_gated_result,
+    unsupported_system_metadata_capability,
+)
 from sqlspec.data_dictionary._registry import (
     get_dialect_config,
     list_registered_dialects,
@@ -36,6 +43,10 @@ from sqlspec.data_dictionary._types import (
     RoutineMetadata,
     SchemaMetadata,
     SystemMetadata,
+    SystemMetadataCapability,
+    SystemMetadataRedactionPolicy,
+    SystemMetadataRequest,
+    SystemMetadataResult,
     TableDetails,
     TableMetadata,
     TableStatisticsMetadata,
@@ -49,6 +60,7 @@ if TYPE_CHECKING:
     from sqlspec.data_dictionary._loader import DataDictionaryLoader, get_data_dictionary_loader
 
 __all__ = (
+    "DEFAULT_SYSTEM_METADATA_DOMAINS",
     "ColumnDetails",
     "ColumnMetadata",
     "CommentMetadata",
@@ -77,6 +89,10 @@ __all__ = (
     "RoutineMetadata",
     "SchemaMetadata",
     "SystemMetadata",
+    "SystemMetadataCapability",
+    "SystemMetadataRedactionPolicy",
+    "SystemMetadataRequest",
+    "SystemMetadataResult",
     "TableDetails",
     "TableMetadata",
     "TableStatisticsMetadata",
@@ -84,11 +100,15 @@ __all__ = (
     "VersionCacheResult",
     "VersionInfo",
     "ViewMetadata",
+    "ensure_system_metadata_request",
     "get_data_dictionary_loader",
     "get_dialect_config",
     "list_registered_dialects",
     "normalize_dialect_name",
     "register_dialect",
+    "system_metadata_capabilities_from_domains",
+    "system_metadata_gated_result",
+    "unsupported_system_metadata_capability",
 )
 
 

--- a/sqlspec/data_dictionary/_capabilities.py
+++ b/sqlspec/data_dictionary/_capabilities.py
@@ -1,0 +1,142 @@
+"""System metadata capability and safety helpers."""
+
+from collections.abc import Sequence
+from typing import Any
+
+from sqlspec.data_dictionary._types import (
+    MetadataFidelity,
+    MetadataRisk,
+    MetadataSource,
+    MetadataSupport,
+    SystemMetadataCapability,
+    SystemMetadataRequest,
+    SystemMetadataResult,
+)
+
+__all__ = (
+    "DEFAULT_SYSTEM_METADATA_DOMAINS",
+    "ensure_system_metadata_request",
+    "system_metadata_capabilities_from_domains",
+    "system_metadata_gated_result",
+    "unsupported_system_metadata_capability",
+)
+
+DEFAULT_SYSTEM_METADATA_DOMAINS: tuple[str, ...] = (
+    "settings",
+    "extensions",
+    "sessions",
+    "statement_history",
+    "table_statistics",
+    "optimizer_statistics",
+    "replication",
+    "performance_counters",
+    "cloud_jobs",
+)
+"""Default system and performance metadata domains for capability disclosure."""
+
+
+def ensure_system_metadata_request(
+    request: SystemMetadataRequest | str | None = None, **kwargs: Any
+) -> SystemMetadataRequest:
+    """Normalize a system metadata request.
+
+    Args:
+        request: Explicit request object, domain string, or None.
+        **kwargs: Request constructor overrides.
+
+    Returns:
+        A system metadata request.
+    """
+    if isinstance(request, SystemMetadataRequest) and not kwargs:
+        return request
+    if isinstance(request, SystemMetadataRequest):
+        domain = request.domain
+        values: dict[str, Any] = {
+            "include_system": request.include_system,
+            "include_performance": request.include_performance,
+            "allow_billed_metadata": request.allow_billed_metadata,
+            "allow_license_gated_diagnostics": request.allow_license_gated_diagnostics,
+            "include_sensitive": request.include_sensitive,
+            "table": request.table,
+            "schema": request.schema,
+            "redaction_policy": request.redaction_policy,
+        }
+        values.update(kwargs)
+        return SystemMetadataRequest(domain, **values)
+    if isinstance(request, str):
+        return SystemMetadataRequest(request, **kwargs)
+    domain = str(kwargs.pop("domain", "system"))
+    return SystemMetadataRequest(domain, **kwargs)
+
+
+def unsupported_system_metadata_capability(domain: str) -> SystemMetadataCapability:
+    """Create the default unsupported system metadata capability.
+
+    Args:
+        domain: System metadata domain name.
+
+    Returns:
+        Unsupported capability with conservative disclosure defaults.
+    """
+    return SystemMetadataCapability.unsupported(domain, source=MetadataSource.SYSTEM_VIEW)
+
+
+def system_metadata_capabilities_from_domains(domains: Sequence[str]) -> tuple[SystemMetadataCapability, ...]:
+    """Create unsupported system metadata capabilities for each domain.
+
+    Args:
+        domains: Domain names to disclose.
+
+    Returns:
+        Tuple of unsupported system metadata capabilities.
+    """
+    return tuple(unsupported_system_metadata_capability(domain) for domain in domains)
+
+
+def system_metadata_gated_result(
+    request: SystemMetadataRequest, capability: SystemMetadataCapability
+) -> SystemMetadataResult:
+    """Return the fail-closed result for a system metadata request.
+
+    Args:
+        request: System metadata request.
+        capability: Capability for the requested domain.
+
+    Returns:
+        Result describing whether execution is gated, unsupported, or permitted.
+    """
+    warnings: list[str] = []
+    support = capability.support
+    fidelity = capability.fidelity
+    if not request.is_enabled:
+        support = MetadataSupport.GATED
+        fidelity = MetadataFidelity.UNSUPPORTED
+        warnings.append("System metadata is disabled by default; pass include_system=True or include_performance=True.")
+    elif capability.requires_billed_opt_in and not request.allow_billed_metadata:
+        support = MetadataSupport.GATED
+        fidelity = MetadataFidelity.UNSUPPORTED
+        warnings.append("System metadata domain requires allow_billed_metadata=True.")
+    elif capability.requires_license_opt_in and not request.allow_license_gated_diagnostics:
+        support = MetadataSupport.GATED
+        fidelity = MetadataFidelity.UNSUPPORTED
+        warnings.append("System metadata domain requires allow_license_gated_diagnostics=True.")
+
+    if not request.include_sensitive and capability.redaction_fields and MetadataRisk.REDACTED not in capability.risks:
+        risks = (*capability.risks, MetadataRisk.REDACTED)
+    else:
+        risks = capability.risks
+
+    gated_capability = SystemMetadataCapability(
+        capability.domain,
+        support,
+        fidelity=fidelity,
+        source=capability.source,
+        risks=risks,
+        required_privileges=capability.required_privileges,
+        cost_implications=capability.cost_implications,
+        license_gate=capability.license_gate,
+        managed_service_restricted=capability.managed_service_restricted,
+        redaction_fields=capability.redaction_fields,
+        warnings=tuple(warnings) + capability.warnings,
+    )
+    return SystemMetadataResult(request, gated_capability, source=gated_capability.source)

--- a/sqlspec/data_dictionary/_types.py
+++ b/sqlspec/data_dictionary/_types.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, TypedDict, cast
 from mypy_extensions import mypyc_attr
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from re import Pattern
 
     from sqlspec.core.statement import SQL
@@ -36,6 +37,10 @@ __all__ = (
     "RoutineMetadata",
     "SchemaMetadata",
     "SystemMetadata",
+    "SystemMetadataCapability",
+    "SystemMetadataRedactionPolicy",
+    "SystemMetadataRequest",
+    "SystemMetadataResult",
     "TableDetails",
     "TableMetadata",
     "TableStatisticsMetadata",
@@ -49,6 +54,7 @@ __all__ = (
 class MetadataSupport(str, Enum):
     """Support status for a metadata domain."""
 
+    GATED = "gated"
     NOT_IMPLEMENTED = "not_implemented"
     SUPPORTED = "supported"
     UNKNOWN = "unknown"
@@ -566,6 +572,525 @@ class PartitionMetadata(ObjectMetadata):
     """Rich metadata for partition, clustering, storage, or table options."""
 
     __slots__ = ()
+
+
+_REDACTED_VALUE = "[REDACTED]"
+_SQL_TEXT_FIELDS = {
+    "current_query",
+    "query",
+    "query_text",
+    "sql",
+    "sql_fulltext",
+    "sql_text",
+    "statement",
+    "statement_text",
+}
+_USER_FIELDS = {
+    "current_user",
+    "login",
+    "login_name",
+    "owner",
+    "principal",
+    "principal_name",
+    "session_user",
+    "user",
+    "user_name",
+    "username",
+    "usename",
+}
+_HOST_FIELDS = {
+    "client_addr",
+    "client_host",
+    "client_hostname",
+    "host",
+    "hostname",
+    "ip_address",
+    "machine",
+    "program_host",
+    "remote_addr",
+}
+_SETTING_VALUE_FIELDS = {"option_value", "parameter_value", "setting_value", "variable_value"}
+_SETTING_NAME_FIELDS = {"name", "option_name", "parameter_name", "setting_name", "variable_name"}
+_CONNECTION_STRING_FIELDS = {"connection_string", "database_url", "dsn", "jdbc_url", "url", "uri"}
+_GRANT_FIELDS = {"grant", "grant_sql", "grant_statement", "grantee", "grantor", "grants", "permission", "permissions"}
+_SENSITIVE_NAME_FRAGMENTS = {
+    "api_key",
+    "auth",
+    "credential",
+    "database_url",
+    "dsn",
+    "jwt",
+    "key",
+    "oauth",
+    "passwd",
+    "password",
+    "secret",
+    "token",
+}
+
+
+def _normalize_redaction_key(key: str) -> str:
+    return key.strip().lower().replace("-", "_")
+
+
+def _is_sensitive_name(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    normalized = _normalize_redaction_key(value)
+    return any(fragment in normalized for fragment in _SENSITIVE_NAME_FRAGMENTS)
+
+
+def _row_setting_name(row: "Mapping[str, object]") -> object | None:
+    for key, value in row.items():
+        if _normalize_redaction_key(str(key)) in _SETTING_NAME_FIELDS:
+            return value
+    return None
+
+
+def _looks_like_connection_string(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    lowered = value.lower()
+    if "://" in value and ("@" in value or "password" in lowered or "token" in lowered):
+        return True
+    if "password=" in lowered or "pwd=" in lowered:
+        return True
+    return "user id=" in lowered and ("server=" in lowered or "host=" in lowered)
+
+
+class SystemMetadataRedactionPolicy:
+    """Redaction policy for system and performance metadata rows.
+
+    Args:
+        redact_sql_text: Redact SQL, query, and statement text fields.
+        redact_users: Redact user, owner, login, and principal fields.
+        redact_hosts: Redact host, address, and machine fields.
+        redact_settings: Redact settings likely to contain secrets.
+        redact_connection_strings: Redact connection string and URL values.
+        redact_grants: Redact grant and permission fields.
+    """
+
+    __slots__ = (
+        "redact_connection_strings",
+        "redact_grants",
+        "redact_hosts",
+        "redact_settings",
+        "redact_sql_text",
+        "redact_users",
+    )
+
+    def __init__(
+        self,
+        *,
+        redact_sql_text: bool = True,
+        redact_users: bool = True,
+        redact_hosts: bool = True,
+        redact_settings: bool = True,
+        redact_connection_strings: bool = True,
+        redact_grants: bool = True,
+    ) -> None:
+        self.redact_sql_text = redact_sql_text
+        self.redact_users = redact_users
+        self.redact_hosts = redact_hosts
+        self.redact_settings = redact_settings
+        self.redact_connection_strings = redact_connection_strings
+        self.redact_grants = redact_grants
+
+    @classmethod
+    def unredacted(cls) -> "SystemMetadataRedactionPolicy":
+        """Create a policy that leaves system metadata rows unchanged."""
+        return cls(
+            redact_sql_text=False,
+            redact_users=False,
+            redact_hosts=False,
+            redact_settings=False,
+            redact_connection_strings=False,
+            redact_grants=False,
+        )
+
+    @classmethod
+    def sensitive_field_names(cls) -> "tuple[str, ...]":
+        """Return the canonical sensitive field categories covered by the default policy."""
+        return ("sql_text", "user", "host", "setting", "connection_string", "grant")
+
+    def redact_row(self, row: "Mapping[str, object]") -> "tuple[dict[str, object], tuple[str, ...]]":
+        """Return a redacted row and the fields that were changed.
+
+        Args:
+            row: Metadata row to redact.
+
+        Returns:
+            A tuple of the redacted row and sorted redacted field names.
+        """
+        redacted: dict[str, object] = {}
+        fields: set[str] = set()
+        for key, value in row.items():
+            field_name = str(key)
+            if self._should_redact_field(field_name, value, row):
+                redacted[field_name] = _REDACTED_VALUE
+                fields.add(field_name)
+                continue
+            redacted[field_name] = value
+        return redacted, tuple(sorted(fields))
+
+    def _should_redact_field(self, key: str, value: object, row: "Mapping[str, object]") -> bool:
+        normalized = _normalize_redaction_key(key)
+        if self.redact_sql_text and (
+            normalized in _SQL_TEXT_FIELDS or normalized.endswith(("_sql", "_query", "_statement"))
+        ):
+            return True
+        if self.redact_users and normalized in _USER_FIELDS:
+            return True
+        if self.redact_hosts and normalized in _HOST_FIELDS:
+            return True
+        if self.redact_connection_strings and (
+            normalized in _CONNECTION_STRING_FIELDS or _looks_like_connection_string(value)
+        ):
+            return True
+        if self.redact_settings and (
+            _is_sensitive_name(normalized)
+            or normalized in _SETTING_VALUE_FIELDS
+            or (normalized == "value" and _is_sensitive_name(_row_setting_name(row)))
+        ):
+            return True
+        return self.redact_grants and normalized in _GRANT_FIELDS
+
+    def to_dict(self) -> "dict[str, bool]":
+        """Serialize redaction settings."""
+        return {
+            "redact_sql_text": self.redact_sql_text,
+            "redact_users": self.redact_users,
+            "redact_hosts": self.redact_hosts,
+            "redact_settings": self.redact_settings,
+            "redact_connection_strings": self.redact_connection_strings,
+            "redact_grants": self.redact_grants,
+        }
+
+
+class SystemMetadataRequest:
+    """Opt-in request for system and performance metadata.
+
+    Args:
+        domain: System metadata domain to query.
+        include_system: Enable system metadata domains such as settings or sessions.
+        include_performance: Enable performance metadata domains such as statistics or history.
+        allow_billed_metadata: Permit domains that may incur cloud or service billing.
+        allow_license_gated_diagnostics: Permit license-gated diagnostics such as AWR/ASH.
+        include_sensitive: Disable default row redaction for this request.
+        table: Optional table target for table-scoped metadata.
+        schema: Optional schema target for table-scoped metadata.
+        redaction_policy: Optional explicit row redaction policy.
+    """
+
+    __slots__ = (
+        "allow_billed_metadata",
+        "allow_license_gated_diagnostics",
+        "domain",
+        "include_performance",
+        "include_sensitive",
+        "include_system",
+        "redaction_policy",
+        "schema",
+        "table",
+    )
+
+    def __init__(
+        self,
+        domain: str,
+        *,
+        include_system: bool = False,
+        include_performance: bool = False,
+        allow_billed_metadata: bool = False,
+        allow_license_gated_diagnostics: bool = False,
+        include_sensitive: bool = False,
+        table: str | None = None,
+        schema: str | None = None,
+        redaction_policy: SystemMetadataRedactionPolicy | None = None,
+        redact_sql_text: bool = True,
+        redact_users: bool = True,
+        redact_hosts: bool = True,
+        redact_settings: bool = True,
+        redact_connection_strings: bool = True,
+        redact_grants: bool = True,
+    ) -> None:
+        self.domain = domain
+        self.include_system = include_system
+        self.include_performance = include_performance
+        self.allow_billed_metadata = allow_billed_metadata
+        self.allow_license_gated_diagnostics = allow_license_gated_diagnostics
+        self.include_sensitive = include_sensitive
+        self.table = table
+        self.schema = schema
+        if redaction_policy is not None:
+            self.redaction_policy = redaction_policy
+        elif include_sensitive:
+            self.redaction_policy = SystemMetadataRedactionPolicy.unredacted()
+        else:
+            self.redaction_policy = SystemMetadataRedactionPolicy(
+                redact_sql_text=redact_sql_text,
+                redact_users=redact_users,
+                redact_hosts=redact_hosts,
+                redact_settings=redact_settings,
+                redact_connection_strings=redact_connection_strings,
+                redact_grants=redact_grants,
+            )
+
+    @property
+    def is_enabled(self) -> bool:
+        """Return whether either system or performance metadata was explicitly enabled."""
+        return self.include_system or self.include_performance
+
+    def to_dict(self) -> "dict[str, object]":
+        """Serialize the request."""
+        return {
+            "domain": self.domain,
+            "include_system": self.include_system,
+            "include_performance": self.include_performance,
+            "allow_billed_metadata": self.allow_billed_metadata,
+            "allow_license_gated_diagnostics": self.allow_license_gated_diagnostics,
+            "include_sensitive": self.include_sensitive,
+            "table": self.table,
+            "schema": self.schema,
+            "redaction_policy": self.redaction_policy.to_dict(),
+        }
+
+
+class SystemMetadataCapability:
+    """Capability disclosure for one system or performance metadata domain.
+
+    Args:
+        domain: System metadata domain name.
+        support: Support status for the domain.
+        fidelity: Fidelity of the domain response.
+        source: Metadata source used for the domain.
+        risks: Risk and gate categories attached to the domain.
+        required_privileges: Required database privileges or roles.
+        cost_implications: Billing or expensive-query disclosure.
+        license_gate: License requirement disclosure.
+        managed_service_restricted: Whether managed services commonly restrict this domain.
+        redaction_fields: Sensitive fields that may appear in rows.
+        warnings: Additional capability warnings.
+    """
+
+    __slots__ = (
+        "cost_implications",
+        "domain",
+        "fidelity",
+        "license_gate",
+        "managed_service_restricted",
+        "redaction_fields",
+        "required_privileges",
+        "risks",
+        "source",
+        "support",
+        "warnings",
+    )
+
+    def __init__(
+        self,
+        domain: str,
+        support: "MetadataSupport | str",
+        *,
+        fidelity: "MetadataFidelity | str" = MetadataFidelity.UNSUPPORTED,
+        source: "MetadataSource | str" = MetadataSource.SYSTEM_VIEW,
+        risks: "tuple[MetadataRisk | str, ...]" = (),
+        required_privileges: "tuple[str, ...]" = (),
+        cost_implications: str | None = None,
+        license_gate: str | None = None,
+        managed_service_restricted: bool = False,
+        redaction_fields: "tuple[str, ...]" = (),
+        warnings: "tuple[str, ...]" = (),
+    ) -> None:
+        self.domain = domain
+        self.support = _coerce_support(support)
+        self.fidelity = _coerce_fidelity(fidelity)
+        self.source = _coerce_source(source)
+        self.risks = tuple(_coerce_risk(risk) for risk in risks)
+        self.required_privileges = required_privileges
+        self.cost_implications = cost_implications
+        self.license_gate = license_gate
+        self.managed_service_restricted = managed_service_restricted
+        self.redaction_fields = redaction_fields
+        self.warnings = warnings
+
+    @classmethod
+    def unsupported(
+        cls, domain: str, *, source: "MetadataSource | str" = MetadataSource.SYSTEM_VIEW
+    ) -> "SystemMetadataCapability":
+        """Create a safe unsupported system-domain capability."""
+        return cls(
+            domain,
+            MetadataSupport.UNSUPPORTED,
+            source=source,
+            risks=(MetadataRisk.PRIVILEGED, MetadataRisk.REDACTED),
+            redaction_fields=SystemMetadataRedactionPolicy.sensitive_field_names(),
+            warnings=("No system metadata query pack is registered for this domain.",),
+        )
+
+    @property
+    def requires_billed_opt_in(self) -> bool:
+        """Return whether this domain requires billed metadata opt-in."""
+        return MetadataRisk.BILLED in self.risks
+
+    @property
+    def requires_license_opt_in(self) -> bool:
+        """Return whether this domain requires license-gated diagnostics opt-in."""
+        return MetadataRisk.LICENSE_GATED in self.risks
+
+    def with_support(
+        self,
+        support: "MetadataSupport | str",
+        *,
+        warnings: "tuple[str, ...]" = (),
+        fidelity: "MetadataFidelity | str | None" = None,
+    ) -> "SystemMetadataCapability":
+        """Return a copy with a different support status and additional warnings."""
+        return SystemMetadataCapability(
+            self.domain,
+            support,
+            fidelity=self.fidelity if fidelity is None else fidelity,
+            source=self.source,
+            risks=self.risks,
+            required_privileges=self.required_privileges,
+            cost_implications=self.cost_implications,
+            license_gate=self.license_gate,
+            managed_service_restricted=self.managed_service_restricted,
+            redaction_fields=self.redaction_fields,
+            warnings=self.warnings + warnings,
+        )
+
+    def to_dict(self) -> "dict[str, object]":
+        """Serialize the capability with stable enum values."""
+        return {
+            "domain": self.domain,
+            "support": self.support.value,
+            "fidelity": self.fidelity.value,
+            "source": self.source.value,
+            "risks": tuple(risk.value for risk in self.risks),
+            "required_privileges": self.required_privileges,
+            "cost_implications": self.cost_implications,
+            "license_gate": self.license_gate,
+            "managed_service_restricted": self.managed_service_restricted,
+            "redaction_fields": self.redaction_fields,
+            "warnings": self.warnings,
+        }
+
+    def __repr__(self) -> str:
+        return (
+            f"SystemMetadataCapability(domain={self.domain!r}, support={self.support!r}, "
+            f"source={self.source!r}, risks={self.risks!r})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SystemMetadataCapability):
+            return NotImplemented
+        return self.to_dict() == other.to_dict()
+
+    def __hash__(self) -> int:
+        return hash((
+            self.domain,
+            self.support,
+            self.fidelity,
+            self.source,
+            self.risks,
+            self.required_privileges,
+            self.cost_implications,
+            self.license_gate,
+            self.managed_service_restricted,
+            self.redaction_fields,
+            self.warnings,
+        ))
+
+
+class SystemMetadataResult:
+    """Result envelope for system and performance metadata.
+
+    Args:
+        request: Request that produced the result.
+        capability: Capability status for the request domain.
+        rows: Redacted metadata rows.
+        source: Metadata source override.
+        warnings: Additional result warnings.
+        redactions: Redacted fields.
+    """
+
+    __slots__ = ("capability", "redactions", "request", "rows", "source", "warnings")
+
+    def __init__(
+        self,
+        request: SystemMetadataRequest,
+        capability: SystemMetadataCapability,
+        *,
+        rows: "tuple[Mapping[str, object], ...]" = (),
+        source: "MetadataSource | str | None" = None,
+        warnings: "tuple[str, ...]" = (),
+        redactions: "tuple[str, ...]" = (),
+    ) -> None:
+        self.request = request
+        self.capability = capability
+        self.rows = tuple(dict(row) for row in rows)
+        self.source = capability.source if source is None else _coerce_source(source)
+        self.warnings = capability.warnings + warnings
+        self.redactions = redactions
+
+    @classmethod
+    def from_rows(
+        cls,
+        request: SystemMetadataRequest,
+        capability: SystemMetadataCapability,
+        *,
+        rows: "tuple[Mapping[str, object], ...]",
+        source: "MetadataSource | str | None" = None,
+        warnings: "tuple[str, ...]" = (),
+    ) -> "SystemMetadataResult":
+        """Create a result from raw rows, applying request redaction first."""
+        redacted_rows: list[dict[str, object]] = []
+        redactions: set[str] = set()
+        for row in rows:
+            redacted, fields = request.redaction_policy.redact_row(row)
+            redacted_rows.append(redacted)
+            redactions.update(fields)
+        return cls(
+            request,
+            capability,
+            rows=tuple(redacted_rows),
+            source=source,
+            warnings=warnings,
+            redactions=tuple(sorted(redactions)),
+        )
+
+    def to_dict(self) -> "dict[str, object]":
+        """Serialize the system metadata result."""
+        return {
+            "request": self.request.to_dict(),
+            "capability": self.capability.to_dict(),
+            "rows": self.rows,
+            "source": self.source.value,
+            "warnings": self.warnings,
+            "redactions": self.redactions,
+        }
+
+    def __repr__(self) -> str:
+        return (
+            f"SystemMetadataResult(request={self.request!r}, capability={self.capability!r}, "
+            f"rows={self.rows!r}, warnings={self.warnings!r}, redactions={self.redactions!r})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SystemMetadataResult):
+            return NotImplemented
+        return self.to_dict() == other.to_dict()
+
+    def __hash__(self) -> int:
+        rows_hash = tuple(tuple(sorted((key, repr(value)) for key, value in row.items())) for row in self.rows)
+        return hash((
+            repr(self.request.to_dict()),
+            self.capability,
+            rows_hash,
+            self.source,
+            self.warnings,
+            self.redactions,
+        ))
 
 
 class SystemMetadata(ObjectMetadata):

--- a/sqlspec/driver/_async.py
+++ b/sqlspec/driver/_async.py
@@ -47,6 +47,9 @@ if TYPE_CHECKING:
         IndexMetadata,
         MetadataCapabilityProfile,
         MetadataResult,
+        SystemMetadataCapability,
+        SystemMetadataRequest,
+        SystemMetadataResult,
         TableMetadata,
         VersionInfo,
     )
@@ -1891,11 +1894,27 @@ class AsyncDataDictionaryBase(DataDictionaryDialectMixin, DataDictionaryMixin):
             "privileges",
             "dependencies",
             "ddl",
-            "system",
         )
         if domains is not None:
             requested_domains = tuple(domains)
         return MetadataCapabilityProfile.from_domains(self.dialect, type(self).__name__, requested_domains)
+
+    async def get_system_metadata_capabilities(
+        self, driver: Any, domains: "Sequence[str] | None" = None
+    ) -> "tuple[SystemMetadataCapability, ...]":
+        """Get opt-in system metadata capability disclosures.
+
+        Args:
+            driver: Async database driver instance.
+            domains: Optional system metadata domains to report.
+
+        Returns:
+            System metadata capabilities. Base implementations report requested domains as unsupported.
+        """
+        from sqlspec.data_dictionary import DEFAULT_SYSTEM_METADATA_DOMAINS, system_metadata_capabilities_from_domains
+
+        requested_domains = DEFAULT_SYSTEM_METADATA_DOMAINS if domains is None else tuple(domains)
+        return system_metadata_capabilities_from_domains(requested_domains)
 
     async def get_schemas(self, driver: Any) -> "MetadataResult":
         """Get schema metadata or an unsupported-domain result."""
@@ -1940,10 +1959,18 @@ class AsyncDataDictionaryBase(DataDictionaryDialectMixin, DataDictionaryMixin):
         return self._unsupported_metadata("ddl")
 
     async def get_system_metadata(
-        self, driver: Any, domain: str, *, include_sensitive: bool = False
-    ) -> "MetadataResult":
-        """Get opt-in system metadata or an unsupported-domain result."""
-        return self._unsupported_metadata("system")
+        self, driver: Any, request: "SystemMetadataRequest | str | None" = None, **kwargs: Any
+    ) -> "SystemMetadataResult":
+        """Get opt-in system metadata or a gated/unsupported result."""
+        from sqlspec.data_dictionary import (
+            ensure_system_metadata_request,
+            system_metadata_gated_result,
+            unsupported_system_metadata_capability,
+        )
+
+        metadata_request = ensure_system_metadata_request(request, **kwargs)
+        capability = unsupported_system_metadata_capability(metadata_request.domain)
+        return system_metadata_gated_result(metadata_request, capability)
 
     @abstractmethod
     async def get_version(self, driver: Any) -> "VersionInfo | None":

--- a/sqlspec/driver/_sync.py
+++ b/sqlspec/driver/_sync.py
@@ -46,6 +46,9 @@ if TYPE_CHECKING:
         IndexMetadata,
         MetadataCapabilityProfile,
         MetadataResult,
+        SystemMetadataCapability,
+        SystemMetadataRequest,
+        SystemMetadataResult,
         TableMetadata,
         VersionInfo,
     )
@@ -1828,11 +1831,27 @@ class SyncDataDictionaryBase(DataDictionaryDialectMixin, DataDictionaryMixin):
             "privileges",
             "dependencies",
             "ddl",
-            "system",
         )
         if domains is not None:
             requested_domains = tuple(domains)
         return MetadataCapabilityProfile.from_domains(self.dialect, type(self).__name__, requested_domains)
+
+    def get_system_metadata_capabilities(
+        self, driver: Any, domains: "Sequence[str] | None" = None
+    ) -> "tuple[SystemMetadataCapability, ...]":
+        """Get opt-in system metadata capability disclosures.
+
+        Args:
+            driver: Sync database driver instance.
+            domains: Optional system metadata domains to report.
+
+        Returns:
+            System metadata capabilities. Base implementations report requested domains as unsupported.
+        """
+        from sqlspec.data_dictionary import DEFAULT_SYSTEM_METADATA_DOMAINS, system_metadata_capabilities_from_domains
+
+        requested_domains = DEFAULT_SYSTEM_METADATA_DOMAINS if domains is None else tuple(domains)
+        return system_metadata_capabilities_from_domains(requested_domains)
 
     def get_schemas(self, driver: Any) -> "MetadataResult":
         """Get schema metadata or an unsupported-domain result."""
@@ -1874,9 +1893,19 @@ class SyncDataDictionaryBase(DataDictionaryDialectMixin, DataDictionaryMixin):
         """Get object DDL or an unsupported-domain result."""
         return self._unsupported_metadata("ddl")
 
-    def get_system_metadata(self, driver: Any, domain: str, *, include_sensitive: bool = False) -> "MetadataResult":
-        """Get opt-in system metadata or an unsupported-domain result."""
-        return self._unsupported_metadata("system")
+    def get_system_metadata(
+        self, driver: Any, request: "SystemMetadataRequest | str | None" = None, **kwargs: Any
+    ) -> "SystemMetadataResult":
+        """Get opt-in system metadata or a gated/unsupported result."""
+        from sqlspec.data_dictionary import (
+            ensure_system_metadata_request,
+            system_metadata_gated_result,
+            unsupported_system_metadata_capability,
+        )
+
+        metadata_request = ensure_system_metadata_request(request, **kwargs)
+        capability = unsupported_system_metadata_capability(metadata_request.domain)
+        return system_metadata_gated_result(metadata_request, capability)
 
     @abstractmethod
     def get_version(self, driver: Any) -> "VersionInfo | None":

--- a/sqlspec/protocols.py
+++ b/sqlspec/protocols.py
@@ -23,6 +23,9 @@ if TYPE_CHECKING:
         IndexMetadata,
         MetadataCapabilityProfile,
         MetadataResult,
+        SystemMetadataCapability,
+        SystemMetadataRequest,
+        SystemMetadataResult,
         TableMetadata,
         VersionInfo,
     )
@@ -944,7 +947,13 @@ class SyncDataDictionaryProtocol(Protocol):
 
     def get_ddl(self, driver: Any, object_name: str, schema: "str | None" = None) -> "MetadataResult": ...
 
-    def get_system_metadata(self, driver: Any, domain: str, *, include_sensitive: bool = False) -> "MetadataResult": ...
+    def get_system_metadata_capabilities(
+        self, driver: Any, domains: "Sequence[str] | None" = None
+    ) -> "tuple[SystemMetadataCapability, ...]": ...
+
+    def get_system_metadata(
+        self, driver: Any, request: "SystemMetadataRequest | str | None" = None, **kwargs: Any
+    ) -> "SystemMetadataResult": ...
 
     def get_version(self, driver: Any) -> "VersionInfo | None": ...
 
@@ -1002,9 +1011,13 @@ class AsyncDataDictionaryProtocol(Protocol):
 
     async def get_ddl(self, driver: Any, object_name: str, schema: "str | None" = None) -> "MetadataResult": ...
 
+    async def get_system_metadata_capabilities(
+        self, driver: Any, domains: "Sequence[str] | None" = None
+    ) -> "tuple[SystemMetadataCapability, ...]": ...
+
     async def get_system_metadata(
-        self, driver: Any, domain: str, *, include_sensitive: bool = False
-    ) -> "MetadataResult": ...
+        self, driver: Any, request: "SystemMetadataRequest | str | None" = None, **kwargs: Any
+    ) -> "SystemMetadataResult": ...
 
     async def get_version(self, driver: Any) -> "VersionInfo | None": ...
 

--- a/tests/integration/adapters/contracts/test_metadata_contract.py
+++ b/tests/integration/adapters/contracts/test_metadata_contract.py
@@ -1,7 +1,10 @@
 """Shared adapter native metadata and statistics contracts."""
 
+from typing import Any, cast
+
 import pytest
 
+from sqlspec.data_dictionary import MetadataSupport, SystemMetadataRequest, SystemMetadataResult
 from tests.integration.adapters.contracts._cases import (
     DriverCaseContext,
     async_driver_params_with,
@@ -88,6 +91,42 @@ async def test_async_data_dictionary_capability_contract(async_capability_driver
     assert isinstance(case.supports_data_dictionary_dependencies, bool)
     assert isinstance(case.supports_data_dictionary_system, bool)
     assert isinstance(case.supports_data_dictionary_transport_metadata, bool)
+
+
+@pytest.mark.parametrize(
+    "sync_capability_driver_case", sync_driver_params_with("supports_data_dictionary"), indirect=True
+)
+def test_sync_data_dictionary_system_metadata_disabled_by_default(
+    sync_capability_driver_case: DriverCaseContext,
+) -> None:
+    """Sync system metadata contract fails closed without explicit opt-in."""
+    data_dictionary = cast("Any", sync_capability_driver_case.driver).data_dictionary
+
+    result = data_dictionary.get_system_metadata(
+        sync_capability_driver_case.driver, SystemMetadataRequest(domain="sessions")
+    )
+
+    assert isinstance(result, SystemMetadataResult)
+    assert result.capability.support == MetadataSupport.GATED
+    assert result.rows == ()
+
+
+@pytest.mark.parametrize(
+    "async_capability_driver_case", async_driver_params_with("supports_data_dictionary"), indirect=True
+)
+async def test_async_data_dictionary_system_metadata_disabled_by_default(
+    async_capability_driver_case: DriverCaseContext,
+) -> None:
+    """Async system metadata contract fails closed without explicit opt-in."""
+    data_dictionary = cast("Any", async_capability_driver_case.driver).data_dictionary
+
+    result = await data_dictionary.get_system_metadata(
+        async_capability_driver_case.driver, SystemMetadataRequest(domain="sessions")
+    )
+
+    assert isinstance(result, SystemMetadataResult)
+    assert result.capability.support == MetadataSupport.GATED
+    assert result.rows == ()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/data_dictionary/test_system_metadata.py
+++ b/tests/unit/data_dictionary/test_system_metadata.py
@@ -1,0 +1,264 @@
+"""Tests for opt-in system and performance metadata policy."""
+
+from typing import Any
+from unittest.mock import Mock
+
+from sqlspec.adapters.adbc.data_dictionary import AdbcDataDictionary
+from sqlspec.data_dictionary import (
+    ColumnMetadata,
+    ForeignKeyMetadata,
+    IndexMetadata,
+    MetadataRisk,
+    MetadataSource,
+    MetadataSupport,
+    SystemMetadataCapability,
+    SystemMetadataRedactionPolicy,
+    SystemMetadataRequest,
+    SystemMetadataResult,
+    TableMetadata,
+    system_metadata_gated_result,
+)
+from sqlspec.driver import AsyncDataDictionaryBase, SyncDataDictionaryBase
+
+
+class ConcreteSyncDataDictionary(SyncDataDictionaryBase):
+    """Concrete sync data dictionary for base behavior tests."""
+
+    dialect = "test"
+
+    def get_version(self, driver: Any) -> None:
+        return None
+
+    def get_feature_flag(self, driver: Any, feature: str) -> bool:
+        return False
+
+    def get_optimal_type(self, driver: Any, type_category: str) -> str:
+        return "TEXT"
+
+    def get_tables(self, driver: Any, schema: str | None = None) -> list[TableMetadata]:
+        return []
+
+    def get_columns(self, driver: Any, table: str | None = None, schema: str | None = None) -> list[ColumnMetadata]:
+        return []
+
+    def get_indexes(self, driver: Any, table: str | None = None, schema: str | None = None) -> list[IndexMetadata]:
+        return []
+
+    def get_foreign_keys(
+        self, driver: Any, table: str | None = None, schema: str | None = None
+    ) -> list[ForeignKeyMetadata]:
+        return []
+
+
+class ConcreteAsyncDataDictionary(AsyncDataDictionaryBase):
+    """Concrete async data dictionary for base behavior tests."""
+
+    dialect = "test"
+
+    async def get_version(self, driver: Any) -> None:
+        return None
+
+    async def get_feature_flag(self, driver: Any, feature: str) -> bool:
+        return False
+
+    async def get_optimal_type(self, driver: Any, type_category: str) -> str:
+        return "TEXT"
+
+    async def get_tables(self, driver: Any, schema: str | None = None) -> list[TableMetadata]:
+        return []
+
+    async def get_columns(
+        self, driver: Any, table: str | None = None, schema: str | None = None
+    ) -> list[ColumnMetadata]:
+        return []
+
+    async def get_indexes(
+        self, driver: Any, table: str | None = None, schema: str | None = None
+    ) -> list[IndexMetadata]:
+        return []
+
+    async def get_foreign_keys(
+        self, driver: Any, table: str | None = None, schema: str | None = None
+    ) -> list[ForeignKeyMetadata]:
+        return []
+
+
+def test_system_metadata_disabled_by_default() -> None:
+    """Base system metadata calls fail closed until explicitly opted in."""
+    result = ConcreteSyncDataDictionary().get_system_metadata(Mock(), SystemMetadataRequest(domain="sessions"))
+
+    assert isinstance(result, SystemMetadataResult)
+    assert result.rows == ()
+    assert result.capability.support == MetadataSupport.GATED
+    assert result.capability.domain == "sessions"
+    assert result.source == MetadataSource.SYSTEM_VIEW
+    assert "disabled by default" in result.warnings[0]
+
+
+def test_structural_metadata_capabilities_do_not_include_system_domain() -> None:
+    """System metadata capability disclosure stays out of structural metadata profiles."""
+    data_dictionary = ConcreteSyncDataDictionary()
+
+    structural = data_dictionary.get_metadata_capabilities(Mock())
+    system = data_dictionary.get_system_metadata_capabilities(Mock(), domains=("sessions",))
+
+    assert structural.get("system").support == MetadataSupport.UNKNOWN
+    assert system[0].domain == "sessions"
+    assert system[0].support == MetadataSupport.UNSUPPORTED
+    assert MetadataRisk.REDACTED in system[0].risks
+
+
+async def test_async_system_metadata_disabled_by_default() -> None:
+    """Async base system metadata follows the same fail-closed policy."""
+    result = await ConcreteAsyncDataDictionary().get_system_metadata(Mock(), SystemMetadataRequest(domain="sessions"))
+
+    assert result.rows == ()
+    assert result.capability.support == MetadataSupport.GATED
+    assert "disabled by default" in result.warnings[0]
+
+
+def test_system_metadata_requires_explicit_billed_opt_in() -> None:
+    """Billed metadata domains require their own explicit opt-in after system opt-in."""
+    request = SystemMetadataRequest(domain="jobs", include_system=True)
+    capability = SystemMetadataCapability(
+        domain="jobs",
+        support=MetadataSupport.SUPPORTED,
+        source=MetadataSource.SYSTEM_VIEW,
+        risks=(MetadataRisk.BILLED,),
+        cost_implications="May bill INFORMATION_SCHEMA job timeline scans.",
+    )
+
+    result = system_metadata_gated_result(request, capability)
+
+    assert result.capability.support == MetadataSupport.GATED
+    assert result.rows == ()
+    assert MetadataRisk.BILLED in result.capability.risks
+    assert any("allow_billed_metadata=True" in warning for warning in result.warnings)
+
+
+def test_system_metadata_requires_explicit_license_opt_in() -> None:
+    """License-gated diagnostics require acknowledgement before any query can run."""
+    request = SystemMetadataRequest(domain="awr", include_performance=True)
+    capability = SystemMetadataCapability(
+        domain="awr",
+        support=MetadataSupport.SUPPORTED,
+        source=MetadataSource.SYSTEM_VIEW,
+        risks=(MetadataRisk.LICENSE_GATED,),
+        license_gate="Oracle Diagnostics Pack",
+    )
+
+    result = system_metadata_gated_result(request, capability)
+
+    assert result.capability.support == MetadataSupport.GATED
+    assert MetadataRisk.LICENSE_GATED in result.capability.risks
+    assert any("allow_license_gated_diagnostics=True" in warning for warning in result.warnings)
+
+
+def test_system_metadata_capability_discloses_policy_concerns() -> None:
+    """System capabilities carry privilege, cost, license, redaction, and managed-service disclosures."""
+    capability = SystemMetadataCapability(
+        domain="activity",
+        support=MetadataSupport.SUPPORTED,
+        required_privileges=("pg_monitor",),
+        risks=(MetadataRisk.PRIVILEGED, MetadataRisk.EXPENSIVE, MetadataRisk.REDACTED),
+        source=MetadataSource.SYSTEM_VIEW,
+        cost_implications="May scan active session views.",
+        license_gate="diagnostics option",
+        managed_service_restricted=True,
+        redaction_fields=("sql_text", "user", "host"),
+    )
+
+    payload = capability.to_dict()
+
+    assert payload["required_privileges"] == ("pg_monitor",)
+    assert payload["cost_implications"] == "May scan active session views."
+    assert payload["license_gate"] == "diagnostics option"
+    assert payload["managed_service_restricted"] is True
+    assert payload["redaction_fields"] == ("sql_text", "user", "host")
+
+
+def test_system_metadata_redacts_sensitive_fields_by_default() -> None:
+    """Default redaction covers SQL text, principals, hosts, settings, connection strings, and grants."""
+    row = {
+        "sql_text": "select * from secret_table where token = 'abc'",
+        "username": "alice",
+        "client_host": "db-client.internal",
+        "setting_name": "database_url",
+        "setting_value": "postgresql://alice:secret@db.internal/app",
+        "connection_string": "Server=db.internal;User Id=alice;Password=secret",
+        "grantee": "reporting_role",
+        "grant_sql": "GRANT SELECT ON secret_table TO reporting_role",
+        "row_count": 42,
+    }
+
+    redacted, fields = SystemMetadataRedactionPolicy().redact_row(row)
+
+    assert redacted["sql_text"] == "[REDACTED]"
+    assert redacted["username"] == "[REDACTED]"
+    assert redacted["client_host"] == "[REDACTED]"
+    assert redacted["setting_value"] == "[REDACTED]"
+    assert redacted["connection_string"] == "[REDACTED]"
+    assert redacted["grantee"] == "[REDACTED]"
+    assert redacted["grant_sql"] == "[REDACTED]"
+    assert redacted["row_count"] == 42
+    assert fields == (
+        "client_host",
+        "connection_string",
+        "grant_sql",
+        "grantee",
+        "setting_value",
+        "sql_text",
+        "username",
+    )
+
+
+def test_system_metadata_result_redacts_rows_by_default() -> None:
+    """Result construction applies the request redaction policy before exposing rows."""
+    request = SystemMetadataRequest(domain="activity", include_system=True)
+    capability = SystemMetadataCapability(
+        domain="activity",
+        support=MetadataSupport.SUPPORTED,
+        source=MetadataSource.SYSTEM_VIEW,
+        redaction_fields=("sql_text", "username"),
+    )
+
+    result = SystemMetadataResult.from_rows(
+        request, capability, rows=({"sql_text": "select password from users", "username": "alice", "pid": 1},)
+    )
+
+    assert result.rows == ({"sql_text": "[REDACTED]", "username": "[REDACTED]", "pid": 1},)
+    assert result.redactions == ("sql_text", "username")
+
+
+def test_adbc_statistics_surface_as_transport_system_metadata() -> None:
+    """ADBC table statistics can be requested through the gated system metadata namespace."""
+    driver = Mock()
+    driver.dialect = "duckdb"
+    driver.connection.adbc_get_statistics.return_value.read_all.return_value.to_pylist.return_value = [
+        {
+            "catalog_name": "memory",
+            "catalog_db_schemas": [
+                {
+                    "db_schema_name": "main",
+                    "db_schema_statistics": [
+                        {
+                            "table_name": "items",
+                            "column_name": None,
+                            "statistic_key": 6,
+                            "statistic_value": 3,
+                            "statistic_is_approximate": True,
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+    request = SystemMetadataRequest(domain="table_statistics", include_performance=True, table="items")
+
+    result = AdbcDataDictionary().get_system_metadata(driver, request)
+
+    assert result.capability.support == MetadataSupport.SUPPORTED
+    assert result.capability.source == MetadataSource.DRIVER_METADATA
+    assert result.rows[0]["table_name"] == "items"
+    assert result.rows[0]["statistic_name"] == "adbc.statistic.row_count"
+    assert MetadataRisk.PRIVILEGED in result.capability.risks


### PR DESCRIPTION
## Summary

- add SystemMetadataRequest, capability, result, and redaction policy types
- add fail-closed sync/async base methods for system/performance metadata
- add ADBC table_statistics bridge through explicit performance opt-in
- add shared contract tests for disabled-by-default behavior