### PR TITLE
feat(data-dictionary): add transport metadata profiles

### DIFF
--- a/sqlspec/adapters/adbc/data_dictionary.py
+++ b/sqlspec/adapters/adbc/data_dictionary.py
@@ -9,12 +9,18 @@ from mypy_extensions import mypyc_attr
 from sqlspec.adapters.sqlite.core import format_identifier
 from sqlspec.data_dictionary import (
     ColumnMetadata,
+    ConstraintMetadata,
+    DDLResult,
     ForeignKeyMetadata,
     IndexMetadata,
+    MetadataCapability,
+    MetadataCapabilityProfile,
     MetadataFidelity,
+    MetadataResult,
     MetadataRisk,
     MetadataSource,
     MetadataSupport,
+    ObjectIdentity,
     SystemMetadataCapability,
     SystemMetadataRequest,
     SystemMetadataResult,
@@ -54,6 +60,30 @@ logger = get_logger("sqlspec.adapters.adbc")
 
 _NATIVE_TABLE_TYPES: Final = frozenset({"table", "base table"})
 _NATIVE_FALLBACK_ERRORS: Final = (AdbcNotSupportedError, AdbcOperationalError)
+_ADBC_METADATA_DOMAINS: Final = (
+    "schemas",
+    "objects",
+    "tables",
+    "columns",
+    "constraints",
+    "indexes",
+    "views",
+    "routines",
+    "privileges",
+    "dependencies",
+    "ddl",
+    "statistics",
+    "system",
+)
+_ADBC_TRANSPORT_WARNING: Final = (
+    "ADBC transport metadata is portable discovery metadata; dialect SQL packs remain the DDL-grade source."
+)
+_ADBC_CONSTRAINT_WARNING: Final = (
+    "ADBC GetObjects constraint metadata is lossy; expressions, enforcement details, privileges, and dialect DDL "
+    "are not preserved."
+)
+_ADBC_DDL_UNSUPPORTED_WARNING: Final = "ADBC metadata is not a lossless DDL source for this dialect."
+_ADBC_STATISTICS_WARNING: Final = "ADBC statistics metadata may be approximate, expensive, and driver-specific."
 
 
 class _NativeMetadataIncompleteError(Exception):
@@ -167,6 +197,54 @@ def _normalize_native_foreign_keys(
     return keys
 
 
+def _generated_constraint_name(table_name: str, constraint_type: str, column_names: "tuple[str, ...]") -> str:
+    constraint_label = constraint_type.lower().replace(" ", "_") or "constraint"
+    column_label = "_".join(column_names) if column_names else "unnamed"
+    return f"{table_name}_{constraint_label}_{column_label}"
+
+
+def _normalize_native_constraints(
+    rows: "list[dict[str, Any]]", table_name_exact: "str | None" = None, dialect: "str | None" = None
+) -> "list[ConstraintMetadata]":
+    constraints: list[ConstraintMetadata] = []
+    for catalog_name, schema_name, table in _iter_object_tables(rows):
+        table_name = str(table["table_name"])
+        if table_name_exact is not None and table_name != table_name_exact:
+            continue
+        resolved_schema = schema_name or catalog_name
+        for constraint in table.get("table_constraints") or []:
+            constraint_type = str(constraint.get("constraint_type") or "").upper()
+            if not constraint_type:
+                continue
+            column_names = tuple(str(column) for column in constraint.get("constraint_column_names") or ())
+            raw_name = constraint.get("constraint_name")
+            constraint_name = (
+                str(raw_name) if raw_name else _generated_constraint_name(table_name, constraint_type, column_names)
+            )
+            identity = ObjectIdentity(
+                name=constraint_name,
+                object_type="constraint",
+                catalog=str(catalog_name) if catalog_name else None,
+                schema=str(resolved_schema) if resolved_schema else None,
+                dialect=dialect,
+                source=MetadataSource.DRIVER_METADATA,
+            )
+            constraints.append(
+                ConstraintMetadata(
+                    identity=identity,
+                    source=MetadataSource.DRIVER_METADATA,
+                    attributes={
+                        "table_name": table_name,
+                        "constraint_type": constraint_type,
+                        "column_names": column_names,
+                        "column_usage": tuple(constraint.get("constraint_column_usage") or ()),
+                        "is_lossy": True,
+                    },
+                )
+            )
+    return constraints
+
+
 _ARROW_DECIMAL_FORMAT: Final = "DECIMAL({precision},{scale})"
 
 
@@ -212,7 +290,26 @@ _ADBC_STATISTIC_NAMES: dict[int, str] = {
 }
 
 
-def _normalize_native_statistics(rows: "list[dict[str, Any]]") -> "list[TableStatisticsMetadata]":
+def _normalize_native_statistic_names(rows: "list[dict[str, Any]]") -> "dict[int, str]":
+    statistic_names: dict[int, str] = {}
+    for entry in rows:
+        key = entry.get("statistic_key")
+        name = entry.get("statistic_name")
+        if key is None or name is None:
+            continue
+        try:
+            statistic_names[int(key)] = str(name)
+        except (TypeError, ValueError):
+            continue
+    return statistic_names
+
+
+def _normalize_native_statistics(
+    rows: "list[dict[str, Any]]", statistic_names: "dict[int, str] | None" = None
+) -> "list[TableStatisticsMetadata]":
+    statistic_name_map = (
+        _ADBC_STATISTIC_NAMES if statistic_names is None else {**_ADBC_STATISTIC_NAMES, **statistic_names}
+    )
     statistics: list[TableStatisticsMetadata] = []
     for catalog in rows:
         catalog_name = catalog.get("catalog_name")
@@ -225,7 +322,7 @@ def _normalize_native_statistics(rows: "list[dict[str, Any]]") -> "list[TableSta
                     "table_name": str(entry["table_name"]),
                     "column_name": str(column_name) if column_name is not None else None,
                     "statistic_key": key,
-                    "statistic_name": _ADBC_STATISTIC_NAMES.get(key, str(key)),
+                    "statistic_name": statistic_name_map.get(key, str(key)),
                     "statistic_value": entry.get("statistic_value"),
                     "is_approximate": bool(entry.get("statistic_is_approximate")),
                 }
@@ -328,6 +425,16 @@ class AdbcDataDictionary(SyncDataDictionaryBase):
             features.update(config.feature_flags.keys())
             features.update(config.feature_versions.keys())
         return sorted(features)
+
+    def get_metadata_capabilities(
+        self, driver: "AdbcDriver", domains: "Sequence[str] | None" = None
+    ) -> "MetadataCapabilityProfile":
+        """Report ADBC transport metadata capabilities without implying DDL fidelity."""
+        dialect = self._normalize_dialect(driver)
+        requested_domains = tuple(domains or _ADBC_METADATA_DOMAINS)
+        probes = self._probe_transport_metadata(driver)
+        capabilities = tuple(self._capability_for_domain(dialect, domain, probes) for domain in requested_domains)
+        return MetadataCapabilityProfile(dialect=dialect, adapter="adbc", capabilities=capabilities)
 
     def get_tables(self, driver: "AdbcDriver", schema: "str | None" = None) -> "list[TableMetadata]":
         """Get tables for the current dialect."""
@@ -552,7 +659,72 @@ class AdbcDataDictionary(SyncDataDictionaryBase):
             msg = f"ADBC driver for dialect {dialect!r} does not support native table statistics: {exc}"
             raise OperationalError(msg) from exc
         rows = reader.read_all().to_pylist()
-        return [entry for entry in _normalize_native_statistics(rows) if entry["table_name"] == table_name]
+        statistic_names = self._native_statistic_names(driver)
+        return [
+            entry for entry in _normalize_native_statistics(rows, statistic_names) if entry["table_name"] == table_name
+        ]
+
+    def get_constraints(
+        self, driver: "AdbcDriver", table: "str | None" = None, schema: "str | None" = None
+    ) -> "MetadataResult":
+        """Get lossy ADBC constraint shells from GetObjects."""
+        dialect = self._normalize_dialect(driver)
+        schema_name = self._resolve_schema(dialect, schema)
+        table_name = self._resolve_identifier(dialect, table) if table is not None else None
+        try:
+            rows = self._native_get_objects(driver, dialect, "all", schema_name, table_name)
+        except (*_NATIVE_FALLBACK_ERRORS, _NativeMetadataIncompleteError) as exc:
+            warning = f"ADBC GetObjects is unavailable for constraints: {exc}"
+            capability = MetadataCapability(
+                domain="constraints",
+                support=MetadataSupport.UNSUPPORTED,
+                fidelity=MetadataFidelity.UNSUPPORTED,
+                source=MetadataSource.DRIVER_METADATA,
+                warnings=(warning,),
+            )
+            return MetadataResult(domain="constraints", capability=capability, warnings=capability.warnings)
+
+        capability = MetadataCapability(
+            domain="constraints",
+            support=MetadataSupport.SUPPORTED,
+            fidelity=MetadataFidelity.LOSSY,
+            source=MetadataSource.DRIVER_METADATA,
+            warnings=(_ADBC_CONSTRAINT_WARNING,),
+        )
+        return MetadataResult(
+            domain="constraints",
+            capability=capability,
+            items=tuple(_normalize_native_constraints(rows, table_name_exact=table_name, dialect=dialect)),
+            warnings=capability.warnings,
+        )
+
+    def get_ddl(self, driver: "AdbcDriver", object_name: str, schema: "str | None" = None) -> "MetadataResult":
+        """Fail closed because ADBC metadata is not a lossless DDL source."""
+        dialect = self._normalize_dialect(driver)
+        schema_name = self._resolve_schema(dialect, schema)
+        identity = ObjectIdentity(
+            name=object_name,
+            object_type="object",
+            schema=schema_name,
+            dialect=dialect,
+            source=MetadataSource.DRIVER_METADATA,
+        )
+        capability = MetadataCapability(
+            domain="ddl",
+            support=MetadataSupport.UNSUPPORTED,
+            fidelity=MetadataFidelity.UNSUPPORTED,
+            source=MetadataSource.DRIVER_METADATA,
+            warnings=(_ADBC_DDL_UNSUPPORTED_WARNING,),
+        )
+        ddl = DDLResult(
+            identity=identity,
+            status=MetadataSupport.UNSUPPORTED,
+            fidelity=MetadataFidelity.UNSUPPORTED,
+            source=MetadataSource.DRIVER_METADATA,
+            ddl=None,
+            warnings=capability.warnings,
+        )
+        return MetadataResult(domain="ddl", capability=capability, items=(ddl,), warnings=capability.warnings)
 
     def get_system_metadata_capabilities(
         self, driver: Any, domains: "Sequence[str] | None" = None
@@ -655,6 +827,141 @@ class AdbcDataDictionary(SyncDataDictionaryBase):
         if required_version is None or version_info is None:
             return False
         return bool(version_info >= required_version)
+
+    def _probe_transport_metadata(self, driver: "AdbcDriver") -> "dict[str, bool]":
+        connection = driver.connection
+        return {
+            "info": self._probe_callable(connection, "adbc_get_info"),
+            "table_types": self._probe_callable(connection, "adbc_get_table_types"),
+            "objects": self._probe_reader_callable(connection, "adbc_get_objects", depth="catalogs"),
+            "table_schema": callable(getattr(connection, "adbc_get_table_schema", None)),
+            "statistics": self._probe_reader_callable(
+                connection, "adbc_get_statistics", table_name_filter="__sqlspec_metadata_probe__", approximate=True
+            ),
+            "statistic_names": self._probe_reader_callable(connection, "adbc_get_statistic_names"),
+        }
+
+    def _probe_callable(self, connection: Any, name: str) -> bool:
+        method = getattr(connection, name, None)
+        if not callable(method):
+            return False
+        try:
+            method()
+        except Exception:
+            return False
+        return True
+
+    def _probe_reader_callable(self, connection: Any, name: str, **kwargs: Any) -> bool:
+        method = getattr(connection, name, None)
+        if not callable(method):
+            return False
+        try:
+            reader = cast("Any", method(**kwargs))
+            reader.read_all()
+        except Exception:
+            return False
+        return True
+
+    def _capability_for_domain(self, dialect: str, domain: str, probes: "dict[str, bool]") -> "MetadataCapability":
+        if domain == "ddl":
+            return MetadataCapability(
+                domain=domain,
+                support=MetadataSupport.UNSUPPORTED,
+                fidelity=MetadataFidelity.UNSUPPORTED,
+                source=MetadataSource.DRIVER_METADATA,
+                warnings=(_ADBC_DDL_UNSUPPORTED_WARNING,),
+            )
+        if domain in {"views", "routines", "privileges", "dependencies"}:
+            return MetadataCapability(
+                domain=domain,
+                support=MetadataSupport.UNSUPPORTED,
+                fidelity=MetadataFidelity.UNSUPPORTED,
+                source=MetadataSource.DRIVER_METADATA,
+                warnings=(_ADBC_TRANSPORT_WARNING,),
+            )
+        if domain in {"statistics", "system"}:
+            if probes["statistics"] or probes["statistic_names"]:
+                fidelity = (
+                    MetadataFidelity.TRANSPORT_FALLBACK
+                    if probes["statistics"] and probes["statistic_names"]
+                    else MetadataFidelity.PARTIAL
+                )
+                return MetadataCapability(
+                    domain=domain,
+                    support=MetadataSupport.SUPPORTED,
+                    fidelity=fidelity,
+                    source=MetadataSource.DRIVER_METADATA,
+                    risks=(MetadataRisk.EXPENSIVE,),
+                    warnings=(_ADBC_STATISTICS_WARNING,),
+                )
+            return MetadataCapability(
+                domain=domain,
+                support=MetadataSupport.UNSUPPORTED,
+                fidelity=MetadataFidelity.UNSUPPORTED,
+                source=MetadataSource.DRIVER_METADATA,
+                warnings=("ADBC statistics metadata is unavailable for this driver.",),
+            )
+        if domain == "constraints":
+            if probes["objects"]:
+                return MetadataCapability(
+                    domain=domain,
+                    support=MetadataSupport.SUPPORTED,
+                    fidelity=MetadataFidelity.LOSSY,
+                    source=MetadataSource.DRIVER_METADATA,
+                    warnings=(_ADBC_CONSTRAINT_WARNING,),
+                )
+            return MetadataCapability(
+                domain=domain,
+                support=MetadataSupport.UNSUPPORTED,
+                fidelity=MetadataFidelity.UNSUPPORTED,
+                source=MetadataSource.DRIVER_METADATA,
+                warnings=("ADBC GetObjects is unavailable for constraints.",),
+            )
+        if domain == "columns" and (probes["objects"] or probes["table_schema"]):
+            return self._transport_capability(domain)
+        if domain in {"schemas", "objects", "tables"} and (probes["objects"] or probes["table_types"]):
+            return self._transport_capability(domain)
+        if domain == "indexes" and self._has_query(dialect, "indexes_by_schema"):
+            return MetadataCapability(
+                domain=domain,
+                support=MetadataSupport.SUPPORTED,
+                fidelity=MetadataFidelity.NATIVE,
+                source=MetadataSource.CATALOG,
+                warnings=("ADBC uses the dialect SQL pack for index metadata; no transport index API is available.",),
+            )
+        return MetadataCapability(
+            domain=domain,
+            support=MetadataSupport.UNSUPPORTED,
+            fidelity=MetadataFidelity.UNSUPPORTED,
+            source=MetadataSource.DRIVER_METADATA,
+            warnings=(_ADBC_TRANSPORT_WARNING,),
+        )
+
+    def _transport_capability(self, domain: str) -> "MetadataCapability":
+        return MetadataCapability(
+            domain=domain,
+            support=MetadataSupport.SUPPORTED,
+            fidelity=MetadataFidelity.TRANSPORT_FALLBACK,
+            source=MetadataSource.DRIVER_METADATA,
+            warnings=(_ADBC_TRANSPORT_WARNING,),
+        )
+
+    def _has_query(self, dialect: str, name: str) -> bool:
+        try:
+            self._get_query(dialect, name)
+        except SQLFileNotFoundError:
+            return False
+        return True
+
+    def _native_statistic_names(self, driver: "AdbcDriver") -> "dict[int, str]":
+        try:
+            reader = driver.connection.adbc_get_statistic_names()
+            rows = reader.read_all().to_pylist()
+        except Exception:
+            return {}
+        if not isinstance(rows, list) or not all(isinstance(row, dict) for row in rows):
+            return {}
+        return _normalize_native_statistic_names(cast("list[dict[str, Any]]", rows))
 
     def _native_object_filters(
         self, dialect: str, schema_name: "str | None", table_name: "str | None"

--- a/sqlspec/adapters/arrow_odbc/data_dictionary.py
+++ b/sqlspec/adapters/arrow_odbc/data_dictionary.py
@@ -6,8 +6,16 @@ from mypy_extensions import mypyc_attr
 
 from sqlspec.data_dictionary import (
     ColumnMetadata,
+    DDLResult,
     ForeignKeyMetadata,
     IndexMetadata,
+    MetadataCapability,
+    MetadataCapabilityProfile,
+    MetadataFidelity,
+    MetadataResult,
+    MetadataSource,
+    MetadataSupport,
+    ObjectIdentity,
     TableMetadata,
     VersionInfo,
     get_data_dictionary_loader,
@@ -18,6 +26,8 @@ from sqlspec.exceptions import SQLFileNotFoundError
 from sqlspec.utils.text import normalize_identifier, quote_identifier
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from sqlspec.adapters.arrow_odbc.driver import ArrowOdbcDriver
     from sqlspec.core import SQL
     from sqlspec.data_dictionary._types import DialectConfig
@@ -25,6 +35,29 @@ if TYPE_CHECKING:
 __all__ = ("ArrowOdbcDataDictionary",)
 
 _ARROW_DECIMAL_FORMAT: Final = "DECIMAL({precision},{scale})"
+_ODBC_METADATA_DOMAINS: Final = (
+    "schemas",
+    "objects",
+    "tables",
+    "columns",
+    "constraints",
+    "indexes",
+    "views",
+    "routines",
+    "privileges",
+    "dependencies",
+    "ddl",
+    "system",
+    "odbc_catalog",
+)
+_ODBC_CATALOG_UNAVAILABLE_WARNING: Final = (
+    "arrow-odbc does not expose SQLGetInfo, SQLGetFunctions, or raw ODBC catalog functions through its Python "
+    "Connection API."
+)
+_ODBC_DDL_UNSUPPORTED_WARNING: Final = "Arrow ODBC transport metadata is not a lossless DDL source."
+_ODBC_COLUMN_PARTIAL_WARNING: Final = (
+    "Arrow ODBC column metadata comes from dialect SQL packs or zero-row Arrow schema probes, not SQLColumns."
+)
 
 
 def _arrow_type_to_sql(data_type: Any) -> str:
@@ -81,6 +114,15 @@ class ArrowOdbcDataDictionary(SyncDataDictionaryBase):
         """Return raw SQL text for a named runtime dialect query."""
         loader = get_data_dictionary_loader()
         return loader.get_query_text(self._dialect, name)
+
+    def get_metadata_capabilities(
+        self, driver: "ArrowOdbcDriver", domains: "Sequence[str] | None" = None
+    ) -> "MetadataCapabilityProfile":
+        """Report Arrow ODBC metadata capabilities without claiming raw catalog support."""
+        _ = driver
+        requested_domains = tuple(domains or _ODBC_METADATA_DOMAINS)
+        capabilities = tuple(self._capability_for_domain(domain) for domain in requested_domains)
+        return MetadataCapabilityProfile(dialect=self._dialect, adapter="arrow_odbc", capabilities=capabilities)
 
     def resolve_schema(self, schema: str | None) -> str | None:
         """Return a schema name using runtime dialect defaults when missing."""
@@ -210,3 +252,84 @@ class ArrowOdbcDataDictionary(SyncDataDictionaryBase):
             return driver.select(self.get_query(query_name), schema_type=ForeignKeyMetadata, **parameters)
         except SQLFileNotFoundError:
             return []
+
+    def get_ddl(self, driver: "ArrowOdbcDriver", object_name: str, schema: str | None = None) -> MetadataResult:
+        """Fail closed because arrow-odbc does not expose lossless DDL metadata."""
+        _ = driver
+        schema_name = self.resolve_schema(schema)
+        identity = ObjectIdentity(
+            name=object_name,
+            object_type="object",
+            schema=schema_name,
+            dialect=self._dialect,
+            source=MetadataSource.DRIVER_METADATA,
+        )
+        capability = MetadataCapability(
+            domain="ddl",
+            support=MetadataSupport.UNSUPPORTED,
+            fidelity=MetadataFidelity.UNSUPPORTED,
+            source=MetadataSource.DRIVER_METADATA,
+            warnings=(_ODBC_DDL_UNSUPPORTED_WARNING,),
+        )
+        ddl = DDLResult(
+            identity=identity,
+            status=MetadataSupport.UNSUPPORTED,
+            fidelity=MetadataFidelity.UNSUPPORTED,
+            source=MetadataSource.DRIVER_METADATA,
+            ddl=None,
+            warnings=capability.warnings,
+        )
+        return MetadataResult(domain="ddl", capability=capability, items=(ddl,), warnings=capability.warnings)
+
+    def _capability_for_domain(self, domain: str) -> MetadataCapability:
+        if domain == "odbc_catalog":
+            return MetadataCapability(
+                domain=domain,
+                support=MetadataSupport.UNSUPPORTED,
+                fidelity=MetadataFidelity.UNSUPPORTED,
+                source=MetadataSource.DRIVER_METADATA,
+                warnings=(_ODBC_CATALOG_UNAVAILABLE_WARNING,),
+            )
+        if domain == "ddl":
+            return MetadataCapability(
+                domain=domain,
+                support=MetadataSupport.UNSUPPORTED,
+                fidelity=MetadataFidelity.UNSUPPORTED,
+                source=MetadataSource.DRIVER_METADATA,
+                warnings=(_ODBC_DDL_UNSUPPORTED_WARNING,),
+            )
+        if domain == "columns":
+            return MetadataCapability(
+                domain=domain,
+                support=MetadataSupport.SUPPORTED,
+                fidelity=MetadataFidelity.PARTIAL,
+                source=MetadataSource.DRIVER_METADATA,
+                warnings=(_ODBC_COLUMN_PARTIAL_WARNING,),
+            )
+        query_by_domain = {
+            "tables": "tables_by_schema",
+            "indexes": "indexes_by_schema",
+            "foreign_keys": "foreign_keys_by_schema",
+        }
+        query_name = query_by_domain.get(domain)
+        if query_name is not None and self._has_query(query_name):
+            return MetadataCapability(
+                domain=domain,
+                support=MetadataSupport.SUPPORTED,
+                fidelity=MetadataFidelity.NATIVE,
+                source=MetadataSource.CATALOG,
+            )
+        return MetadataCapability(
+            domain=domain,
+            support=MetadataSupport.UNSUPPORTED,
+            fidelity=MetadataFidelity.UNSUPPORTED,
+            source=MetadataSource.DRIVER_METADATA,
+            warnings=(_ODBC_CATALOG_UNAVAILABLE_WARNING,),
+        )
+
+    def _has_query(self, name: str) -> bool:
+        try:
+            self.get_query(name)
+        except SQLFileNotFoundError:
+            return False
+        return True

--- a/tests/unit/adapters/test_adbc/test_data_dictionary.py
+++ b/tests/unit/adapters/test_adbc/test_data_dictionary.py
@@ -1,6 +1,6 @@
 """Unit tests for ADBC native metadata normalization and fallback."""
 
-from typing import Any
+from typing import Any, cast
 from unittest.mock import Mock
 
 import pyarrow as pa
@@ -18,6 +18,7 @@ from sqlspec.adapters.adbc.data_dictionary import (
     _normalize_native_statistics,
     _normalize_native_tables,
 )
+from sqlspec.data_dictionary import MetadataFidelity, MetadataSource, MetadataSupport
 from sqlspec.exceptions import OperationalError
 
 SQLITE_OBJECTS_PAYLOAD: list[dict[str, Any]] = [
@@ -389,3 +390,135 @@ def test_get_statistics_filters_exact_table() -> None:
 
     assert len(statistics) == 1
     assert statistics[0]["table_name"] == "items"
+
+
+def test_adbc_capabilities_include_get_info_table_types_statistics() -> None:
+    """ADBC capability profiles should report explicit transport metadata support."""
+    driver = Mock()
+    driver.dialect = "duckdb"
+    driver.connection.adbc_get_info.return_value = {"vendor_name": "duckdb", "driver_name": "duckdb"}
+    driver.connection.adbc_get_table_types.return_value = ["BASE TABLE", "VIEW"]
+    driver.connection.adbc_get_objects.return_value = _make_reader([])
+    driver.connection.adbc_get_statistics.return_value = _make_reader([])
+    driver.connection.adbc_get_statistic_names.return_value = _make_reader([
+        {"statistic_key": 6, "statistic_name": "row_count"}
+    ])
+
+    profile = AdbcDataDictionary().get_metadata_capabilities(
+        driver, domains=("tables", "columns", "constraints", "statistics", "ddl")
+    )
+
+    assert profile.dialect == "duckdb"
+    assert profile.adapter == "adbc"
+    assert profile.get("tables").support == MetadataSupport.SUPPORTED
+    assert profile.get("tables").fidelity == MetadataFidelity.TRANSPORT_FALLBACK
+    assert profile.get("tables").source == MetadataSource.DRIVER_METADATA
+    assert profile.get("columns").support == MetadataSupport.SUPPORTED
+    assert profile.get("statistics").support == MetadataSupport.SUPPORTED
+    assert profile.get("statistics").risks
+    assert profile.get("ddl").support == MetadataSupport.UNSUPPORTED
+    driver.connection.adbc_get_info.assert_called_once()
+    driver.connection.adbc_get_table_types.assert_called_once()
+    driver.connection.adbc_get_objects.assert_called()
+    driver.connection.adbc_get_statistics.assert_called_once()
+    driver.connection.adbc_get_statistic_names.assert_called_once()
+
+
+def test_adbc_get_objects_unique_check_constraints_are_lossy() -> None:
+    """ADBC GetObjects constraint shells should be surfaced with lossy fidelity."""
+    driver = Mock()
+    driver.dialect = "duckdb"
+    driver.connection.adbc_get_objects.return_value = _make_reader([
+        {
+            "catalog_name": "memory",
+            "catalog_db_schemas": [
+                {
+                    "db_schema_name": "main",
+                    "db_schema_tables": [
+                        {
+                            "table_name": "items",
+                            "table_type": "BASE TABLE",
+                            "table_columns": [],
+                            "table_constraints": [
+                                {
+                                    "constraint_name": "uq_items_name",
+                                    "constraint_type": "UNIQUE",
+                                    "constraint_column_names": ["name"],
+                                    "constraint_column_usage": None,
+                                },
+                                {
+                                    "constraint_name": "ck_items_qty",
+                                    "constraint_type": "CHECK",
+                                    "constraint_column_names": ["quantity"],
+                                    "constraint_column_usage": None,
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+    ])
+
+    result = AdbcDataDictionary().get_constraints(driver, table="items")
+
+    assert result.capability.support == MetadataSupport.SUPPORTED
+    assert result.capability.fidelity == MetadataFidelity.LOSSY
+    assert result.capability.source == MetadataSource.DRIVER_METADATA
+    assert result.warnings
+    constraint_items = [cast("Any", item) for item in result.items]
+    assert [item.identity.name for item in constraint_items] == ["uq_items_name", "ck_items_qty"]
+    assert [item.attributes["constraint_type"] for item in constraint_items] == ["UNIQUE", "CHECK"]
+    assert all(item.attributes["is_lossy"] is True for item in constraint_items)
+
+
+def test_adbc_ddl_is_unsupported_without_dialect_pack() -> None:
+    """ADBC transport metadata should not claim lossless DDL."""
+    driver = Mock()
+    driver.dialect = "duckdb"
+
+    result = AdbcDataDictionary().get_ddl(driver, "items", schema="main")
+
+    assert result.capability.support == MetadataSupport.UNSUPPORTED
+    assert result.capability.source == MetadataSource.DRIVER_METADATA
+    assert result.items
+    ddl = cast("Any", result.items[0])
+    assert ddl.ddl is None
+    assert ddl.status == MetadataSupport.UNSUPPORTED
+    assert ddl.fidelity == MetadataFidelity.UNSUPPORTED
+    assert ddl.source == MetadataSource.DRIVER_METADATA
+    assert ddl.warnings
+
+
+def test_get_statistics_uses_native_statistic_names_when_available() -> None:
+    """ADBC statistic-name metadata should replace built-in fallback labels."""
+    driver = Mock()
+    driver.dialect = "duckdb"
+    driver.connection.adbc_get_statistics.return_value = _make_reader([
+        {
+            "catalog_name": "memory",
+            "catalog_db_schemas": [
+                {
+                    "db_schema_name": "main",
+                    "db_schema_statistics": [
+                        {
+                            "table_name": "items",
+                            "column_name": None,
+                            "statistic_key": 777,
+                            "statistic_value": 3,
+                            "statistic_is_approximate": False,
+                        }
+                    ],
+                }
+            ],
+        }
+    ])
+    driver.connection.adbc_get_statistic_names.return_value = _make_reader([
+        {"statistic_key": 777, "statistic_name": "vendor.custom_count"}
+    ])
+
+    statistics = AdbcDataDictionary().get_statistics(driver, "items", approximate=False)
+
+    assert statistics[0]["statistic_name"] == "vendor.custom_count"
+    assert statistics[0]["is_approximate"] is False
+    driver.connection.adbc_get_statistic_names.assert_called_once()

--- a/tests/unit/adapters/test_arrow_odbc/test_driver.py
+++ b/tests/unit/adapters/test_arrow_odbc/test_driver.py
@@ -20,6 +20,7 @@ from sqlspec.adapters.arrow_odbc import (
 )
 from sqlspec.adapters.arrow_odbc.data_dictionary import ArrowOdbcDataDictionary
 from sqlspec.core import LimitOffsetFilter, OrderByFilter
+from sqlspec.data_dictionary import MetadataFidelity, MetadataSource, MetadataSupport
 from sqlspec.exceptions import SQLFileNotFoundError, SQLParsingError, SQLSpecError
 
 if TYPE_CHECKING:
@@ -184,6 +185,24 @@ def test_get_columns_probe_failure_returns_empty(monkeypatch: pytest.MonkeyPatch
 
     assert driver.data_dictionary.get_columns(driver, table="items") == []
     assert connection.read_calls[-1]["query"] == 'SELECT * FROM "items" WHERE 1=0'
+
+
+def test_arrow_odbc_data_dictionary_catalog_support_is_explicitly_unavailable_without_bridge() -> None:
+    """arrow-odbc should not claim raw ODBC catalog APIs without a bridge."""
+    connection = FakeConnection()
+    driver = ArrowOdbcDriver(cast("ArrowOdbcConnection", connection), driver_features={"chunk_size": 2})
+
+    profile = driver.data_dictionary.get_metadata_capabilities(driver, domains=("odbc_catalog", "columns", "ddl"))
+
+    catalog = profile.get("odbc_catalog")
+    assert profile.adapter == "arrow_odbc"
+    assert catalog.support == MetadataSupport.UNSUPPORTED
+    assert catalog.fidelity == MetadataFidelity.UNSUPPORTED
+    assert catalog.source == MetadataSource.DRIVER_METADATA
+    assert catalog.warnings
+    assert profile.get("columns").support == MetadataSupport.SUPPORTED
+    assert profile.get("columns").fidelity == MetadataFidelity.PARTIAL
+    assert profile.get("ddl").support == MetadataSupport.UNSUPPORTED
 
 
 def test_resolve_dialect_from_dbms_name() -> None:


### PR DESCRIPTION
## Summary

- add ADBC transport metadata capability profiles and lossy constraint normalization
- expose ADBC statistics names and explicit unsupported DDL behavior
- add arrow-odbc capability reporting for unavailable raw ODBC catalog APIs