### PR TITLE
fix: remove DuckDB deprecation warning from select dispatch

### DIFF
--- a/sqlspec/adapters/duckdb/driver.py
+++ b/sqlspec/adapters/duckdb/driver.py
@@ -120,7 +120,7 @@ class DuckDBDriver(SyncDriverAdapterBase):
         is_select_like = statement.returns_rows() or self._should_force_select(statement, cursor)
 
         if is_select_like:
-            arrow_table = cursor.fetch_arrow_table()
+            arrow_table = cursor.to_arrow_table()
             data = arrow_table.to_pylist()
             _restore_uuid_columns(data, cursor.description)
             column_names = list(arrow_table.column_names)

--- a/tests/unit/adapters/test_duckdb/test_type_converter.py
+++ b/tests/unit/adapters/test_duckdb/test_type_converter.py
@@ -28,12 +28,17 @@ class _ArrowCursor:
     def __init__(self) -> None:
         self.executed: list[tuple[str, object]] = []
         self.reader_calls: list[int | None] = []
+        self.description = [("id", "INTEGER")]
 
     def execute(self, sql: str, parameters: object) -> None:
         self.executed.append((sql, parameters))
 
     def arrow(self) -> object:
         msg = "select_to_arrow should use DuckDB cursor.to_arrow_table()"
+        raise AssertionError(msg)
+
+    def fetch_arrow_table(self) -> pa.Table:
+        msg = "dispatch_execute should use DuckDB cursor.to_arrow_table()"
         raise AssertionError(msg)
 
     def to_arrow_table(self) -> pa.Table:
@@ -71,6 +76,16 @@ def test_arrow_select_to_arrow_uses_to_arrow_table() -> None:
     driver = _ArrowDriver(cursor)
     result = driver.select_to_arrow("SELECT 1 AS id")
     assert result.get_data().to_pydict() == {"id": [1]}
+    assert cursor.executed == [("SELECT 1 AS id", ())]
+
+
+def test_dispatch_execute_select_uses_to_arrow_table() -> None:
+    cursor = _ArrowCursor()
+    driver = _ArrowDriver(cursor)
+
+    result = driver.select("SELECT 1 AS id")
+
+    assert result == [{"id": 1}]
     assert cursor.executed == [("SELECT 1 AS id", ())]
 
 


### PR DESCRIPTION
## Summary

- Replace DuckDB select dispatch deprecated `fetch_arrow_table()` call with `to_arrow_table()`.
- Add a regression test that fails if normal select dispatch calls `fetch_arrow_table()`.

Fixes #623