### PR TITLE
fix: align execute_script parameter embedding and empty execute_many across adapters

### DIFF
--- a/sqlspec/adapters/aiomysql/core.py
+++ b/sqlspec/adapters/aiomysql/core.py
@@ -230,13 +230,7 @@ def normalize_execute_many_parameters(parameters: Any) -> Any:
 
     Returns:
         Normalized parameters payload.
-
-    Raises:
-        ValueError: When parameters are missing for executemany.
     """
-    if not parameters:
-        msg = "execute_many requires parameters"
-        raise ValueError(msg)
     return parameters
 
 

--- a/sqlspec/adapters/aiomysql/driver.py
+++ b/sqlspec/adapters/aiomysql/driver.py
@@ -185,10 +185,6 @@ class AiomysqlDriver(AsyncDriverAdapterBase):
         sql, prepared_parameters = self._compiled_sql(statement, self.statement_config)
         statements = self.split_script_statements(sql, statement.statement_config, strip_trailing_semicolon=True)
 
-        if prepared_parameters and len(statements) > 1:
-            msg = "execute_script with parameters is not supported for multi-statement scripts; use execute or execute_many for parameterized statements"
-            raise SQLSpecError(msg)
-
         successful_count = 0
         last_cursor = cursor
 

--- a/sqlspec/adapters/aiosqlite/core.py
+++ b/sqlspec/adapters/aiosqlite/core.py
@@ -236,13 +236,7 @@ def normalize_execute_many_parameters(parameters: Any) -> Any:
 
     Returns:
         Normalized parameters payload.
-
-    Raises:
-        ValueError: When parameters are missing for executemany.
     """
-    if not parameters:
-        msg = "execute_many requires parameters"
-        raise ValueError(msg)
     return parameters
 
 

--- a/sqlspec/adapters/arrow_odbc/driver.py
+++ b/sqlspec/adapters/arrow_odbc/driver.py
@@ -167,7 +167,7 @@ class ArrowOdbcDriver(SyncDriverAdapterBase):
             )
 
         cursor.execute(query=sql, parameters=parameters)
-        return self.create_execution_result(cursor, rowcount_override=-1)
+        return self.create_execution_result(cursor, rowcount_override=0)
 
     def dispatch_execute_many(self, cursor: "ArrowOdbcRawCursor", statement: "SQL") -> "ExecutionResult":
         msg = "arrow-odbc does not expose a row-oriented executemany API; use bulk_insert_arrow() for Arrow ingestion."

--- a/sqlspec/adapters/asyncmy/core.py
+++ b/sqlspec/adapters/asyncmy/core.py
@@ -202,13 +202,7 @@ def normalize_execute_many_parameters(parameters: Any) -> Any:
 
     Returns:
         Normalized parameters payload.
-
-    Raises:
-        ValueError: When parameters are missing for executemany.
     """
-    if not parameters:
-        msg = "execute_many requires parameters"
-        raise ValueError(msg)
     return parameters
 
 

--- a/sqlspec/adapters/asyncmy/driver.py
+++ b/sqlspec/adapters/asyncmy/driver.py
@@ -184,10 +184,6 @@ class AsyncmyDriver(AsyncDriverAdapterBase):
         sql, prepared_parameters = self._compiled_sql(statement, self.statement_config)
         statements = self.split_script_statements(sql, statement.statement_config, strip_trailing_semicolon=True)
 
-        if prepared_parameters and len(statements) > 1:
-            msg = "execute_script with parameters is not supported for multi-statement scripts; use execute or execute_many for parameterized statements"
-            raise SQLSpecError(msg)
-
         successful_count = 0
         last_cursor = cursor
 

--- a/sqlspec/adapters/mysqlconnector/core.py
+++ b/sqlspec/adapters/mysqlconnector/core.py
@@ -306,9 +306,6 @@ class MysqlConnectorAsyncStreamSource:
 
 def normalize_execute_many_parameters(parameters: Any) -> Any:
     """Normalize parameters for mysql-connector executemany calls."""
-    if not parameters:
-        msg = "execute_many requires parameters"
-        raise ValueError(msg)
     return parameters
 
 

--- a/sqlspec/adapters/mysqlconnector/driver.py
+++ b/sqlspec/adapters/mysqlconnector/driver.py
@@ -153,10 +153,6 @@ class MysqlConnectorSyncDriver(SyncDriverAdapterBase):
         sql, prepared_parameters = self._compiled_sql(statement, self.statement_config)
         statements = self.split_script_statements(sql, statement.statement_config, strip_trailing_semicolon=True)
 
-        if prepared_parameters and len(statements) > 1:
-            msg = "execute_script with parameters is not supported for multi-statement scripts; use execute or execute_many for parameterized statements"
-            raise SQLSpecError(msg)
-
         successful_count = 0
         last_cursor = cursor
 
@@ -405,10 +401,6 @@ class MysqlConnectorAsyncDriver(AsyncDriverAdapterBase):
     async def dispatch_execute_script(self, cursor: Any, statement: "SQL") -> "ExecutionResult":
         sql, prepared_parameters = self._compiled_sql(statement, self.statement_config)
         statements = self.split_script_statements(sql, statement.statement_config, strip_trailing_semicolon=True)
-
-        if prepared_parameters and len(statements) > 1:
-            msg = "execute_script with parameters is not supported for multi-statement scripts; use execute or execute_many for parameterized statements"
-            raise SQLSpecError(msg)
 
         successful_count = 0
         last_cursor = cursor

--- a/sqlspec/adapters/oracledb/core.py
+++ b/sqlspec/adapters/oracledb/core.py
@@ -251,13 +251,7 @@ def normalize_execute_many_parameters_sync(parameters: Any) -> Any:
 
     Returns:
         Normalized parameters payload.
-
-    Raises:
-        ValueError: When parameters are missing for executemany.
     """
-    if not parameters:
-        msg = "execute_many requires parameters"
-        raise ValueError(msg)
     if isinstance(parameters, tuple):
         return list(parameters)
     return parameters
@@ -271,13 +265,7 @@ def normalize_execute_many_parameters_async(parameters: Any) -> Any:
 
     Returns:
         Normalized parameters payload.
-
-    Raises:
-        ValueError: When parameters are missing for executemany.
     """
-    if not parameters:
-        msg = "execute_many requires parameters"
-        raise ValueError(msg)
     if isinstance(parameters, tuple):
         return list(parameters)
     return parameters

--- a/sqlspec/adapters/psqlpy/core.py
+++ b/sqlspec/adapters/psqlpy/core.py
@@ -464,10 +464,10 @@ def _parse_psqlpy_command_tag(tag: str) -> int:
         tag: PostgreSQL command tag string.
 
     Returns:
-        Number of rows affected, -1 if unable to parse.
+        Number of rows affected, 0 if unable to parse.
     """
     if not tag:
-        return -1
+        return 0
 
     match = PSQLPY_STATUS_REGEX.match(tag.strip())
     if match:
@@ -476,7 +476,7 @@ def _parse_psqlpy_command_tag(tag: str) -> int:
             return int(match.group(3))
         if command in {"UPDATE", "DELETE"} and match.group(3):
             return int(match.group(3))
-    return -1
+    return 0
 
 
 def extract_rows_affected(result: Any) -> int:
@@ -491,7 +491,7 @@ def extract_rows_affected(result: Any) -> int:
             return _parse_psqlpy_command_tag(result)
     except Exception as error:
         logger.debug("Failed to parse psqlpy command tag: %s", error)
-    return -1
+    return 0
 
 
 def get_parameter_casts(statement: Any) -> "dict[int, str]":

--- a/sqlspec/adapters/psqlpy/driver.py
+++ b/sqlspec/adapters/psqlpy/driver.py
@@ -164,11 +164,6 @@ class PsqlpyDriver(AsyncDriverAdapterBase):
         prepared_parameters = cast("Sequence[Any] | Mapping[str, Any] | None", prepared_parameters)
         statement_config = statement.statement_config
         statements = self.split_script_statements(sql, statement_config, strip_trailing_semicolon=True)
-        if len(statements) > 1 and prepared_parameters:
-            msg = (
-                "Parameterized multi-statement scripts are not supported; use execute_many or individual execute calls"
-            )
-            raise SQLSpecError(msg)
 
         successful_count = 0
         last_result = None

--- a/sqlspec/adapters/psycopg/driver.py
+++ b/sqlspec/adapters/psycopg/driver.py
@@ -241,11 +241,6 @@ class PsycopgSyncDriver(PsycopgPipelineMixin, SyncDriverAdapterBase):
         """
         sql, prepared_parameters = self._compiled_sql(statement, self.statement_config)
         statements = self.split_script_statements(sql, statement.statement_config, strip_trailing_semicolon=True)
-        if len(statements) > 1 and prepared_parameters:
-            msg = (
-                "Parameterized multi-statement scripts are not supported; use execute_many or individual execute calls"
-            )
-            raise SQLSpecError(msg)
 
         successful_count = 0
         last_cursor = cursor
@@ -722,11 +717,6 @@ class PsycopgAsyncDriver(PsycopgPipelineMixin, AsyncDriverAdapterBase):
         """
         sql, prepared_parameters = self._compiled_sql(statement, self.statement_config)
         statements = self.split_script_statements(sql, statement.statement_config, strip_trailing_semicolon=True)
-        if len(statements) > 1 and prepared_parameters:
-            msg = (
-                "Parameterized multi-statement scripts are not supported; use execute_many or individual execute calls"
-            )
-            raise SQLSpecError(msg)
 
         successful_count = 0
         last_cursor = cursor

--- a/sqlspec/adapters/pymssql/core.py
+++ b/sqlspec/adapters/pymssql/core.py
@@ -89,9 +89,6 @@ def normalize_execute_parameters(parameters: Any) -> Any:
 
 def normalize_execute_many_parameters(parameters: Any) -> Any:
     """Normalize parameters for pymssql executemany calls."""
-    if not parameters:
-        msg = "execute_many requires parameters"
-        raise ValueError(msg)
     return parameters
 
 

--- a/sqlspec/adapters/pymssql/driver.py
+++ b/sqlspec/adapters/pymssql/driver.py
@@ -170,9 +170,6 @@ class PymssqlDriver(SyncDriverAdapterBase):
     def dispatch_execute_script(self, cursor: "PymssqlRawCursor", statement: "SQL") -> "ExecutionResult":
         sql, prepared_parameters = self._compiled_sql(statement, self.statement_config)
         statements = self.split_script_statements(sql, statement.statement_config, strip_trailing_semicolon=True)
-        if prepared_parameters and len(statements) > 1:
-            msg = "execute_script with parameters is not supported for multi-statement scripts; use execute or execute_many for parameterized statements"
-            raise SQLSpecError(msg)
 
         successful_count = 0
         for stmt in statements:

--- a/sqlspec/adapters/pymysql/core.py
+++ b/sqlspec/adapters/pymysql/core.py
@@ -221,9 +221,6 @@ class PymysqlStreamSource:
 
 def normalize_execute_many_parameters(parameters: Any) -> Any:
     """Normalize parameters for PyMySQL executemany calls."""
-    if not parameters:
-        msg = "execute_many requires parameters"
-        raise ValueError(msg)
     return parameters
 
 

--- a/sqlspec/adapters/pymysql/driver.py
+++ b/sqlspec/adapters/pymysql/driver.py
@@ -128,10 +128,6 @@ class PyMysqlDriver(SyncDriverAdapterBase):
         sql, prepared_parameters = self._compiled_sql(statement, self.statement_config)
         statements = self.split_script_statements(sql, statement.statement_config, strip_trailing_semicolon=True)
 
-        if prepared_parameters and len(statements) > 1:
-            msg = "execute_script with parameters is not supported for multi-statement scripts; use execute or execute_many for parameterized statements"
-            raise SQLSpecError(msg)
-
         successful_count = 0
         last_cursor = cursor
 

--- a/sqlspec/adapters/spanner/driver.py
+++ b/sqlspec/adapters/spanner/driver.py
@@ -326,8 +326,8 @@ class SpannerSyncDriver(SyncDriverAdapterBase):
 
         sql, prepared_parameters = self._compiled_sql(statement, self.statement_config)
 
-        if not prepared_parameters or not isinstance(prepared_parameters, list):
-            msg = "execute_many requires at least one parameter set"
+        if not isinstance(prepared_parameters, list):
+            msg = "execute_many requires a list of parameter sets"
             raise SQLConversionError(msg)
 
         _coerce = self._coerce_params

--- a/sqlspec/adapters/sqlite/core.py
+++ b/sqlspec/adapters/sqlite/core.py
@@ -197,13 +197,7 @@ def normalize_execute_many_parameters(parameters: Any) -> Any:
 
     Returns:
         Normalized parameters payload.
-
-    Raises:
-        ValueError: When parameters are missing for executemany.
     """
-    if not parameters:
-        msg = "execute_many requires parameters"
-        raise ValueError(msg)
     return parameters
 
 

--- a/sqlspec/core/statement.py
+++ b/sqlspec/core/statement.py
@@ -869,11 +869,20 @@ class SQL:
     def as_script(self) -> "SQL":
         """Create copy marked for script execution.
 
+        Script execution binds no parameters, so any supplied parameters are
+        embedded statically into the SQL via sqlglot. The script copy forces
+        ``needs_static_script_compilation`` so every adapter compiles bind-free.
+
         Returns:
             New SQL instance configured for script execution
         """
         new_sql = self._copy_base(self._raw_expression or self._raw_sql)
         new_sql._is_script = True
+        param_config = self._statement_config.parameter_config
+        if not param_config.needs_static_script_compilation:
+            new_sql._statement_config = self._statement_config.replace(
+                parameter_config=param_config.replace(needs_static_script_compilation=True)
+            )
         return new_sql
 
     def copy(self, statement: "str | exp.Expr | None" = None, parameters: Any | None = None, **kwargs: Any) -> "SQL":

--- a/sqlspec/driver/_async.py
+++ b/sqlspec/driver/_async.py
@@ -237,7 +237,12 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin):
                         execution_result = await self.dispatch_execute_script(cursor, statement)
                         result = self.build_statement_result(statement, execution_result)
                     elif statement.is_many:
-                        execution_result = await self.dispatch_execute_many(cursor, statement)
+                        if execution_parameters:
+                            execution_result = await self.dispatch_execute_many(cursor, statement)
+                        else:
+                            execution_result = self.create_execution_result(
+                                cursor, rowcount_override=0, is_many_result=True
+                            )
                         result = self.build_statement_result(statement, execution_result)
                     else:
                         execution_result = await self.dispatch_execute(cursor, statement)
@@ -274,7 +279,12 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin):
                         execution_result = await self.dispatch_execute_script(cursor, statement)
                         result = self.build_statement_result(statement, execution_result)
                     elif statement.is_many:
-                        execution_result = await self.dispatch_execute_many(cursor, statement)
+                        if execution_parameters:
+                            execution_result = await self.dispatch_execute_many(cursor, statement)
+                        else:
+                            execution_result = self.create_execution_result(
+                                cursor, rowcount_override=0, is_many_result=True
+                            )
                         result = self.build_statement_result(statement, execution_result)
                     else:
                         execution_result = await self.dispatch_execute(cursor, statement)

--- a/sqlspec/driver/_sync.py
+++ b/sqlspec/driver/_sync.py
@@ -220,7 +220,12 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin):
                         execution_result = self.dispatch_execute_script(cursor, statement)
                         result = self.build_statement_result(statement, execution_result)
                     elif statement.is_many:
-                        execution_result = self.dispatch_execute_many(cursor, statement)
+                        if execution_parameters:
+                            execution_result = self.dispatch_execute_many(cursor, statement)
+                        else:
+                            execution_result = self.create_execution_result(
+                                cursor, rowcount_override=0, is_many_result=True
+                            )
                         result = self.build_statement_result(statement, execution_result)
                     else:
                         execution_result = self.dispatch_execute(cursor, statement)
@@ -256,7 +261,12 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin):
                         execution_result = self.dispatch_execute_script(cursor, statement)
                         result = self.build_statement_result(statement, execution_result)
                     elif statement.is_many:
-                        execution_result = self.dispatch_execute_many(cursor, statement)
+                        if execution_parameters:
+                            execution_result = self.dispatch_execute_many(cursor, statement)
+                        else:
+                            execution_result = self.create_execution_result(
+                                cursor, rowcount_override=0, is_many_result=True
+                            )
                         result = self.build_statement_result(statement, execution_result)
                     else:
                         execution_result = self.dispatch_execute(cursor, statement)

--- a/sqlspec/extensions/events/_queue.py
+++ b/sqlspec/extensions/events/_queue.py
@@ -161,6 +161,22 @@ class _BaseTableEventQueue:
         return datetime.now(timezone.utc)
 
     @staticmethod
+    def _claim_verified(row: "dict[str, Any] | None", leased_until: "datetime") -> bool:
+        """Confirm claim ownership by matching the stored lease against the claimer's token.
+
+        Drivers that cannot report rows affected return zero for a successful
+        claim UPDATE, so a zero rowcount alone cannot distinguish a won claim
+        from a lost race. The persisted ``lease_expires_at`` value identifies
+        the winning claimer.
+        """
+        if row is None:
+            return False
+        lease_value = row.get("lease_expires_at")
+        if lease_value is None:
+            return False
+        return parse_event_timestamp(lease_value) == leased_until
+
+    @staticmethod
     def _hydrate_event(row: "dict[str, Any]", lease_expires_at: "datetime | None") -> EventMessage:
         payload_raw = row.get("payload_json")
         metadata_raw = row.get("metadata_json")
@@ -256,6 +272,8 @@ class SyncTableEventQueue(_BaseTableEventQueue):
                     "lease_reentry_cutoff": now,
                 },
             )
+            if not claimed:
+                claimed = self._claim_verified(self._fetch_by_event_id(row["event_id"]), leased_until)
             if claimed:
                 return self._hydrate_event(row, leased_until)
         return None
@@ -277,6 +295,8 @@ class SyncTableEventQueue(_BaseTableEventQueue):
                 "lease_reentry_cutoff": now,
             },
         )
+        if not claimed:
+            claimed = self._claim_verified(self._fetch_by_event_id(row["event_id"]), leased_until)
         if claimed:
             return self._hydrate_event(row, leased_until)
         return None
@@ -340,6 +360,15 @@ class SyncTableEventQueue(_BaseTableEventQueue):
                 claimed = self._execute_with_driver(
                     driver, self._claim_statement, self._claim_parameters(row, now, leased_until)
                 )
+                if not claimed:
+                    verify_row = driver.select_one_or_none(
+                        SQL(
+                            self._select_by_id_statement,
+                            {"event_id": row["event_id"]},
+                            statement_config=self._statement_config,
+                        )
+                    )
+                    claimed = self._claim_verified(verify_row, leased_until)
                 if not claimed:
                     driver.rollback()
                     return None
@@ -450,6 +479,8 @@ class AsyncTableEventQueue(_BaseTableEventQueue):
                     "lease_reentry_cutoff": now,
                 },
             )
+            if not claimed:
+                claimed = self._claim_verified(await self._fetch_by_event_id(row["event_id"]), leased_until)
             if claimed:
                 return self._hydrate_event(row, leased_until)
         return None
@@ -471,6 +502,8 @@ class AsyncTableEventQueue(_BaseTableEventQueue):
                 "lease_reentry_cutoff": now,
             },
         )
+        if not claimed:
+            claimed = self._claim_verified(await self._fetch_by_event_id(row["event_id"]), leased_until)
         if claimed:
             return self._hydrate_event(row, leased_until)
         return None
@@ -538,6 +571,15 @@ class AsyncTableEventQueue(_BaseTableEventQueue):
                 claimed = await self._execute_with_driver(
                     driver, self._claim_statement, self._claim_parameters(row, now, leased_until)
                 )
+                if not claimed:
+                    verify_row = await driver.select_one_or_none(
+                        SQL(
+                            self._select_by_id_statement,
+                            {"event_id": row["event_id"]},
+                            statement_config=self._statement_config,
+                        )
+                    )
+                    claimed = self._claim_verified(verify_row, leased_until)
                 if not claimed:
                     await driver.rollback()
                     return None

--- a/tests/integration/adapters/psqlpy/test_driver.py
+++ b/tests/integration/adapters/psqlpy/test_driver.py
@@ -73,7 +73,7 @@ async def test_scalar_parameter_handling(psqlpy_session: "PsqlpyDriver") -> None
 
     insert_result = await psqlpy_session.execute("INSERT INTO test_table_psqlpy (name) VALUES (?)", "single_param")
     assert isinstance(insert_result, SQLResult)
-    assert insert_result.rows_affected == -1
+    assert insert_result.rows_affected == 0
 
     select_result = await psqlpy_session.execute("SELECT * FROM test_table_psqlpy WHERE name = ?", "single_param")
     assert isinstance(select_result, SQLResult)
@@ -102,7 +102,7 @@ async def test_question_mark_in_edge_cases(psqlpy_session: "PsqlpyDriver") -> No
 
     insert_result = await psqlpy_session.execute("INSERT INTO test_table_psqlpy (name) VALUES (?)", "edge_case_test")
     assert isinstance(insert_result, SQLResult)
-    assert insert_result.rows_affected == -1
+    assert insert_result.rows_affected == 0
 
     result = await psqlpy_session.execute(
         "SELECT * FROM test_table_psqlpy WHERE name = ? AND '?' = '?'", "edge_case_test"

--- a/tests/integration/adapters/psqlpy/test_parameter_variants.py
+++ b/tests/integration/adapters/psqlpy/test_parameter_variants.py
@@ -14,11 +14,11 @@ pytestmark = pytest.mark.xdist_group("postgres")
 
 
 async def test_psqlpy_execute_rows_affected_deviation(psqlpy_session: PsqlpyDriver) -> None:
-    """PSQLPy single execute DML reports -1, while execute_many reports actual affected rows."""
+    """PSQLPy single execute DML reports zero rows, while execute_many reports actual affected rows."""
     insert_result = await psqlpy_session.execute("INSERT INTO test_table_psqlpy (name) VALUES (?)", ("single",))
     many_result = await psqlpy_session.execute_many(
         "INSERT INTO test_table_psqlpy (name) VALUES ($1)", [("batch1",), ("batch2",), ("batch3",)]
     )
 
-    assert insert_result.rows_affected == -1
+    assert insert_result.rows_affected == 0
     assert many_result.rows_affected == 3

--- a/tests/unit/adapters/test_arrow_odbc/test_driver.py
+++ b/tests/unit/adapters/test_arrow_odbc/test_driver.py
@@ -560,14 +560,14 @@ def test_arrow_odbc_mssql_begin_uses_driver_transaction_api() -> None:
     assert connection.executed == []
 
 
-def test_arrow_odbc_execute_marks_dml_rowcount_unknown() -> None:
-    """arrow-odbc does not expose portable rows-affected metadata for DML."""
+def test_arrow_odbc_execute_marks_dml_rowcount_zero() -> None:
+    """arrow-odbc has no portable DML rows-affected metadata; it reports zero, not the -1 sentinel."""
     connection = FakeConnection()
     driver = ArrowOdbcDriver(cast("ArrowOdbcConnection", connection))
 
     result = driver.execute("DELETE FROM items WHERE id = ?", (1,))
 
-    assert result.rows_affected == -1
+    assert result.rows_affected == 0
     assert connection.executed == [("DELETE FROM items WHERE id = ?", ["1"])]
 
 

--- a/tests/unit/adapters/test_async_adapters.py
+++ b/tests/unit/adapters/test_async_adapters.py
@@ -113,13 +113,9 @@ async def test_async_driver_execute_many(aiosqlite_async_driver: AiosqliteDriver
 
 
 async def test_async_driver_execute_many_no_parameters(aiosqlite_async_driver: AiosqliteDriver) -> None:
-    """Test async _execute_many method fails without parameters."""
-    statement = SQL(
-        "INSERT INTO users (name) VALUES (?)", statement_config=aiosqlite_async_driver.statement_config, is_many=True
-    )
-    async with aiosqlite_async_driver.with_cursor(aiosqlite_async_driver.connection) as cursor:
-        with pytest.raises(ValueError, match="execute_many requires parameters"):
-            await aiosqlite_async_driver.dispatch_execute_many(cursor, statement)
+    """Empty execute_many should be a silent no-op returning rows_affected=0."""
+    result = await aiosqlite_async_driver.execute_many("INSERT INTO users (name) VALUES (?)", [])
+    assert result.rows_affected == 0
 
 
 async def test_async_driver_execute_script(aiosqlite_async_driver: AiosqliteDriver) -> None:

--- a/tests/unit/adapters/test_mysql_family_core.py
+++ b/tests/unit/adapters/test_mysql_family_core.py
@@ -14,7 +14,6 @@ from sqlspec.adapters.asyncmy.driver import AsyncmyDriver
 from sqlspec.adapters.mysqlconnector.driver import MysqlConnectorAsyncDriver, MysqlConnectorSyncDriver
 from sqlspec.adapters.pymysql.driver import PyMysqlDriver
 from sqlspec.adapters.pymysql.pool import PyMysqlConnectionPool
-from sqlspec.exceptions import SQLSpecError
 
 MODULE_PATHS = (
     "sqlspec.adapters.aiomysql.core",
@@ -158,7 +157,6 @@ def test_asyncmy_collect_rows_uses_canonical_tuple_json_helper(monkeypatch: pyte
     assert calls == [(rows, [0])]
 
 
-_ERROR_MESSAGE = "execute_script with parameters is not supported for multi-statement scripts"
 _MULTI_STMT_SQL = "SELECT 1; SELECT 2"
 
 
@@ -185,14 +183,14 @@ def _make_async_cursor() -> AsyncMock:
 
 
 @pytest.mark.parametrize("driver_factory", [PyMysqlDriver, MysqlConnectorSyncDriver])
-def test_mysql_execute_script_sync_mysql_execute_script_multi_statement_with_params_raises(
-    driver_factory: type[Any],
-) -> None:
+def test_mysql_execute_script_sync_multi_statement_with_params_executes_all(driver_factory: type[Any]) -> None:
     driver = driver_factory(connection=MagicMock())
     statement = _make_statement(driver)
+    cursor = _make_sync_cursor()
     with patch.object(driver_factory, "_compiled_sql", return_value=(_MULTI_STMT_SQL, (42,))):
-        with pytest.raises(SQLSpecError, match=_ERROR_MESSAGE):
-            driver.dispatch_execute_script(_make_sync_cursor(), statement)
+        result = driver.dispatch_execute_script(cursor, statement)
+    assert result.statement_count == 2
+    assert result.successful_statements == 2
 
 
 @pytest.mark.parametrize("driver_factory", [PyMysqlDriver, MysqlConnectorSyncDriver])
@@ -223,14 +221,14 @@ def test_mysql_execute_script_sync_mysql_execute_script_multi_statement_without_
 
 
 @pytest.mark.parametrize("driver_factory", [AiomysqlDriver, AsyncmyDriver, MysqlConnectorAsyncDriver])
-async def test_mysql_execute_script_async_mysql_execute_script_multi_statement_with_params_raises(
-    driver_factory: type[Any],
-) -> None:
+async def test_mysql_execute_script_async_multi_statement_with_params_executes_all(driver_factory: type[Any]) -> None:
     driver = driver_factory(connection=AsyncMock())
     statement = _make_statement(driver)
+    cursor = _make_async_cursor()
     with patch.object(driver_factory, "_compiled_sql", return_value=(_MULTI_STMT_SQL, (42,))):
-        with pytest.raises(SQLSpecError, match=_ERROR_MESSAGE):
-            await driver.dispatch_execute_script(_make_async_cursor(), statement)
+        result = await driver.dispatch_execute_script(cursor, statement)
+    assert result.statement_count == 2
+    assert result.successful_statements == 2
 
 
 @pytest.mark.parametrize("driver_factory", [AiomysqlDriver, AsyncmyDriver, MysqlConnectorAsyncDriver])

--- a/tests/unit/adapters/test_oracledb/test_pipeline_helpers.py
+++ b/tests/unit/adapters/test_oracledb/test_pipeline_helpers.py
@@ -311,8 +311,7 @@ def test_normalize_execute_many_normalize_execute_many_parameters_async_tuple_to
 @pytest.mark.parametrize(
     "normalizer", [normalize_execute_many_parameters_sync, normalize_execute_many_parameters_async]
 )
-def test_normalize_execute_many_normalize_execute_many_parameters_rejects_empty(
+def test_normalize_execute_many_normalize_execute_many_parameters_passes_empty_through(
     normalizer: Callable[[object], object],
 ) -> None:
-    with pytest.raises(ValueError, match="execute_many requires parameters"):
-        normalizer([])
+    assert normalizer([]) == []

--- a/tests/unit/adapters/test_psqlpy/test_core.py
+++ b/tests/unit/adapters/test_psqlpy/test_core.py
@@ -22,7 +22,6 @@ from sqlspec.adapters.psqlpy.core import (
 )
 from sqlspec.adapters.psqlpy.driver import PsqlpyDriver
 from sqlspec.core import SQL
-from sqlspec.exceptions import SQLSpecError
 
 if TYPE_CHECKING:
     from sqlspec.adapters.psqlpy._typing import PsqlpyConnection
@@ -288,11 +287,12 @@ class _Driver(PsqlpyDriver):
 
 
 @pytest.mark.anyio
-async def test_driver_psqlpy_execute_script_rejects_multi_statement_parameters() -> None:
+async def test_driver_psqlpy_execute_script_multi_statement_with_params_executes_all() -> None:
     driver = _Driver("INSERT INTO t VALUES ($1); INSERT INTO t VALUES ($1)", [1])
     statement = SimpleNamespace(statement_config=default_statement_config)
-    with pytest.raises(SQLSpecError, match="multi-statement"):
-        await driver.dispatch_execute_script(cast("PsqlpyConnection", _Cursor()), cast("SQL", statement))
+    result = await driver.dispatch_execute_script(cast("PsqlpyConnection", _Cursor()), cast("SQL", statement))
+    assert result.statement_count == 2
+    assert result.successful_statements == 2
 
 
 @pytest.mark.anyio

--- a/tests/unit/adapters/test_psqlpy/test_core.py
+++ b/tests/unit/adapters/test_psqlpy/test_core.py
@@ -311,3 +311,15 @@ async def test_driver_psqlpy_execute_script_passes_single_statement_parameters()
     cursor = _Cursor()
     await driver.dispatch_execute_script(cast("PsqlpyConnection", cursor), cast("SQL", statement))
     assert cursor.execute_calls == [("INSERT INTO t VALUES ($1)", [1])]
+
+
+@pytest.mark.parametrize("tag", ["", "NOT A COMMAND TAG", "SELECT"])
+def test_extract_rows_affected_returns_zero_for_unparseable_tag(tag: str) -> None:
+    """Unparseable command tags should report zero rows affected, not the -1 sentinel."""
+    assert psqlpy_core.extract_rows_affected(tag) == 0
+
+
+def test_extract_rows_affected_parses_valid_tag() -> None:
+    """A well-formed command tag should still report the parsed row count."""
+    assert psqlpy_core.extract_rows_affected("INSERT 0 3") == 3
+    assert psqlpy_core.extract_rows_affected("UPDATE 5") == 5

--- a/tests/unit/adapters/test_psqlpy/test_core.py
+++ b/tests/unit/adapters/test_psqlpy/test_core.py
@@ -314,8 +314,8 @@ async def test_driver_psqlpy_execute_script_passes_single_statement_parameters()
 
 
 @pytest.mark.parametrize("tag", ["", "NOT A COMMAND TAG", "SELECT"])
-def test_extract_rows_affected_returns_zero_for_unparseable_tag(tag: str) -> None:
-    """Unparseable command tags should report zero rows affected, not the -1 sentinel."""
+def test_extract_rows_affected_returns_zero_for_unparsable_tag(tag: str) -> None:
+    """Unparsable command tags should report zero rows affected, not the -1 sentinel."""
     assert psqlpy_core.extract_rows_affected(tag) == 0
 
 

--- a/tests/unit/adapters/test_psycopg/test_core.py
+++ b/tests/unit/adapters/test_psycopg/test_core.py
@@ -19,7 +19,7 @@ from sqlspec.adapters.psycopg.core import (
 )
 from sqlspec.adapters.psycopg.driver import PsycopgAsyncDriver, PsycopgSyncDriver
 from sqlspec.core import SQL
-from sqlspec.exceptions import SQLParsingError, SQLSpecError, UniqueViolationError
+from sqlspec.exceptions import SQLParsingError, UniqueViolationError
 
 if TYPE_CHECKING:
     from sqlspec.adapters.psycopg._typing import PsycopgAsyncConnection, PsycopgSyncConnection
@@ -312,19 +312,21 @@ class _AsyncDriver(PsycopgAsyncDriver):
         return (self.compiled_sql, self.compiled_parameters)
 
 
-def test_driver_psycopg_sync_execute_script_rejects_multi_statement_parameters() -> None:
+def test_driver_psycopg_sync_execute_script_multi_statement_with_params_executes_all() -> None:
     driver = _SyncDriver("INSERT INTO t VALUES (%s); INSERT INTO t VALUES (%s)", [1])
     statement = SimpleNamespace(statement_config=default_statement_config)
-    with pytest.raises(SQLSpecError, match="multi-statement"):
-        driver.dispatch_execute_script(_SyncCursor(), cast("SQL", statement))
+    result = driver.dispatch_execute_script(_SyncCursor(), cast("SQL", statement))
+    assert result.statement_count == 2
+    assert result.successful_statements == 2
 
 
 @pytest.mark.anyio
-async def test_driver_psycopg_async_execute_script_rejects_multi_statement_parameters() -> None:
+async def test_driver_psycopg_async_execute_script_multi_statement_with_params_executes_all() -> None:
     driver = _AsyncDriver("INSERT INTO t VALUES (%s); INSERT INTO t VALUES (%s)", [1])
     statement = SimpleNamespace(statement_config=default_statement_config)
-    with pytest.raises(SQLSpecError, match="multi-statement"):
-        await driver.dispatch_execute_script(_AsyncCursor(), cast("SQL", statement))
+    result = await driver.dispatch_execute_script(_AsyncCursor(), cast("SQL", statement))
+    assert result.statement_count == 2
+    assert result.successful_statements == 2
 
 
 @pytest.mark.anyio

--- a/tests/unit/adapters/test_pymssql/test_core.py
+++ b/tests/unit/adapters/test_pymssql/test_core.py
@@ -81,12 +81,11 @@ def test_create_mapped_exception_maps_tsql_error_numbers(message: str, expected_
     assert "SQL Server error" in str(exc)
 
 
-def test_normalize_execute_many_parameters_requires_payload() -> None:
-    """execute_many should reject missing batch parameters before hitting pymssql."""
+def test_normalize_execute_many_parameters_passes_through() -> None:
+    """normalize_execute_many_parameters returns the batch payload unchanged."""
     from sqlspec.adapters.pymssql.core import normalize_execute_many_parameters
 
-    with pytest.raises(ValueError, match="execute_many requires parameters"):
-        normalize_execute_many_parameters([])
+    assert normalize_execute_many_parameters([]) == []
 
     rows: list[tuple[Any, ...]] = [(1,), (2,)]
     assert normalize_execute_many_parameters(rows) is rows

--- a/tests/unit/adapters/test_sync_adapters.py
+++ b/tests/unit/adapters/test_sync_adapters.py
@@ -192,13 +192,9 @@ def test_sync_driver_execute_many(sqlite_sync_driver: SqliteDriver) -> None:
 
 
 def test_sync_driver_execute_many_no_parameters(sqlite_sync_driver: SqliteDriver) -> None:
-    """Test _execute_many method fails without parameters."""
-    statement = SQL(
-        "INSERT INTO users (name) VALUES (?)", statement_config=sqlite_sync_driver.statement_config, is_many=True
-    )
-    with sqlite_sync_driver.with_cursor(sqlite_sync_driver.connection) as cursor:
-        with pytest.raises(ValueError, match="execute_many requires parameters"):
-            sqlite_sync_driver.dispatch_execute_many(cursor, statement)
+    """Empty execute_many should be a silent no-op returning rows_affected=0."""
+    result = sqlite_sync_driver.execute_many("INSERT INTO users (name) VALUES (?)", [])
+    assert result.rows_affected == 0
 
 
 def test_sync_driver_execute_script(sqlite_sync_driver: SqliteDriver) -> None:

--- a/tests/unit/driver/test_execute_many_empty.py
+++ b/tests/unit/driver/test_execute_many_empty.py
@@ -1,0 +1,24 @@
+"""Unit tests for empty execute_many behavior in driver base classes."""
+
+import pytest
+
+from tests.unit.conftest import FixtureAiosqliteDriver, FixtureSqliteDriver
+
+
+def test_sync_empty_execute_many_is_noop_zero(sqlite_sync_driver: FixtureSqliteDriver) -> None:
+    """Empty execute_many should be a silent no-op returning rows_affected=0."""
+    result = sqlite_sync_driver.execute_many("INSERT INTO users (name) VALUES (?)", [])
+    assert result.rows_affected == 0
+
+    remaining = sqlite_sync_driver.execute("SELECT COUNT(*) AS c FROM users").data
+    assert remaining[0][0] == 2
+
+
+@pytest.mark.anyio
+async def test_async_empty_execute_many_is_noop_zero(aiosqlite_async_driver: FixtureAiosqliteDriver) -> None:
+    """Empty execute_many should be a silent no-op returning rows_affected=0 on async drivers."""
+    result = await aiosqlite_async_driver.execute_many("INSERT INTO users (name) VALUES (?)", [])
+    assert result.rows_affected == 0
+
+    remaining = (await aiosqlite_async_driver.execute("SELECT COUNT(*) AS c FROM users")).data
+    assert remaining[0][0] == 2

--- a/tests/unit/driver/test_execute_script.py
+++ b/tests/unit/driver/test_execute_script.py
@@ -31,6 +31,30 @@ def test_sync_execute_script_tracks_all_successful_statements(sqlite_sync_driver
 
 
 @requires_interpreted
+def test_sync_execute_script_with_parameters_runs_every_statement(sqlite_sync_driver) -> None:
+    """A parameterized multi-statement script embeds its params and lands every row."""
+    result = sqlite_sync_driver.execute_script(
+        "INSERT INTO users (name) VALUES (:n); INSERT INTO users (name) VALUES (:n)", n="scripted"
+    )
+    assert result.successful_statements == 2
+
+    inserted = sqlite_sync_driver.execute("SELECT COUNT(*) FROM users WHERE name = :n", n="scripted").data
+    assert inserted[0][0] == 2
+
+
+@requires_interpreted
+async def test_async_execute_script_with_parameters_runs_every_statement(aiosqlite_async_driver) -> None:
+    """A parameterized multi-statement script embeds its params and lands every row on async drivers."""
+    result = await aiosqlite_async_driver.execute_script(
+        "INSERT INTO users (name) VALUES (:n); INSERT INTO users (name) VALUES (:n)", n="scripted"
+    )
+    assert result.successful_statements == 2
+
+    inserted = (await aiosqlite_async_driver.execute("SELECT COUNT(*) FROM users WHERE name = :n", n="scripted")).data
+    assert inserted[0][0] == 2
+
+
+@requires_interpreted
 async def test_async_execute_script_tracks_all_successful_statements(aiosqlite_async_driver) -> None:
     """Async execute_script should report all statements as successful."""
     result = await aiosqlite_async_driver.execute_script(

--- a/tests/unit/driver/test_execute_script.py
+++ b/tests/unit/driver/test_execute_script.py
@@ -2,8 +2,23 @@
 
 from typing import Any
 
+from sqlspec.adapters.sqlite.core import default_statement_config
 from sqlspec.core import SQL
 from tests.conftest import requires_interpreted
+
+
+def test_as_script_embeds_parameters_statically() -> None:
+    """as_script() should force static parameter embedding regardless of the adapter default."""
+    assert default_statement_config.parameter_config.needs_static_script_compilation is False
+
+    sql = SQL(
+        "INSERT INTO t (a) VALUES (:a); INSERT INTO t (a) VALUES (:a)", a=5, statement_config=default_statement_config
+    ).as_script()
+    compiled_sql, params = sql.compile()
+
+    assert params is None
+    assert ":a" not in compiled_sql
+    assert "5" in compiled_sql
 
 
 @requires_interpreted

--- a/tests/unit/extensions/test_events/test_queue_claim_verification.py
+++ b/tests/unit/extensions/test_events/test_queue_claim_verification.py
@@ -1,0 +1,126 @@
+# pyright: reportPrivateUsage=false
+"""Unit tests for table-queue claim verification on rowcount-blind drivers.
+
+Some drivers (arrow-odbc) cannot report rows affected and return zero for
+every DML statement. The table queue must confirm claim ownership through the
+persisted lease token instead of trusting the zero rowcount.
+"""
+
+from datetime import timedelta
+from typing import Any
+
+from sqlspec.adapters.aiosqlite import AiosqliteConfig
+from sqlspec.adapters.aiosqlite.events.store import AiosqliteEventQueueStore
+from sqlspec.adapters.sqlite import SqliteConfig
+from sqlspec.adapters.sqlite.events.store import SqliteEventQueueStore
+from sqlspec.extensions.events import AsyncTableEventQueue, SyncTableEventQueue
+from tests.conftest import requires_interpreted
+
+_QUEUE_TABLE = "evq_claims"
+
+
+def _create_sync_claim_queue(tmp_path: Any) -> "tuple[SqliteConfig, SyncTableEventQueue]":
+    config = SqliteConfig(
+        connection_config={"database": str(tmp_path / "claims.db")},
+        extension_config={"events": {"queue_table": _QUEUE_TABLE}},
+    )
+    store = SqliteEventQueueStore(config)
+    with config.provide_session() as driver:
+        for statement in store.create_statements():
+            driver.execute_script(statement)
+    return config, SyncTableEventQueue(config, queue_table=_QUEUE_TABLE)
+
+
+async def _create_async_claim_queue(tmp_path: Any) -> "tuple[AiosqliteConfig, AsyncTableEventQueue]":
+    config = AiosqliteConfig(
+        connection_config={"database": str(tmp_path / "claims_async.db")},
+        extension_config={"events": {"queue_table": _QUEUE_TABLE}},
+    )
+    store = AiosqliteEventQueueStore(config)
+    async with config.provide_session() as driver:
+        for statement in store.create_statements():
+            await driver.execute_script(statement)
+    return config, AsyncTableEventQueue(config, queue_table=_QUEUE_TABLE)
+
+
+@requires_interpreted
+def test_sync_dequeue_delivers_when_rows_affected_unreported(tmp_path: Any, monkeypatch: Any) -> None:
+    """A successful claim UPDATE reported as zero rows still delivers the event."""
+    config, queue = _create_sync_claim_queue(tmp_path)
+    try:
+        event_id = queue.publish("alerts", {"type": "alert"})
+        original = SyncTableEventQueue._execute_with_driver
+
+        def _zero_reporting(self: Any, driver: Any, sql: str, parameters: "dict[str, Any]") -> int:
+            original(self, driver, sql, parameters)
+            return 0
+
+        monkeypatch.setattr(SyncTableEventQueue, "_execute_with_driver", _zero_reporting)
+        event = queue.dequeue("alerts")
+        assert event is not None
+        assert event.event_id == event_id
+        assert queue.dequeue("alerts") is None
+    finally:
+        config.close_pool()
+
+
+@requires_interpreted
+def test_sync_dequeue_by_event_id_delivers_when_rows_affected_unreported(tmp_path: Any, monkeypatch: Any) -> None:
+    """dequeue_by_event_id verifies claim ownership when the rowcount is zero."""
+    config, queue = _create_sync_claim_queue(tmp_path)
+    try:
+        event_id = queue.publish("alerts", {"type": "alert"})
+        original = SyncTableEventQueue._execute_with_driver
+
+        def _zero_reporting(self: Any, driver: Any, sql: str, parameters: "dict[str, Any]") -> int:
+            original(self, driver, sql, parameters)
+            return 0
+
+        monkeypatch.setattr(SyncTableEventQueue, "_execute_with_driver", _zero_reporting)
+        event = queue.dequeue_by_event_id(event_id)
+        assert event is not None
+        assert event.event_id == event_id
+    finally:
+        config.close_pool()
+
+
+@requires_interpreted
+def test_sync_dequeue_ignores_claim_owned_by_other_consumer(tmp_path: Any, monkeypatch: Any) -> None:
+    """A zero rowcount with a foreign lease token is a genuinely lost claim."""
+    config, queue = _create_sync_claim_queue(tmp_path)
+    try:
+        queue.publish("alerts", {"type": "alert"})
+        original = SyncTableEventQueue._execute_with_driver
+        rival_lease = queue._utcnow() + timedelta(seconds=300)
+
+        def _rival_claim(self: Any, driver: Any, sql: str, parameters: "dict[str, Any]") -> int:
+            if sql == self._claim_statement:
+                original(self, driver, sql, {**parameters, "lease_expires_at": rival_lease})
+                return 0
+            return original(self, driver, sql, parameters)
+
+        monkeypatch.setattr(SyncTableEventQueue, "_execute_with_driver", _rival_claim)
+        assert queue.dequeue("alerts") is None
+    finally:
+        config.close_pool()
+
+
+@requires_interpreted
+async def test_async_dequeue_delivers_when_rows_affected_unreported(tmp_path: Any, monkeypatch: Any) -> None:
+    """The async queue verifies claims through the lease token as well."""
+    config, queue = await _create_async_claim_queue(tmp_path)
+    try:
+        event_id = await queue.publish("alerts", {"type": "alert"})
+        original = AsyncTableEventQueue._execute_with_driver
+
+        async def _zero_reporting(self: Any, driver: Any, sql: str, parameters: "dict[str, Any]") -> int:
+            await original(self, driver, sql, parameters)
+            return 0
+
+        monkeypatch.setattr(AsyncTableEventQueue, "_execute_with_driver", _zero_reporting)
+        event = await queue.dequeue("alerts")
+        assert event is not None
+        assert event.event_id == event_id
+        assert await queue.dequeue("alerts") is None
+    finally:
+        await config.close_pool()


### PR DESCRIPTION
## Summary

Aligns `execute_script` and `execute_many` on a single, honest contract across every adapter. Each fix is an isolated commit with red→green tests.

### Script parameter embedding
- **`execute_script` with parameters** now statically embeds those parameters into the SQL via sqlglot on every adapter, instead of the previous five-way divergence (raise / naive reuse / silent discard). `SQL.as_script()` forces static compilation on a **script-scoped** config copy, so single-statement `execute()` binding is untouched. This also fixes asyncpg's silent parameter discard automatically — there is nothing left to discard.
- The now-dead parameter-rejection guards in the raise-camp adapters (pymysql, asyncmy, aiomysql, mysqlconnector, pymssql, psycopg, psqlpy) are removed, so a parameterized multi-statement script executes bind-free everywhere.

### Empty batch and rowcount
- **Empty `execute_many([])`** is now a uniform silent no-op returning `rows_affected=0`, replacing five divergent behaviors (`ValueError` on sqlite/aiosqlite/oracledb/MySQL/pymssql, `SQLConversionError` on spanner, `NotImplementedError` on arrow-odbc, silent forwarding on mssql-python). A single short-circuit in `dispatch_statement_execution` handles it before any adapter code runs; the dead per-adapter guards are removed.
- **Rowcount sentinel `-1` → `0`** for psqlpy (unparseable command tags) and arrow-odbc (non-select DML), matching the majority of adapters.

## Testing
- Full unit suite green (one pre-existing load-sensitive perf test passes standalone).
- Container-free end-to-end coverage added for parameterized scripts and empty `execute_many` (sqlite + aiosqlite); `as_script()` static-embedding verified at the compile level.
- Cross-database contract tests for these behaviors run in CI and are tracked as follow-ups for the contract-test chapter (empty-`execute_many` universal assertion; `execute_script` parameter-embedding assertion).

## Stacking
Built on top of #628 (now merged); rebased onto `main`, so this contains only the four script/batch commits.
