### PR TITLE
feat(data-dictionary): add DDL dependency graph

### DIFF
--- a/sqlspec/adapters/adbc/data_dictionary.py
+++ b/sqlspec/adapters/adbc/data_dictionary.py
@@ -698,33 +698,31 @@ class AdbcDataDictionary(SyncDataDictionaryBase):
             warnings=capability.warnings,
         )
 
-    def get_ddl(self, driver: "AdbcDriver", object_name: str, schema: "str | None" = None) -> "MetadataResult":
+    def get_ddl(
+        self,
+        driver: "AdbcDriver",
+        object_name: str,
+        schema: "str | None" = None,
+        *,
+        object_type: str = "table",
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> "DDLResult":
         """Fail closed because ADBC metadata is not a lossless DDL source."""
+        _ = include_dependencies, prefer_native, redact
         dialect = self._normalize_dialect(driver)
         schema_name = self._resolve_schema(dialect, schema)
         identity = ObjectIdentity(
             name=object_name,
-            object_type="object",
+            object_type=object_type,
             schema=schema_name,
             dialect=dialect,
             source=MetadataSource.DRIVER_METADATA,
         )
-        capability = MetadataCapability(
-            domain="ddl",
-            support=MetadataSupport.UNSUPPORTED,
-            fidelity=MetadataFidelity.UNSUPPORTED,
-            source=MetadataSource.DRIVER_METADATA,
-            warnings=(_ADBC_DDL_UNSUPPORTED_WARNING,),
+        return DDLResult.unsupported(
+            identity, source=MetadataSource.DRIVER_METADATA, warnings=(_ADBC_DDL_UNSUPPORTED_WARNING,)
         )
-        ddl = DDLResult(
-            identity=identity,
-            status=MetadataSupport.UNSUPPORTED,
-            fidelity=MetadataFidelity.UNSUPPORTED,
-            source=MetadataSource.DRIVER_METADATA,
-            ddl=None,
-            warnings=capability.warnings,
-        )
-        return MetadataResult(domain="ddl", capability=capability, items=(ddl,), warnings=capability.warnings)
 
     def get_system_metadata_capabilities(
         self, driver: Any, domains: "Sequence[str] | None" = None

--- a/sqlspec/adapters/arrow_odbc/data_dictionary.py
+++ b/sqlspec/adapters/arrow_odbc/data_dictionary.py
@@ -12,7 +12,6 @@ from sqlspec.data_dictionary import (
     MetadataCapability,
     MetadataCapabilityProfile,
     MetadataFidelity,
-    MetadataResult,
     MetadataSource,
     MetadataSupport,
     ObjectIdentity,
@@ -253,33 +252,30 @@ class ArrowOdbcDataDictionary(SyncDataDictionaryBase):
         except SQLFileNotFoundError:
             return []
 
-    def get_ddl(self, driver: "ArrowOdbcDriver", object_name: str, schema: str | None = None) -> MetadataResult:
+    def get_ddl(
+        self,
+        driver: "ArrowOdbcDriver",
+        object_name: str,
+        schema: str | None = None,
+        *,
+        object_type: str = "table",
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> DDLResult:
         """Fail closed because arrow-odbc does not expose lossless DDL metadata."""
-        _ = driver
+        _ = driver, include_dependencies, prefer_native, redact
         schema_name = self.resolve_schema(schema)
         identity = ObjectIdentity(
             name=object_name,
-            object_type="object",
+            object_type=object_type,
             schema=schema_name,
             dialect=self._dialect,
             source=MetadataSource.DRIVER_METADATA,
         )
-        capability = MetadataCapability(
-            domain="ddl",
-            support=MetadataSupport.UNSUPPORTED,
-            fidelity=MetadataFidelity.UNSUPPORTED,
-            source=MetadataSource.DRIVER_METADATA,
-            warnings=(_ODBC_DDL_UNSUPPORTED_WARNING,),
+        return DDLResult.unsupported(
+            identity, source=MetadataSource.DRIVER_METADATA, warnings=(_ODBC_DDL_UNSUPPORTED_WARNING,)
         )
-        ddl = DDLResult(
-            identity=identity,
-            status=MetadataSupport.UNSUPPORTED,
-            fidelity=MetadataFidelity.UNSUPPORTED,
-            source=MetadataSource.DRIVER_METADATA,
-            ddl=None,
-            warnings=capability.warnings,
-        )
-        return MetadataResult(domain="ddl", capability=capability, items=(ddl,), warnings=capability.warnings)
 
     def _capability_for_domain(self, domain: str) -> MetadataCapability:
         if domain == "odbc_catalog":

--- a/sqlspec/adapters/spanner/data_dictionary.py
+++ b/sqlspec/adapters/spanner/data_dictionary.py
@@ -12,7 +12,6 @@ from sqlspec.data_dictionary import (
     MetadataCapability,
     MetadataCapabilityProfile,
     MetadataFidelity,
-    MetadataResult,
     MetadataRisk,
     MetadataSource,
     MetadataSupport,
@@ -175,21 +174,31 @@ class SpannerDataDictionary(SyncDataDictionaryBase):
         )
         return MetadataCapabilityProfile(self.dialect, adapter=type(self).__name__, capabilities=capabilities)
 
-    def get_ddl(self, driver: Any, object_name: str, schema: "str | None" = None) -> "MetadataResult":
+    def get_ddl(
+        self,
+        driver: Any,
+        object_name: str,
+        schema: "str | None" = None,
+        *,
+        object_type: str = "table",
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> "DDLResult":
         """Get Spanner DDL through the Database Admin API."""
+        _ = include_dependencies, prefer_native, redact
         ddl_statements = _get_spanner_ddl_statements(driver)
         identity = ObjectIdentity(
             name=object_name,
-            object_type="object",
+            object_type=object_type,
             schema=schema,
             dialect=self.dialect,
             source=MetadataSource.NATIVE_API,
         )
-        capability = _spanner_capability_for_domain("ddl", mode="googlesql")
         if not ddl_statements:
-            return MetadataResult(domain="ddl", capability=capability, items=(), warnings=_SPANNER_DDL_WARNINGS)
+            return DDLResult.unsupported(identity, source=MetadataSource.NATIVE_API, warnings=_SPANNER_DDL_WARNINGS)
         ddl = _select_spanner_ddl_for_object(ddl_statements, object_name)
-        result = DDLResult(
+        return DDLResult(
             identity=identity,
             status=MetadataSupport.SUPPORTED,
             fidelity=MetadataFidelity.NATIVE,
@@ -197,7 +206,6 @@ class SpannerDataDictionary(SyncDataDictionaryBase):
             ddl=ddl,
             warnings=_SPANNER_DDL_WARNINGS,
         )
-        return MetadataResult(domain="ddl", capability=capability, items=(result,), warnings=_SPANNER_DDL_WARNINGS)
 
 
 def _spanner_capability_for_domain(domain: str, *, mode: str) -> "MetadataCapability":

--- a/sqlspec/data_dictionary/__init__.py
+++ b/sqlspec/data_dictionary/__init__.py
@@ -9,6 +9,17 @@ from sqlspec.data_dictionary._capabilities import (
     system_metadata_gated_result,
     unsupported_system_metadata_capability,
 )
+from sqlspec.data_dictionary._dependencies import (
+    DependencyCycle,
+    DependencyCycleError,
+    DependencyDirection,
+    DependencyEdge,
+    DependencyEdgeKind,
+    DependencySortResult,
+    DependencyStrength,
+    dependency_edges_from_foreign_keys,
+    sort_dependencies,
+)
 from sqlspec.data_dictionary._registry import (
     get_dialect_config,
     list_registered_dialects,
@@ -67,7 +78,14 @@ __all__ = (
     "ConstraintMetadata",
     "DDLResult",
     "DataDictionaryLoader",
+    "DependencyCycle",
+    "DependencyCycleError",
+    "DependencyDirection",
+    "DependencyEdge",
+    "DependencyEdgeKind",
     "DependencyMetadata",
+    "DependencySortResult",
+    "DependencyStrength",
     "DialectConfig",
     "FeatureFlags",
     "FeatureVersions",
@@ -100,6 +118,7 @@ __all__ = (
     "VersionCacheResult",
     "VersionInfo",
     "ViewMetadata",
+    "dependency_edges_from_foreign_keys",
     "ensure_system_metadata_request",
     "get_data_dictionary_loader",
     "get_dialect_config",
@@ -109,6 +128,7 @@ __all__ = (
     "system_metadata_capabilities_from_domains",
     "system_metadata_gated_result",
     "unsupported_system_metadata_capability",
+    "sort_dependencies",
 )
 
 

--- a/sqlspec/data_dictionary/__init__.py
+++ b/sqlspec/data_dictionary/__init__.py
@@ -18,6 +18,8 @@ from sqlspec.data_dictionary._dependencies import (
     DependencySortResult,
     DependencyStrength,
     dependency_edges_from_foreign_keys,
+    dependency_edges_from_metadata,
+    sort_ddl_results,
     sort_dependencies,
 )
 from sqlspec.data_dictionary._registry import (
@@ -119,16 +121,18 @@ __all__ = (
     "VersionInfo",
     "ViewMetadata",
     "dependency_edges_from_foreign_keys",
+    "dependency_edges_from_metadata",
     "ensure_system_metadata_request",
     "get_data_dictionary_loader",
     "get_dialect_config",
     "list_registered_dialects",
     "normalize_dialect_name",
     "register_dialect",
+    "sort_ddl_results",
+    "sort_dependencies",
     "system_metadata_capabilities_from_domains",
     "system_metadata_gated_result",
     "unsupported_system_metadata_capability",
-    "sort_dependencies",
 )
 
 

--- a/sqlspec/data_dictionary/_dependencies.py
+++ b/sqlspec/data_dictionary/_dependencies.py
@@ -1,0 +1,366 @@
+"""Typed dependency graph helpers for data-dictionary DDL ordering."""
+
+from collections import defaultdict
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from sqlspec.data_dictionary._types import ForeignKeyMetadata, MetadataSource, ObjectIdentity
+from sqlspec.exceptions import SQLSpecError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from typing import Literal
+
+__all__ = (
+    "DependencyCycle",
+    "DependencyCycleError",
+    "DependencyDirection",
+    "DependencyEdge",
+    "DependencyEdgeKind",
+    "DependencySortResult",
+    "DependencyStrength",
+    "dependency_edges_from_foreign_keys",
+    "sort_dependencies",
+)
+
+
+class DependencyEdgeKind(str, Enum):
+    """Kinds of metadata dependency edges used for DDL ordering."""
+
+    CHECK_EXPRESSION = "check_expression"
+    DEFAULT_EXPRESSION = "default_expression"
+    EXTENSION_OWNED = "extension_owned"
+    FOREIGN_KEY = "foreign_key"
+    GENERATED_EXPRESSION = "generated_expression"
+    INDEX_EXPRESSION = "index_expression"
+    MATERIALIZED_VIEW = "materialized_view"
+    PARTITION_PARENT = "partition_parent"
+    ROLE_GRANT = "role_grant"
+    ROUTINE_REFERENCE = "routine_reference"
+    SEQUENCE_OWNER = "sequence_owner"
+    SEQUENCE_USE = "sequence_use"
+    TRIGGER_TARGET = "trigger_target"
+    VIEW_REFERENCE = "view_reference"
+
+
+class DependencyStrength(str, Enum):
+    """Strength of a dependency for ordering and diagnostics."""
+
+    HARD = "hard"
+    INFORMATIONAL = "informational"
+    SOFT = "soft"
+
+
+class DependencyDirection(str, Enum):
+    """Relative direction for create and drop ordering."""
+
+    FROM_BEFORE_TO = "from_before_to"
+    TO_BEFORE_FROM = "to_before_from"
+
+
+class DependencyEdge:
+    """Typed dependency edge between two metadata objects.
+
+    ``from_object`` is the dependent object and ``to_object`` is the prerequisite object.
+    Creation order normally places ``to_object`` before ``from_object``; drop order reverses it.
+    """
+
+    __slots__ = (
+        "confidence",
+        "create_direction",
+        "drop_direction",
+        "from_object",
+        "kind",
+        "source",
+        "strength",
+        "to_object",
+    )
+
+    def __init__(
+        self,
+        from_object: ObjectIdentity,
+        to_object: ObjectIdentity,
+        kind: "DependencyEdgeKind | str",
+        *,
+        strength: "DependencyStrength | str" = DependencyStrength.HARD,
+        create_direction: "DependencyDirection | str" = DependencyDirection.TO_BEFORE_FROM,
+        drop_direction: "DependencyDirection | str" = DependencyDirection.FROM_BEFORE_TO,
+        source: "MetadataSource | str" = MetadataSource.UNKNOWN,
+        confidence: float = 1.0,
+    ) -> None:
+        if confidence < 0.0 or confidence > 1.0:
+            msg = "Dependency confidence must be between 0.0 and 1.0"
+            raise ValueError(msg)
+        self.from_object = from_object
+        self.to_object = to_object
+        self.kind = _coerce_edge_kind(kind)
+        self.strength = _coerce_strength(strength)
+        self.create_direction = _coerce_direction(create_direction)
+        self.drop_direction = _coerce_direction(drop_direction)
+        self.source = _coerce_source(source)
+        self.confidence = confidence
+
+    def to_dict(self) -> "dict[str, object]":
+        """Serialize the edge with stable string enum values."""
+        return {
+            "from": self.from_object.to_dict(),
+            "to": self.to_object.to_dict(),
+            "kind": self.kind.value,
+            "strength": self.strength.value,
+            "create_direction": self.create_direction.value,
+            "drop_direction": self.drop_direction.value,
+            "source": self.source.value,
+            "confidence": self.confidence,
+        }
+
+    def __repr__(self) -> str:
+        return (
+            f"DependencyEdge(from_object={self.from_object!r}, to_object={self.to_object!r}, "
+            f"kind={self.kind!r}, strength={self.strength!r}, create_direction={self.create_direction!r}, "
+            f"drop_direction={self.drop_direction!r}, source={self.source!r}, confidence={self.confidence!r})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, DependencyEdge):
+            return NotImplemented
+        return self.to_dict() == other.to_dict()
+
+    def __hash__(self) -> int:
+        return hash((
+            self.from_object,
+            self.to_object,
+            self.kind,
+            self.strength,
+            self.create_direction,
+            self.drop_direction,
+            self.source,
+            self.confidence,
+        ))
+
+
+class DependencyCycle:
+    """Named dependency cycle with participating objects and edge diagnostics."""
+
+    __slots__ = ("edges", "objects")
+
+    def __init__(self, objects: "tuple[ObjectIdentity, ...]", edges: "tuple[DependencyEdge, ...]") -> None:
+        self.objects = objects
+        self.edges = edges
+
+    def describe(self) -> str:
+        """Return a compact human-readable cycle diagnostic."""
+        if not self.edges:
+            return " -> ".join(_format_identity(identity) for identity in self.objects)
+        return "; ".join(
+            f"{_format_identity(edge.from_object)} --{edge.kind.value}--> {_format_identity(edge.to_object)}"
+            for edge in self.edges
+        )
+
+    def to_dict(self) -> "dict[str, object]":
+        """Serialize the cycle for structured diagnostics."""
+        return {
+            "objects": tuple(identity.to_dict() for identity in self.objects),
+            "edges": tuple(edge.to_dict() for edge in self.edges),
+        }
+
+    def __repr__(self) -> str:
+        return f"DependencyCycle(objects={self.objects!r}, edges={self.edges!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, DependencyCycle):
+            return NotImplemented
+        return self.to_dict() == other.to_dict()
+
+    def __hash__(self) -> int:
+        return hash((self.objects, self.edges))
+
+
+class DependencyCycleError(SQLSpecError):
+    """Raised when dependency sorting finds one or more cycles."""
+
+    def __init__(self, cycles: "Sequence[DependencyCycle]") -> None:
+        self.cycles = tuple(cycles)
+        detail = "Dependency cycle detected"
+        if self.cycles:
+            detail = f"{detail}: " + " | ".join(cycle.describe() for cycle in self.cycles)
+        super().__init__(detail)
+
+
+class DependencySortResult:
+    """Result from dependency graph sorting."""
+
+    __slots__ = ("cycles", "ordered")
+
+    def __init__(self, ordered: "tuple[ObjectIdentity, ...]", cycles: "tuple[DependencyCycle, ...]" = ()) -> None:
+        self.ordered = ordered
+        self.cycles = cycles
+
+    @property
+    def is_acyclic(self) -> bool:
+        """Return whether sorting completed without cycles."""
+        return not self.cycles
+
+    def raise_for_cycles(self) -> None:
+        """Raise a diagnostic exception if cycles were found."""
+        if self.cycles:
+            raise DependencyCycleError(self.cycles)
+
+    def to_dict(self) -> "dict[str, object]":
+        """Serialize the sort result."""
+        return {
+            "ordered": tuple(identity.to_dict() for identity in self.ordered),
+            "cycles": tuple(cycle.to_dict() for cycle in self.cycles),
+        }
+
+    def __repr__(self) -> str:
+        return f"DependencySortResult(ordered={self.ordered!r}, cycles={self.cycles!r})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, DependencySortResult):
+            return NotImplemented
+        return self.to_dict() == other.to_dict()
+
+    def __hash__(self) -> int:
+        return hash((self.ordered, self.cycles))
+
+
+def dependency_edges_from_foreign_keys(
+    foreign_keys: "Iterable[ForeignKeyMetadata]",
+    *,
+    dialect: str | None = None,
+    source: "MetadataSource | str" = MetadataSource.CATALOG,
+) -> "tuple[DependencyEdge, ...]":
+    """Convert FK metadata into typed dependency edges."""
+    metadata_source = _coerce_source(source)
+    edges: list[DependencyEdge] = []
+    for fk in foreign_keys:
+        referenced_schema = fk.referenced_schema or fk.schema
+        if fk.table_name == fk.referenced_table and fk.schema == referenced_schema:
+            continue
+        from_object = ObjectIdentity(fk.table_name, "table", schema=fk.schema, dialect=dialect, source=metadata_source)
+        to_object = ObjectIdentity(
+            fk.referenced_table, "table", schema=referenced_schema, dialect=dialect, source=metadata_source
+        )
+        edges.append(
+            DependencyEdge(
+                from_object,
+                to_object,
+                DependencyEdgeKind.FOREIGN_KEY,
+                strength=DependencyStrength.HARD,
+                source=metadata_source,
+            )
+        )
+    return tuple(edges)
+
+
+def sort_dependencies(
+    objects: "Iterable[ObjectIdentity]",
+    edges: "Iterable[DependencyEdge]",
+    *,
+    order: "Literal['create', 'drop']" = "create",
+) -> DependencySortResult:
+    """Sort metadata objects by typed dependency edges.
+
+    Args:
+        objects: Initial object identities to include in the graph.
+        edges: Dependency edges. Edge endpoints are added to the graph automatically.
+        order: ``"create"`` for dependencies before dependents, ``"drop"`` for dependents before dependencies.
+
+    Returns:
+        Ordered objects plus cycle diagnostics if cycles prevented a complete order.
+    """
+    edge_tuple = tuple(edges)
+    nodes = _dedupe_objects((
+        *tuple(objects),
+        *(edge.from_object for edge in edge_tuple),
+        *(edge.to_object for edge in edge_tuple),
+    ))
+    dependencies: dict[ObjectIdentity, set[ObjectIdentity]] = {node: set() for node in nodes}
+    dependents: dict[ObjectIdentity, set[ObjectIdentity]] = defaultdict(set)
+
+    for edge in edge_tuple:
+        dependent, dependency = _edge_order(edge, order)
+        dependencies.setdefault(dependent, set()).add(dependency)
+        dependencies.setdefault(dependency, set())
+        dependents[dependency].add(dependent)
+
+    ordered: list[ObjectIdentity] = []
+    ready = [node for node in nodes if not dependencies[node]]
+    ready_seen = set(ready)
+
+    while ready:
+        node = ready.pop(0)
+        ordered.append(node)
+        for dependent in _ordered_nodes(dependents.get(node, ()), nodes):
+            dependencies[dependent].discard(node)
+            if not dependencies[dependent] and dependent not in ready_seen and dependent not in ordered:
+                ready.append(dependent)
+                ready_seen.add(dependent)
+
+    unresolved = tuple(node for node in nodes if node not in ordered)
+    if not unresolved:
+        return DependencySortResult(tuple(ordered))
+
+    unresolved_set = set(unresolved)
+    cycle_edges = tuple(
+        edge for edge in edge_tuple if edge.from_object in unresolved_set and edge.to_object in unresolved_set
+    )
+    return DependencySortResult(tuple(ordered), (DependencyCycle(unresolved, cycle_edges),))
+
+
+def _edge_order(edge: DependencyEdge, order: "Literal['create', 'drop']") -> "tuple[ObjectIdentity, ObjectIdentity]":
+    direction = edge.create_direction if order == "create" else edge.drop_direction
+    if direction == DependencyDirection.TO_BEFORE_FROM:
+        return edge.from_object, edge.to_object
+    return edge.to_object, edge.from_object
+
+
+def _dedupe_objects(objects: "Iterable[ObjectIdentity]") -> "tuple[ObjectIdentity, ...]":
+    seen: set[ObjectIdentity] = set()
+    ordered: list[ObjectIdentity] = []
+    for identity in objects:
+        if identity in seen:
+            continue
+        ordered.append(identity)
+        seen.add(identity)
+    return tuple(ordered)
+
+
+def _ordered_nodes(
+    nodes: "Iterable[ObjectIdentity]", preferred_order: "Sequence[ObjectIdentity]"
+) -> "tuple[ObjectIdentity, ...]":
+    node_set = set(nodes)
+    return tuple(node for node in preferred_order if node in node_set)
+
+
+def _format_identity(identity: ObjectIdentity) -> str:
+    name = identity.name
+    if identity.schema:
+        name = f"{identity.schema}.{name}"
+    if identity.catalog:
+        name = f"{identity.catalog}.{name}"
+    return f"{name} ({identity.object_type})"
+
+
+def _coerce_edge_kind(value: "DependencyEdgeKind | str") -> DependencyEdgeKind:
+    if isinstance(value, DependencyEdgeKind):
+        return value
+    return DependencyEdgeKind(value)
+
+
+def _coerce_strength(value: "DependencyStrength | str") -> DependencyStrength:
+    if isinstance(value, DependencyStrength):
+        return value
+    return DependencyStrength(value)
+
+
+def _coerce_direction(value: "DependencyDirection | str") -> DependencyDirection:
+    if isinstance(value, DependencyDirection):
+        return value
+    return DependencyDirection(value)
+
+
+def _coerce_source(value: "MetadataSource | str") -> MetadataSource:
+    if isinstance(value, MetadataSource):
+        return value
+    return MetadataSource(value)

--- a/sqlspec/data_dictionary/_dependencies.py
+++ b/sqlspec/data_dictionary/_dependencies.py
@@ -4,7 +4,13 @@ from collections import defaultdict
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from sqlspec.data_dictionary._types import ForeignKeyMetadata, MetadataSource, ObjectIdentity
+from sqlspec.data_dictionary._types import (
+    DDLResult,
+    DependencyMetadata,
+    ForeignKeyMetadata,
+    MetadataSource,
+    ObjectIdentity,
+)
 from sqlspec.exceptions import SQLSpecError
 
 if TYPE_CHECKING:
@@ -20,6 +26,8 @@ __all__ = (
     "DependencySortResult",
     "DependencyStrength",
     "dependency_edges_from_foreign_keys",
+    "dependency_edges_from_metadata",
+    "sort_ddl_results",
     "sort_dependencies",
 )
 
@@ -253,6 +261,60 @@ def dependency_edges_from_foreign_keys(
     return tuple(edges)
 
 
+def dependency_edges_from_metadata(
+    dependencies: "Iterable[DependencyMetadata]",
+    *,
+    dialect: str | None = None,
+    source: "MetadataSource | str | None" = None,
+) -> "tuple[DependencyEdge, ...]":
+    """Convert rich dependency metadata rows into typed dependency edges.
+
+    Dependency query packs do not all return the same vendor column names. This
+    helper accepts SQLSpec's rich ``DependencyMetadata`` wrapper and looks for
+    stable attribute aliases such as ``referenced_name``, ``referenced_schema``,
+    ``referenced_type``, ``kind``, ``strength``, and ``confidence``.
+    """
+    edges: list[DependencyEdge] = []
+    for dependency in dependencies:
+        edge = _dependency_edge_from_metadata(dependency, dialect=dialect, source=source)
+        if edge is not None:
+            edges.append(edge)
+    return tuple(edges)
+
+
+def sort_ddl_results(
+    ddl_results: "Iterable[DDLResult]", *, order: "Literal['create', 'drop']" = "create", raise_on_cycles: bool = True
+) -> "tuple[DDLResult, ...]":
+    """Sort DDL result objects by their typed dependency edges.
+
+    Args:
+        ddl_results: DDL payloads to order.
+        order: ``"create"`` or ``"drop"`` dependency direction.
+        raise_on_cycles: Raise ``DependencyCycleError`` instead of returning a partial order.
+
+    Returns:
+        DDL results in dependency order. Results not represented in the sorted
+        graph are appended in their original order.
+    """
+    result_tuple = tuple(ddl_results)
+    result_by_identity = {result.identity: result for result in result_tuple}
+    edges = tuple(edge for result in result_tuple for edge in result.dependencies)
+    sort_result = sort_dependencies(result_by_identity.keys(), edges, order=order)
+    if raise_on_cycles:
+        sort_result.raise_for_cycles()
+
+    ordered: list[DDLResult] = []
+    seen: set[ObjectIdentity] = set()
+    for identity in sort_result.ordered:
+        result = result_by_identity.get(identity)
+        if result is None:
+            continue
+        ordered.append(result)
+        seen.add(identity)
+    ordered.extend(result for result in result_tuple if result.identity not in seen)
+    return tuple(ordered)
+
+
 def sort_dependencies(
     objects: "Iterable[ObjectIdentity]",
     edges: "Iterable[DependencyEdge]",
@@ -364,3 +426,109 @@ def _coerce_source(value: "MetadataSource | str") -> MetadataSource:
     if isinstance(value, MetadataSource):
         return value
     return MetadataSource(value)
+
+
+def _dependency_edge_from_metadata(
+    dependency: DependencyMetadata, *, dialect: str | None, source: "MetadataSource | str | None"
+) -> "DependencyEdge | None":
+    attributes = dependency.attributes
+    target = _dependency_target_identity(attributes, dialect=dialect, source=source or dependency.source)
+    if target is None:
+        return None
+    edge_source = dependency.source if source is None else _coerce_source(source)
+    return DependencyEdge(
+        dependency.identity,
+        target,
+        _dependency_kind(attributes, dependency.identity.object_type),
+        strength=_dependency_strength(attributes),
+        source=edge_source,
+        confidence=_dependency_confidence(attributes),
+    )
+
+
+def _dependency_target_identity(
+    attributes: "dict[str, object]", *, dialect: str | None, source: "MetadataSource | str"
+) -> "ObjectIdentity | None":
+    identity = _object_identity_attribute(attributes, "referenced_identity", "target_identity", "to_identity")
+    if identity is not None:
+        return identity
+    referenced_name = _string_attribute(
+        attributes, "referenced_name", "referenced_object_name", "target_name", "to_name", "depends_on"
+    )
+    if referenced_name is None:
+        return None
+    return ObjectIdentity(
+        referenced_name,
+        _string_attribute(attributes, "referenced_type", "referenced_object_type", "target_type", "to_type")
+        or "object",
+        catalog=_string_attribute(attributes, "referenced_catalog", "target_catalog", "to_catalog"),
+        schema=_string_attribute(attributes, "referenced_schema", "target_schema", "to_schema"),
+        dialect=dialect or _string_attribute(attributes, "referenced_dialect", "target_dialect", "to_dialect"),
+        source=_coerce_source(source),
+    )
+
+
+def _object_identity_attribute(attributes: "dict[str, object]", *names: str) -> "ObjectIdentity | None":
+    for name in names:
+        value = attributes.get(name)
+        if isinstance(value, ObjectIdentity):
+            return value
+    return None
+
+
+def _string_attribute(attributes: "dict[str, object]", *names: str) -> "str | None":
+    for name in names:
+        value = attributes.get(name)
+        if value is None:
+            continue
+        return str(value)
+    return None
+
+
+def _dependency_kind(attributes: "dict[str, object]", from_type: str) -> DependencyEdgeKind:
+    raw_kind = _string_attribute(attributes, "kind", "edge_kind", "dependency_kind", "dependency_type", "type")
+    if raw_kind is not None:
+        normalized = raw_kind.strip().lower().replace("-", "_").replace(" ", "_")
+        aliases = {
+            "fk": DependencyEdgeKind.FOREIGN_KEY,
+            "foreign_key_constraint": DependencyEdgeKind.FOREIGN_KEY,
+            "sequence": DependencyEdgeKind.SEQUENCE_USE,
+            "sequence_dependency": DependencyEdgeKind.SEQUENCE_USE,
+            "view": DependencyEdgeKind.VIEW_REFERENCE,
+            "view_dependency": DependencyEdgeKind.VIEW_REFERENCE,
+        }
+        if normalized in aliases:
+            return aliases[normalized]
+        try:
+            return DependencyEdgeKind(normalized)
+        except ValueError:
+            pass
+    normalized_type = from_type.strip().lower()
+    if normalized_type in {"view", "materialized_view"}:
+        return DependencyEdgeKind.VIEW_REFERENCE
+    if normalized_type == "trigger":
+        return DependencyEdgeKind.TRIGGER_TARGET
+    if normalized_type in {"function", "procedure", "routine"}:
+        return DependencyEdgeKind.ROUTINE_REFERENCE
+    return DependencyEdgeKind.ROUTINE_REFERENCE
+
+
+def _dependency_strength(attributes: "dict[str, object]") -> DependencyStrength:
+    raw_strength = _string_attribute(attributes, "strength", "dependency_strength")
+    if raw_strength is None:
+        return DependencyStrength.HARD
+    return _coerce_strength(raw_strength.strip().lower().replace("-", "_").replace(" ", "_"))
+
+
+def _dependency_confidence(attributes: "dict[str, object]") -> float:
+    value = attributes.get("confidence")
+    if value is None:
+        return 1.0
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, int | float):
+        return float(value)
+    try:
+        return float(str(value))
+    except ValueError:
+        return 1.0

--- a/sqlspec/data_dictionary/_types.py
+++ b/sqlspec/data_dictionary/_types.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
     from re import Pattern
 
     from sqlspec.core.statement import SQL
+    from sqlspec.data_dictionary._dependencies import DependencyEdge
 
 __all__ = (
     "ColumnDetails",
@@ -448,7 +449,7 @@ class MetadataQuery:
 class DDLResult:
     """DDL text and fidelity status for one database object."""
 
-    __slots__ = ("ddl", "fidelity", "identity", "source", "status", "warnings")
+    __slots__ = ("context", "ddl", "dependencies", "fidelity", "identity", "redactions", "source", "status", "warnings")
 
     def __init__(
         self,
@@ -458,6 +459,9 @@ class DDLResult:
         fidelity: "MetadataFidelity | str" = MetadataFidelity.UNSUPPORTED,
         source: "MetadataSource | str" = MetadataSource.UNKNOWN,
         ddl: str | None = None,
+        dependencies: "tuple[DependencyEdge, ...]" = (),
+        redactions: "tuple[str, ...]" = (),
+        context: "dict[str, object] | None" = None,
         warnings: "tuple[str, ...]" = (),
     ) -> None:
         self.identity = identity
@@ -465,7 +469,55 @@ class DDLResult:
         self.fidelity = _coerce_fidelity(fidelity)
         self.source = _coerce_source(source)
         self.ddl = ddl
+        self.dependencies = dependencies
+        self.redactions = redactions
+        self.context = {} if context is None else context
         self.warnings = warnings
+
+    @classmethod
+    def unsupported(
+        cls,
+        identity: ObjectIdentity,
+        *,
+        source: "MetadataSource | str" = MetadataSource.UNKNOWN,
+        warnings: "tuple[str, ...]" = (),
+        context: "dict[str, object] | None" = None,
+    ) -> "DDLResult":
+        """Create an explicit unsupported DDL result."""
+        return cls(
+            identity,
+            status=MetadataSupport.UNSUPPORTED,
+            fidelity=MetadataFidelity.UNSUPPORTED,
+            source=source,
+            ddl=None,
+            context=context,
+            warnings=warnings,
+        )
+
+    @classmethod
+    def lossy(
+        cls,
+        identity: ObjectIdentity,
+        *,
+        ddl: str | None,
+        source: "MetadataSource | str",
+        dependencies: "tuple[DependencyEdge, ...]" = (),
+        redactions: "tuple[str, ...]" = (),
+        context: "dict[str, object] | None" = None,
+        warnings: "tuple[str, ...]" = (),
+    ) -> "DDLResult":
+        """Create an explicit lossy DDL result."""
+        return cls(
+            identity,
+            status=MetadataSupport.SUPPORTED,
+            fidelity=MetadataFidelity.LOSSY,
+            source=source,
+            ddl=ddl,
+            dependencies=dependencies,
+            redactions=redactions,
+            context=context,
+            warnings=warnings,
+        )
 
     def to_dict(self) -> "dict[str, object]":
         """Serialize the DDL result."""
@@ -475,6 +527,9 @@ class DDLResult:
             "fidelity": self.fidelity.value,
             "source": self.source.value,
             "ddl": self.ddl,
+            "dependencies": tuple(_serialize_metadata_item(dependency) for dependency in self.dependencies),
+            "redactions": self.redactions,
+            "context": self.context,
             "warnings": self.warnings,
         }
 
@@ -484,7 +539,17 @@ class DDLResult:
         return self.to_dict() == other.to_dict()
 
     def __hash__(self) -> int:
-        return hash((self.identity, self.status, self.fidelity, self.source, self.ddl, self.warnings))
+        return hash((
+            self.identity,
+            self.status,
+            self.fidelity,
+            self.source,
+            self.ddl,
+            self.dependencies,
+            self.redactions,
+            _hashable_mapping(self.context),
+            self.warnings,
+        ))
 
 
 class ObjectMetadata:
@@ -1471,3 +1536,7 @@ def _serialize_metadata_item(item: object) -> object:
     if callable(to_dict):
         return to_dict()
     return item
+
+
+def _hashable_mapping(value: "dict[str, object]") -> "tuple[tuple[str, str], ...]":
+    return tuple(sorted((key, repr(item)) for key, item in value.items()))

--- a/sqlspec/driver/_async.py
+++ b/sqlspec/driver/_async.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from sqlspec.core import ArrowResult, SQLResult, Statement, StatementConfig, StatementFilter
     from sqlspec.data_dictionary import (
         ColumnMetadata,
+        DDLResult,
         ForeignKeyMetadata,
         IndexMetadata,
         MetadataCapabilityProfile,
@@ -1954,8 +1955,54 @@ class AsyncDataDictionaryBase(DataDictionaryDialectMixin, DataDictionaryMixin):
         """Get dependency metadata or an unsupported-domain result."""
         return self._unsupported_metadata("dependencies")
 
-    async def get_ddl(self, driver: Any, object_name: str, schema: "str | None" = None) -> "MetadataResult":
-        """Get object DDL or an unsupported-domain result."""
+    async def get_ddl(
+        self,
+        driver: Any,
+        object_name: str,
+        schema: "str | None" = None,
+        *,
+        object_type: str = "table",
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> "DDLResult":
+        """Get object DDL or an explicit unsupported DDL result."""
+        return await self.get_object_ddl(
+            driver,
+            object_name,
+            schema=schema,
+            object_type=object_type,
+            include_dependencies=include_dependencies,
+            prefer_native=prefer_native,
+            redact=redact,
+        )
+
+    async def get_object_ddl(
+        self,
+        driver: Any,
+        object_name: str,
+        *,
+        schema: "str | None" = None,
+        object_type: str = "table",
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> "DDLResult":
+        """Get one object's DDL or an explicit unsupported DDL result."""
+        return self._unsupported_ddl(object_name, schema=schema, object_type=object_type)
+
+    async def get_schema_ddl(
+        self,
+        driver: Any,
+        schema: "str | None" = None,
+        *,
+        include_domains: "Sequence[str] | None" = None,
+        exclude_domains: "Sequence[str] | None" = None,
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> "MetadataResult":
+        """Get schema DDL items or an unsupported-domain result."""
         return self._unsupported_metadata("ddl")
 
     async def get_system_metadata(
@@ -2068,3 +2115,11 @@ class AsyncDataDictionaryBase(DataDictionaryDialectMixin, DataDictionaryMixin):
         from sqlspec.data_dictionary import MetadataResult
 
         return MetadataResult.unsupported(domain)
+
+    def _unsupported_ddl(self, object_name: str, *, schema: "str | None", object_type: str) -> "DDLResult":
+        from sqlspec.data_dictionary import DDLResult, ObjectIdentity
+
+        return DDLResult.unsupported(
+            ObjectIdentity(object_name, object_type, schema=schema, dialect=self.dialect),
+            warnings=(f"{self.dialect} DDL extraction is not implemented",),
+        )

--- a/sqlspec/driver/_common.py
+++ b/sqlspec/driver/_common.py
@@ -1,6 +1,5 @@
 """Common driver attributes and utilities."""
 
-import graphlib
 import hashlib
 import logging
 from collections import OrderedDict
@@ -32,7 +31,15 @@ from sqlspec.core.filters import find_filter as _find_filter_impl
 from sqlspec.core.metrics import StackExecutionMetrics
 from sqlspec.core.parameters import ParameterProcessor, structural_fingerprint, value_fingerprint
 from sqlspec.core.statement import ProcessedState
-from sqlspec.data_dictionary import ForeignKeyMetadata, VersionCacheResult, VersionInfo, get_data_dictionary_loader
+from sqlspec.data_dictionary import (
+    ForeignKeyMetadata,
+    ObjectIdentity,
+    VersionCacheResult,
+    VersionInfo,
+    dependency_edges_from_foreign_keys,
+    get_data_dictionary_loader,
+    sort_dependencies,
+)
 from sqlspec.data_dictionary._registry import get_dialect_config
 from sqlspec.driver._query_cache import STMT_CACHE_MAX_SIZE, CachedQuery, QueryCache
 from sqlspec.driver._storage_helpers import (
@@ -625,7 +632,7 @@ class DataDictionaryMixin:
         }
 
     def sort_tables_topologically(self, tables: "list[str]", foreign_keys: "list[ForeignKeyMetadata]") -> "list[str]":
-        """Sort tables topologically based on foreign key dependencies using Python.
+        """Sort tables topologically based on typed foreign key dependency edges.
 
         Args:
             tables: List of table names.
@@ -634,16 +641,14 @@ class DataDictionaryMixin:
         Returns:
             List of table names in topological order (dependencies first).
         """
-        sorter: graphlib.TopologicalSorter[str] = graphlib.TopologicalSorter()
-        for table in tables:
-            sorter.add(table)
-
+        table_schemas: dict[str, str | None] = {}
         for fk in foreign_keys:
-            if fk.table_name == fk.referenced_table:
-                continue
-            sorter.add(fk.table_name, fk.referenced_table)
-
-        return list(sorter.static_order())
+            table_schemas.setdefault(fk.table_name, fk.schema)
+            table_schemas.setdefault(fk.referenced_table, fk.referenced_schema or fk.schema)
+        table_objects = tuple(ObjectIdentity(table, "table", schema=table_schemas.get(table)) for table in tables)
+        result = sort_dependencies(table_objects, dependency_edges_from_foreign_keys(foreign_keys, source="unknown"))
+        result.raise_for_cycles()
+        return [identity.name for identity in result.ordered]
 
     def _resolve_log_adapter(self) -> str:
         """Resolve adapter identifier for logging."""

--- a/sqlspec/driver/_sync.py
+++ b/sqlspec/driver/_sync.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from sqlspec.core import ArrowResult, SQLResult, Statement, StatementConfig, StatementFilter
     from sqlspec.data_dictionary import (
         ColumnMetadata,
+        DDLResult,
         ForeignKeyMetadata,
         IndexMetadata,
         MetadataCapabilityProfile,
@@ -1889,8 +1890,54 @@ class SyncDataDictionaryBase(DataDictionaryDialectMixin, DataDictionaryMixin):
         """Get dependency metadata or an unsupported-domain result."""
         return self._unsupported_metadata("dependencies")
 
-    def get_ddl(self, driver: Any, object_name: str, schema: "str | None" = None) -> "MetadataResult":
-        """Get object DDL or an unsupported-domain result."""
+    def get_ddl(
+        self,
+        driver: Any,
+        object_name: str,
+        schema: "str | None" = None,
+        *,
+        object_type: str = "table",
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> "DDLResult":
+        """Get object DDL or an explicit unsupported DDL result."""
+        return self.get_object_ddl(
+            driver,
+            object_name,
+            schema=schema,
+            object_type=object_type,
+            include_dependencies=include_dependencies,
+            prefer_native=prefer_native,
+            redact=redact,
+        )
+
+    def get_object_ddl(
+        self,
+        driver: Any,
+        object_name: str,
+        *,
+        schema: "str | None" = None,
+        object_type: str = "table",
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> "DDLResult":
+        """Get one object's DDL or an explicit unsupported DDL result."""
+        return self._unsupported_ddl(object_name, schema=schema, object_type=object_type)
+
+    def get_schema_ddl(
+        self,
+        driver: Any,
+        schema: "str | None" = None,
+        *,
+        include_domains: "Sequence[str] | None" = None,
+        exclude_domains: "Sequence[str] | None" = None,
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> "MetadataResult":
+        """Get schema DDL items or an unsupported-domain result."""
         return self._unsupported_metadata("ddl")
 
     def get_system_metadata(
@@ -2003,3 +2050,11 @@ class SyncDataDictionaryBase(DataDictionaryDialectMixin, DataDictionaryMixin):
         from sqlspec.data_dictionary import MetadataResult
 
         return MetadataResult.unsupported(domain)
+
+    def _unsupported_ddl(self, object_name: str, *, schema: "str | None", object_type: str) -> "DDLResult":
+        from sqlspec.data_dictionary import DDLResult, ObjectIdentity
+
+        return DDLResult.unsupported(
+            ObjectIdentity(object_name, object_type, schema=schema, dialect=self.dialect),
+            warnings=(f"{self.dialect} DDL extraction is not implemented",),
+        )

--- a/sqlspec/protocols.py
+++ b/sqlspec/protocols.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from sqlspec.core import StatementConfig
     from sqlspec.data_dictionary import (
         ColumnMetadata,
+        DDLResult,
         ForeignKeyMetadata,
         IndexMetadata,
         MetadataCapabilityProfile,
@@ -945,7 +946,41 @@ class SyncDataDictionaryProtocol(Protocol):
         self, driver: Any, object_name: "str | None" = None, schema: "str | None" = None
     ) -> "MetadataResult": ...
 
-    def get_ddl(self, driver: Any, object_name: str, schema: "str | None" = None) -> "MetadataResult": ...
+    def get_ddl(
+        self,
+        driver: Any,
+        object_name: str,
+        schema: "str | None" = None,
+        *,
+        object_type: str = "table",
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> "DDLResult": ...
+
+    def get_object_ddl(
+        self,
+        driver: Any,
+        object_name: str,
+        *,
+        schema: "str | None" = None,
+        object_type: str = "table",
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> "DDLResult": ...
+
+    def get_schema_ddl(
+        self,
+        driver: Any,
+        schema: "str | None" = None,
+        *,
+        include_domains: "Sequence[str] | None" = None,
+        exclude_domains: "Sequence[str] | None" = None,
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> "MetadataResult": ...
 
     def get_system_metadata_capabilities(
         self, driver: Any, domains: "Sequence[str] | None" = None
@@ -1009,7 +1044,41 @@ class AsyncDataDictionaryProtocol(Protocol):
         self, driver: Any, object_name: "str | None" = None, schema: "str | None" = None
     ) -> "MetadataResult": ...
 
-    async def get_ddl(self, driver: Any, object_name: str, schema: "str | None" = None) -> "MetadataResult": ...
+    async def get_ddl(
+        self,
+        driver: Any,
+        object_name: str,
+        schema: "str | None" = None,
+        *,
+        object_type: str = "table",
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> "DDLResult": ...
+
+    async def get_object_ddl(
+        self,
+        driver: Any,
+        object_name: str,
+        *,
+        schema: "str | None" = None,
+        object_type: str = "table",
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> "DDLResult": ...
+
+    async def get_schema_ddl(
+        self,
+        driver: Any,
+        schema: "str | None" = None,
+        *,
+        include_domains: "Sequence[str] | None" = None,
+        exclude_domains: "Sequence[str] | None" = None,
+        include_dependencies: bool = True,
+        prefer_native: bool = True,
+        redact: bool = True,
+    ) -> "MetadataResult": ...
 
     async def get_system_metadata_capabilities(
         self, driver: Any, domains: "Sequence[str] | None" = None

--- a/tests/unit/adapters/test_adbc/test_data_dictionary.py
+++ b/tests/unit/adapters/test_adbc/test_data_dictionary.py
@@ -477,17 +477,24 @@ def test_adbc_ddl_is_unsupported_without_dialect_pack() -> None:
     driver = Mock()
     driver.dialect = "duckdb"
 
-    result = AdbcDataDictionary().get_ddl(driver, "items", schema="main")
+    result = AdbcDataDictionary().get_ddl(
+        driver,
+        "items",
+        schema="main",
+        object_type="view",
+        include_dependencies=False,
+        prefer_native=False,
+        redact=False,
+    )
 
-    assert result.capability.support == MetadataSupport.UNSUPPORTED
-    assert result.capability.source == MetadataSource.DRIVER_METADATA
-    assert result.items
-    ddl = cast("Any", result.items[0])
-    assert ddl.ddl is None
-    assert ddl.status == MetadataSupport.UNSUPPORTED
-    assert ddl.fidelity == MetadataFidelity.UNSUPPORTED
-    assert ddl.source == MetadataSource.DRIVER_METADATA
-    assert ddl.warnings
+    assert result.identity.name == "items"
+    assert result.identity.object_type == "view"
+    assert result.identity.schema == "main"
+    assert result.ddl is None
+    assert result.status == MetadataSupport.UNSUPPORTED
+    assert result.fidelity == MetadataFidelity.UNSUPPORTED
+    assert result.source == MetadataSource.DRIVER_METADATA
+    assert result.warnings
 
 
 def test_get_statistics_uses_native_statistic_names_when_available() -> None:

--- a/tests/unit/adapters/test_arrow_odbc/test_driver.py
+++ b/tests/unit/adapters/test_arrow_odbc/test_driver.py
@@ -20,7 +20,7 @@ from sqlspec.adapters.arrow_odbc import (
 )
 from sqlspec.adapters.arrow_odbc.data_dictionary import ArrowOdbcDataDictionary
 from sqlspec.core import LimitOffsetFilter, OrderByFilter
-from sqlspec.data_dictionary import MetadataFidelity, MetadataSource, MetadataSupport
+from sqlspec.data_dictionary import DDLResult, MetadataFidelity, MetadataSource, MetadataSupport
 from sqlspec.exceptions import SQLFileNotFoundError, SQLParsingError, SQLSpecError
 
 if TYPE_CHECKING:
@@ -203,6 +203,26 @@ def test_arrow_odbc_data_dictionary_catalog_support_is_explicitly_unavailable_wi
     assert profile.get("columns").support == MetadataSupport.SUPPORTED
     assert profile.get("columns").fidelity == MetadataFidelity.PARTIAL
     assert profile.get("ddl").support == MetadataSupport.UNSUPPORTED
+
+
+def test_arrow_odbc_get_ddl_returns_unsupported_ddl_result() -> None:
+    """arrow-odbc DDL requests should follow the shared DDLResult contract."""
+    connection = FakeConnection()
+    driver = ArrowOdbcDriver(cast("ArrowOdbcConnection", connection), driver_features={"chunk_size": 2})
+
+    result = driver.data_dictionary.get_ddl(
+        driver, "items", schema="dbo", object_type="view", include_dependencies=False, prefer_native=False, redact=False
+    )
+
+    assert isinstance(result, DDLResult)
+    assert result.identity.name == "items"
+    assert result.identity.object_type == "view"
+    assert result.identity.schema == "dbo"
+    assert result.status == MetadataSupport.UNSUPPORTED
+    assert result.fidelity == MetadataFidelity.UNSUPPORTED
+    assert result.source == MetadataSource.DRIVER_METADATA
+    assert result.ddl is None
+    assert result.warnings
 
 
 def test_resolve_dialect_from_dbms_name() -> None:

--- a/tests/unit/data_dictionary/test_bigquery_spanner_metadata.py
+++ b/tests/unit/data_dictionary/test_bigquery_spanner_metadata.py
@@ -5,7 +5,6 @@ from typing import Any, cast
 from sqlspec.adapters.bigquery import data_dictionary as bigquery_data_dictionary
 from sqlspec.adapters.spanner.data_dictionary import SpannerDataDictionary
 from sqlspec.data_dictionary import (
-    DDLResult,
     MetadataFidelity,
     MetadataRisk,
     MetadataSource,
@@ -141,11 +140,10 @@ def test_spanner_get_ddl_uses_admin_api_capability() -> None:
     result = dictionary.get_ddl(cast(Any, driver), "Singers")
     ddl_capability = dictionary.get_metadata_capabilities(cast(Any, driver)).get("ddl")
 
-    assert result.capability.support == MetadataSupport.SUPPORTED
-    assert result.capability.source == MetadataSource.NATIVE_API
-    assert result.capability.fidelity == MetadataFidelity.NATIVE
-    ddl_result = cast(DDLResult, result.items[0])
-    assert ddl_result.ddl == "CREATE TABLE Singers (SingerId INT64) PRIMARY KEY (SingerId)"
+    assert result.status == MetadataSupport.SUPPORTED
+    assert result.source == MetadataSource.NATIVE_API
+    assert result.fidelity == MetadataFidelity.NATIVE
+    assert result.ddl == "CREATE TABLE Singers (SingerId INT64) PRIMARY KEY (SingerId)"
     assert driver.database.get_ddl_calls == 1
     assert ddl_capability.source == MetadataSource.NATIVE_API
     assert MetadataRisk.PRIVILEGED in ddl_capability.risks

--- a/tests/unit/data_dictionary/test_ddl_dependencies.py
+++ b/tests/unit/data_dictionary/test_ddl_dependencies.py
@@ -1,0 +1,152 @@
+"""Unit tests for DDL dependency graph helpers."""
+
+from typing import cast
+
+import pytest
+
+from sqlspec.data_dictionary import (
+    DDLResult,
+    DependencyCycleError,
+    DependencyDirection,
+    DependencyEdge,
+    DependencyEdgeKind,
+    DependencySortResult,
+    DependencyStrength,
+    ForeignKeyMetadata,
+    MetadataFidelity,
+    MetadataSource,
+    MetadataSupport,
+    ObjectIdentity,
+    dependency_edges_from_foreign_keys,
+    sort_dependencies,
+)
+from sqlspec.driver._common import DataDictionaryMixin
+
+
+def test_dependency_graph_sorts_views_sequences_and_tables() -> None:
+    """Creation order includes non-table dependencies before dependent objects."""
+    sequence = ObjectIdentity("order_id_seq", "sequence", schema="public")
+    users = ObjectIdentity("users", "table", schema="public")
+    orders = ObjectIdentity("orders", "table", schema="public")
+    order_summary = ObjectIdentity("order_summary", "view", schema="public")
+
+    result = sort_dependencies(
+        (order_summary, orders, sequence, users),
+        (
+            DependencyEdge(orders, sequence, DependencyEdgeKind.SEQUENCE_USE),
+            DependencyEdge(orders, users, DependencyEdgeKind.FOREIGN_KEY),
+            DependencyEdge(order_summary, orders, DependencyEdgeKind.VIEW_REFERENCE),
+        ),
+    )
+
+    assert isinstance(result, DependencySortResult)
+    assert result.cycles == ()
+    positions = {identity: index for index, identity in enumerate(result.ordered)}
+    assert positions[sequence] < positions[orders]
+    assert positions[users] < positions[orders]
+    assert positions[orders] < positions[order_summary]
+
+    drop_result = sort_dependencies(
+        (order_summary, orders, sequence, users),
+        (
+            DependencyEdge(orders, sequence, DependencyEdgeKind.SEQUENCE_USE),
+            DependencyEdge(orders, users, DependencyEdgeKind.FOREIGN_KEY),
+            DependencyEdge(order_summary, orders, DependencyEdgeKind.VIEW_REFERENCE),
+        ),
+        order="drop",
+    )
+    drop_positions = {identity: index for index, identity in enumerate(drop_result.ordered)}
+    assert drop_positions[order_summary] < drop_positions[orders]
+    assert drop_positions[orders] < drop_positions[sequence]
+    assert drop_positions[orders] < drop_positions[users]
+
+
+def test_dependency_graph_reports_cycle_with_edge_kind() -> None:
+    """Cycle diagnostics name participating objects and dependency edge kinds."""
+    invoice_view = ObjectIdentity("invoice_view", "view", schema="public")
+    refresh_routine = ObjectIdentity("refresh_invoice_view", "routine", schema="public")
+    edges = (
+        DependencyEdge(invoice_view, refresh_routine, DependencyEdgeKind.ROUTINE_REFERENCE),
+        DependencyEdge(refresh_routine, invoice_view, DependencyEdgeKind.VIEW_REFERENCE),
+    )
+
+    result = sort_dependencies((invoice_view, refresh_routine), edges)
+
+    assert result.ordered == ()
+    assert len(result.cycles) == 1
+    cycle = result.cycles[0]
+    assert cycle.objects == (invoice_view, refresh_routine)
+    assert {edge.kind for edge in cycle.edges} == {
+        DependencyEdgeKind.ROUTINE_REFERENCE,
+        DependencyEdgeKind.VIEW_REFERENCE,
+    }
+    with pytest.raises(DependencyCycleError) as exc_info:
+        result.raise_for_cycles()
+    message = str(exc_info.value)
+    assert "invoice_view" in message
+    assert "refresh_invoice_view" in message
+    assert "routine_reference" in message
+    assert "view_reference" in message
+
+
+def test_ddl_result_requires_fidelity_status_and_dependency_context() -> None:
+    """DDL payloads expose fidelity, source, status, redaction, context, and dependencies."""
+    sequence = ObjectIdentity("order_id_seq", "sequence", schema="public")
+    orders = ObjectIdentity("orders", "table", schema="public")
+    dependency = DependencyEdge(orders, sequence, DependencyEdgeKind.SEQUENCE_USE, source=MetadataSource.CATALOG)
+
+    result = DDLResult(
+        orders,
+        status=MetadataSupport.SUPPORTED,
+        fidelity=MetadataFidelity.HYBRID,
+        source=MetadataSource.GENERATED,
+        ddl="CREATE TABLE public.orders (id integer DEFAULT nextval('order_id_seq'))",
+        dependencies=(dependency,),
+        redactions=("owner",),
+        context={"dialect": "postgres", "server_version": "16.0"},
+    )
+
+    payload = result.to_dict()
+
+    assert payload["status"] == "supported"
+    assert payload["fidelity"] == "hybrid"
+    assert payload["source"] == "generated"
+    assert payload["redactions"] == ("owner",)
+    assert payload["context"] == {"dialect": "postgres", "server_version": "16.0"}
+    dependencies = cast("tuple[dict[str, object], ...]", payload["dependencies"])
+    assert dependencies[0]["kind"] == "sequence_use"
+
+    unsupported = DDLResult.unsupported(
+        orders, source=MetadataSource.UNKNOWN, warnings=("DDL extraction is not implemented for this dialect",)
+    )
+    assert unsupported.ddl is None
+    assert unsupported.status == MetadataSupport.UNSUPPORTED
+    assert unsupported.fidelity == MetadataFidelity.UNSUPPORTED
+    assert unsupported.warnings == ("DDL extraction is not implemented for this dialect",)
+
+
+def test_fk_topology_is_represented_as_dependency_edges() -> None:
+    """The legacy FK sorter is backed by typed dependency edges."""
+    fk = ForeignKeyMetadata(
+        table_name="orders",
+        column_name="user_id",
+        referenced_table="users",
+        referenced_column="id",
+        constraint_name="orders_user_id_fkey",
+        schema="public",
+        referenced_schema="public",
+    )
+
+    edges = dependency_edges_from_foreign_keys((fk,))
+
+    assert len(edges) == 1
+    edge = edges[0]
+    assert edge.from_object.name == "orders"
+    assert edge.to_object.name == "users"
+    assert edge.kind == DependencyEdgeKind.FOREIGN_KEY
+    assert edge.strength == DependencyStrength.HARD
+    assert edge.create_direction == DependencyDirection.TO_BEFORE_FROM
+    assert edge.drop_direction == DependencyDirection.FROM_BEFORE_TO
+
+    sorted_tables = DataDictionaryMixin().sort_tables_topologically(["orders", "users"], [fk])
+    assert sorted_tables == ["users", "orders"]

--- a/tests/unit/data_dictionary/test_ddl_dependencies.py
+++ b/tests/unit/data_dictionary/test_ddl_dependencies.py
@@ -10,6 +10,7 @@ from sqlspec.data_dictionary import (
     DependencyDirection,
     DependencyEdge,
     DependencyEdgeKind,
+    DependencyMetadata,
     DependencySortResult,
     DependencyStrength,
     ForeignKeyMetadata,
@@ -18,6 +19,8 @@ from sqlspec.data_dictionary import (
     MetadataSupport,
     ObjectIdentity,
     dependency_edges_from_foreign_keys,
+    dependency_edges_from_metadata,
+    sort_ddl_results,
     sort_dependencies,
 )
 from sqlspec.driver._common import DataDictionaryMixin
@@ -150,3 +153,124 @@ def test_fk_topology_is_represented_as_dependency_edges() -> None:
 
     sorted_tables = DataDictionaryMixin().sort_tables_topologically(["orders", "users"], [fk])
     assert sorted_tables == ["users", "orders"]
+
+
+def test_postgres_pilot_sorts_catalog_dependency_metadata_and_native_ddl() -> None:
+    """PostgreSQL pg_depend-style metadata can drive typed DDL ordering."""
+    sequence = ObjectIdentity("order_id_seq", "sequence", schema="public", dialect="postgres")
+    table = ObjectIdentity("orders", "table", schema="public", dialect="postgres")
+    view = ObjectIdentity("order_summary", "view", schema="public", dialect="postgres")
+    dependencies = (
+        DependencyMetadata(
+            table,
+            source=MetadataSource.CATALOG,
+            attributes={"referenced_identity": sequence, "kind": "sequence_use", "confidence": 1.0},
+        ),
+        DependencyMetadata(
+            view,
+            source=MetadataSource.CATALOG,
+            attributes={
+                "referenced_name": "orders",
+                "referenced_schema": "public",
+                "referenced_type": "table",
+                "kind": "view_reference",
+            },
+        ),
+    )
+    edges = dependency_edges_from_metadata(dependencies, dialect="postgres")
+    ddl_results = (
+        DDLResult(
+            view,
+            status=MetadataSupport.SUPPORTED,
+            fidelity=MetadataFidelity.NATIVE,
+            source=MetadataSource.CATALOG,
+            ddl="CREATE VIEW public.order_summary AS SELECT count(*) FROM public.orders",
+            dependencies=(edges[1],),
+        ),
+        DDLResult(
+            table,
+            status=MetadataSupport.SUPPORTED,
+            fidelity=MetadataFidelity.HYBRID,
+            source=MetadataSource.GENERATED,
+            ddl="CREATE TABLE public.orders (id integer DEFAULT nextval('public.order_id_seq'))",
+            dependencies=(edges[0],),
+            warnings=("Table DDL combines generated table text with native catalog dependencies.",),
+        ),
+        DDLResult(
+            sequence,
+            status=MetadataSupport.SUPPORTED,
+            fidelity=MetadataFidelity.NATIVE,
+            source=MetadataSource.CATALOG,
+            ddl="CREATE SEQUENCE public.order_id_seq",
+        ),
+    )
+
+    ordered = sort_ddl_results(ddl_results)
+
+    assert [result.identity.name for result in ordered] == ["order_id_seq", "orders", "order_summary"]
+    assert ordered[1].fidelity == MetadataFidelity.HYBRID
+    assert ordered[1].dependencies[0].kind == DependencyEdgeKind.SEQUENCE_USE
+
+
+def test_sqlite_duckdb_pilot_sorts_native_schema_sql_dependencies() -> None:
+    """Embedded native schema SQL can be ordered with parsed dependency edges."""
+    users = ObjectIdentity("users", "table", schema="main", dialect="sqlite")
+    orders = ObjectIdentity("orders", "table", schema="main", dialect="sqlite")
+    orders_view = ObjectIdentity("orders_view", "view", schema="main", dialect="sqlite")
+    trigger = ObjectIdentity("orders_ai", "trigger", schema="main", dialect="sqlite")
+    edges = (
+        DependencyEdge(orders, users, DependencyEdgeKind.FOREIGN_KEY, source=MetadataSource.PARSED_SQL, confidence=0.8),
+        DependencyEdge(
+            orders_view, orders, DependencyEdgeKind.VIEW_REFERENCE, source=MetadataSource.PARSED_SQL, confidence=0.8
+        ),
+        DependencyEdge(
+            trigger, orders, DependencyEdgeKind.TRIGGER_TARGET, source=MetadataSource.PARSED_SQL, confidence=0.8
+        ),
+    )
+    ddl_results = (
+        DDLResult(
+            trigger,
+            status=MetadataSupport.SUPPORTED,
+            fidelity=MetadataFidelity.LOSSY,
+            source=MetadataSource.PARSED_SQL,
+            ddl="CREATE TRIGGER orders_ai AFTER INSERT ON orders BEGIN SELECT 1; END",
+            dependencies=(edges[2],),
+            warnings=("Dependency edges were parsed from native schema SQL.",),
+        ),
+        DDLResult(
+            orders_view,
+            status=MetadataSupport.SUPPORTED,
+            fidelity=MetadataFidelity.NATIVE,
+            source=MetadataSource.CATALOG,
+            ddl="CREATE VIEW orders_view AS SELECT * FROM orders",
+            dependencies=(edges[1],),
+        ),
+        DDLResult(
+            orders,
+            status=MetadataSupport.SUPPORTED,
+            fidelity=MetadataFidelity.NATIVE,
+            source=MetadataSource.CATALOG,
+            ddl="CREATE TABLE orders (id integer primary key, user_id integer references users(id))",
+            dependencies=(edges[0],),
+        ),
+        DDLResult(
+            users,
+            status=MetadataSupport.SUPPORTED,
+            fidelity=MetadataFidelity.NATIVE,
+            source=MetadataSource.CATALOG,
+            ddl="CREATE TABLE users (id integer primary key)",
+        ),
+    )
+
+    create_order = sort_ddl_results(ddl_results)
+    drop_order = sort_ddl_results(ddl_results, order="drop")
+    create_positions = {result.identity.name: index for index, result in enumerate(create_order)}
+    drop_positions = {result.identity.name: index for index, result in enumerate(drop_order)}
+
+    assert create_positions["users"] < create_positions["orders"]
+    assert create_positions["orders"] < create_positions["orders_view"]
+    assert create_positions["orders"] < create_positions["orders_ai"]
+    assert drop_positions["orders_view"] < drop_positions["orders"]
+    assert drop_positions["orders_ai"] < drop_positions["orders"]
+    assert drop_positions["orders"] < drop_positions["users"]
+    assert create_order[-1].dependencies[0].confidence == 0.8


### PR DESCRIPTION
## Summary

- add typed dependency graph edges, cycle diagnostics, and DDLResult dependency context
- add fail-closed get_ddl/get_object_ddl/get_schema_ddl base APIs
- add FK, rich dependency metadata, and DDLResult ordering helpers
- add PostgreSQL and SQLite/DuckDB pilot ordering tests