### PR TITLE
fix(core): prevent Empty-sentinel dereference in SQL statement compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ destroy:                                            ## Destroy the virtual envir
 	@echo "${INFO} Destroying virtual environment... 🗑️"
 	@uv run pre-commit clean >/dev/null 2>&1
 	@rm -rf .venv
+	@find sqlspec \( -name '*.so' -o -name '*.c' \) -delete >/dev/null 2>&1 || true
 	@echo "${OK} Virtual environment destroyed 🗑️"
 
 # =============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ maintainers = [{ name = "Litestar Developers", email = "hello@litestar.dev" }]
 name = "sqlspec"
 readme = "README.md"
 requires-python = ">=3.10, <4.0"
-version = "0.54.2"
+version = "0.54.3"
 
 [project.urls]
 Discord = "https://discord.gg/litestar"
@@ -307,7 +307,7 @@ opt_level = "3"   # Maximum optimization (0-3)
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.54.2"
+current_version = "0.54.3"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to v{new_version}"

--- a/sqlspec/core/result/_base.py
+++ b/sqlspec/core/result/_base.py
@@ -71,7 +71,17 @@ class StatementResult(ABC, Iterable[Any]):
         metadata: Additional metadata about the operation.
     """
 
-    __slots__ = ("data", "execution_time", "last_inserted_id", "metadata", "rows_affected", "statement")
+    __slots__ = (
+        "_operation_type",
+        "data",
+        "execution_time",
+        "last_inserted_id",
+        "metadata",
+        "rows_affected",
+        "statement",
+    )
+
+    _operation_type: "OperationType"
 
     def __init__(
         self,
@@ -93,6 +103,7 @@ class StatementResult(ABC, Iterable[Any]):
             metadata: Additional metadata about the operation.
         """
         self.statement = statement
+        self._operation_type = statement.operation_type
         self.data = data
         self.rows_affected = rows_affected
         self.last_inserted_id = last_inserted_id
@@ -147,7 +158,7 @@ class StatementResult(ABC, Iterable[Any]):
         Returns:
             The type of SQL operation that produced this result.
         """
-        return self.statement.operation_type
+        return self._operation_type
 
 
 @mypyc_attr(allow_interpreted_subclasses=False)
@@ -163,7 +174,6 @@ class SQLResult(StatementResult):
 
     __slots__ = (
         "_materialized_dicts",
-        "_operation_type",
         "_row_format",
         "_schema_row_cache",
         "_schema_rows_cache",
@@ -179,8 +189,6 @@ class SQLResult(StatementResult):
         "total_count",
         "total_statements",
     )
-
-    _operation_type: "OperationType"
 
     def __init__(
         self,
@@ -259,15 +267,6 @@ class SQLResult(StatementResult):
                 self.column_names = list(first_row.keys())
         if self.total_count is None:
             self.total_count = len(data) if data is not None else 0
-
-    @property
-    def operation_type(self) -> "OperationType":
-        """Get operation type for this result.
-
-        Returns:
-            The type of SQL operation that produced this result.
-        """
-        return self._operation_type
 
     def _get_rows(self) -> "list[dict[str, Any]]":
         """Get row data as list of dicts, materializing lazily from raw format.

--- a/sqlspec/core/statement.py
+++ b/sqlspec/core/statement.py
@@ -478,8 +478,9 @@ class SQL:
         self._is_many = sql_obj.is_many
         self._is_script = sql_obj.is_script
         self._declared_parameters = sql_obj._declared_parameters
-        if sql_obj.is_processed:
-            self._processed_state = sql_obj.get_processed_state()
+        source_state = sql_obj.get_processed_state()
+        if source_state is not Empty:
+            self._processed_state = source_state
 
     @staticmethod
     def _should_auto_detect_many(parameters: tuple) -> bool:
@@ -611,9 +612,10 @@ class SQL:
     @property
     def operation_type(self) -> "OperationType":
         """SQL operation type."""
-        if self._processed_state is Empty:
+        state = self._processed_state
+        if state is Empty:
             return "COMMAND"
-        return self._processed_state.operation_type
+        return state.operation_type
 
     @property
     def statement_config(self) -> "StatementConfig":
@@ -626,8 +628,9 @@ class SQL:
 
         This intentionally mirrors statement_expression for compatibility.
         """
-        if self._processed_state is not Empty:
-            return self._processed_state.parsed_expression
+        state = self._processed_state
+        if state is not Empty:
+            return state.parsed_expression
         return self._raw_expression
 
     @property
@@ -651,7 +654,8 @@ class SQL:
     @property
     def is_processed(self) -> bool:
         """Check if SQL has been processed (public API)."""
-        return self._processed_state is not Empty
+        state = self._processed_state
+        return state is not Empty
 
     def get_processed_state(self) -> Any:
         """Get processed state (public API)."""
@@ -671,8 +675,9 @@ class SQL:
         Returns:
             Parsed SQLGlot expression or None if not parsed
         """
-        if self._processed_state is not Empty:
-            return self._processed_state.parsed_expression
+        state = self._processed_state
+        if state is not Empty:
+            return state.parsed_expression
         return self._raw_expression
 
     @property
@@ -688,16 +693,18 @@ class SQL:
     @property
     def validation_errors(self) -> "list[str]":
         """Validation errors."""
-        if self._processed_state is Empty:
+        state = self._processed_state
+        if state is Empty:
             return []
-        return self._processed_state.validation_errors.copy()
+        return state.validation_errors.copy()
 
     @property
     def has_errors(self) -> bool:
         """Check if there are validation errors."""
-        if self._processed_state is Empty:
+        state = self._processed_state
+        if state is Empty:
             return False
-        return bool(self._processed_state.validation_errors)
+        return bool(state.validation_errors)
 
     def returns_rows(self) -> bool:
         """Check if statement returns rows.
@@ -705,21 +712,23 @@ class SQL:
         Returns:
             True if the SQL statement returns result rows
         """
-        if self._processed_state is Empty:
+        state = self._processed_state
+        if state is Empty:
             self.compile()
-            if self._processed_state is Empty:
+            state = self._processed_state
+            if state is Empty:
                 return False
 
-        profile = self._processed_state.operation_profile
+        profile = state.operation_profile
         if profile.returns_rows:
             return True
 
-        op_type = self._processed_state.operation_type
+        op_type = state.operation_type
         if op_type in RETURNS_ROWS_OPERATIONS:
             return True
 
-        if self._processed_state.parsed_expression:
-            expr = self._processed_state.parsed_expression
+        if state.parsed_expression:
+            expr = state.parsed_expression
             if isinstance(expr, (exp.Insert, exp.Update, exp.Delete)) and expr.args.get("returning"):
                 return True
 
@@ -731,19 +740,20 @@ class SQL:
         Returns:
             True if the operation modifies data (INSERT/UPDATE/DELETE)
         """
-        if self._processed_state is Empty:
+        state = self._processed_state
+        if state is Empty:
             return False
 
-        profile = self._processed_state.operation_profile
+        profile = state.operation_profile
         if profile.modifies_rows:
             return True
 
-        op_type = self._processed_state.operation_type
+        op_type = state.operation_type
         if op_type in MODIFYING_OPERATIONS:
             return True
 
-        if self._processed_state.parsed_expression:
-            return isinstance(self._processed_state.parsed_expression, (exp.Insert, exp.Update, exp.Delete, exp.Merge))
+        if state.parsed_expression:
+            return isinstance(state.parsed_expression, (exp.Insert, exp.Update, exp.Delete, exp.Merge))
 
         return False
 
@@ -753,63 +763,57 @@ class SQL:
         Returns:
             Tuple of compiled SQL string and execution parameters
         """
-        if self._processed_state is not Empty:
-            if self._compiled_from_cache:
-                state = self._processed_state
-                if state.execution_parameters is None:
-                    self._processed_state = Empty
-                    self._compiled_from_cache = False
-                else:
-                    can_reuse = (
-                        not self._statement_config.parameter_config.needs_static_script_compilation
-                        and self._can_reuse_cached_state(state)
-                    )
-                    if can_reuse:
-                        return self._rebind_cached_parameters(state)
-                    self._processed_state = Empty
-                    self._compiled_from_cache = False
-            else:
-                return self._processed_state.compiled_sql, self._processed_state.execution_parameters
-        if self._processed_state is Empty:
-            try:
-                config = self._statement_config
-                raw_sql = self._materialized_raw_sql()
-                params = self._named_parameters or self._positional_parameters
-                is_many = self._is_many
-                param_fingerprint = structural_fingerprint(params, is_many=is_many)
-                pipeline_fingerprint: Any | None = (
-                    None if config.parameter_config.needs_static_script_compilation else param_fingerprint
-                )
-                compiled_result = pipeline.compile_with_pipeline(
-                    config,
-                    raw_sql,
-                    params,
-                    is_many=is_many,
-                    expression=self._raw_expression,
-                    param_fingerprint=pipeline_fingerprint,
-                )
+        state = self._processed_state
+        if state is not Empty:
+            if not self._compiled_from_cache:
+                return state.compiled_sql, state.execution_parameters
+            if state.execution_parameters is not None and (
+                not self._statement_config.parameter_config.needs_static_script_compilation
+                and self._can_reuse_cached_state(state)
+            ):
+                return self._rebind_cached_parameters(state)
 
-                self._processed_state = self._build_processed_state(
-                    compiled_sql=compiled_result.compiled_sql,
-                    execution_parameters=compiled_result.execution_parameters,
-                    parsed_expression=compiled_result.expression,
-                    operation_type=compiled_result.operation_type,
-                    input_named_parameters=compiled_result.input_named_parameters,
-                    applied_wrap_types=compiled_result.applied_wrap_types,
-                    filter_hash=hash_filters(self._filters),
-                    parameter_fingerprint=param_fingerprint,
-                    parameter_casts=compiled_result.parameter_casts,
-                    parameter_profile=compiled_result.parameter_profile,
-                    operation_profile=compiled_result.operation_profile,
-                    validation_errors=[],
-                    is_many=self._is_many,
-                )
-            except sqlspec.exceptions.SQLSpecError:
-                raise
-            except Exception as e:
-                self._processed_state = self._handle_compile_failure(e)
+        try:
+            config = self._statement_config
+            raw_sql = self._materialized_raw_sql()
+            params = self._named_parameters or self._positional_parameters
+            is_many = self._is_many
+            param_fingerprint = structural_fingerprint(params, is_many=is_many)
+            pipeline_fingerprint: Any | None = (
+                None if config.parameter_config.needs_static_script_compilation else param_fingerprint
+            )
+            compiled_result = pipeline.compile_with_pipeline(
+                config,
+                raw_sql,
+                params,
+                is_many=is_many,
+                expression=self._raw_expression,
+                param_fingerprint=pipeline_fingerprint,
+            )
 
-        return self._processed_state.compiled_sql, self._processed_state.execution_parameters
+            new_state = self._build_processed_state(
+                compiled_sql=compiled_result.compiled_sql,
+                execution_parameters=compiled_result.execution_parameters,
+                parsed_expression=compiled_result.expression,
+                operation_type=compiled_result.operation_type,
+                input_named_parameters=compiled_result.input_named_parameters,
+                applied_wrap_types=compiled_result.applied_wrap_types,
+                filter_hash=hash_filters(self._filters),
+                parameter_fingerprint=param_fingerprint,
+                parameter_casts=compiled_result.parameter_casts,
+                parameter_profile=compiled_result.parameter_profile,
+                operation_profile=compiled_result.operation_profile,
+                validation_errors=[],
+                is_many=self._is_many,
+            )
+        except sqlspec.exceptions.SQLSpecError:
+            raise
+        except Exception as e:
+            new_state = self._handle_compile_failure(e)
+
+        self._processed_state = new_state
+        self._compiled_from_cache = False
+        return new_state.compiled_sql, new_state.execution_parameters
 
     def _rebind_cached_parameters(self, state: "ProcessedState") -> "tuple[str, Any]":
         params = self._named_parameters or self._positional_parameters
@@ -917,8 +921,10 @@ class SQL:
         new_sql._pooled = True
 
         # Reset mutable state
-        new_sql._compiled_from_cache = self._processed_state is not Empty
-        new_sql._processed_state = self._processed_state if self._processed_state is not Empty else Empty
+        source_state = self._processed_state
+        is_processed = source_state is not Empty
+        new_sql._compiled_from_cache = is_processed
+        new_sql._processed_state = source_state if is_processed else Empty
         new_sql._hash = None
         new_sql._filters = self._filters.copy()
         new_sql._named_parameters = {}
@@ -1028,20 +1034,16 @@ class SQL:
             The SQLGlot expression for this statement
         """
         # Preserve authoring-time parameter names when applying dynamic query modifiers.
-        if (
-            self._processed_state is not Empty
-            and self._processed_state.input_named_parameters
-            and self._raw_expression is None
-            and self._raw_sql
-        ):
+        state = self._processed_state
+        if state is not Empty and state.input_named_parameters and self._raw_expression is None and self._raw_sql:
             try:
                 parsed = sqlglot.parse_one(self._raw_sql, dialect=self._dialect)
                 if isinstance(parsed, exp.Expr):
                     return parsed
             except ParseError:
                 pass
-        if self._processed_state is not Empty and self._processed_state.parsed_expression is not None:
-            return self._processed_state.parsed_expression.copy()
+        if state is not Empty and state.parsed_expression is not None:
+            return state.parsed_expression.copy()
         # Then check statement_expression (from compilation)
         if self.statement_expression is not None:
             return self.statement_expression.copy()
@@ -1524,6 +1526,7 @@ class SQL:
         converted_sql, converted_params = converter.convert_placeholder_style(
             raw_sql_for_builder, raw_params, ParameterStyle.NAMED_COLON, is_many=False
         )
+        state = self._processed_state
 
         if (
             self._raw_expression is not None
@@ -1532,12 +1535,12 @@ class SQL:
         ):
             expression = self._raw_expression.copy()
         elif (
-            self._processed_state is not Empty
-            and self._processed_state.parsed_expression is not None
+            state is not Empty
+            and state.parsed_expression is not None
             and converted_sql == raw_sql_for_builder
             and builder_dialect == self._dialect
         ):
-            expression = self._processed_state.parsed_expression.copy()
+            expression = state.parsed_expression.copy()
         else:
             try:
                 expression = sqlglot.parse_one(converted_sql, dialect=builder_dialect)

--- a/tests/unit/core/test_result.py
+++ b/tests/unit/core/test_result.py
@@ -78,6 +78,25 @@ def test_sql_result_helpers_do_not_upper_operation_type() -> None:
     assert result.get_data() == []
 
 
+def test_arrow_result_operation_type_survives_statement_reset() -> None:
+    stmt = SQL("SELECT * FROM users")
+    stmt.compile()
+    result = ArrowResult(statement=stmt, data=None)
+
+    stmt.reset()
+
+    assert stmt.operation_type == "COMMAND"
+    assert result.operation_type == "SELECT"
+
+
+def test_sql_result_operation_type_explicit_value_overrides_base_snapshot() -> None:
+    stmt = SQL("SELECT * FROM users")
+    stmt.compile()
+    result = SQLResult(statement=stmt, operation_type="INSERT")
+
+    assert result.operation_type == "INSERT"
+
+
 def test_stack_result_type_does_not_upper_sql_result_operation_type() -> None:
     stmt = SQL("SELECT * FROM users")
     result = SQLResult(statement=stmt, operation_type=_operation_type("SELECT"), data=[])

--- a/tests/unit/core/test_statement_concurrency.py
+++ b/tests/unit/core/test_statement_concurrency.py
@@ -1,0 +1,52 @@
+# pyright: reportPrivateUsage=false
+"""Threaded regression tests for shared SQL statement state."""
+
+import threading
+
+from sqlspec.core.statement import SQL
+from sqlspec.exceptions import SQLSpecError
+
+
+def test_concurrent_compile_reset_vs_current_expression() -> None:
+    raw = "SELECT id, name FROM users WHERE id = :id"
+    sql = SQL(raw, {"id": 1})
+    sql.compile()
+    crashes: list[BaseException] = []
+    iterations = 2000
+    start = threading.Barrier(4)
+
+    def writer() -> None:
+        start.wait()
+        for _ in range(iterations):
+            try:
+                sql.reset()
+                sql._raw_sql = raw
+                sql._named_parameters["id"] = 1
+                sql.compile()
+            except (AttributeError, TypeError) as exc:
+                crashes.append(exc)
+            except SQLSpecError:
+                pass
+
+    def reader() -> None:
+        start.wait()
+        for _ in range(iterations):
+            try:
+                sql._current_expression()
+                sql.returns_rows()
+                _ = sql.operation_type
+            except (AttributeError, TypeError) as exc:
+                crashes.append(exc)
+            except SQLSpecError:
+                pass
+
+    threads = [threading.Thread(target=writer), threading.Thread(target=reader), threading.Thread(target=reader)]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=5)
+    for thread in threads:
+        thread.join(timeout=30)
+
+    live_threads = [thread for thread in threads if thread.is_alive()]
+    assert live_threads == []
+    assert not crashes, f"sentinel/state crash under concurrency: {crashes[:3]}"

--- a/tests/unit/core/test_statement_empty_copy.py
+++ b/tests/unit/core/test_statement_empty_copy.py
@@ -1,0 +1,37 @@
+# pyright: reportPrivateUsage=false
+"""Regression tests for SQL empty-copy processed-state sharing."""
+
+from sqlspec.core.statement import SQL
+from sqlspec.typing import Empty
+
+
+def test_empty_copy_flag_state_consistency_processed() -> None:
+    source = SQL("SELECT 1")
+    source.compile()
+
+    copied = source._create_empty_copy()
+
+    assert copied._compiled_from_cache is True
+    assert copied._processed_state is not Empty
+    assert copied._processed_state is source._processed_state
+
+
+def test_empty_copy_flag_state_consistency_unprocessed() -> None:
+    source = SQL("SELECT 1")
+
+    copied = source._create_empty_copy()
+
+    assert copied._compiled_from_cache is False
+    assert copied._processed_state is Empty
+
+
+def test_empty_copy_reset_does_not_release_shared_state() -> None:
+    source = SQL("SELECT 1")
+    source.compile()
+    shared = source._processed_state
+    copied = source._create_empty_copy()
+
+    copied.reset()
+
+    assert source._processed_state is shared
+    assert source._processed_state is not Empty

--- a/tests/unit/utils/test_mypyc_smoke.py
+++ b/tests/unit/utils/test_mypyc_smoke.py
@@ -143,8 +143,22 @@ def test_construction_checks_build_provider_signatures_without_requiring_compila
     assert {result["name"] for result in results} == {
         "fastapi_filter_construction",
         "litestar_filter_construction",
+        "statement_cache_rebind",
+        "statement_sentinel_identity",
         "sqlspec_construction",
     }
+
+
+def test_statement_construction_checks_pass_without_requiring_compilation() -> None:
+    module = _load_mypyc_smoke_module()
+
+    results = module.run_construction_checks(require_compiled=False)
+    result_by_name = {result["name"]: result for result in results}
+
+    for name in ("statement_cache_rebind", "statement_sentinel_identity"):
+        result = result_by_name[name]
+        assert result["imported"] is True
+        assert result["error"] is None
 
 
 def test_smoke_runner_skips_optional_adk_dependency(monkeypatch: MonkeyPatch) -> None:

--- a/tools/scripts/mypyc_smoke.py
+++ b/tools/scripts/mypyc_smoke.py
@@ -113,6 +113,69 @@ def _check_sqlspec_construction() -> dict[str, Any]:
     return result
 
 
+def _check_statement_sentinel_identity(*, require_compiled: bool = False) -> dict[str, Any]:
+    """Check that statement and typing modules share the same Empty sentinel."""
+    result = _new_smoke_result(
+        name="statement_sentinel_identity",
+        module="sqlspec.core.statement",
+        attribute="Empty",
+        compiled_required=require_compiled,
+    )
+    try:
+        statement_module = importlib.import_module("sqlspec.core.statement")
+        private_typing = importlib.import_module("sqlspec._typing")
+        public_typing = importlib.import_module("sqlspec.typing")
+    except Exception as exc:
+        result["error"] = f"{type(exc).__name__}: {exc}"
+        return result
+
+    result["imported"] = True
+    result["compiled"] = is_compiled_module(statement_module)
+    if require_compiled and not result["compiled"]:
+        result["error"] = "module was imported from Python source, not a compiled extension"
+        return result
+    try:
+        assert statement_module.Empty is private_typing.Empty is public_typing.Empty
+    except AssertionError as exc:
+        result["error"] = f"{type(exc).__name__}: Empty sentinel identity mismatch"
+    return result
+
+
+def _check_statement_cache_rebind(*, require_compiled: bool = False) -> dict[str, Any]:
+    """Exercise a cache-hit copy, parameter rebind, and expression snapshot."""
+    result = _new_smoke_result(
+        name="statement_cache_rebind",
+        module="sqlspec.core.statement",
+        attribute="SQL",
+        compiled_required=require_compiled,
+    )
+    try:
+        statement_module = importlib.import_module("sqlspec.core.statement")
+        sqlglot_exp = importlib.import_module("sqlglot.expressions")
+        sql_cls = statement_module.SQL
+    except Exception as exc:
+        result["error"] = f"{type(exc).__name__}: {exc}"
+        return result
+
+    result["imported"] = True
+    result["compiled"] = is_compiled_module(statement_module)
+    if require_compiled and not result["compiled"]:
+        result["error"] = "module was imported from Python source, not a compiled extension"
+        return result
+    try:
+        original = sql_cls("SELECT * FROM t WHERE id = :id", {"id": 1})
+        original.compile()
+        copy = original.copy(parameters={"id": 2})
+        assert copy._compiled_from_cache is True
+        assert copy.get_processed_state() is original.get_processed_state()
+        copy.compile()
+        expression = copy._current_expression()
+        assert isinstance(expression, sqlglot_exp.Expr)
+    except Exception as exc:
+        result["error"] = f"{type(exc).__name__}: {exc}"
+    return result
+
+
 def run_smoke(*, require_compiled: bool = False) -> list[dict[str, Any]]:
     """Import the compiled-wheel smoke matrix and return per-entry results."""
     results: list[dict[str, Any]] = []
@@ -284,6 +347,8 @@ def run_construction_checks(*, require_compiled: bool = False) -> list[dict[str,
     """Run construction-time smoke checks for provider classes."""
     return [
         _check_sqlspec_construction(),
+        _check_statement_sentinel_identity(require_compiled=require_compiled),
+        _check_statement_cache_rebind(require_compiled=require_compiled),
         _check_fastapi_filter_construction(require_compiled=require_compiled),
         _check_litestar_filter_construction(require_compiled=require_compiled),
     ]

--- a/uv.lock
+++ b/uv.lock
@@ -1435,7 +1435,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -6648,7 +6648,7 @@ wheels = [
 
 [[package]]
 name = "sqlspec"
-version = "0.54.2"
+version = "0.54.3"
 source = { editable = "." }
 dependencies = [
     { name = "mypy-extensions" },


### PR DESCRIPTION
## Summary
- Snapshot `_processed_state` into locals before guard/deref reads and avoid transient `Empty` publication during compile cache invalidation.
- Keep cache-copy `ProcessedState` sharing while making flag/state assignment derive from one source read.
- Snapshot result `operation_type` at construction so Arrow results do not read a reset statement later.