### PR TITLE
fix: correctness bug batch across drivers, builder, litestar, migrations, and loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -392,6 +392,9 @@ filterwarnings = [
   "ignore::DeprecationWarning:pkg_resources.*",
   "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
   "ignore::DeprecationWarning:pkg_resources",
+  # opentelemetry reads entry points via importlib.metadata's deprecated
+  # SelectableGroups dict interface at import time; nothing we can change here.
+  "ignore:SelectableGroups dict interface is deprecated:DeprecationWarning",
   "ignore:You are using a Python version .+ google\\.api_core:FutureWarning",
   "ignore::DeprecationWarning:google.rpc",
   "ignore::DeprecationWarning:google.gcloud",
@@ -481,7 +484,7 @@ strict = true
 warn_redundant_casts = true
 warn_return_any = true
 warn_unreachable = false
-warn_unused_configs = true
+warn_unused_configs = false
 warn_unused_ignores = true
 
 [[tool.mypy.overrides]]

--- a/sqlspec/adapters/adbc/_typing.py
+++ b/sqlspec/adapters/adbc/_typing.py
@@ -8,6 +8,7 @@ compilation to avoid ABI boundary issues.
 import contextlib
 from typing import TYPE_CHECKING, Any
 
+from adbc_driver_manager import Error as _AdbcNativeError
 from adbc_driver_manager.dbapi import Connection
 from adbc_driver_manager.dbapi import Cursor as _AdbcRawCursor
 
@@ -23,12 +24,14 @@ if TYPE_CHECKING:
 
     AdbcConnection: TypeAlias = _AdbcConnection
     AdbcRawCursor: TypeAlias = _AdbcRawCursor
+    AdbcNativeError: TypeAlias = _AdbcNativeError
 
 if not TYPE_CHECKING:
     AdbcConnection = _AdbcConnection
     AdbcRawCursor = _AdbcRawCursor
+    AdbcNativeError = _AdbcNativeError
 
-__all__ = ("AdbcConnection", "AdbcCursor", "AdbcRawCursor", "AdbcSessionContext")
+__all__ = ("AdbcConnection", "AdbcCursor", "AdbcNativeError", "AdbcRawCursor", "AdbcSessionContext")
 
 
 class AdbcCursor:

--- a/sqlspec/adapters/adbc/driver.py
+++ b/sqlspec/adapters/adbc/driver.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 
 from typing_extensions import final
 
-from sqlspec.adapters.adbc._typing import AdbcCursor, AdbcSessionContext
+from sqlspec.adapters.adbc._typing import AdbcCursor, AdbcNativeError, AdbcSessionContext
 from sqlspec.adapters.adbc.core import (
     _prepare_batch_with_casts,
     collect_rows,
@@ -79,8 +79,10 @@ class AdbcExceptionHandler(BaseSyncExceptionHandler):
     def _handle_exception(self, exc_type: "type[BaseException] | None", exc_val: "BaseException") -> bool:
         if exc_type is None:
             return False
-        self.pending_exception = create_mapped_exception(exc_val)
-        return True
+        if issubclass(exc_type, AdbcNativeError):
+            self.pending_exception = create_mapped_exception(exc_val)
+            return True
+        return False
 
 
 class AdbcSelectStreamSource:

--- a/sqlspec/adapters/aiomysql/driver.py
+++ b/sqlspec/adapters/aiomysql/driver.py
@@ -403,12 +403,10 @@ class AiomysqlDriver(AsyncDriverAdapterBase):
     def _connection_in_transaction(self) -> bool:
         """Check if connection is in transaction.
 
-        aiomysql does not expose reliable transaction state.
-
         Returns:
-            False - aiomysql requires explicit transaction management.
+            True when the server reports an open transaction.
         """
-        return False
+        return bool(self.connection.get_transaction_status())
 
 
 register_driver_profile("aiomysql", driver_profile)

--- a/sqlspec/adapters/aiosqlite/pool.py
+++ b/sqlspec/adapters/aiosqlite/pool.py
@@ -740,19 +740,13 @@ class AiosqliteConnectionPool:
         Raises:
             AiosqliteConnectTimeoutError: If acquisition times out
         """
-        # Fast path: try to get connection without timeout wrapper
-        # Only use timeout when we need to wait for a connection
         try:
-            connection = await self._get_connection()
+            connection = await asyncio.wait_for(self._get_connection(), timeout=self._connect_timeout)
         except AiosqlitePoolClosedError:
             raise
-        except Exception:
-            # If fast path fails, fall back to timeout-wrapped acquisition
-            try:
-                connection = await asyncio.wait_for(self._get_connection(), timeout=self._connect_timeout)
-            except asyncio.TimeoutError as e:
-                msg = f"Connection acquisition timed out after {self._connect_timeout}s"
-                raise AiosqliteConnectTimeoutError(msg) from e
+        except asyncio.TimeoutError as e:
+            msg = f"Connection acquisition timed out after {self._connect_timeout}s"
+            raise AiosqliteConnectTimeoutError(msg) from e
 
         return connection
 

--- a/sqlspec/adapters/asyncmy/driver.py
+++ b/sqlspec/adapters/asyncmy/driver.py
@@ -386,12 +386,10 @@ class AsyncmyDriver(AsyncDriverAdapterBase):
     def _connection_in_transaction(self) -> bool:
         """Check if connection is in transaction.
 
-        AsyncMy uses explicit BEGIN and does not expose reliable transaction state.
-
         Returns:
-            False - AsyncMy requires explicit transaction management.
+            True when the server reports an open transaction.
         """
-        return False
+        return bool(self.connection.get_transaction_status())
 
 
 register_driver_profile("asyncmy", driver_profile)

--- a/sqlspec/adapters/duckdb/driver.py
+++ b/sqlspec/adapters/duckdb/driver.py
@@ -64,8 +64,10 @@ class DuckDBExceptionHandler(BaseSyncExceptionHandler):
     def _handle_exception(self, exc_type: "type[BaseException] | None", exc_val: "BaseException") -> bool:
         if exc_type is None:
             return False
-        self.pending_exception = create_mapped_exception(exc_val)
-        return True
+        if issubclass(exc_type, duckdb.Error):
+            self.pending_exception = create_mapped_exception(exc_val)
+            return True
+        return False
 
 
 class DuckDBDriver(SyncDriverAdapterBase):

--- a/sqlspec/adapters/mysqlconnector/config.py
+++ b/sqlspec/adapters/mysqlconnector/config.py
@@ -350,10 +350,8 @@ class MysqlConnectorSyncConfig(
 
     def _acquire_sync_connection(self) -> MysqlConnectorSyncConnection:
         """Acquire and initialize a sync mysql-connector connection."""
-        if self.connection_instance is not None:
-            connection = cast("MysqlConnectorSyncConnection", self.connection_instance.get_connection())
-        else:
-            connection = self.create_connection()
+        pool = self.provide_pool()
+        connection = cast("MysqlConnectorSyncConnection", pool.get_connection())
         self._ensure_connection(connection)
         return connection
 

--- a/sqlspec/adapters/psycopg/config.py
+++ b/sqlspec/adapters/psycopg/config.py
@@ -654,8 +654,6 @@ class PsycopgAsyncConfig(AsyncDatabaseConfig[PsycopgAsyncConnection, AsyncConnec
         """Create the actual async connection pool."""
 
         all_config = dict(self.connection_config)
-        open_provided = "open" in all_config
-        open_setting = all_config.pop("open", None)
 
         pool_parameters = {
             "connection_class": all_config.pop("connection_class", None),
@@ -669,11 +667,12 @@ class PsycopgAsyncConfig(AsyncDatabaseConfig[PsycopgAsyncConnection, AsyncConnec
             "reconnect_timeout": all_config.pop("reconnect_timeout", 300.0),
             "reconnect_failed": all_config.pop("reconnect_failed", None),
             "num_workers": all_config.pop("num_workers", 3),
-            "open": open_setting if open_provided else False,
             "check": all_config.pop("check", None),
             "reset": all_config.pop("reset", None),
             "close_returns": all_config.pop("close_returns", False),
         }
+        open_pool = all_config.pop("open", True)
+        pool_parameters["open"] = False if open_pool is True else open_pool
 
         pool_parameters["configure"] = all_config.pop("configure", self._configure_async_connection)
 
@@ -687,7 +686,7 @@ class PsycopgAsyncConfig(AsyncDatabaseConfig[PsycopgAsyncConnection, AsyncConnec
         else:
             pool = AsyncConnectionPool("", kwargs=all_config, **pool_parameters)
 
-        if not open_provided:
+        if open_pool is True:
             await pool.open()
 
         return pool

--- a/sqlspec/adapters/sqlite/pool.py
+++ b/sqlspec/adapters/sqlite/pool.py
@@ -258,7 +258,12 @@ class SqliteConnectionPool:
         connection = self._get_thread_connection()
         try:
             yield connection
-        finally:
+        except Exception:
+            with contextlib.suppress(Exception):
+                if connection.in_transaction:
+                    connection.rollback()
+            raise
+        else:
             with contextlib.suppress(Exception):
                 if connection.in_transaction:
                     connection.commit()

--- a/sqlspec/builder/_factory.py
+++ b/sqlspec/builder/_factory.py
@@ -1220,7 +1220,7 @@ class SQLFactory:
             ANY expression.
         """
         if isinstance(values, list):
-            literals = [SQLFactory.to_literal(v) for v in values]
+            literals = [SQLFactory.to_literal(v).expression for v in values]
             return FunctionExpression(exp.Any(this=exp.Array(expressions=literals)))
         if isinstance(values, str):
             parsed: exp.Expr = exp.maybe_parse(values)

--- a/sqlspec/extensions/litestar/plugin.py
+++ b/sqlspec/extensions/litestar/plugin.py
@@ -448,15 +448,11 @@ class SQLSpecPlugin(InitPluginProtocol, CLIPlugin):
         Returns:
             The annotation for the configuration.
         """
-        for state in self._plugin_configs:
-            if key in {state.config, state.annotation} or key in {state.connection_key, state.pool_key}:
-                return cast(
-                    "type[SyncDatabaseConfig[Any, Any, Any] | NoPoolSyncConfig[Any, Any] | AsyncDatabaseConfig[Any, Any, Any] | NoPoolAsyncConfig[Any, Any]]",
-                    state.annotation,
-                )
-
-        msg = f"No configuration found for {key}"
-        raise KeyError(msg)
+        state = self._get_plugin_state(key)
+        return cast(
+            "type[SyncDatabaseConfig[Any, Any, Any] | NoPoolSyncConfig[Any, Any] | AsyncDatabaseConfig[Any, Any, Any] | NoPoolAsyncConfig[Any, Any]]",
+            state.annotation,
+        )
 
     @overload
     def get_config(
@@ -487,17 +483,8 @@ class SQLSpecPlugin(InitPluginProtocol, CLIPlugin):
         Returns:
             The configuration instance for the specified name.
         """
-        if isinstance(name, str):
-            for state in self._plugin_configs:
-                if name in {state.connection_key, state.pool_key, state.session_key}:
-                    return cast("DatabaseConfigProtocol[Any, Any, Any]", state.config)  # type: ignore[redundant-cast]
-
-        for state in self._plugin_configs:
-            if name in {state.config, state.annotation}:
-                return cast("DatabaseConfigProtocol[Any, Any, Any]", state.config)  # type: ignore[redundant-cast]
-
-        msg = f"No database configuration found for name '{name}'. Available keys: {self._get_available_keys()}"
-        raise KeyError(msg)
+        state = self._get_plugin_state(name)
+        return cast("DatabaseConfigProtocol[Any, Any, Any]", state.config)  # type: ignore[redundant-cast]
 
     def _ensure_connection_sync(self, plugin_state: PluginConfigState, state: "State", scope: "Scope") -> Any:
         """Ensure a connection exists in scope, creating one from the pool if needed (sync)."""

--- a/sqlspec/loader.py
+++ b/sqlspec/loader.py
@@ -624,36 +624,34 @@ class SQLFileLoader:
                     runtime.increment_metric("loader.cache.hit")
                 return True
 
-            self._load_uncached_file(file_path, namespace, content=file_content)
+            loaded_statements = self._load_uncached_file(file_path, namespace, content=file_content)
         else:
-            self._load_uncached_file(file_path, namespace)
+            loaded_statements = self._load_uncached_file(file_path, namespace)
 
         if path_str in self._files:
             sql_file = self._files[path_str]
-            file_statements: dict[str, NamedStatement] = {}
-            for query_name, query_path in self._query_to_file.items():
-                if query_path == path_str:
-                    stored_name = query_name
-                    if namespace and query_name.startswith(f"{namespace}."):
-                        stored_name = query_name[len(namespace) + 1 :]
-                    file_statements[stored_name] = self._queries[query_name]
-
-            cached_file_data = SQLFileCacheEntry(sql_file=sql_file, parsed_statements=file_statements)
+            cached_file_data = SQLFileCacheEntry(sql_file=sql_file, parsed_statements=loaded_statements)
             cache.put_file(cache_key_str, cached_file_data)
             if runtime is not None:
                 runtime.increment_metric("loader.cache.miss")
                 runtime.increment_metric("loader.files.loaded")
-                runtime.increment_metric("loader.statements.loaded", len(file_statements))
+                runtime.increment_metric("loader.statements.loaded", len(loaded_statements))
 
         return True
 
-    def _load_uncached_file(self, file_path: str | Path, namespace: "str | None", content: "str | None" = None) -> None:
+    def _load_uncached_file(
+        self, file_path: str | Path, namespace: "str | None", content: "str | None" = None
+    ) -> "dict[str, NamedStatement]":
         """Load a single SQL file without using cache.
 
         Args:
             file_path: Path to the SQL file.
             namespace: Optional namespace prefix for queries.
             content: Pre-read file content. If provided, skips the disk read.
+
+        Returns:
+            The file's parsed statements keyed by un-namespaced name, or an empty
+            dict when the file contains no named statements.
         """
         path_str = str(file_path)
         runtime = self._runtime
@@ -665,7 +663,7 @@ class SQLFileLoader:
             log_with_context(
                 logger, logging.DEBUG, "sql.load", file_path=path_str, status="skipped", reason="no_named_statements"
             )
-            return
+            return {}
 
         sql_file = SQLFile(content=content, path=path_str)
         self._files[path_str] = sql_file
@@ -688,6 +686,7 @@ class SQLFileLoader:
         if runtime is not None:
             runtime.increment_metric("loader.files.loaded")
             runtime.increment_metric("loader.statements.loaded", len(statements))
+        return statements
 
     def add_named_sql(
         self,

--- a/sqlspec/migrations/fix.py
+++ b/sqlspec/migrations/fix.py
@@ -78,7 +78,7 @@ class MigrationFixer:
 
             for old_path in matching_files:
                 suffix = old_path.suffix
-                description = old_path.stem.replace(f"{old_version}_", "")
+                description = old_path.stem.removeprefix(f"{old_version}_")
 
                 new_filename = f"{new_version}_{description}{suffix}"
                 new_path = self.migrations_path / new_filename

--- a/tests/unit/adapters/test_adbc/test_driver.py
+++ b/tests/unit/adapters/test_adbc/test_driver.py
@@ -14,6 +14,15 @@ def test_adbc_driver_classes_are_final() -> None:
     assert getattr(AdbcDriver, "__final__", False) is True
 
 
+def test_handle_exception_propagates_non_native_error() -> None:
+    """Non-native exceptions propagate unchanged and are not mapped to a DB error."""
+    handler = AdbcExceptionHandler()
+    with pytest.raises(KeyError):
+        with handler:
+            raise KeyError("internal bug")
+    assert handler.pending_exception is None
+
+
 def test_dispatch_execute_many_non_postgres_uses_compiled_parameter_sets(monkeypatch: pytest.MonkeyPatch) -> None:
     connection = MagicMock()
     connection.adbc_get_info.return_value = {"vendor_name": "sqlite", "driver_name": "sqlite"}

--- a/tests/unit/adapters/test_aiomysql/test_driver.py
+++ b/tests/unit/adapters/test_aiomysql/test_driver.py
@@ -1,0 +1,24 @@
+"""Unit tests for the aiomysql driver transaction-state contract."""
+
+from typing import Any, cast
+
+import pytest
+
+from sqlspec.adapters.aiomysql.driver import AiomysqlDriver
+
+pytest.importorskip("aiomysql", reason="aiomysql adapter requires the aiomysql package")
+
+
+class _FakeConnection:
+    def __init__(self, in_transaction: bool) -> None:
+        self._in_transaction = in_transaction
+
+    def get_transaction_status(self) -> bool:
+        return self._in_transaction
+
+
+@pytest.mark.parametrize("in_transaction", [True, False])
+def test_connection_in_transaction_reflects_driver_state(in_transaction: bool) -> None:
+    """_connection_in_transaction() must reflect the connection's real transaction status."""
+    driver = AiomysqlDriver(connection=cast("Any", _FakeConnection(in_transaction)))
+    assert driver._connection_in_transaction() is in_transaction

--- a/tests/unit/adapters/test_aiosqlite/test_pool.py
+++ b/tests/unit/adapters/test_aiosqlite/test_pool.py
@@ -4,7 +4,7 @@ import asyncio
 
 import pytest
 
-from sqlspec.adapters.aiosqlite.pool import AiosqliteConnectTimeoutError, AiosqliteConnectionPool
+from sqlspec.adapters.aiosqlite.pool import AiosqliteConnectionPool, AiosqliteConnectTimeoutError
 
 pytest.importorskip("aiosqlite", reason="aiosqlite adapter requires the aiosqlite package")
 

--- a/tests/unit/adapters/test_aiosqlite/test_pool.py
+++ b/tests/unit/adapters/test_aiosqlite/test_pool.py
@@ -1,0 +1,22 @@
+"""Unit tests for the aiosqlite connection pool acquisition contract."""
+
+import asyncio
+
+import pytest
+
+from sqlspec.adapters.aiosqlite.pool import AiosqliteConnectTimeoutError, AiosqliteConnectionPool
+
+pytest.importorskip("aiosqlite", reason="aiosqlite adapter requires the aiosqlite package")
+
+
+async def test_acquire_enforces_connect_timeout_on_pool_exhaustion() -> None:
+    """A saturated pool must raise AiosqliteConnectTimeoutError, not hang forever."""
+    pool = AiosqliteConnectionPool({"database": ":memory:"}, pool_size=1, connect_timeout=0.2)
+    held = await pool.acquire()
+    try:
+        with pytest.raises(AiosqliteConnectTimeoutError):
+            # Outer guard: a regression (unbounded wait) fails the test instead of hanging the suite.
+            await asyncio.wait_for(pool.acquire(), timeout=5.0)
+    finally:
+        await pool.release(held)
+        await pool.close()

--- a/tests/unit/adapters/test_aiosqlite/test_pool.py
+++ b/tests/unit/adapters/test_aiosqlite/test_pool.py
@@ -10,12 +10,15 @@ pytest.importorskip("aiosqlite", reason="aiosqlite adapter requires the aiosqlit
 
 
 async def test_acquire_enforces_connect_timeout_on_pool_exhaustion() -> None:
-    """A saturated pool must raise AiosqliteConnectTimeoutError, not hang forever."""
+    """A saturated pool raises AiosqliteConnectTimeoutError instead of blocking.
+
+    The acquire is bounded by an outer wait_for so the test fails fast rather than
+    hanging the suite if the pool blocks.
+    """
     pool = AiosqliteConnectionPool({"database": ":memory:"}, pool_size=1, connect_timeout=0.2)
     held = await pool.acquire()
     try:
         with pytest.raises(AiosqliteConnectTimeoutError):
-            # Outer guard: a regression (unbounded wait) fails the test instead of hanging the suite.
             await asyncio.wait_for(pool.acquire(), timeout=5.0)
     finally:
         await pool.release(held)

--- a/tests/unit/adapters/test_asyncmy/test_driver.py
+++ b/tests/unit/adapters/test_asyncmy/test_driver.py
@@ -1,0 +1,24 @@
+"""Unit tests for the asyncmy driver transaction-state contract."""
+
+from typing import Any, cast
+
+import pytest
+
+from sqlspec.adapters.asyncmy.driver import AsyncmyDriver
+
+pytest.importorskip("asyncmy", reason="asyncmy adapter requires the asyncmy package")
+
+
+class _FakeConnection:
+    def __init__(self, in_transaction: bool) -> None:
+        self._in_transaction = in_transaction
+
+    def get_transaction_status(self) -> bool:
+        return self._in_transaction
+
+
+@pytest.mark.parametrize("in_transaction", [True, False])
+def test_connection_in_transaction_reflects_driver_state(in_transaction: bool) -> None:
+    """_connection_in_transaction() must reflect the connection's real transaction status."""
+    driver = AsyncmyDriver(connection=cast("Any", _FakeConnection(in_transaction)))
+    assert driver._connection_in_transaction() is in_transaction

--- a/tests/unit/adapters/test_duckdb/test_exception_mapping.py
+++ b/tests/unit/adapters/test_duckdb/test_exception_mapping.py
@@ -135,3 +135,14 @@ def test_create_mapped_exception_repeated_calls_consistent() -> None:
     assert type(first) is type(second)
     assert isinstance(first, NotFoundError)
     assert isinstance(second, NotFoundError)
+
+
+def test_handle_exception_propagates_non_native_error() -> None:
+    """Non-native exceptions propagate unchanged and are not mapped to a DB error."""
+    from sqlspec.adapters.duckdb.driver import DuckDBExceptionHandler
+
+    handler = DuckDBExceptionHandler()
+    with pytest.raises(KeyError):
+        with handler:
+            raise KeyError("internal bug")
+    assert handler.pending_exception is None

--- a/tests/unit/adapters/test_mysqlconnector/test_config.py
+++ b/tests/unit/adapters/test_mysqlconnector/test_config.py
@@ -43,6 +43,45 @@ def test_async_config_uses_connector_python_host_default_and_disables_local_infi
     assert config.connection_config["allow_local_infile"] is False
 
 
+def test_acquire_sync_connection_lazily_creates_pool_once(monkeypatch: "pytest.MonkeyPatch") -> None:
+    """_acquire_sync_connection routes through the SQLSpec pool (created once) and never leaks pool kwargs into connect()."""
+    from sqlspec.adapters.mysqlconnector import config as cfg_module
+
+    created_pools: list[Any] = []
+    connect_calls: list[dict[str, Any]] = []
+
+    class _FakePool:
+        def __init__(self, **kwargs: Any) -> None:
+            self.init_kwargs = kwargs
+            created_pools.append(self)
+
+        def get_connection(self) -> Any:
+            return MagicMock()
+
+    def _fake_connect(**kwargs: Any) -> Any:
+        connect_calls.append(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr(cfg_module, "MysqlConnectorConnectionPool", _FakePool)
+    monkeypatch.setattr(cfg_module.mysql.connector, "connect", _fake_connect)
+
+    config = MysqlConnectorSyncConfig(
+        connection_config={"pool_name": "sqlspec", "pool_size": 3, "pool_reset_session": True}
+    )
+
+    first = config._acquire_sync_connection()
+    second = config._acquire_sync_connection()
+
+    assert len(created_pools) == 1
+    assert config.connection_instance is created_pools[0]
+    assert first is not None
+    assert second is not None
+    for call in connect_calls:
+        assert "pool_name" not in call
+        assert "pool_size" not in call
+        assert "pool_reset_session" not in call
+
+
 @pytest.mark.parametrize("config_cls", [MysqlConnectorSyncConfig, MysqlConnectorAsyncConfig])
 def test_local_infile_uses_connector_python_security_gate(config_cls: type[Any]) -> None:
     """LOAD DATA LOCAL INFILE should use mysql-connector's native consent gate."""

--- a/tests/unit/adapters/test_psycopg/test_config.py
+++ b/tests/unit/adapters/test_psycopg/test_config.py
@@ -214,8 +214,7 @@ async def test_psycopg_async_minimal_pool_omits_prepare_threshold(monkeypatch: p
 
 
 @pytest.mark.parametrize(
-    ("open_value", "expect_open_call"),
-    [({}, True), ({"open": True}, True), ({"open": False}, False)],
+    ("open_value", "expect_open_call"), [({}, True), ({"open": True}, True), ({"open": False}, False)]
 )
 async def test_psycopg_async_pool_always_constructs_closed(
     monkeypatch: pytest.MonkeyPatch, open_value: "dict[str, Any]", expect_open_call: bool

--- a/tests/unit/adapters/test_psycopg/test_config.py
+++ b/tests/unit/adapters/test_psycopg/test_config.py
@@ -213,6 +213,26 @@ async def test_psycopg_async_minimal_pool_omits_prepare_threshold(monkeypatch: p
     assert pool_kwargs["kwargs"] == {}
 
 
+@pytest.mark.parametrize(
+    ("open_value", "expect_open_call"),
+    [({}, True), ({"open": True}, True), ({"open": False}, False)],
+)
+async def test_psycopg_async_pool_always_constructs_closed(
+    monkeypatch: pytest.MonkeyPatch, open_value: "dict[str, Any]", expect_open_call: bool
+) -> None:
+    """The async pool is always constructed with open=False; pool.open() is awaited only when open resolves truthy."""
+    _CapturedAsyncPool.calls.clear()
+    _CapturedAsyncPool.open_calls = 0
+    monkeypatch.setattr(psycopg_config, "AsyncConnectionPool", _CapturedAsyncPool)
+
+    connection_config = {"conninfo": "postgresql://user:pass@localhost/db", **open_value}
+    await PsycopgAsyncConfig(connection_config=cast("Any", connection_config))._create_pool()  # pyright: ignore[reportPrivateUsage]
+
+    _, pool_kwargs = _CapturedAsyncPool.calls[-1]
+    assert pool_kwargs["open"] is False
+    assert _CapturedAsyncPool.open_calls == (1 if expect_open_call else 0)
+
+
 @pytest.mark.anyio
 async def test_psycopg_async_pool_preserves_conninfo_with_explicit_connection_kwargs(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/adapters/test_sqlite/test_pool.py
+++ b/tests/unit/adapters/test_sqlite/test_pool.py
@@ -1,0 +1,51 @@
+"""Unit tests for the SQLite thread-local connection pool."""
+
+import pytest
+
+from sqlspec.adapters.sqlite.pool import SqliteConnectionPool
+
+pytest.importorskip("sqlite3", reason="SQLite adapter requires the stdlib sqlite3 module")
+
+
+def test_get_connection_rolls_back_open_transaction_on_exception() -> None:
+    """A mid-transaction exception must not commit partial work.
+
+    The pool is thread-local, so the connection survives the failed block; an
+    open transaction must be rolled back (not committed) when the caller's
+    with-block exits via exception.
+    """
+    pool = SqliteConnectionPool(connection_parameters={"database": ":memory:"}, enable_optimizations=False)
+    with pool.get_connection() as connection:
+        connection.execute("CREATE TABLE widgets (id INTEGER PRIMARY KEY)")
+        connection.commit()
+
+    class _BoomError(RuntimeError):
+        pass
+
+    with pytest.raises(_BoomError), pool.get_connection() as connection:
+        connection.execute("INSERT INTO widgets (id) VALUES (1)")
+        assert connection.in_transaction
+        raise _BoomError
+
+    with pool.get_connection() as connection:
+        count = connection.execute("SELECT COUNT(*) FROM widgets").fetchone()[0]
+    assert count == 0
+
+    pool.close()
+
+
+def test_get_connection_commits_open_transaction_on_clean_exit() -> None:
+    """A clean with-block exit commits the open transaction."""
+    pool = SqliteConnectionPool(connection_parameters={"database": ":memory:"}, enable_optimizations=False)
+    with pool.get_connection() as connection:
+        connection.execute("CREATE TABLE widgets (id INTEGER PRIMARY KEY)")
+        connection.commit()
+
+    with pool.get_connection() as connection:
+        connection.execute("INSERT INTO widgets (id) VALUES (1)")
+
+    with pool.get_connection() as connection:
+        count = connection.execute("SELECT COUNT(*) FROM widgets").fetchone()[0]
+    assert count == 1
+
+    pool.close()

--- a/tests/unit/builder/test_sql_factory.py
+++ b/tests/unit/builder/test_sql_factory.py
@@ -734,6 +734,21 @@ def test_any_factory_still_returns_any_expression() -> None:
     assert isinstance(result.expression, exp.Any)
 
 
+def test_any_factory_values_render_via_sql() -> None:
+    """Test SQLFactory.any list values render to SQL without raising."""
+    result = SQLFactory.any([1, 2, 3])
+    rendered = result.expression.sql().upper()
+    assert "ANY" in rendered
+    assert "1" in rendered and "2" in rendered and "3" in rendered
+
+
+def test_not_any_factory_values_render_via_sql() -> None:
+    """Test SQLFactory.not_any_ list values render to SQL without raising."""
+    rendered = SQLFactory.not_any_([1, 2, 3]).expression.sql().upper()
+    assert "NOT" in rendered
+    assert "ANY" in rendered
+
+
 def test_not_any_factory_where_clause_contains_not() -> None:
     """Test not_any_ emits NOT when composed into a WHERE clause."""
     query = sql.select("*").from_("users").where(SQLFactory.not_any_("SELECT id FROM blocked_users").expression)

--- a/tests/unit/exceptions/test_exception_handler.py
+++ b/tests/unit/exceptions/test_exception_handler.py
@@ -46,27 +46,27 @@ def test_async_exception_handlers_inherit_shared_base() -> None:
     assert issubclass(AsyncpgExceptionHandler, BaseAsyncExceptionHandler)
 
 
-def test_duckdb_exception_handler_maps_any_present_exception(monkeypatch: pytest.MonkeyPatch) -> None:
-    """DuckDB handler should map any exception when one is present."""
-    pytest.importorskip("duckdb")
+def test_duckdb_exception_handler_maps_native_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DuckDB handler should map a native duckdb.Error to a SQLSpec exception."""
+    import duckdb
+
     from sqlspec.adapters.duckdb import driver as duckdb_driver
 
     mapped = RuntimeError("mapped")
     seen: dict[str, object] = {}
 
-    def fake_create_mapped_exception(exc_val: BaseException, *, logger: object | None = None) -> Exception:
+    def fake_create_mapped_exception(exc_val: BaseException) -> Exception:
         seen["exc_val"] = exc_val
-        seen["logger"] = logger
         return mapped
 
     monkeypatch.setattr(duckdb_driver, "create_mapped_exception", fake_create_mapped_exception)
 
-    error = ValueError("boom")
+    error = duckdb.Error("boom")
     handler = duckdb_driver.DuckDBExceptionHandler()
 
     assert handler.__exit__(type(error), error, None) is True
     assert handler.pending_exception is mapped
-    assert seen == {"exc_val": error, "logger": None}
+    assert seen == {"exc_val": error}
 
 
 def test_mysqlconnector_sync_exception_handler_preserves_suppression(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -240,23 +240,20 @@ async def test_aiosqlite_handler_maps_sqlite_error() -> None:
 
 def test_duckdb_handler_maps_constraint_exception(monkeypatch: pytest.MonkeyPatch) -> None:
     """DuckDB handler should map constraint errors to specific violation types."""
-    pytest.importorskip("duckdb")
-    from sqlspec.adapters.duckdb import core as duckdb_core
+    import duckdb
+
     from sqlspec.adapters.duckdb.driver import DuckDBExceptionHandler
     from sqlspec.exceptions import UniqueViolationError
 
-    def fake_create_mapped_exception(exc_val: "BaseException", *, logger: object | None = None) -> Exception:
-        assert logger is None
+    def fake_create_mapped_exception(exc_val: "BaseException") -> Exception:
         return UniqueViolationError(str(exc_val))
 
-    monkeypatch.setattr(duckdb_core, "create_mapped_exception", fake_create_mapped_exception)
-    # Also patch the driver module's reference
     from sqlspec.adapters.duckdb import driver as duckdb_driver
 
     monkeypatch.setattr(duckdb_driver, "create_mapped_exception", fake_create_mapped_exception)
 
     handler = DuckDBExceptionHandler()
-    error = RuntimeError("unique constraint violation")
+    error = duckdb.ConstraintException("unique constraint violation")
     result = handler.__exit__(type(error), error, None)
     assert result is True
     assert isinstance(handler.pending_exception, UniqueViolationError)

--- a/tests/unit/extensions/test_litestar/test_plugin_state_lookup.py
+++ b/tests/unit/extensions/test_litestar/test_plugin_state_lookup.py
@@ -1,0 +1,32 @@
+"""Regression tests for SQLSpecPlugin key-lookup parity across state accessors."""
+
+from litestar.config.app import AppConfig
+
+from sqlspec.adapters.aiosqlite.config import AiosqliteConfig
+from sqlspec.base import SQLSpec
+from sqlspec.extensions.litestar.plugin import DEFAULT_CONNECTION_KEY, DEFAULT_SESSION_KEY, SQLSpecPlugin
+
+
+def _build_initialized_plugin() -> SQLSpecPlugin:
+    sqlspec = SQLSpec()
+    sqlspec.add_config(AiosqliteConfig(connection_config={"database": ":memory:"}))
+    plugin = SQLSpecPlugin(sqlspec=sqlspec)
+    # on_app_init populates PluginConfigState.annotation (field(init=False)).
+    plugin.on_app_init(AppConfig())
+    return plugin
+
+
+def test_get_annotation_resolves_by_session_key() -> None:
+    """get_annotation() must resolve the session key like get_config()/_get_plugin_state()."""
+    plugin = _build_initialized_plugin()
+    by_connection = plugin.get_annotation(DEFAULT_CONNECTION_KEY)
+    by_session = plugin.get_annotation(DEFAULT_SESSION_KEY)
+    assert by_session is by_connection
+
+
+def test_get_config_and_get_annotation_agree_on_session_key() -> None:
+    """Both accessors resolve the same config for the session key."""
+    plugin = _build_initialized_plugin()
+    config = plugin.get_config(DEFAULT_SESSION_KEY)
+    assert plugin.get_config(DEFAULT_CONNECTION_KEY) is config
+    assert plugin.get_annotation(DEFAULT_SESSION_KEY) is type(config)

--- a/tests/unit/extensions/test_litestar/test_plugin_state_lookup.py
+++ b/tests/unit/extensions/test_litestar/test_plugin_state_lookup.py
@@ -8,10 +8,10 @@ from sqlspec.extensions.litestar.plugin import DEFAULT_CONNECTION_KEY, DEFAULT_S
 
 
 def _build_initialized_plugin() -> SQLSpecPlugin:
+    """Build a plugin and run on_app_init, which populates PluginConfigState.annotation."""
     sqlspec = SQLSpec()
     sqlspec.add_config(AiosqliteConfig(connection_config={"database": ":memory:"}))
     plugin = SQLSpecPlugin(sqlspec=sqlspec)
-    # on_app_init populates PluginConfigState.annotation (field(init=False)).
     plugin.on_app_init(AppConfig())
     return plugin
 

--- a/tests/unit/loader/test_sql_file_loader.py
+++ b/tests/unit/loader/test_sql_file_loader.py
@@ -88,6 +88,26 @@ def test_load_uncached_file_accepts_pre_read_content(monkeypatch, tmp_path: Path
     assert loader.has_query("from_memory")
 
 
+def test_load_uncached_file_returns_parsed_statements(tmp_path: Path) -> None:
+    """_load_uncached_file returns the file's statements keyed by un-namespaced name."""
+    sql_file = tmp_path / "widgets.sql"
+    sql_file.write_text("-- name: get_widget\nSELECT 1;\n\n-- name: list_widgets\nSELECT 2;\n")
+    loader = SQLFileLoader()
+
+    result = loader._load_uncached_file(sql_file, "ns")
+
+    assert set(result) == {"get_widget", "list_widgets"}
+
+
+def test_load_uncached_file_returns_empty_dict_without_statements(tmp_path: Path) -> None:
+    """_load_uncached_file returns an empty dict when the file has no named statements."""
+    sql_file = tmp_path / "empty.sql"
+    sql_file.write_text("SELECT 1;\n")
+    loader = SQLFileLoader()
+
+    assert loader._load_uncached_file(sql_file, None) == {}
+
+
 def test_load_single_file_reads_once_on_stale_cache(monkeypatch, tmp_path: Path) -> None:
     """A stale cache entry should not cause a checksum read and a parse read."""
     sql_file = tmp_path / "queries.sql"

--- a/tests/unit/migrations/test_fix_regex_precision.py
+++ b/tests/unit/migrations/test_fix_regex_precision.py
@@ -16,6 +16,17 @@ def temp_migrations_dir(tmp_path: Path) -> Path:
     return migrations_dir
 
 
+def test_plan_renames_preserves_version_digits_embedded_in_description(temp_migrations_dir: Path) -> None:
+    """plan_renames must strip only the leading version prefix, not later occurrences."""
+    fixer = MigrationFixer(temp_migrations_dir)
+    (temp_migrations_dir / "0001_add_0001_series_column.sql").write_text("-- name: migrate-0001-up\n")
+
+    renames = fixer.plan_renames({"0001": "0002"})
+
+    assert len(renames) == 1
+    assert renames[0].new_path.name == "0002_add_0001_series_column.sql"
+
+
 def test_update_file_content_only_replaces_specific_version(temp_migrations_dir: Path) -> None:
     """Test only specific old_version is replaced, not other versions."""
     fixer = MigrationFixer(temp_migrations_dir)

--- a/tests/unit/tools/test_pgo_training.py
+++ b/tests/unit/tools/test_pgo_training.py
@@ -1,0 +1,13 @@
+"""Regression guard for the PGO training workload imports."""
+
+from tools.scripts.pgo_training import _train_serialization
+
+
+def test_train_serialization_runs() -> None:
+    """The serialization workload must execute without import errors.
+
+    A prior revision lazily imported a non-existent sqlspec._serialization module,
+    crashing the PGO training CI path with ModuleNotFoundError. This exercises the
+    real code path (the broken import is inside the function body).
+    """
+    _train_serialization()

--- a/tests/unit/tools/test_pgo_training.py
+++ b/tests/unit/tools/test_pgo_training.py
@@ -4,10 +4,5 @@ from tools.scripts.pgo_training import _train_serialization
 
 
 def test_train_serialization_runs() -> None:
-    """The serialization workload must execute without import errors.
-
-    A prior revision lazily imported a non-existent sqlspec._serialization module,
-    crashing the PGO training CI path with ModuleNotFoundError. This exercises the
-    real code path (the broken import is inside the function body).
-    """
+    """The serialization workload must execute without import errors."""
     _train_serialization()

--- a/tools/scripts/pgo_training.py
+++ b/tools/scripts/pgo_training.py
@@ -160,7 +160,12 @@ def _train_serialization() -> None:
     """Exercise JSON encode/decode paths."""
     from datetime import datetime, timezone
 
-    from sqlspec._serialization import convert_date_to_iso, convert_datetime_to_gmt_iso, decode_json, encode_json
+    from sqlspec.utils.serializers._json import (
+        convert_date_to_iso,
+        convert_datetime_to_gmt_iso,
+        decode_json,
+        encode_json,
+    )
 
     small_obj = {"key": "value", "num": 42}
     medium_obj = {f"field_{i}": i * 1.5 for i in range(20)}


### PR DESCRIPTION
## Summary

A batch of independent correctness fixes across drivers, the builder, the Litestar plugin, migrations, and the SQL file loader. Each fix is isolated to its own commit with a red→green regression test.

### Connection & pool lifecycle
- **sqlite**: `get_connection()` committed any open transaction on `finally`, persisting partial work when the caller's block raised. It now rolls back on exceptional exit and commits only on clean exit.
- **aiosqlite**: `connect_timeout` was unenforced on pool exhaustion (the untimed fast path fell into an unbounded wait). Acquisition is now always bounded by `connect_timeout`.
- **psycopg (async)**: a user-provided `open=True` took psycopg's deprecated construct-and-open path. The pool is now always constructed with `open=False` and opened via `await pool.open()` when requested.
- **mysqlconnector (sync)**: acquisition bypassed the SQLSpec pool and leaked `pool_name`/`pool_size`/`pool_reset_session` into `connect()`, silently activating the driver's own global pool. It now routes through `provide_pool()`.

### Transaction & exception honesty
- **aiomysql / asyncmy**: `_connection_in_transaction()` was hardcoded `False`, so the single-transaction guard could `begin()` inside an open transaction. Both now report `get_transaction_status()`.
- **adbc / duckdb**: `_handle_exception` relabeled *any* exception as a database error, masking internal bugs. Both now gate on the native driver error base (like sqlite), letting non-native exceptions propagate.

### Builder, Litestar, migrations, loader
- **builder**: `sql.any([...])` / `not_any_` embedded wrapper objects into the AST and raised on `.sql()`; literals are now unwrapped.
- **Litestar plugin**: `get_annotation()` omitted the session key and raised `KeyError` where `get_config()` succeeded; both now share one lookup.
- **migrations**: the rename planner used `str.replace`, corrupting descriptions that re-embedded the version digits; it now uses `removeprefix`.
- **loader**: cache-miss loads rescanned every registered query (O(files × queries)); the per-file statement dict is now reused directly.

### Tooling & repo hygiene
- **PGO training**: `_train_serialization` imported a non-existent module; fixed to the real serializer path.
- Silenced opentelemetry's import-time `SelectableGroups` deprecation warning (upstream, Python 3.10 only) and disabled the stale `warn_unused_configs` mypy note that every make target already overrides.
