### PR TITLE
fix: consolidate streaming, Arrow, and event contracts

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,18 @@ Unreleased
   return result envelopes, object DDL lookups return ``DDLResult`` directly, and
   callers should inspect capability or DDL status instead of treating empty
   lists as unsupported metadata.
+* Standardized event transport configuration on ``notify``, ``notify_queue``,
+  ``poll_queue``, ``aq``, and ``txeventq``. Retired transport names now raise
+  an explicit configuration error with the canonical replacement.
+
+**Fixed:**
+
+* Event channels now honor adapter ``events_backend`` driver features when no
+  extension-level backend is configured.
+* Early mysql-connector row-stream cleanup now consumes unread results without
+  reconnecting underneath an active transaction.
+* Public row streams continue to clean up duck-typed sources whose ``close()``
+  method uses the original no-argument contract.
 
 **Docs:**
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -134,7 +134,7 @@ v0.52.0 - SQL Server adapters, ADK profiles, and cloud connectors
 **Changed:**
 
 * Standardized Oracle native event backend names to ``aq`` and ``txeventq``;
-  ``table_queue`` remains the default backend.
+  ``poll_queue`` remains the default backend.
 * Moved ADK optimization and storage tuning options into adapter-local config
   types instead of the shared global config surface.
 * Tightened adapter typing and core pipeline internals for the compiler,

--- a/docs/reference/extensions/events.rst
+++ b/docs/reference/extensions/events.rst
@@ -6,6 +6,24 @@ Pub/sub event channel system with database-backed queue support. Provides
 both sync and async channels with listener management and native backend
 integration for databases that support LISTEN/NOTIFY.
 
+Backend names
+=============
+
+``events.backend`` uses transport names that describe durability and wakeup
+behavior:
+
+* ``notify`` is a transient native notification. It is a worker wakeup hint,
+  not a task or event ledger.
+* ``notify_queue`` is a durable table queue with a native notification wakeup
+  hint. The table is the source of truth.
+* ``poll_queue`` is a durable table queue discovered by polling.
+* ``aq`` is Oracle Advanced Queuing.
+* ``txeventq`` is Oracle Transactional Event Queues.
+
+``polling`` is not a SQLSpec backend name. Litestar Queues uses it for the
+fallback worker mode where no push wakeup transport is available and the
+worker waits for its configured polling interval.
+
 Native LISTEN/NOTIFY model
 ==========================
 
@@ -27,15 +45,15 @@ queue-handle cache backed by a single dedicated session per backend instance.
 ``dequeue`` honors ``min(poll_interval, aq_wait_seconds)`` as its wait bound so
 the caller's polling cadence is respected.
 
-``ack`` / ``nack`` semantics are unchanged. Native backends remain
-fire-and-forget; hybrid (``listen_notify_durable``) backends acknowledge
-through the durable table queue.
+``ack`` / ``nack`` semantics are unchanged. ``notify`` remains
+fire-and-forget; ``notify_queue`` acknowledges through the durable table
+queue.
 
 Oracle native event backends
 ============================
 
 Oracle provides two **native** messaging backends in addition to the default
-``table_queue``:
+``poll_queue``:
 
 * ``aq`` — classic Oracle Advanced Queuing (AQ).
 * ``txeventq`` — Oracle Transactional Event Queues (TxEventQ).
@@ -52,7 +70,7 @@ underlying queue is provisioned. Select one via ``events.backend``:
         extension_config={"events": {"backend": "txeventq"}},
     )
 
-The default remains ``table_queue``, which works on every Oracle edition
+The default remains ``poll_queue``, which works on every Oracle edition
 without extra privileges; both native backends are opt-in.
 
 Requirements

--- a/docs/reference/extensions/events.rst
+++ b/docs/reference/extensions/events.rst
@@ -22,6 +22,11 @@ The durable queue is the source of truth for ``notify_queue``; native
 notifications only prompt consumers to check it. Durable event queues are not
 browser fan-out transports.
 
+Set ``extension_config["events"]["backend"]`` to select the transport. The
+adapter ``driver_features["events_backend"]`` value is used only when the
+extension setting is absent. Retired transport names fail with an explicit
+canonical replacement instead of silently changing delivery semantics.
+
 ``polling`` is not a SQLSpec backend name. Litestar Queues uses it for the
 fallback worker mode where no push wakeup transport is available and the
 worker waits for its configured polling interval.

--- a/docs/reference/extensions/events.rst
+++ b/docs/reference/extensions/events.rst
@@ -6,19 +6,21 @@ Pub/sub event channel system with database-backed queue support. Provides
 both sync and async channels with listener management and native backend
 integration for databases that support LISTEN/NOTIFY.
 
-Backend names
-=============
+Transport selection
+===================
 
-``events.backend`` uses transport names that describe durability and wakeup
-behavior:
+Choose a transport by delivery semantics:
 
-* ``notify`` is a transient native notification. It is a worker wakeup hint,
-  not a task or event ledger.
-* ``notify_queue`` is a durable table queue with a native notification wakeup
-  hint. The table is the source of truth.
-* ``poll_queue`` is a durable table queue discovered by polling.
-* ``aq`` is Oracle Advanced Queuing.
-* ``txeventq`` is Oracle Transactional Event Queues.
+* ``notify`` — transient native notification with no replay or retry.
+* ``notify_queue`` — durable competing-consumer queue with a native wakeup hint.
+* ``poll_queue`` — durable competing-consumer queue discovered by polling.
+* ``aq`` — Oracle Advanced Queuing, with explicit provisioning and privileges.
+* ``txeventq`` — Oracle Transactional Event Queues, with explicit provisioning
+  and privileges.
+
+The durable queue is the source of truth for ``notify_queue``; native
+notifications only prompt consumers to check it. Durable event queues are not
+browser fan-out transports.
 
 ``polling`` is not a SQLSpec backend name. Litestar Queues uses it for the
 fallback worker mode where no push wakeup transport is available and the
@@ -46,8 +48,7 @@ queue-handle cache backed by a single dedicated session per backend instance.
 the caller's polling cadence is respected.
 
 ``ack`` / ``nack`` semantics are unchanged. ``notify`` remains
-fire-and-forget; ``notify_queue`` acknowledges through the durable table
-queue.
+fire-and-forget; ``notify_queue`` acknowledges through the durable table queue.
 
 Oracle native event backends
 ============================

--- a/sqlspec/adapters/adbc/config.py
+++ b/sqlspec/adapters/adbc/config.py
@@ -1,6 +1,6 @@
 """ADBC database configuration."""
 
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
 
 from typing_extensions import NotRequired
 
@@ -126,7 +126,7 @@ class AdbcDriverFeatures(TypedDict):
     enable_paradedb: NotRequired[bool]
     enable_events: NotRequired[bool]
     on_connection_create: "NotRequired[Callable[[AdbcConnection], None]]"
-    events_backend: NotRequired[str]
+    events_backend: NotRequired[Literal["poll_queue"]]
 
 
 class AdbcConnectionContext(SyncPoolConnectionContext):

--- a/sqlspec/adapters/adbc/config.py
+++ b/sqlspec/adapters/adbc/config.py
@@ -111,9 +111,9 @@ class AdbcDriverFeatures(TypedDict):
         on_connection_create: Callback executed when a connection is created.
             Receives the raw ADBC connection for low-level driver configuration.
         events_backend: Event channel backend selection.
-        Only option: "table_queue" (durable table-backed queue with retries and exactly-once delivery).
-            ADBC does not have native pub/sub, so table_queue is the only backend.
-            Defaults to "table_queue".
+        Only option: "poll_queue" (durable table-backed queue with retries and exactly-once delivery).
+            ADBC does not have native pub/sub, so poll_queue is the only backend.
+            Defaults to "poll_queue".
     """
 
     json_serializer: "NotRequired[Callable[[Any], str]]"

--- a/sqlspec/adapters/adbc/config.py
+++ b/sqlspec/adapters/adbc/config.py
@@ -111,7 +111,7 @@ class AdbcDriverFeatures(TypedDict):
         on_connection_create: Callback executed when a connection is created.
             Receives the raw ADBC connection for low-level driver configuration.
         events_backend: Event channel backend selection.
-        Only option: "poll_queue" (durable table-backed queue with retries and exactly-once delivery).
+        Only option: "poll_queue" (durable table-backed queue with lease-based retries and acknowledgements).
             ADBC does not have native pub/sub, so poll_queue is the only backend.
             Defaults to "poll_queue".
     """

--- a/sqlspec/adapters/adbc/driver.py
+++ b/sqlspec/adapters/adbc/driver.py
@@ -132,7 +132,7 @@ class AdbcSelectStreamSource:
             if rows:
                 return rows
 
-    def close(self) -> None:
+    def close(self, error: bool = False) -> None:
         self._reader = None
         cursor_manager = self._cursor_manager
         self._cursor_manager = None

--- a/sqlspec/adapters/aiomysql/config.py
+++ b/sqlspec/adapters/aiomysql/config.py
@@ -145,7 +145,7 @@ class AiomysqlDriverFeatures(TypedDict):
      Provides pub/sub capabilities via table-backed queue (MySQL/MariaDB have no native pub/sub).
      Requires extension_config["events"] for migration setup.
     events_backend: Event channel backend selection.
-     Only option: "poll_queue" (durable table-backed queue with retries and exactly-once delivery).
+     Only option: "poll_queue" (durable table-backed queue with lease-based retries and acknowledgements).
      MySQL/MariaDB do not have native pub/sub, so poll_queue is the only backend.
      Defaults to "poll_queue".
     """

--- a/sqlspec/adapters/aiomysql/config.py
+++ b/sqlspec/adapters/aiomysql/config.py
@@ -145,9 +145,9 @@ class AiomysqlDriverFeatures(TypedDict):
      Provides pub/sub capabilities via table-backed queue (MySQL/MariaDB have no native pub/sub).
      Requires extension_config["events"] for migration setup.
     events_backend: Event channel backend selection.
-     Only option: "table_queue" (durable table-backed queue with retries and exactly-once delivery).
-     MySQL/MariaDB do not have native pub/sub, so table_queue is the only backend.
-     Defaults to "table_queue".
+     Only option: "poll_queue" (durable table-backed queue with retries and exactly-once delivery).
+     MySQL/MariaDB do not have native pub/sub, so poll_queue is the only backend.
+     Defaults to "poll_queue".
     """
 
     json_serializer: NotRequired["Callable[[Any], str]"]

--- a/sqlspec/adapters/aiomysql/config.py
+++ b/sqlspec/adapters/aiomysql/config.py
@@ -1,6 +1,6 @@
 """aiomysql database configuration."""
 
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
 from weakref import WeakSet
 
 from mypy_extensions import mypyc_attr
@@ -154,7 +154,7 @@ class AiomysqlDriverFeatures(TypedDict):
     json_deserializer: NotRequired["Callable[[str], Any]"]
     on_connection_create: "NotRequired[Callable[[AiomysqlConnection], Awaitable[None]]]"
     enable_events: NotRequired[bool]
-    events_backend: NotRequired[str]
+    events_backend: NotRequired[Literal["poll_queue"]]
     enable_local_infile_bulk_load: NotRequired[bool]
 
 

--- a/sqlspec/adapters/aiomysql/core.py
+++ b/sqlspec/adapters/aiomysql/core.py
@@ -214,7 +214,7 @@ class AiomysqlStreamSource:
         deserializer = cast("Callable[[Any], Any]", self._driver.driver_features.get("json_deserializer", from_json))
         return collect_stream_rows(rows, self._row_plan, deserializer)
 
-    async def close(self) -> None:
+    async def close(self, error: bool = False) -> None:
         cursor = self._cursor
         self._cursor = None
         if cursor is not None:

--- a/sqlspec/adapters/aiomysql/core.py
+++ b/sqlspec/adapters/aiomysql/core.py
@@ -196,8 +196,8 @@ class AiomysqlStreamSource:
         handler = self._driver.handle_database_exceptions()
         async with handler:
             cursor = await self._driver.connection.cursor(SSCursor)
-            await cursor.execute(self._sql, normalize_execute_parameters(self._parameters))
             self._cursor = cursor
+            await cursor.execute(self._sql, normalize_execute_parameters(self._parameters))
             self._row_plan = resolve_row_plan(self._cursor.description, self._json_type_codes)
         self._driver._check_pending_exception(handler)
 

--- a/sqlspec/adapters/aiosqlite/config.py
+++ b/sqlspec/adapters/aiosqlite/config.py
@@ -150,7 +150,7 @@ class AiosqliteDriverFeatures(TypedDict):
     json_deserializer: "NotRequired[Callable[[str], Any]]"
     on_connection_create: "NotRequired[Callable[[AiosqliteConnection], Awaitable[None]]]"
     enable_events: NotRequired[bool]
-    events_backend: NotRequired[str]
+    events_backend: NotRequired[Literal["poll_queue"]]
     custom_functions: "NotRequired[Sequence[AiosqliteFunctionConfig]]"
     custom_collations: "NotRequired[Sequence[AiosqliteCollationConfig]]"
     custom_aggregates: "NotRequired[Sequence[AiosqliteAggregateConfig]]"

--- a/sqlspec/adapters/aiosqlite/config.py
+++ b/sqlspec/adapters/aiosqlite/config.py
@@ -122,9 +122,9 @@ class AiosqliteDriverFeatures(TypedDict):
      Provides pub/sub capabilities via table-backed queue (SQLite has no native pub/sub).
      Requires extension_config["events"] for migration setup.
     events_backend: Event channel backend selection.
-     Only option: "table_queue" (durable table-backed queue with retries and exactly-once delivery).
-     SQLite does not have native pub/sub, so table_queue is the only backend.
-     Defaults to "table_queue".
+     Only option: "poll_queue" (durable table-backed queue with retries and exactly-once delivery).
+     SQLite does not have native pub/sub, so poll_queue is the only backend.
+     Defaults to "poll_queue".
     custom_functions: Register SQL functions that run on the aiosqlite worker thread.
      Each entry must include name, narg, and func. Callable values are plain sync callables.
     custom_collations: Register SQL collations that compare two string values.

--- a/sqlspec/adapters/aiosqlite/config.py
+++ b/sqlspec/adapters/aiosqlite/config.py
@@ -122,7 +122,7 @@ class AiosqliteDriverFeatures(TypedDict):
      Provides pub/sub capabilities via table-backed queue (SQLite has no native pub/sub).
      Requires extension_config["events"] for migration setup.
     events_backend: Event channel backend selection.
-     Only option: "poll_queue" (durable table-backed queue with retries and exactly-once delivery).
+     Only option: "poll_queue" (durable table-backed queue with lease-based retries and acknowledgements).
      SQLite does not have native pub/sub, so poll_queue is the only backend.
      Defaults to "poll_queue".
     custom_functions: Register SQL functions that run on the aiosqlite worker thread.

--- a/sqlspec/adapters/aiosqlite/core.py
+++ b/sqlspec/adapters/aiosqlite/core.py
@@ -204,8 +204,8 @@ class AiosqliteStreamSource:
         async with handler:
             cursor = await self._driver.connection.cursor()
             cursor.arraysize = self._chunk_size
-            await cursor.execute(self._sql, normalize_execute_parameters(self._parameters))
             self._cursor = cursor
+            await cursor.execute(self._sql, normalize_execute_parameters(self._parameters))
         self._driver._check_pending_exception(handler)
 
     async def fetch_chunk(self) -> "list[dict[str, Any]]":

--- a/sqlspec/adapters/aiosqlite/core.py
+++ b/sqlspec/adapters/aiosqlite/core.py
@@ -220,7 +220,7 @@ class AiosqliteStreamSource:
             self._column_names = [description[0] for description in self._cursor.description]
         return rows_to_dicts(rows, self._column_names)
 
-    async def close(self) -> None:
+    async def close(self, error: bool = False) -> None:
         cursor = self._cursor
         self._cursor = None
         if cursor is not None:

--- a/sqlspec/adapters/arrow_odbc/driver.py
+++ b/sqlspec/adapters/arrow_odbc/driver.py
@@ -89,7 +89,7 @@ class ArrowOdbcStreamSource:
             if rows:
                 return rows
 
-    def close(self) -> None:
+    def close(self, error: bool = False) -> None:
         reader = self._reader
         self._reader = None
         close = getattr(reader, "close", None)

--- a/sqlspec/adapters/asyncmy/config.py
+++ b/sqlspec/adapters/asyncmy/config.py
@@ -173,7 +173,7 @@ class AsyncmyDriverFeatures(TypedDict):
      Provides pub/sub capabilities via table-backed queue (MySQL/MariaDB have no native pub/sub).
      Requires extension_config["events"] for migration setup.
     events_backend: Event channel backend selection.
-     Only option: "poll_queue" (durable table-backed queue with retries and exactly-once delivery).
+     Only option: "poll_queue" (durable table-backed queue with lease-based retries and acknowledgements).
      MySQL/MariaDB do not have native pub/sub, so poll_queue is the only backend.
      Defaults to "poll_queue".
     """

--- a/sqlspec/adapters/asyncmy/config.py
+++ b/sqlspec/adapters/asyncmy/config.py
@@ -173,9 +173,9 @@ class AsyncmyDriverFeatures(TypedDict):
      Provides pub/sub capabilities via table-backed queue (MySQL/MariaDB have no native pub/sub).
      Requires extension_config["events"] for migration setup.
     events_backend: Event channel backend selection.
-     Only option: "table_queue" (durable table-backed queue with retries and exactly-once delivery).
-     MySQL/MariaDB do not have native pub/sub, so table_queue is the only backend.
-     Defaults to "table_queue".
+     Only option: "poll_queue" (durable table-backed queue with retries and exactly-once delivery).
+     MySQL/MariaDB do not have native pub/sub, so poll_queue is the only backend.
+     Defaults to "poll_queue".
     """
 
     json_serializer: NotRequired["Callable[[Any], str]"]

--- a/sqlspec/adapters/asyncmy/config.py
+++ b/sqlspec/adapters/asyncmy/config.py
@@ -1,7 +1,7 @@
 """Asyncmy database configuration."""
 
 import inspect
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
 from weakref import WeakSet
 
 from mypy_extensions import mypyc_attr
@@ -182,7 +182,7 @@ class AsyncmyDriverFeatures(TypedDict):
     json_deserializer: NotRequired["Callable[[str], Any]"]
     on_connection_create: "NotRequired[Callable[[AsyncmyConnection], Awaitable[None]]]"
     enable_events: NotRequired[bool]
-    events_backend: NotRequired[str]
+    events_backend: NotRequired[Literal["poll_queue"]]
 
 
 class _AsyncmySessionFactory(AsyncPoolSessionFactory):

--- a/sqlspec/adapters/asyncmy/core.py
+++ b/sqlspec/adapters/asyncmy/core.py
@@ -168,8 +168,8 @@ class AsyncmyStreamSource:
         handler = self._driver.handle_database_exceptions()
         async with handler:
             cursor = self._driver.connection.cursor(SSCursor)
-            await cursor.execute(self._sql, normalize_execute_parameters(self._parameters))
             self._cursor = cursor
+            await cursor.execute(self._sql, normalize_execute_parameters(self._parameters))
             self._row_plan = resolve_row_plan(self._cursor.description, self._json_type_codes)
         self._driver._check_pending_exception(handler)
 

--- a/sqlspec/adapters/asyncmy/core.py
+++ b/sqlspec/adapters/asyncmy/core.py
@@ -186,7 +186,7 @@ class AsyncmyStreamSource:
         deserializer = cast("Callable[[Any], Any]", self._driver.driver_features.get("json_deserializer", from_json))
         return collect_stream_rows(rows, self._row_plan, deserializer)
 
-    async def close(self) -> None:
+    async def close(self, error: bool = False) -> None:
         cursor = self._cursor
         self._cursor = None
         if cursor is not None:

--- a/sqlspec/adapters/asyncpg/config.py
+++ b/sqlspec/adapters/asyncpg/config.py
@@ -161,14 +161,13 @@ class AsyncpgDriverFeatures(TypedDict):
     enable_events: Enable database event channel support.
      Defaults to True when extension_config["events"] is configured.
      Provides pub/sub capabilities via LISTEN/NOTIFY or table-backed fallback.
-     Requires extension_config["events"] for migration setup when using table_queue backend.
+     Requires extension_config["events"] for migration setup when using poll_queue backend.
     events_backend: Event channel backend selection.
-     Options: "listen_notify", "table_queue", "listen_notify_durable"
-     - "listen_notify": Zero-copy PostgreSQL LISTEN/NOTIFY (ephemeral, real-time)
-     - "table_queue": Durable table-backed queue with retries and exactly-once delivery
-     - "listen_notify_durable": Hybrid - combines real-time LISTEN/NOTIFY with table durability (recommended for production)
-     Defaults to "listen_notify" for backward compatibility.
-     Note: "listen_notify_durable" provides best of both worlds - <100ms latency with full durability.
+     Options: "notify", "poll_queue", "notify_queue"
+     - "notify": Zero-copy PostgreSQL LISTEN/NOTIFY (ephemeral, real-time)
+     - "poll_queue": Durable table-backed queue with retries and exactly-once delivery
+     - "notify_queue": Hybrid - combines real-time LISTEN/NOTIFY with table durability (recommended for production)
+     Defaults to "notify". Select "notify_queue" when the event table must remain the source of truth.
     """
 
     json_serializer: NotRequired["Callable[[Any], str]"]

--- a/sqlspec/adapters/asyncpg/config.py
+++ b/sqlspec/adapters/asyncpg/config.py
@@ -161,13 +161,13 @@ class AsyncpgDriverFeatures(TypedDict):
     enable_events: Enable database event channel support.
      Defaults to True when extension_config["events"] is configured.
      Provides pub/sub capabilities via LISTEN/NOTIFY or table-backed fallback.
-     Requires extension_config["events"] for migration setup when using poll_queue backend.
+     Requires extension_config["events"] for migration setup when using poll_queue or notify_queue.
     events_backend: Event channel backend selection.
-     Options: "notify", "poll_queue", "notify_queue"
-     - "notify": Zero-copy PostgreSQL LISTEN/NOTIFY (ephemeral, real-time)
-     - "poll_queue": Durable table-backed queue with retries and exactly-once delivery
-     - "notify_queue": Hybrid - combines real-time LISTEN/NOTIFY with table durability (recommended for production)
-     Defaults to "notify". Select "notify_queue" when the event table must remain the source of truth.
+     Options: "notify", "notify_queue", "poll_queue"
+     - "notify": Transient PostgreSQL LISTEN/NOTIFY with no replay or retry
+     - "notify_queue": Durable queue plus a PostgreSQL notification wakeup hint
+     - "poll_queue": Durable queue discovered by polling
+     Defaults to "notify".
     """
 
     json_serializer: NotRequired["Callable[[Any], str]"]
@@ -184,7 +184,7 @@ class AsyncpgDriverFeatures(TypedDict):
     enable_alloydb_iam_auth: NotRequired[bool]
     alloydb_ip_type: NotRequired[str]
     enable_events: NotRequired[bool]
-    events_backend: NotRequired[str]
+    events_backend: NotRequired[Literal["notify", "notify_queue", "poll_queue"]]
     connection_instance: NotRequired["AsyncpgPool"]
     on_connection_create: NotRequired["Callable[[AsyncpgConnection], Awaitable[None]]"]
 

--- a/sqlspec/adapters/asyncpg/core.py
+++ b/sqlspec/adapters/asyncpg/core.py
@@ -521,13 +521,16 @@ class AsyncpgStreamSource:
         self._driver._check_pending_exception(handler)
         return [dict(record) for record in records]
 
-    async def close(self) -> None:
+    async def close(self, error: bool = False) -> None:
         self._cursor = None
         transaction = self._transaction
         self._transaction = None
         if transaction is not None:
             try:
-                await transaction.commit()
+                if error:
+                    await transaction.rollback()
+                else:
+                    await transaction.commit()
             except Exception:
                 with contextlib.suppress(Exception):
                     await transaction.rollback()

--- a/sqlspec/adapters/asyncpg/events/backend.py
+++ b/sqlspec/adapters/asyncpg/events/backend.py
@@ -34,7 +34,7 @@ class AsyncpgHybridEventsBackend:
 
     supports_sync = False
     supports_async = True
-    backend_name = "listen_notify_durable"
+    backend_name = "notify_queue"
 
     def __init__(self, config: "AsyncpgConfig", queue: "AsyncTableEventQueue") -> None:
         if not config.is_async:
@@ -124,7 +124,7 @@ class AsyncpgEventsBackend:
 
     supports_sync = False
     supports_async = True
-    backend_name = "listen_notify"
+    backend_name = "notify"
 
     def __init__(self, config: "AsyncpgConfig") -> None:
         if not config.is_async:
@@ -183,12 +183,12 @@ def create_event_backend(
 ) -> AsyncpgEventsBackend | AsyncpgHybridEventsBackend | None:
     """EventChannel factory for the native backend."""
     match backend_name:
-        case "listen_notify":
+        case "notify":
             try:
                 return AsyncpgEventsBackend(config)
             except ImproperConfigurationError:
                 return None
-        case "listen_notify_durable":
+        case "notify_queue":
             queue_backend = cast(
                 "AsyncTableEventQueue", build_queue_backend(config, extension_settings, adapter_name="asyncpg")
             )

--- a/sqlspec/adapters/bigquery/config.py
+++ b/sqlspec/adapters/bigquery/config.py
@@ -84,9 +84,9 @@ class BigQueryDriverFeatures(TypedDict):
             Provides pub/sub capabilities via table-backed queue (BigQuery has no native pub/sub).
             Requires extension_config["events"] for migration setup.
         events_backend: Event channel backend selection.
-        Only option: "table_queue" (durable table-backed queue with retries and exactly-once delivery).
-            BigQuery does not have native pub/sub, so table_queue is the only backend.
-            Defaults to "table_queue".
+        Only option: "poll_queue" (durable table-backed queue with retries and exactly-once delivery).
+            BigQuery does not have native pub/sub, so poll_queue is the only backend.
+            Defaults to "poll_queue".
         job_retry_deadline: Total seconds to keep retrying transient job failures. Defaults to 60.0.
             Values <= 0 disable retries entirely: API requests are not retried and ``job_retry`` is
             withheld from ``client.query()``, which also bypasses the client's built-in

--- a/sqlspec/adapters/bigquery/config.py
+++ b/sqlspec/adapters/bigquery/config.py
@@ -1,6 +1,6 @@
 """BigQuery database configuration."""
 
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
 
 from google.cloud.bigquery import LoadJobConfig, QueryJobConfig
 from typing_extensions import NotRequired
@@ -114,7 +114,7 @@ class BigQueryDriverFeatures(TypedDict):
     json_serializer: NotRequired["Callable[[Any], str]"]
     enable_uuid_conversion: NotRequired[bool]
     enable_events: NotRequired[bool]
-    events_backend: NotRequired[str]
+    events_backend: NotRequired[Literal["poll_queue"]]
     job_retry_deadline: NotRequired[float]
     job_result_timeout: NotRequired[float]
     use_query_and_wait: NotRequired[bool]

--- a/sqlspec/adapters/bigquery/config.py
+++ b/sqlspec/adapters/bigquery/config.py
@@ -84,7 +84,7 @@ class BigQueryDriverFeatures(TypedDict):
             Provides pub/sub capabilities via table-backed queue (BigQuery has no native pub/sub).
             Requires extension_config["events"] for migration setup.
         events_backend: Event channel backend selection.
-        Only option: "poll_queue" (durable table-backed queue with retries and exactly-once delivery).
+        Only option: "poll_queue" (durable table-backed queue with lease-based retries and acknowledgements).
             BigQuery does not have native pub/sub, so poll_queue is the only backend.
             Defaults to "poll_queue".
         job_retry_deadline: Total seconds to keep retrying transient job failures. Defaults to 60.0.

--- a/sqlspec/adapters/bigquery/core.py
+++ b/sqlspec/adapters/bigquery/core.py
@@ -868,7 +868,7 @@ class BigQueryStreamSource:
             if rows:
                 return rows
 
-    def close(self) -> None:
+    def close(self, error: bool = False) -> None:
         job = self._job
         self._job = None
         self._pages = None

--- a/sqlspec/adapters/bigquery/driver.py
+++ b/sqlspec/adapters/bigquery/driver.py
@@ -435,7 +435,7 @@ class BigQueryDriver(SyncDriverAdapterBase):
             ArrowResult with native Arrow data (if Storage API available) or converted data
 
         Raises:
-            MissingDependencyError: If pyarrow not installed, or if Storage API not available and native_only=True
+            MissingDependencyError: If pyarrow is not installed.
         """
         ensure_pyarrow()
 
@@ -486,9 +486,7 @@ class BigQueryDriver(SyncDriverAdapterBase):
                     "3. Grant permissions: roles/bigquery.dataViewer\n"
                     "4. Use a real BigQuery endpoint instead of the local emulator"
                 )
-                raise MissingDependencyError(
-                    package="google-cloud-bigquery-storage", install_package="google-cloud-bigquery-storage"
-                ) from RuntimeError(msg)
+                raise ImproperConfigurationError(msg) from RuntimeError(msg)
 
             # Fallback to conversion path
             result: ArrowResult = super().select_to_arrow(

--- a/sqlspec/adapters/cockroach_asyncpg/config.py
+++ b/sqlspec/adapters/cockroach_asyncpg/config.py
@@ -111,7 +111,7 @@ class CockroachAsyncpgDriverFeatures(TypedDict):
     enable_pgvector: NotRequired[bool]
     on_connection_create: "NotRequired[Callable[[CockroachAsyncpgConnection], Awaitable[None]]]"
     enable_events: NotRequired[bool]
-    events_backend: NotRequired[str]
+    events_backend: NotRequired[Literal["poll_queue"]]
 
 
 class _CockroachAsyncpgSessionFactory(AsyncPoolSessionFactory):

--- a/sqlspec/adapters/cockroach_psycopg/config.py
+++ b/sqlspec/adapters/cockroach_psycopg/config.py
@@ -1,6 +1,6 @@
 """CockroachDB configuration using psycopg."""
 
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
 
 from psycopg import crdb as psycopg_crdb
 from psycopg_pool import AsyncConnectionPool, ConnectionPool
@@ -117,7 +117,7 @@ class CockroachPsycopgDriverFeatures(TypedDict):
     json_deserializer: NotRequired["Callable[[str], Any]"]
     on_connection_create: "NotRequired[Callable[..., Any]]"
     enable_events: NotRequired[bool]
-    events_backend: NotRequired[str]
+    events_backend: NotRequired[Literal["poll_queue"]]
 
 
 class CockroachPsycopgSyncConnectionContext(SyncPoolConnectionContext):

--- a/sqlspec/adapters/duckdb/config.py
+++ b/sqlspec/adapters/duckdb/config.py
@@ -163,7 +163,7 @@ class DuckDBDriverFeatures(TypedDict):
             Provides pub/sub capabilities via table-backed queue (DuckDB has no native pub/sub).
             Requires extension_config["events"] for migration setup.
         events_backend: Event channel backend selection.
-        Only option: "poll_queue" (durable table-backed queue with retries and exactly-once delivery).
+        Only option: "poll_queue" (durable table-backed queue with lease-based retries and acknowledgements).
             DuckDB does not have native pub/sub, so poll_queue is the only backend.
             Defaults to "poll_queue".
     """

--- a/sqlspec/adapters/duckdb/config.py
+++ b/sqlspec/adapters/duckdb/config.py
@@ -163,9 +163,9 @@ class DuckDBDriverFeatures(TypedDict):
             Provides pub/sub capabilities via table-backed queue (DuckDB has no native pub/sub).
             Requires extension_config["events"] for migration setup.
         events_backend: Event channel backend selection.
-        Only option: "table_queue" (durable table-backed queue with retries and exactly-once delivery).
-            DuckDB does not have native pub/sub, so table_queue is the only backend.
-            Defaults to "table_queue".
+        Only option: "poll_queue" (durable table-backed queue with retries and exactly-once delivery).
+            DuckDB does not have native pub/sub, so poll_queue is the only backend.
+            Defaults to "poll_queue".
     """
 
     extensions: NotRequired[Sequence[DuckDBExtensionConfig]]

--- a/sqlspec/adapters/duckdb/config.py
+++ b/sqlspec/adapters/duckdb/config.py
@@ -1,7 +1,7 @@
 """DuckDB database configuration with connection pooling."""
 
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
 
 from typing_extensions import NotRequired
 
@@ -175,7 +175,7 @@ class DuckDBDriverFeatures(TypedDict):
     enable_uuid_conversion: NotRequired[bool]
     extension_flags: NotRequired["dict[str, Any]"]
     enable_events: NotRequired[bool]
-    events_backend: NotRequired[str]
+    events_backend: NotRequired[Literal["poll_queue"]]
 
 
 class DuckDBConnectionContext(SyncPoolConnectionContext):

--- a/sqlspec/adapters/mssql_python/driver.py
+++ b/sqlspec/adapters/mssql_python/driver.py
@@ -122,7 +122,7 @@ class MssqlPythonStreamSource:
             self._column_names = column_names
         return rows_to_dicts(rows, column_names)
 
-    def close(self) -> None:
+    def close(self, error: bool = False) -> None:
         cursor_manager = self._cursor_manager
         self._cursor_manager = None
         if cursor_manager is not None:

--- a/sqlspec/adapters/mysqlconnector/config.py
+++ b/sqlspec/adapters/mysqlconnector/config.py
@@ -189,7 +189,7 @@ class MysqlConnectorDriverFeatures(TypedDict):
     json_deserializer: NotRequired["Callable[[str], Any]"]
     on_connection_create: "NotRequired[Callable[..., Any]]"
     enable_events: NotRequired[bool]
-    events_backend: NotRequired[str]
+    events_backend: NotRequired[Literal["poll_queue"]]
     cursor_options: NotRequired[MysqlConnectorCursorParams]
     enable_local_infile_bulk_load: NotRequired[bool]
 

--- a/sqlspec/adapters/mysqlconnector/config.py
+++ b/sqlspec/adapters/mysqlconnector/config.py
@@ -180,7 +180,7 @@ class MysqlConnectorDriverFeatures(TypedDict):
     enable_events: Enable database event channel support.
      Defaults to True when extension_config["events"] is configured.
     events_backend: Event channel backend selection.
-     Only option: "table_queue".
+     Only option: "poll_queue".
     cursor_options: Cursor keyword arguments SQLSpec forwards to
      ``connection.cursor()`` for statement execution.
     """

--- a/sqlspec/adapters/mysqlconnector/core.py
+++ b/sqlspec/adapters/mysqlconnector/core.py
@@ -211,8 +211,8 @@ class MysqlConnectorSyncStreamSource:
         handler = self._driver.handle_database_exceptions()
         with handler:
             cursor = self._driver.connection.cursor(**self._cursor_options)
-            cursor.execute(self._sql, normalize_execute_parameters(self._parameters))
             self._cursor = cursor
+            cursor.execute(self._sql, normalize_execute_parameters(self._parameters))
             self._row_plan = resolve_row_plan(self._cursor.description, self._json_type_codes)
         self._driver._check_pending_exception(handler)
 
@@ -233,8 +233,6 @@ class MysqlConnectorSyncStreamSource:
         cursor = self._cursor
         self._cursor = None
         if cursor is not None:
-            with contextlib.suppress(Exception):
-                cursor.fetchall()
             with contextlib.suppress(Exception):
                 cursor.close()
 
@@ -276,8 +274,8 @@ class MysqlConnectorAsyncStreamSource:
         handler = self._driver.handle_database_exceptions()
         async with handler:
             cursor = await self._driver.connection.cursor(**self._cursor_options)
-            await cursor.execute(self._sql, normalize_execute_parameters(self._parameters))
             self._cursor = cursor
+            await cursor.execute(self._sql, normalize_execute_parameters(self._parameters))
             self._row_plan = resolve_row_plan(self._cursor.description, self._json_type_codes)
         self._driver._check_pending_exception(handler)
 
@@ -298,8 +296,6 @@ class MysqlConnectorAsyncStreamSource:
         cursor = self._cursor
         self._cursor = None
         if cursor is not None:
-            with contextlib.suppress(Exception):
-                await cursor.fetchall()
             with contextlib.suppress(Exception):
                 await cursor.close()
 

--- a/sqlspec/adapters/mysqlconnector/core.py
+++ b/sqlspec/adapters/mysqlconnector/core.py
@@ -232,16 +232,15 @@ class MysqlConnectorSyncStreamSource:
     def close(self, error: bool = False) -> None:
         cursor = self._cursor
         self._cursor = None
-        if cursor is not None:
-            with contextlib.suppress(Exception):
-                cursor.close()
         connection = self._driver.connection
         raw_connection = getattr(connection, "_cnx", None) or connection
-        if getattr(raw_connection, "unread_result", False):
-            with contextlib.suppress(Exception):
-                raw_connection.shutdown()
-                raw_connection.unread_result = False
-                raw_connection.reconnect()
+        try:
+            if getattr(raw_connection, "unread_result", False):
+                raw_connection.consume_results()
+        finally:
+            if cursor is not None:
+                with contextlib.suppress(Exception):
+                    cursor.close()
 
 
 class MysqlConnectorAsyncStreamSource:
@@ -302,16 +301,15 @@ class MysqlConnectorAsyncStreamSource:
     async def close(self, error: bool = False) -> None:
         cursor = self._cursor
         self._cursor = None
-        if cursor is not None:
-            with contextlib.suppress(Exception):
-                await cursor.close()
         connection = self._driver.connection
         raw_connection = getattr(connection, "_cnx", None) or connection
-        if getattr(raw_connection, "unread_result", False):
-            with contextlib.suppress(Exception):
-                await raw_connection.shutdown()
-                raw_connection.unread_result = False
-                await raw_connection.reconnect()
+        try:
+            if getattr(raw_connection, "unread_result", False):
+                await raw_connection.consume_results()
+        finally:
+            if cursor is not None:
+                with contextlib.suppress(Exception):
+                    await cursor.close()
 
 
 def normalize_execute_many_parameters(parameters: Any) -> Any:

--- a/sqlspec/adapters/mysqlconnector/core.py
+++ b/sqlspec/adapters/mysqlconnector/core.py
@@ -229,12 +229,19 @@ class MysqlConnectorSyncStreamSource:
         deserializer = cast("Callable[[Any], Any]", self._driver.driver_features.get("json_deserializer", from_json))
         return collect_stream_rows(rows, self._row_plan, deserializer)
 
-    def close(self) -> None:
+    def close(self, error: bool = False) -> None:
         cursor = self._cursor
         self._cursor = None
         if cursor is not None:
             with contextlib.suppress(Exception):
                 cursor.close()
+        connection = self._driver.connection
+        raw_connection = getattr(connection, "_cnx", None) or connection
+        if getattr(raw_connection, "unread_result", False):
+            with contextlib.suppress(Exception):
+                raw_connection.shutdown()
+                raw_connection.unread_result = False
+                raw_connection.reconnect()
 
 
 class MysqlConnectorAsyncStreamSource:
@@ -292,12 +299,19 @@ class MysqlConnectorAsyncStreamSource:
         deserializer = cast("Callable[[Any], Any]", self._driver.driver_features.get("json_deserializer", from_json))
         return collect_stream_rows(rows, self._row_plan, deserializer)
 
-    async def close(self) -> None:
+    async def close(self, error: bool = False) -> None:
         cursor = self._cursor
         self._cursor = None
         if cursor is not None:
             with contextlib.suppress(Exception):
                 await cursor.close()
+        connection = self._driver.connection
+        raw_connection = getattr(connection, "_cnx", None) or connection
+        if getattr(raw_connection, "unread_result", False):
+            with contextlib.suppress(Exception):
+                await raw_connection.shutdown()
+                raw_connection.unread_result = False
+                await raw_connection.reconnect()
 
 
 def normalize_execute_many_parameters(parameters: Any) -> Any:

--- a/sqlspec/adapters/oracledb/config.py
+++ b/sqlspec/adapters/oracledb/config.py
@@ -57,7 +57,7 @@ OracleProtocol = Literal["tcp", "tcps"]
 OracleServerType = Literal["dedicated", "shared", "pooled"]
 OraclePoolBoundary = Literal["statement", "transaction"]
 OracleVectorReturnFormat = Literal["array", "list", "numpy"]
-OracleEventsBackend = Literal["aq", "table_queue", "txeventq"]
+OracleEventsBackend = Literal["aq", "poll_queue", "txeventq"]
 
 
 class OracleConnectionParams(TypedDict):
@@ -188,16 +188,16 @@ class OracleDriverFeatures(TypedDict):
     enable_events: Enable SQLSpec event queue support.
      Defaults to True when extension_config["events"] is configured.
      Provides pub/sub capabilities via Oracle Advanced Queuing or table-backed fallback.
-     Requires extension_config["events"] for migration setup when using table_queue backend.
+     Requires extension_config["events"] for migration setup when using poll_queue backend.
      This is separate from connection_config["events"], which enables python-oracledb
      Thick mode database event notifications for HA and continuous query notification.
     events_backend: Event channel backend selection.
-     Options: "aq", "table_queue", "txeventq"
+     Options: "aq", "poll_queue", "txeventq"
      - "aq": Oracle Advanced Queuing (native messaging, requires DBMS_AQADM privileges)
      - "txeventq": Oracle Transactional Event Queues (native messaging, requires
        DBMS_AQADM privileges; provisioned via DBMS_AQADM.CREATE_TRANSACTIONAL_EVENT_QUEUE)
-     - "table_queue": Durable table-backed queue with retries and exactly-once delivery
-     Defaults to "table_queue" (works on all Oracle editions without special privileges).
+     - "poll_queue": Durable table-backed queue with retries and exactly-once delivery
+     Defaults to "poll_queue" (works on all Oracle editions without special privileges).
     enable_direct_path_load: Route load_from_arrow through Connection.direct_path_load.
      Thin-mode only; falls back to executemany when the API is absent or the
      connection is in Thick mode. Defaults to True; set to False to force

--- a/sqlspec/adapters/oracledb/config.py
+++ b/sqlspec/adapters/oracledb/config.py
@@ -196,7 +196,7 @@ class OracleDriverFeatures(TypedDict):
      - "aq": Oracle Advanced Queuing (native messaging, requires DBMS_AQADM privileges)
      - "txeventq": Oracle Transactional Event Queues (native messaging, requires
        DBMS_AQADM privileges; provisioned via DBMS_AQADM.CREATE_TRANSACTIONAL_EVENT_QUEUE)
-     - "poll_queue": Durable table-backed queue with retries and exactly-once delivery
+     - "poll_queue": Durable table-backed queue with lease-based retries and acknowledgements
      Defaults to "poll_queue" (works on all Oracle editions without special privileges).
     enable_direct_path_load: Route load_from_arrow through Connection.direct_path_load.
      Thin-mode only; falls back to executemany when the API is absent or the

--- a/sqlspec/adapters/oracledb/core.py
+++ b/sqlspec/adapters/oracledb/core.py
@@ -661,13 +661,13 @@ class OracleSyncStreamSource:
         handler = self._driver.handle_database_exceptions()
         with handler:
             cursor = self._driver.connection.cursor()
+            self._cursor = cursor
             cursor.arraysize = self._chunk_size
             cursor.prefetchrows = self._chunk_size
             fetch_kwargs = build_fetch_kwargs(self._driver.driver_features)
             if self._fetch_lobs is not None:
                 fetch_kwargs["fetch_lobs"] = self._fetch_lobs
             cast("Any", cursor).execute(self._sql, self._parameters or {}, **fetch_kwargs)
-            self._cursor = cursor
         self._driver._check_pending_exception(handler)
 
     def fetch_chunk(self) -> "list[dict[str, Any]]":
@@ -720,13 +720,13 @@ class OracleAsyncStreamSource:
         handler = self._driver.handle_database_exceptions()
         async with handler:
             cursor = self._driver.connection.cursor()
+            self._cursor = cursor
             cursor.arraysize = self._chunk_size
             cursor.prefetchrows = self._chunk_size
             fetch_kwargs = build_fetch_kwargs(self._driver.driver_features)
             if self._fetch_lobs is not None:
                 fetch_kwargs["fetch_lobs"] = self._fetch_lobs
             await cast("Any", cursor).execute(self._sql, self._parameters or {}, **fetch_kwargs)
-            self._cursor = cursor
         self._driver._check_pending_exception(handler)
 
     async def fetch_chunk(self) -> "list[dict[str, Any]]":

--- a/sqlspec/adapters/oracledb/core.py
+++ b/sqlspec/adapters/oracledb/core.py
@@ -687,7 +687,7 @@ class OracleSyncStreamSource:
             self._column_names = column_names
         return rows_to_dicts(rows, column_names)
 
-    def close(self) -> None:
+    def close(self, error: bool = False) -> None:
         cursor = self._cursor
         self._cursor = None
         if cursor is not None:
@@ -746,7 +746,7 @@ class OracleAsyncStreamSource:
             self._column_names = column_names
         return rows_to_dicts(rows, column_names)
 
-    async def close(self) -> None:
+    async def close(self, error: bool = False) -> None:
         cursor = self._cursor
         self._cursor = None
         if cursor is not None:

--- a/sqlspec/adapters/psqlpy/config.py
+++ b/sqlspec/adapters/psqlpy/config.py
@@ -108,13 +108,13 @@ class PsqlpyDriverFeatures(TypedDict):
     enable_events: Enable database event channel support.
      Defaults to True when extension_config["events"] is configured.
      Provides pub/sub capabilities via LISTEN/NOTIFY or table-backed fallback.
-     Requires extension_config["events"] for migration setup when using table_queue backend.
+     Requires extension_config["events"] for migration setup when using poll_queue backend.
     events_backend: Event channel backend selection.
-     Options: "listen_notify", "table_queue", "listen_notify_durable"
-     - "listen_notify": Zero-copy PostgreSQL LISTEN/NOTIFY (ephemeral, real-time) - coming soon
-     - "table_queue": Durable table-backed queue with retries and exactly-once delivery (current default)
-     - "listen_notify_durable": Hybrid - real-time + durable (available when native support lands)
-     Defaults to "table_queue" until native LISTEN/NOTIFY support is implemented.
+     Options: "notify", "poll_queue", "notify_queue"
+     - "notify": PostgreSQL LISTEN/NOTIFY wakeups (transient, not a durable ledger)
+     - "poll_queue": Durable table-backed queue discovered by polling
+     - "notify_queue": Durable table-backed queue with LISTEN/NOTIFY wakeups
+     Defaults to "notify".
     """
 
     enable_cast_detection: NotRequired[bool]

--- a/sqlspec/adapters/psqlpy/config.py
+++ b/sqlspec/adapters/psqlpy/config.py
@@ -1,6 +1,6 @@
 """Psqlpy database configuration."""
 
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
 
 from mypy_extensions import mypyc_attr
 from typing_extensions import NotRequired
@@ -108,12 +108,12 @@ class PsqlpyDriverFeatures(TypedDict):
     enable_events: Enable database event channel support.
      Defaults to True when extension_config["events"] is configured.
      Provides pub/sub capabilities via LISTEN/NOTIFY or table-backed fallback.
-     Requires extension_config["events"] for migration setup when using poll_queue backend.
+     Requires extension_config["events"] for migration setup when using poll_queue or notify_queue.
     events_backend: Event channel backend selection.
-     Options: "notify", "poll_queue", "notify_queue"
-     - "notify": PostgreSQL LISTEN/NOTIFY wakeups (transient, not a durable ledger)
-     - "poll_queue": Durable table-backed queue discovered by polling
-     - "notify_queue": Durable table-backed queue with LISTEN/NOTIFY wakeups
+     Options: "notify", "notify_queue", "poll_queue"
+     - "notify": Transient PostgreSQL LISTEN/NOTIFY with no replay or retry
+     - "notify_queue": Durable queue plus a PostgreSQL notification wakeup hint
+     - "poll_queue": Durable queue discovered by polling
      Defaults to "notify".
     """
 
@@ -124,7 +124,7 @@ class PsqlpyDriverFeatures(TypedDict):
     json_deserializer: NotRequired["Callable[[str], Any]"]
     on_connection_create: "NotRequired[Callable[[PsqlpyConnection], Awaitable[None]]]"
     enable_events: NotRequired[bool]
-    events_backend: NotRequired[str]
+    events_backend: NotRequired[Literal["notify", "notify_queue", "poll_queue"]]
 
 
 class _PsqlpySessionFactory(AsyncPoolSessionFactory):

--- a/sqlspec/adapters/psqlpy/core.py
+++ b/sqlspec/adapters/psqlpy/core.py
@@ -341,7 +341,7 @@ class PsqlpyStreamSource:
             return []
         return cast("list[dict[str, Any]]", query_result.result())
 
-    async def close(self) -> None:
+    async def close(self, error: bool = False) -> None:
         cursor = self._cursor
         self._cursor = None
         if cursor is not None:
@@ -351,7 +351,10 @@ class PsqlpyStreamSource:
         self._transaction = None
         if transaction is not None:
             try:
-                await transaction.commit()
+                if error:
+                    await transaction.rollback()
+                else:
+                    await transaction.commit()
             except Exception:
                 with contextlib.suppress(Exception):
                     await transaction.rollback()

--- a/sqlspec/adapters/psqlpy/events/backend.py
+++ b/sqlspec/adapters/psqlpy/events/backend.py
@@ -36,7 +36,7 @@ class PsqlpyEventsBackend:
 
     supports_sync = False
     supports_async = True
-    backend_name = "listen_notify"
+    backend_name = "notify"
 
     def __init__(self, config: "PsqlpyConfig") -> None:
         if "psqlpy" not in type(config).__module__:
@@ -97,7 +97,7 @@ class PsqlpyHybridEventsBackend:
 
     supports_sync = False
     supports_async = True
-    backend_name = "listen_notify_durable"
+    backend_name = "notify_queue"
 
     def __init__(self, config: "PsqlpyConfig", queue: "AsyncTableEventQueue") -> None:
         if "psqlpy" not in type(config).__module__:
@@ -185,12 +185,12 @@ def create_event_backend(
 ) -> PsqlpyEventsBackend | PsqlpyHybridEventsBackend | None:
     """EventChannel factory for the native psqlpy backend."""
     match backend_name:
-        case "listen_notify":
+        case "notify":
             try:
                 return PsqlpyEventsBackend(config)
             except ImproperConfigurationError:
                 return None
-        case "listen_notify_durable":
+        case "notify_queue":
             queue = cast("AsyncTableEventQueue", build_queue_backend(config, extension_settings, adapter_name="psqlpy"))
             try:
                 return PsqlpyHybridEventsBackend(config, queue)

--- a/sqlspec/adapters/psycopg/config.py
+++ b/sqlspec/adapters/psycopg/config.py
@@ -134,12 +134,12 @@ class PsycopgDriverFeatures(TypedDict):
     enable_events: Enable database event channel support.
      Defaults to True when extension_config["events"] is configured.
      Provides pub/sub capabilities via LISTEN/NOTIFY or table-backed fallback.
-     Requires extension_config["events"] for migration setup when using poll_queue backend.
+     Requires extension_config["events"] for migration setup when using poll_queue or notify_queue.
     events_backend: Event channel backend selection.
-     Options: "notify", "poll_queue", "notify_queue"
-     - "notify": PostgreSQL LISTEN/NOTIFY wakeups (transient, not a durable ledger)
-     - "poll_queue": Durable table-backed queue discovered by polling
-     - "notify_queue": Durable table-backed queue with LISTEN/NOTIFY wakeups
+     Options: "notify", "notify_queue", "poll_queue"
+     - "notify": Transient PostgreSQL LISTEN/NOTIFY with no replay or retry
+     - "notify_queue": Durable queue plus a PostgreSQL notification wakeup hint
+     - "poll_queue": Durable queue discovered by polling
      Defaults to "notify".
     enable_alloydb: Enable sync-only Google AlloyDB connector integration.
      Requires google-cloud-alloydb-connector. Defaults to False.
@@ -156,7 +156,7 @@ class PsycopgDriverFeatures(TypedDict):
     json_deserializer: NotRequired["Callable[[str], Any]"]
     on_connection_create: NotRequired["Callable[..., Any]"]
     enable_events: NotRequired[bool]
-    events_backend: NotRequired[str]
+    events_backend: NotRequired[Literal["notify", "notify_queue", "poll_queue"]]
     enable_alloydb: NotRequired[bool]
     alloydb_instance_uri: NotRequired[str]
     enable_alloydb_iam_auth: NotRequired[bool]

--- a/sqlspec/adapters/psycopg/config.py
+++ b/sqlspec/adapters/psycopg/config.py
@@ -134,13 +134,13 @@ class PsycopgDriverFeatures(TypedDict):
     enable_events: Enable database event channel support.
      Defaults to True when extension_config["events"] is configured.
      Provides pub/sub capabilities via LISTEN/NOTIFY or table-backed fallback.
-     Requires extension_config["events"] for migration setup when using table_queue backend.
+     Requires extension_config["events"] for migration setup when using poll_queue backend.
     events_backend: Event channel backend selection.
-     Options: "listen_notify", "table_queue", "listen_notify_durable"
-     - "listen_notify": Zero-copy PostgreSQL LISTEN/NOTIFY (ephemeral, real-time) - coming soon
-     - "table_queue": Durable table-backed queue with retries and exactly-once delivery (current default)
-     - "listen_notify_durable": Hybrid - real-time + durable (available when native support lands)
-     Defaults to "table_queue" until native LISTEN/NOTIFY support is implemented.
+     Options: "notify", "poll_queue", "notify_queue"
+     - "notify": PostgreSQL LISTEN/NOTIFY wakeups (transient, not a durable ledger)
+     - "poll_queue": Durable table-backed queue discovered by polling
+     - "notify_queue": Durable table-backed queue with LISTEN/NOTIFY wakeups
+     Defaults to "notify".
     enable_alloydb: Enable sync-only Google AlloyDB connector integration.
      Requires google-cloud-alloydb-connector. Defaults to False.
     alloydb_instance_uri: AlloyDB instance URI in projects/... resource path form.

--- a/sqlspec/adapters/psycopg/core.py
+++ b/sqlspec/adapters/psycopg/core.py
@@ -327,7 +327,7 @@ class PsycopgSyncStreamSource:
             self._column_names = [column.name for column in self._cursor.description]
         return rows_to_dicts(rows, self._column_names)
 
-    def close(self) -> None:
+    def close(self, error: bool = False) -> None:
         cursor = self._cursor
         self._cursor = None
         if cursor is not None:
@@ -337,7 +337,10 @@ class PsycopgSyncStreamSource:
         self._transaction = None
         if transaction is not None:
             with contextlib.suppress(Exception):
-                transaction.__exit__(None, None, None)
+                if error:
+                    transaction.__exit__(RuntimeError, RuntimeError("stream failed"), None)
+                else:
+                    transaction.__exit__(None, None, None)
 
 
 class PsycopgAsyncStreamSource:
@@ -388,7 +391,7 @@ class PsycopgAsyncStreamSource:
             self._column_names = [column.name for column in self._cursor.description]
         return rows_to_dicts(rows, self._column_names)
 
-    async def close(self) -> None:
+    async def close(self, error: bool = False) -> None:
         cursor = self._cursor
         self._cursor = None
         if cursor is not None:
@@ -398,7 +401,10 @@ class PsycopgAsyncStreamSource:
         self._transaction = None
         if transaction is not None:
             with contextlib.suppress(Exception):
-                await transaction.__aexit__(None, None, None)
+                if error:
+                    await transaction.__aexit__(RuntimeError, RuntimeError("stream failed"), None)
+                else:
+                    await transaction.__aexit__(None, None, None)
 
 
 def resolve_rowcount(cursor: Any) -> int:

--- a/sqlspec/adapters/psycopg/events/backend.py
+++ b/sqlspec/adapters/psycopg/events/backend.py
@@ -41,7 +41,7 @@ class PsycopgSyncEventsBackend:
 
     supports_sync = True
     supports_async = False
-    backend_name = "listen_notify"
+    backend_name = "notify"
 
     def __init__(self, config: "PsycopgSyncConfig") -> None:
         if "psycopg" not in type(config).__module__:
@@ -108,7 +108,7 @@ class PsycopgAsyncEventsBackend:
 
     supports_sync = False
     supports_async = True
-    backend_name = "listen_notify"
+    backend_name = "notify"
 
     def __init__(self, config: "PsycopgAsyncConfig") -> None:
         if "psycopg" not in type(config).__module__:
@@ -166,7 +166,7 @@ class PsycopgSyncHybridEventsBackend:
 
     supports_sync = True
     supports_async = False
-    backend_name = "listen_notify_durable"
+    backend_name = "notify_queue"
 
     def __init__(self, config: "PsycopgSyncConfig", queue: "SyncTableEventQueue") -> None:
         if "psycopg" not in type(config).__module__:
@@ -264,7 +264,7 @@ class PsycopgAsyncHybridEventsBackend:
 
     supports_sync = False
     supports_async = True
-    backend_name = "listen_notify_durable"
+    backend_name = "notify_queue"
 
     def __init__(self, config: "PsycopgAsyncConfig", queue: "AsyncTableEventQueue") -> None:
         if "psycopg" not in type(config).__module__:
@@ -358,17 +358,17 @@ def create_event_backend(
     """EventChannel factory for the native psycopg backend."""
     is_async = config.is_async
     match (backend_name, is_async):
-        case ("listen_notify", False):
+        case ("notify", False):
             try:
                 return PsycopgSyncEventsBackend(config)  # type: ignore[arg-type]
             except ImproperConfigurationError:
                 return None
-        case ("listen_notify", True):
+        case ("notify", True):
             try:
                 return PsycopgAsyncEventsBackend(config)  # type: ignore[arg-type]
             except ImproperConfigurationError:
                 return None
-        case ("listen_notify_durable", False):
+        case ("notify_queue", False):
             sync_queue = cast(
                 "SyncTableEventQueue", build_queue_backend(config, extension_settings, adapter_name="psycopg")
             )
@@ -376,7 +376,7 @@ def create_event_backend(
                 return PsycopgSyncHybridEventsBackend(config, sync_queue)  # type: ignore[arg-type]
             except ImproperConfigurationError:
                 return None
-        case ("listen_notify_durable", True):
+        case ("notify_queue", True):
             async_queue = cast(
                 "AsyncTableEventQueue", build_queue_backend(config, extension_settings, adapter_name="psycopg")
             )

--- a/sqlspec/adapters/pymssql/config.py
+++ b/sqlspec/adapters/pymssql/config.py
@@ -1,7 +1,7 @@
 """pymssql database configuration."""
 
 from collections.abc import Callable, Mapping
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
 
 from typing_extensions import NotRequired
 
@@ -72,7 +72,7 @@ class PymssqlDriverFeatures(TypedDict):
     json_deserializer: NotRequired["Callable[[str], Any]"]
     on_connection_create: "NotRequired[Callable[[PymssqlConnection], None]]"
     enable_events: NotRequired[bool]
-    events_backend: NotRequired[str]
+    events_backend: NotRequired[Literal["poll_queue"]]
 
 
 class PymssqlConnectionContext(SyncPoolConnectionContext):

--- a/sqlspec/adapters/pymssql/driver.py
+++ b/sqlspec/adapters/pymssql/driver.py
@@ -110,7 +110,7 @@ class PymssqlStreamSource:
             self._column_names = column_names
         return rows_to_dicts(rows, column_names)
 
-    def close(self) -> None:
+    def close(self, error: bool = False) -> None:
         cursor_manager = self._cursor_manager
         self._cursor_manager = None
         if cursor_manager is not None:

--- a/sqlspec/adapters/pymysql/config.py
+++ b/sqlspec/adapters/pymysql/config.py
@@ -2,7 +2,7 @@
 
 import ssl
 from collections.abc import Callable, Mapping
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
 
 from typing_extensions import NotRequired
 
@@ -138,7 +138,7 @@ class PyMysqlDriverFeatures(TypedDict):
     json_deserializer: NotRequired["Callable[[str], Any]"]
     on_connection_create: "NotRequired[Callable[[PyMysqlConnection], None]]"
     enable_events: NotRequired[bool]
-    events_backend: NotRequired[str]
+    events_backend: NotRequired[Literal["poll_queue"]]
     enable_local_infile_bulk_load: NotRequired[bool]
     enable_cloud_sql: NotRequired[bool]
     cloud_sql_instance: NotRequired[str]

--- a/sqlspec/adapters/pymysql/core.py
+++ b/sqlspec/adapters/pymysql/core.py
@@ -193,8 +193,8 @@ class PymysqlStreamSource:
         handler = self._driver.handle_database_exceptions()
         with handler:
             cursor = self._driver.connection.cursor(SSCursor)
-            cursor.execute(self._sql, normalize_execute_parameters(self._parameters))
             self._cursor = cursor
+            cursor.execute(self._sql, normalize_execute_parameters(self._parameters))
             self._row_plan = resolve_row_plan(self._cursor.description, self._json_type_codes)
         self._driver._check_pending_exception(handler)
 

--- a/sqlspec/adapters/pymysql/core.py
+++ b/sqlspec/adapters/pymysql/core.py
@@ -211,7 +211,7 @@ class PymysqlStreamSource:
         deserializer = cast("Callable[[Any], Any]", self._driver.driver_features.get("json_deserializer", from_json))
         return collect_stream_rows(rows, self._row_plan, deserializer)
 
-    def close(self) -> None:
+    def close(self, error: bool = False) -> None:
         cursor = self._cursor
         self._cursor = None
         if cursor is not None:

--- a/sqlspec/adapters/spanner/config.py
+++ b/sqlspec/adapters/spanner/config.py
@@ -1,6 +1,6 @@
 """Spanner configuration."""
 
-from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict, cast
 
 from typing_extensions import NotRequired
 
@@ -161,7 +161,7 @@ class SpannerDriverFeatures(TypedDict):
     directed_read_options: "NotRequired[DirectedReadOptions | None]"
     session_labels: "NotRequired[dict[str, str]]"
     enable_events: "NotRequired[bool]"
-    events_backend: "NotRequired[str]"
+    events_backend: "NotRequired[Literal['poll_queue']]"
     enable_batch_write_api: "NotRequired[bool]"
 
 

--- a/sqlspec/adapters/spanner/config.py
+++ b/sqlspec/adapters/spanner/config.py
@@ -145,7 +145,7 @@ class SpannerDriverFeatures(TypedDict):
         enable_events: Enable database event channel support.
             Defaults to True when extension_config["events"] is configured.
         events_backend: Backend type for event handling.
-            Spanner only supports "table_queue" (no native pub/sub).
+            Spanner only supports "poll_queue" (no native pub/sub).
         enable_batch_write_api: Route load_from_arrow through the Spanner Batch Write API
             (Database.mutation_groups().batch_write()) for high-throughput, independently
             committed mutation groups instead of a single in-transaction insert_or_update.

--- a/sqlspec/adapters/spanner/driver.py
+++ b/sqlspec/adapters/spanner/driver.py
@@ -227,7 +227,7 @@ class _SpannerSelectStreamSource:
         self._column_names = resolved_column_names
         return rows_to_dicts(converted_rows, resolved_column_names)
 
-    def close(self) -> None:
+    def close(self, error: bool = False) -> None:
         result_set = self._result_set
         if result_set is not None:
             close = getattr(result_set, "close", None)

--- a/sqlspec/adapters/spanner/driver.py
+++ b/sqlspec/adapters/spanner/driver.py
@@ -18,7 +18,6 @@ from sqlspec.adapters.spanner.core import (
     build_param_type_signature,
     coerce_params,
     collect_rows,
-    create_arrow_data,
     create_mapped_exception,
     default_statement_config,
     driver_profile,
@@ -28,7 +27,7 @@ from sqlspec.adapters.spanner.core import (
     supports_write,
 )
 from sqlspec.adapters.spanner.data_dictionary import SpannerDataDictionary
-from sqlspec.core import StatementConfig, create_arrow_result, register_driver_profile
+from sqlspec.core import StatementConfig, register_driver_profile
 from sqlspec.driver import (
     BaseSyncExceptionHandler,
     ExecutionResult,
@@ -51,7 +50,7 @@ if TYPE_CHECKING:
     from sqlspec.core import ArrowResult, SQLResult, Statement, StatementFilter
     from sqlspec.core.statement import SQL
     from sqlspec.storage import StorageBridgeJob, StorageDestination, StorageFormat, StorageTelemetry
-    from sqlspec.typing import ArrowReturnFormat, SchemaT, StatementParameters
+    from sqlspec.typing import SchemaT, StatementParameters
 
 __all__ = (
     "SpannerDataDictionary",
@@ -569,13 +568,6 @@ class SpannerSyncDriver(SyncDriverAdapterBase):
     # ─────────────────────────────────────────────────────────────────────────────
     # ARROW API METHODS
     # ─────────────────────────────────────────────────────────────────────────────
-
-    def select_to_arrow(self, statement: "Any", /, *parameters: "Any", **kwargs: Any) -> "ArrowResult":
-        result = self.execute(statement, *parameters, **kwargs)
-
-        return_format = cast("ArrowReturnFormat", kwargs.get("return_format", "table"))
-        arrow_data = create_arrow_data(result.get_data(), return_format)
-        return create_arrow_result(result.statement, arrow_data, rows_affected=result.rows_affected)
 
     # ─────────────────────────────────────────────────────────────────────────────
     # STORAGE API METHODS

--- a/sqlspec/adapters/sqlite/config.py
+++ b/sqlspec/adapters/sqlite/config.py
@@ -102,9 +102,9 @@ class SqliteDriverFeatures(TypedDict):
      Provides pub/sub capabilities via table-backed queue (SQLite has no native pub/sub).
      Requires extension_config["events"] for migration setup.
     events_backend: Event channel backend selection.
-     Only option: "table_queue" (durable table-backed queue with retries and exactly-once delivery).
-     SQLite does not have native pub/sub, so table_queue is the only backend.
-     Defaults to "table_queue".
+     Only option: "poll_queue" (durable table-backed queue with retries and exactly-once delivery).
+     SQLite does not have native pub/sub, so poll_queue is the only backend.
+     Defaults to "poll_queue".
     custom_functions: Register SQL functions that run on the connection thread.
      Each entry must include name, narg, and func.
     custom_collations: Register SQL collations that compare two string values.

--- a/sqlspec/adapters/sqlite/config.py
+++ b/sqlspec/adapters/sqlite/config.py
@@ -130,7 +130,7 @@ class SqliteDriverFeatures(TypedDict):
     json_deserializer: "NotRequired[Callable[[str], Any]]"
     on_connection_create: "NotRequired[Callable[[SqliteConnection], None]]"
     enable_events: NotRequired[bool]
-    events_backend: NotRequired[str]
+    events_backend: NotRequired[Literal["poll_queue"]]
     custom_functions: "NotRequired[Sequence[SqliteFunctionConfig]]"
     custom_collations: "NotRequired[Sequence[SqliteCollationConfig]]"
     custom_aggregates: "NotRequired[Sequence[SqliteAggregateConfig]]"

--- a/sqlspec/adapters/sqlite/config.py
+++ b/sqlspec/adapters/sqlite/config.py
@@ -102,7 +102,7 @@ class SqliteDriverFeatures(TypedDict):
      Provides pub/sub capabilities via table-backed queue (SQLite has no native pub/sub).
      Requires extension_config["events"] for migration setup.
     events_backend: Event channel backend selection.
-     Only option: "poll_queue" (durable table-backed queue with retries and exactly-once delivery).
+     Only option: "poll_queue" (durable table-backed queue with lease-based retries and acknowledgements).
      SQLite does not have native pub/sub, so poll_queue is the only backend.
      Defaults to "poll_queue".
     custom_functions: Register SQL functions that run on the connection thread.

--- a/sqlspec/adapters/sqlite/core.py
+++ b/sqlspec/adapters/sqlite/core.py
@@ -181,7 +181,7 @@ class SqliteStreamSource:
             self._column_names = [description[0] for description in self._cursor.description]
         return rows_to_dicts(rows, self._column_names)
 
-    def close(self) -> None:
+    def close(self, error: bool = False) -> None:
         cursor = self._cursor
         self._cursor = None
         if cursor is not None:

--- a/sqlspec/adapters/sqlite/core.py
+++ b/sqlspec/adapters/sqlite/core.py
@@ -165,8 +165,8 @@ class SqliteStreamSource:
         with handler:
             cursor = self._driver.connection.cursor()
             cursor.arraysize = self._chunk_size
-            cursor.execute(self._sql, normalize_execute_parameters(self._parameters))
             self._cursor = cursor
+            cursor.execute(self._sql, normalize_execute_parameters(self._parameters))
         self._driver._check_pending_exception(handler)
 
     def fetch_chunk(self) -> "list[dict[str, Any]]":

--- a/sqlspec/config.py
+++ b/sqlspec/config.py
@@ -540,13 +540,14 @@ class EventsConfig(TypedDict):
     Use in ``extension_config["events"]``.
     """
 
-    backend: NotRequired[Literal["listen_notify", "table_queue", "listen_notify_durable", "aq"]]
-    """Backend implementation. PostgreSQL adapters default to 'listen_notify', others to 'table_queue'.
+    backend: NotRequired[Literal["notify", "notify_queue", "poll_queue", "aq", "txeventq"]]
+    """Backend implementation. PostgreSQL adapters default to 'notify', others to 'poll_queue'.
 
-    - listen_notify: Real-time PostgreSQL LISTEN/NOTIFY (ephemeral)
-    - table_queue: Durable table-backed queue with retries (all adapters)
-    - listen_notify_durable: Hybrid combining both (PostgreSQL only)
-    - aq: Oracle Advanced Queueing
+    - notify: Transient PostgreSQL LISTEN/NOTIFY wakeup; not a durable event ledger
+    - notify_queue: Durable table queue with PostgreSQL LISTEN/NOTIFY wakeups
+    - poll_queue: Durable table queue discovered by polling
+    - aq: Oracle Advanced Queuing
+    - txeventq: Oracle Transactional Event Queues
     """
 
     queue_table: NotRequired[str]

--- a/sqlspec/driver/_stream.py
+++ b/sqlspec/driver/_stream.py
@@ -11,6 +11,7 @@ interpreted adapter sources can feed compiled stream classes):
 
 import builtins
 import contextlib
+import inspect
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, cast, overload
 
 from typing_extensions import Self
@@ -43,7 +44,7 @@ class SyncRowSource(Protocol):
 
     def fetch_chunk(self) -> "list[dict[str, Any]]": ...
 
-    def close(self, error: bool = False) -> None: ...
+    def close(self) -> None: ...
 
 
 class AsyncRowSource(Protocol):
@@ -53,7 +54,29 @@ class AsyncRowSource(Protocol):
 
     async def fetch_chunk(self) -> "list[dict[str, Any]]": ...
 
-    async def close(self, error: bool = False) -> None: ...
+    async def close(self) -> None: ...
+
+
+def _close_sync_source(source: SyncRowSource, error: bool) -> None:
+    """Close a source while preserving the original no-argument contract."""
+    close = source.close
+    try:
+        inspect.signature(close).bind(error=error)
+    except (TypeError, ValueError):
+        close()
+        return
+    cast("Any", close)(error=error)
+
+
+async def _close_async_source(source: AsyncRowSource, error: bool) -> None:
+    """Close an async source while preserving the original no-argument contract."""
+    close = source.close
+    try:
+        inspect.signature(close).bind(error=error)
+    except (TypeError, ValueError):
+        await close()
+        return
+    await cast("Any", close)(error=error)
 
 
 def rows_to_dicts(rows: "list[Any]", column_names: "list[str]") -> "list[dict[str, Any]]":
@@ -142,7 +165,7 @@ class SyncRowStream(Generic[RowT]):
         self._buffer = []
         self._buffer_index = 0
         with contextlib.suppress(Exception):
-            self._source.close(error=error)
+            _close_sync_source(self._source, error)
 
 
 class AsyncRowStream(Generic[RowT]):
@@ -224,7 +247,7 @@ class AsyncRowStream(Generic[RowT]):
         self._buffer = []
         self._buffer_index = 0
         with contextlib.suppress(Exception):
-            await self._source.close(error=error)
+            await _close_async_source(self._source, error)
 
 
 class EagerSyncRowSource:

--- a/sqlspec/driver/_stream.py
+++ b/sqlspec/driver/_stream.py
@@ -149,6 +149,7 @@ class SyncRowStream(Generic[RowT]):
         except Exception:
             return
 
+
 class AsyncRowStream(Generic[RowT]):
     """Async bounded-memory iterator backed by an async chunk source."""
 
@@ -234,6 +235,7 @@ class AsyncRowStream(Generic[RowT]):
                 await self._source.close()
         except Exception:
             return
+
 
 class EagerSyncRowSource:
     """Chunk source over pre-materialized rows (eager fallback; not bounded-memory)."""

--- a/sqlspec/driver/_stream.py
+++ b/sqlspec/driver/_stream.py
@@ -96,7 +96,7 @@ class SyncRowStream(Generic[RowT]):
     def __exit__(
         self, exc_type: "type[BaseException] | None", exc_val: "BaseException | None", exc_tb: "TracebackType | None"
     ) -> None:
-        self.close()
+        self._close(error=exc_type is not None)
 
     def __iter__(self) -> "SyncRowStream[RowT]":
         return self
@@ -186,7 +186,7 @@ class AsyncRowStream(Generic[RowT]):
     async def __aexit__(
         self, exc_type: "type[BaseException] | None", exc_val: "BaseException | None", exc_tb: "TracebackType | None"
     ) -> None:
-        await self.aclose()
+        await self._aclose(error=exc_type is not None)
 
     async def __anext__(self) -> RowT:
         if self._closed:

--- a/sqlspec/driver/_stream.py
+++ b/sqlspec/driver/_stream.py
@@ -43,7 +43,7 @@ class SyncRowSource(Protocol):
 
     def fetch_chunk(self) -> "list[dict[str, Any]]": ...
 
-    def close(self) -> None: ...
+    def close(self, error: bool = False) -> None: ...
 
 
 class AsyncRowSource(Protocol):
@@ -53,7 +53,7 @@ class AsyncRowSource(Protocol):
 
     async def fetch_chunk(self) -> "list[dict[str, Any]]": ...
 
-    async def close(self) -> None: ...
+    async def close(self, error: bool = False) -> None: ...
 
 
 def rows_to_dicts(rows: "list[Any]", column_names: "list[str]") -> "list[dict[str, Any]]":
@@ -109,13 +109,13 @@ class SyncRowStream(Generic[RowT]):
             try:
                 self._source.start()
             except BaseException:
-                self.close()
+                self._close(error=True)
                 raise
         if self._buffer_index >= len(self._buffer):
             try:
                 chunk = self._source.fetch_chunk()
             except BaseException:
-                self.close()
+                self._close(error=True)
                 raise
             if not chunk:
                 self.close()
@@ -133,14 +133,21 @@ class SyncRowStream(Generic[RowT]):
         return cast("list[RowT]", to_schema(chunk, schema_type=schema_type))
 
     def close(self) -> None:
+        self._close(error=False)
+
+    def _close(self, error: bool = False) -> None:
         if self._closed:
             return
         self._closed = True
         self._buffer = []
         self._buffer_index = 0
-        with contextlib.suppress(Exception):
-            self._source.close()
-
+        try:
+            self._source.close(error=error)
+        except TypeError:
+            with contextlib.suppress(Exception):
+                self._source.close()
+        except Exception:
+            return
 
 class AsyncRowStream(Generic[RowT]):
     """Async bounded-memory iterator backed by an async chunk source."""
@@ -188,13 +195,13 @@ class AsyncRowStream(Generic[RowT]):
             try:
                 await self._source.start()
             except BaseException:
-                await self.aclose()
+                await self._aclose(error=True)
                 raise
         if self._buffer_index >= len(self._buffer):
             try:
                 chunk = await self._source.fetch_chunk()
             except BaseException:
-                await self.aclose()
+                await self._aclose(error=True)
                 raise
             if not chunk:
                 await self.aclose()
@@ -212,14 +219,21 @@ class AsyncRowStream(Generic[RowT]):
         return cast("list[RowT]", to_schema(chunk, schema_type=schema_type))
 
     async def aclose(self) -> None:
+        await self._aclose(error=False)
+
+    async def _aclose(self, error: bool = False) -> None:
         if self._closed:
             return
         self._closed = True
         self._buffer = []
         self._buffer_index = 0
-        with contextlib.suppress(Exception):
-            await self._source.close()
-
+        try:
+            await self._source.close(error=error)
+        except TypeError:
+            with contextlib.suppress(Exception):
+                await self._source.close()
+        except Exception:
+            return
 
 class EagerSyncRowSource:
     """Chunk source over pre-materialized rows (eager fallback; not bounded-memory)."""
@@ -239,7 +253,7 @@ class EagerSyncRowSource:
         self._position += len(chunk)
         return chunk
 
-    def close(self) -> None:
+    def close(self, error: bool = False) -> None:
         self._rows = []
 
 
@@ -261,7 +275,7 @@ class EagerAsyncRowSource:
         self._position += len(chunk)
         return chunk
 
-    async def close(self) -> None:
+    async def close(self, error: bool = False) -> None:
         self._rows = []
 
 
@@ -286,5 +300,5 @@ class _LazyEagerAsyncRowSource:
         self._position += len(chunk)
         return chunk
 
-    async def close(self) -> None:
+    async def close(self, error: bool = False) -> None:
         self._rows = []

--- a/sqlspec/driver/_stream.py
+++ b/sqlspec/driver/_stream.py
@@ -141,13 +141,8 @@ class SyncRowStream(Generic[RowT]):
         self._closed = True
         self._buffer = []
         self._buffer_index = 0
-        try:
+        with contextlib.suppress(Exception):
             self._source.close(error=error)
-        except TypeError:
-            with contextlib.suppress(Exception):
-                self._source.close()
-        except Exception:
-            return
 
 
 class AsyncRowStream(Generic[RowT]):
@@ -228,13 +223,8 @@ class AsyncRowStream(Generic[RowT]):
         self._closed = True
         self._buffer = []
         self._buffer_index = 0
-        try:
+        with contextlib.suppress(Exception):
             await self._source.close(error=error)
-        except TypeError:
-            with contextlib.suppress(Exception):
-                await self._source.close()
-        except Exception:
-            return
 
 
 class EagerSyncRowSource:

--- a/sqlspec/extensions/events/_channel.py
+++ b/sqlspec/extensions/events/_channel.py
@@ -92,6 +92,12 @@ def _resolve_event_type(payload: "dict[str, Any]", metadata: "dict[str, Any] | N
 
 
 _POSTGRES_ADAPTERS = frozenset({"asyncpg", "psycopg", "psqlpy"})
+_EVENT_BACKENDS = frozenset({"notify", "notify_queue", "poll_queue", "aq", "txeventq"})
+_RETIRED_EVENT_BACKENDS = {
+    "listen_notify": "notify",
+    "listen_notify_durable": "notify_queue",
+    "table_queue": "poll_queue",
+}
 
 
 def _get_default_backend(adapter_name: "str | None") -> str:
@@ -99,6 +105,26 @@ def _get_default_backend(adapter_name: "str | None") -> str:
     if adapter_name in _POSTGRES_ADAPTERS:
         return "notify"
     return "poll_queue"
+
+
+def _resolve_backend_name(config: Any, extension_settings: "dict[str, Any]", adapter_name: "str | None") -> str:
+    """Resolve and validate event backend configuration."""
+    backend_name = extension_settings.get("backend")
+    if backend_name is None:
+        driver_features = getattr(config, "driver_features", {})
+        if isinstance(driver_features, dict):
+            backend_name = driver_features.get("events_backend")
+    if backend_name is None:
+        return _get_default_backend(adapter_name)
+    if backend_name in _RETIRED_EVENT_BACKENDS:
+        replacement = _RETIRED_EVENT_BACKENDS[backend_name]
+        msg = f"Event backend {backend_name!r} was removed; use {replacement!r}"
+        raise ImproperConfigurationError(msg)
+    if backend_name not in _EVENT_BACKENDS:
+        valid = ", ".join(sorted(_EVENT_BACKENDS))
+        msg = f"Unknown event backend {backend_name!r}; expected one of: {valid}"
+        raise ImproperConfigurationError(msg)
+    return cast("str", backend_name)
 
 
 def load_native_backend(
@@ -363,7 +389,7 @@ class SyncEventChannel:
         hints = get_runtime_hints(self._adapter_name, config)
         self._poll_interval_default = float(extension_settings.get("poll_interval") or hints.poll_interval)
         queue_backend = build_queue_backend(config, extension_settings, adapter_name=self._adapter_name, hints=hints)
-        backend_name = extension_settings.get("backend") or _get_default_backend(self._adapter_name)
+        backend_name = _resolve_backend_name(config, extension_settings, self._adapter_name)
         native_backend = load_native_backend(config, backend_name, extension_settings, adapter_name=self._adapter_name)
         if native_backend is None:
             if backend_name not in {None, "poll_queue"}:
@@ -591,7 +617,7 @@ class AsyncEventChannel:
         hints = get_runtime_hints(self._adapter_name, config)
         self._poll_interval_default = float(extension_settings.get("poll_interval") or hints.poll_interval)
         queue_backend = build_queue_backend(config, extension_settings, adapter_name=self._adapter_name, hints=hints)
-        backend_name = extension_settings.get("backend") or _get_default_backend(self._adapter_name)
+        backend_name = _resolve_backend_name(config, extension_settings, self._adapter_name)
         native_backend = load_native_backend(config, backend_name, extension_settings, adapter_name=self._adapter_name)
         if native_backend is None:
             if backend_name not in {None, "poll_queue"}:

--- a/sqlspec/extensions/events/_channel.py
+++ b/sqlspec/extensions/events/_channel.py
@@ -97,15 +97,15 @@ _POSTGRES_ADAPTERS = frozenset({"asyncpg", "psycopg", "psqlpy"})
 def _get_default_backend(adapter_name: "str | None") -> str:
     """Return the default events backend for an adapter."""
     if adapter_name in _POSTGRES_ADAPTERS:
-        return "listen_notify"
-    return "table_queue"
+        return "notify"
+    return "poll_queue"
 
 
 def load_native_backend(
     config: Any, backend_name: str | None, extension_settings: "dict[str, Any]", adapter_name: "str | None" = None
 ) -> Any | None:
     """Load adapter-specific native backend if available."""
-    if backend_name in {None, "table_queue"}:
+    if backend_name in {None, "poll_queue"}:
         return None
     adapter_name = adapter_name or resolve_adapter_name(config)
     if adapter_name is None:
@@ -366,24 +366,24 @@ class SyncEventChannel:
         backend_name = extension_settings.get("backend") or _get_default_backend(self._adapter_name)
         native_backend = load_native_backend(config, backend_name, extension_settings, adapter_name=self._adapter_name)
         if native_backend is None:
-            if backend_name not in {None, "table_queue"}:
+            if backend_name not in {None, "poll_queue"}:
                 log_with_context(
                     logger,
                     logging.WARNING,
                     "event.listen",
                     adapter_name=self._adapter_name,
                     backend_name=backend_name,
-                    fallback_backend="table_queue",
+                    fallback_backend="poll_queue",
                     status="backend_unavailable",
                 )
             self._backend = cast("SyncEventBackendProtocol", queue_backend)
-            backend_label = "table_queue"
+            backend_label = "poll_queue"
         else:
             self._backend = cast("SyncEventBackendProtocol", native_backend)
             if isinstance(native_backend, SyncEventBackendProtocol):
                 backend_label = native_backend.backend_name
             else:
-                backend_label = backend_name or "table_queue"
+                backend_label = backend_name or "poll_queue"
         self._config = config
         self._backend_name = backend_label
         self._runtime = config.get_observability_runtime()
@@ -594,24 +594,24 @@ class AsyncEventChannel:
         backend_name = extension_settings.get("backend") or _get_default_backend(self._adapter_name)
         native_backend = load_native_backend(config, backend_name, extension_settings, adapter_name=self._adapter_name)
         if native_backend is None:
-            if backend_name not in {None, "table_queue"}:
+            if backend_name not in {None, "poll_queue"}:
                 log_with_context(
                     logger,
                     logging.WARNING,
                     "event.listen",
                     adapter_name=self._adapter_name,
                     backend_name=backend_name,
-                    fallback_backend="table_queue",
+                    fallback_backend="poll_queue",
                     status="backend_unavailable",
                 )
             self._backend = cast("AsyncEventBackendProtocol", queue_backend)
-            backend_label = "table_queue"
+            backend_label = "poll_queue"
         else:
             self._backend = cast("AsyncEventBackendProtocol", native_backend)
             if isinstance(native_backend, AsyncEventBackendProtocol):
                 backend_label = native_backend.backend_name
             else:
-                backend_label = backend_name or "table_queue"
+                backend_label = backend_name or "poll_queue"
         self._config = config
         self._backend_name = backend_label
         self._runtime = config.get_observability_runtime()

--- a/sqlspec/extensions/events/_queue.py
+++ b/sqlspec/extensions/events/_queue.py
@@ -221,7 +221,7 @@ class SyncTableEventQueue(_BaseTableEventQueue):
 
     supports_sync: ClassVar[bool] = True
     supports_async: ClassVar[bool] = False
-    backend_name: ClassVar[str] = "table_queue"
+    backend_name: ClassVar[str] = "poll_queue"
 
     def publish(self, channel: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None" = None) -> str:
         event_id = uuid4().hex
@@ -428,7 +428,7 @@ class AsyncTableEventQueue(_BaseTableEventQueue):
 
     supports_sync: ClassVar[bool] = False
     supports_async: ClassVar[bool] = True
-    backend_name: ClassVar[str] = "table_queue"
+    backend_name: ClassVar[str] = "poll_queue"
 
     async def publish(self, channel: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None" = None) -> str:
         event_id = uuid4().hex

--- a/tests/integration/adapters/asyncpg/extensions/events/test_listen_notify.py
+++ b/tests/integration/adapters/asyncpg/extensions/events/test_listen_notify.py
@@ -40,7 +40,7 @@ async def test_asyncpg_hybrid_listen_notify_durable(postgres_service: "Any", tmp
     config = AsyncpgConfig(
         connection_config={"dsn": _dsn(postgres_service)},
         migration_config={"script_location": str(migrations), "include_extensions": ["events"]},
-        extension_config={"events": {"backend": "listen_notify_durable"}},
+        extension_config={"events": {"backend": "notify_queue"}},
     )
 
     await AsyncMigrationCommands(config).upgrade()
@@ -49,7 +49,7 @@ async def test_asyncpg_hybrid_listen_notify_durable(postgres_service: "Any", tmp
     spec.add_config(config)
     channel = spec.event_channel(config)
 
-    assert channel._backend_name == "listen_notify_durable"
+    assert channel._backend_name == "notify_queue"
 
     received: list[Any] = []
 
@@ -87,7 +87,7 @@ async def test_asyncpg_concurrent_multi_channel_subscribe(postgres_service: "Any
     """
 
     config = AsyncpgConfig(
-        connection_config={"dsn": _dsn(postgres_service)}, extension_config={"events": {"backend": "listen_notify"}}
+        connection_config={"dsn": _dsn(postgres_service)}, extension_config={"events": {"backend": "notify"}}
     )
 
     spec = SQLSpec()

--- a/tests/integration/adapters/contracts/_events_cases.py
+++ b/tests/integration/adapters/contracts/_events_cases.py
@@ -27,7 +27,7 @@ class EventsCase:
     adapter: str
     mode: Literal["sync", "async"]
     marks: tuple[Mark | MarkDecorator, ...] = ()
-    force_table_queue: bool = False
+    force_poll_queue: bool = False
 
 
 @dataclass(frozen=True)
@@ -74,7 +74,7 @@ SYNC_EVENTS_CASES = (
         "psycopg",
         "sync",
         marks=(POSTGRES_XDIST_MARK,),
-        force_table_queue=True,
+        force_poll_queue=True,
     ),
     EventsCase(
         "oracledb-sync",
@@ -82,7 +82,7 @@ SYNC_EVENTS_CASES = (
         "oracledb",
         "sync",
         marks=(ORACLE_XDIST_MARK,),
-        force_table_queue=True,
+        force_poll_queue=True,
     ),
 )
 
@@ -109,7 +109,7 @@ ASYNC_EVENTS_CASES = (
         "psqlpy",
         "async",
         marks=(POSTGRES_XDIST_MARK, pytest.mark.anyio),
-        force_table_queue=True,
+        force_poll_queue=True,
     ),
     EventsCase(
         "psycopg-async",
@@ -117,7 +117,7 @@ ASYNC_EVENTS_CASES = (
         "psycopg",
         "async",
         marks=(POSTGRES_XDIST_MARK, pytest.mark.anyio),
-        force_table_queue=True,
+        force_poll_queue=True,
     ),
     EventsCase(
         "oracledb-async",
@@ -125,7 +125,7 @@ ASYNC_EVENTS_CASES = (
         "oracledb",
         "async",
         marks=(ORACLE_XDIST_MARK, pytest.mark.anyio),
-        force_table_queue=True,
+        force_poll_queue=True,
     ),
 )
 
@@ -134,25 +134,19 @@ SYNC_EVENTS_PARAMS = tuple(pytest.param(case, id=case.id, marks=case.marks) for 
 ASYNC_EVENTS_PARAMS = tuple(pytest.param(case, id=case.id, marks=case.marks) for case in ASYNC_EVENTS_CASES)
 
 SYNC_LISTEN_NOTIFY_CASES = (
-    ListenNotifyCase(
-        "psycopg-sync", "listen_notify_config_psycopg_sync", "psycopg", "sync", marks=(POSTGRES_XDIST_MARK,)
-    ),
+    ListenNotifyCase("psycopg-sync", "notify_config_psycopg_sync", "psycopg", "sync", marks=(POSTGRES_XDIST_MARK,)),
 )
 
 ASYNC_LISTEN_NOTIFY_CASES = (
     ListenNotifyCase(
-        "asyncpg-async",
-        "listen_notify_config_asyncpg",
-        "asyncpg",
-        "async",
-        marks=(POSTGRES_XDIST_MARK, pytest.mark.anyio),
+        "asyncpg-async", "notify_config_asyncpg", "asyncpg", "async", marks=(POSTGRES_XDIST_MARK, pytest.mark.anyio)
     ),
     ListenNotifyCase(
-        "psqlpy-async", "listen_notify_config_psqlpy", "psqlpy", "async", marks=(POSTGRES_XDIST_MARK, pytest.mark.anyio)
+        "psqlpy-async", "notify_config_psqlpy", "psqlpy", "async", marks=(POSTGRES_XDIST_MARK, pytest.mark.anyio)
     ),
     ListenNotifyCase(
         "psycopg-async",
-        "listen_notify_config_psycopg_async",
+        "notify_config_psycopg_async",
         "psycopg",
         "async",
         marks=(POSTGRES_XDIST_MARK, pytest.mark.anyio),

--- a/tests/integration/adapters/contracts/_events_cases.py
+++ b/tests/integration/adapters/contracts/_events_cases.py
@@ -134,19 +134,25 @@ SYNC_EVENTS_PARAMS = tuple(pytest.param(case, id=case.id, marks=case.marks) for 
 ASYNC_EVENTS_PARAMS = tuple(pytest.param(case, id=case.id, marks=case.marks) for case in ASYNC_EVENTS_CASES)
 
 SYNC_LISTEN_NOTIFY_CASES = (
-    ListenNotifyCase("psycopg-sync", "notify_config_psycopg_sync", "psycopg", "sync", marks=(POSTGRES_XDIST_MARK,)),
+    ListenNotifyCase(
+        "psycopg-sync", "listen_notify_config_psycopg_sync", "psycopg", "sync", marks=(POSTGRES_XDIST_MARK,)
+    ),
 )
 
 ASYNC_LISTEN_NOTIFY_CASES = (
     ListenNotifyCase(
-        "asyncpg-async", "notify_config_asyncpg", "asyncpg", "async", marks=(POSTGRES_XDIST_MARK, pytest.mark.anyio)
+        "asyncpg-async",
+        "listen_notify_config_asyncpg",
+        "asyncpg",
+        "async",
+        marks=(POSTGRES_XDIST_MARK, pytest.mark.anyio),
     ),
     ListenNotifyCase(
-        "psqlpy-async", "notify_config_psqlpy", "psqlpy", "async", marks=(POSTGRES_XDIST_MARK, pytest.mark.anyio)
+        "psqlpy-async", "listen_notify_config_psqlpy", "psqlpy", "async", marks=(POSTGRES_XDIST_MARK, pytest.mark.anyio)
     ),
     ListenNotifyCase(
         "psycopg-async",
-        "notify_config_psycopg_async",
+        "listen_notify_config_psycopg_async",
         "psycopg",
         "async",
         marks=(POSTGRES_XDIST_MARK, pytest.mark.anyio),

--- a/tests/integration/adapters/contracts/conftest.py
+++ b/tests/integration/adapters/contracts/conftest.py
@@ -1039,7 +1039,7 @@ def listen_notify_config_asyncpg(postgres_service: PostgresService) -> Callable[
     def make(*, suffix: str) -> AsyncpgConfig:
         return AsyncpgConfig(
             connection_config={"dsn": _postgres_conninfo(postgres_service)},
-            extension_config={"events": {"backend": "listen_notify"}},
+            extension_config={"events": {"backend": "notify"}},
         )
 
     return make
@@ -1052,7 +1052,7 @@ def listen_notify_config_psqlpy(postgres_service: PostgresService) -> Callable[.
     def make(*, suffix: str) -> PsqlpyConfig:
         return PsqlpyConfig(
             connection_config=PsqlpyPoolParams(dsn=_psqlpy_dsn(postgres_service)),
-            extension_config={"events": {"backend": "listen_notify"}},
+            extension_config={"events": {"backend": "notify"}},
         )
 
     return make
@@ -1065,7 +1065,7 @@ def listen_notify_config_psycopg_sync(postgres_service: PostgresService) -> Call
     def make(*, suffix: str) -> PsycopgSyncConfig:
         return PsycopgSyncConfig(
             connection_config={"conninfo": _postgres_conninfo(postgres_service)},
-            extension_config={"events": {"backend": "listen_notify"}},
+            extension_config={"events": {"backend": "notify"}},
         )
 
     return make
@@ -1078,7 +1078,7 @@ def listen_notify_config_psycopg_async(postgres_service: PostgresService) -> Cal
     def make(*, suffix: str) -> PsycopgAsyncConfig:
         return PsycopgAsyncConfig(
             connection_config={"conninfo": _postgres_conninfo(postgres_service)},
-            extension_config={"events": {"backend": "listen_notify"}},
+            extension_config={"events": {"backend": "notify"}},
         )
 
     return make

--- a/tests/integration/adapters/contracts/events_behaviors.py
+++ b/tests/integration/adapters/contracts/events_behaviors.py
@@ -42,7 +42,7 @@ def _events_extension_config(case: EventsCase, behavior: str) -> "tuple[str, dic
     queue_table = f"evq_{token}"
     events_config: dict[str, Any] = {"queue_table": queue_table}
     if case.force_table_queue:
-        events_config["backend"] = "table_queue"
+        events_config["backend"] = "poll_queue"
     return queue_table, {"events": events_config}, token
 
 
@@ -103,7 +103,7 @@ def assert_sync_listen_notify_delivery_contract(make_config: Any, case: ListenNo
     channel = spec.event_channel(config)
     listener: Any | None = None
     try:
-        assert channel._backend_name == "listen_notify"  # pyright: ignore[reportPrivateUsage]
+        assert channel._backend_name == "notify"  # pyright: ignore[reportPrivateUsage]
         received: list[Any] = []
         listener = channel.listen(channel_name, received.append, poll_interval=_LISTEN_NOTIFY_POLL_INTERVAL)
         time.sleep(_LISTEN_NOTIFY_SUBSCRIBE_WAIT)
@@ -144,7 +144,7 @@ async def assert_async_listen_notify_delivery_contract(make_config: Any, case: L
     channel = spec.event_channel(config)
     listener: Any | None = None
     try:
-        assert channel._backend_name == "listen_notify"  # pyright: ignore[reportPrivateUsage]
+        assert channel._backend_name == "notify"  # pyright: ignore[reportPrivateUsage]
         received: list[Any] = []
 
         async def _handler(message: Any) -> None:
@@ -186,7 +186,7 @@ def assert_sync_events_queue_lifecycle_contract(make_config: Any, case: EventsCa
     config = make_config(extension_config=extension_config, suffix=suffix)
     try:
         _spec, channel = setup_sync_event_channel(config)
-        assert channel._backend_name == "table_queue"  # pyright: ignore[reportPrivateUsage]
+        assert channel._backend_name == "poll_queue"  # pyright: ignore[reportPrivateUsage]
         event_id = channel.publish("notifications", {"action": "queue"})
         message = _consume_sync(channel, "notifications")
         assert message.event_id == event_id
@@ -204,7 +204,7 @@ async def assert_async_events_queue_lifecycle_contract(make_config: Any, case: E
     config = make_config(extension_config=extension_config, suffix=suffix)
     try:
         _spec, channel = await setup_async_event_channel(config)
-        assert channel._backend_name == "table_queue"  # pyright: ignore[reportPrivateUsage]
+        assert channel._backend_name == "poll_queue"  # pyright: ignore[reportPrivateUsage]
         event_id = await channel.publish("notifications", {"action": "queue"})
         message = await _consume_async(channel, "notifications")
         assert message.event_id == event_id

--- a/tests/integration/adapters/contracts/events_behaviors.py
+++ b/tests/integration/adapters/contracts/events_behaviors.py
@@ -41,7 +41,7 @@ def _events_extension_config(case: EventsCase, behavior: str) -> "tuple[str, dic
     token = f"{case.id}_{behavior}".replace("-", "_")
     queue_table = f"evq_{token}"
     events_config: dict[str, Any] = {"queue_table": queue_table}
-    if case.force_table_queue:
+    if case.force_poll_queue:
         events_config["backend"] = "poll_queue"
     return queue_table, {"events": events_config}, token
 

--- a/tests/integration/adapters/psqlpy/extensions/events/test_listen_notify.py
+++ b/tests/integration/adapters/psqlpy/extensions/events/test_listen_notify.py
@@ -26,7 +26,7 @@ async def test_psqlpy_concurrent_same_channel_subscribers(postgres_service: "Any
 
     config = PsqlpyConfig(
         connection_config=PsqlpyPoolParams(dsn=_dsn(postgres_service)),
-        extension_config={"events": {"backend": "listen_notify"}},
+        extension_config={"events": {"backend": "notify"}},
     )
 
     spec = SQLSpec()
@@ -78,7 +78,7 @@ async def test_psqlpy_listen_notify_hybrid(postgres_service: "Any", tmp_path) ->
     config = PsqlpyConfig(
         connection_config=PsqlpyPoolParams(dsn=_dsn(postgres_service)),
         migration_config={"script_location": str(migrations), "include_extensions": ["events"]},
-        extension_config={"events": {"backend": "listen_notify_durable"}},
+        extension_config={"events": {"backend": "notify_queue"}},
     )
 
     await AsyncMigrationCommands(config).upgrade()

--- a/tests/integration/adapters/psycopg/extensions/events/test_listen_notify.py
+++ b/tests/integration/adapters/psycopg/extensions/events/test_listen_notify.py
@@ -27,7 +27,7 @@ def test_psycopg_sync_hybrid_listen_notify_durable(postgres_service: "Any", tmp_
     config = PsycopgSyncConfig(
         connection_config={"conninfo": _conninfo(postgres_service)},
         migration_config={"script_location": str(migrations), "include_extensions": ["events"]},
-        extension_config={"events": {"backend": "listen_notify_durable"}},
+        extension_config={"events": {"backend": "notify_queue"}},
     )
 
     SyncMigrationCommands(config).upgrade()
@@ -62,8 +62,7 @@ async def test_psycopg_async_multi_channel_listen_delivery(postgres_service: "An
     """
 
     config = PsycopgAsyncConfig(
-        connection_config={"conninfo": _conninfo(postgres_service)},
-        extension_config={"events": {"backend": "listen_notify"}},
+        connection_config={"conninfo": _conninfo(postgres_service)}, extension_config={"events": {"backend": "notify"}}
     )
 
     spec = SQLSpec()
@@ -105,8 +104,7 @@ def test_psycopg_sync_multi_channel_listen_delivery(postgres_service: "Any") -> 
     """Sync psycopg: same multi-channel LISTEN drop bug as the async variant."""
 
     config = PsycopgSyncConfig(
-        connection_config={"conninfo": _conninfo(postgres_service)},
-        extension_config={"events": {"backend": "listen_notify"}},
+        connection_config={"conninfo": _conninfo(postgres_service)}, extension_config={"events": {"backend": "notify"}}
     )
 
     spec = SQLSpec()
@@ -153,7 +151,7 @@ async def test_psycopg_async_hybrid_listen_notify_durable(postgres_service: "Any
     config = PsycopgAsyncConfig(
         connection_config={"conninfo": _conninfo(postgres_service)},
         migration_config={"script_location": str(migrations), "include_extensions": ["events"]},
-        extension_config={"events": {"backend": "listen_notify_durable"}},
+        extension_config={"events": {"backend": "notify_queue"}},
     )
 
     await AsyncMigrationCommands(config).upgrade()

--- a/tests/integration/extensions/events/test_native_concurrency.py
+++ b/tests/integration/extensions/events/test_native_concurrency.py
@@ -58,16 +58,14 @@ def _asyncpg_factory(service: Any) -> Any:
     config_module = importlib.import_module("sqlspec.adapters.asyncpg")
     config_cls = config_module.AsyncpgConfig
     dsn = f"postgresql://{service.user}:{service.password}@{service.host}:{service.port}/{service.database}"
-    return config_cls(connection_config={"dsn": dsn}, extension_config={"events": {"backend": "listen_notify"}})
+    return config_cls(connection_config={"dsn": dsn}, extension_config={"events": {"backend": "notify"}})
 
 
 def _psycopg_async_factory(service: Any) -> Any:
     config_module = importlib.import_module("sqlspec.adapters.psycopg")
     config_cls = config_module.PsycopgAsyncConfig
     conninfo = f"postgresql://{service.user}:{service.password}@{service.host}:{service.port}/{service.database}"
-    return config_cls(
-        connection_config={"conninfo": conninfo}, extension_config={"events": {"backend": "listen_notify"}}
-    )
+    return config_cls(connection_config={"conninfo": conninfo}, extension_config={"events": {"backend": "notify"}})
 
 
 def _psqlpy_factory(service: Any) -> Any:
@@ -75,7 +73,7 @@ def _psqlpy_factory(service: Any) -> Any:
     config_cls = config_module.PsqlpyConfig
     params_cls = config_module.PsqlpyPoolParams
     dsn = f"postgres://{service.user}:{service.password}@{service.host}:{service.port}/{service.database}"
-    return config_cls(connection_config=params_cls(dsn=dsn), extension_config={"events": {"backend": "listen_notify"}})
+    return config_cls(connection_config=params_cls(dsn=dsn), extension_config={"events": {"backend": "notify"}})
 
 
 _FACTORIES: "dict[str, ConfigFactory]" = {

--- a/tests/integration/extensions/litestar/test_channels_backend_concurrency.py
+++ b/tests/integration/extensions/litestar/test_channels_backend_concurrency.py
@@ -56,16 +56,14 @@ def _asyncpg_factory(service: Any) -> Any:
     config_module = importlib.import_module("sqlspec.adapters.asyncpg")
     config_cls = config_module.AsyncpgConfig
     dsn = f"postgresql://{service.user}:{service.password}@{service.host}:{service.port}/{service.database}"
-    return config_cls(connection_config={"dsn": dsn}, extension_config={"events": {"backend": "listen_notify"}})
+    return config_cls(connection_config={"dsn": dsn}, extension_config={"events": {"backend": "notify"}})
 
 
 def _psycopg_async_factory(service: Any) -> Any:
     config_module = importlib.import_module("sqlspec.adapters.psycopg")
     config_cls = config_module.PsycopgAsyncConfig
     conninfo = f"postgresql://{service.user}:{service.password}@{service.host}:{service.port}/{service.database}"
-    return config_cls(
-        connection_config={"conninfo": conninfo}, extension_config={"events": {"backend": "listen_notify"}}
-    )
+    return config_cls(connection_config={"conninfo": conninfo}, extension_config={"events": {"backend": "notify"}})
 
 
 def _psqlpy_factory(service: Any) -> Any:
@@ -73,7 +71,7 @@ def _psqlpy_factory(service: Any) -> Any:
     config_cls = config_module.PsqlpyConfig
     params_cls = config_module.PsqlpyPoolParams
     dsn = f"postgres://{service.user}:{service.password}@{service.host}:{service.port}/{service.database}"
-    return config_cls(connection_config=params_cls(dsn=dsn), extension_config={"events": {"backend": "listen_notify"}})
+    return config_cls(connection_config=params_cls(dsn=dsn), extension_config={"events": {"backend": "notify"}})
 
 
 _FACTORIES: "dict[str, ConfigFactory]" = {

--- a/tests/unit/adapters/test_cockroach_asyncpg/test_config.py
+++ b/tests/unit/adapters/test_cockroach_asyncpg/test_config.py
@@ -308,6 +308,6 @@ def test_cockroach_asyncpg_driver_features_typed_dict_accepts_json_features() ->
 
 def test_cockroach_asyncpg_driver_features_typed_dict_accepts_event_features() -> None:
     """TypedDict should accept event backend features."""
-    features: CockroachAsyncpgDriverFeatures = {"enable_events": True, "events_backend": "table_queue"}
+    features: CockroachAsyncpgDriverFeatures = {"enable_events": True, "events_backend": "poll_queue"}
     assert features["enable_events"] is True
-    assert features["events_backend"] == "table_queue"
+    assert features["events_backend"] == "poll_queue"

--- a/tests/unit/adapters/test_cockroach_psycopg/test_config.py
+++ b/tests/unit/adapters/test_cockroach_psycopg/test_config.py
@@ -438,9 +438,9 @@ def test_cockroach_psycopg_driver_features_typed_dict_accepts_json_features() ->
 
 def test_cockroach_psycopg_driver_features_typed_dict_accepts_event_features() -> None:
     """TypedDict should accept event backend features."""
-    features: CockroachPsycopgDriverFeatures = {"enable_events": True, "events_backend": "table_queue"}
+    features: CockroachPsycopgDriverFeatures = {"enable_events": True, "events_backend": "poll_queue"}
     assert features["enable_events"] is True
-    assert features["events_backend"] == "table_queue"
+    assert features["events_backend"] == "poll_queue"
 
 
 def test_cockroach_psycopg_driver_features_rejects_unused_uuid_preference() -> None:

--- a/tests/unit/adapters/test_mysqlconnector/test_config.py
+++ b/tests/unit/adapters/test_mysqlconnector/test_config.py
@@ -289,6 +289,45 @@ async def test_async_dispatch_select_stream_uses_driver_cursor_options(monkeypat
     connection.cursor.assert_awaited_once_with(prepared=True, buffered=False)
 
 
+def test_sync_stream_close_reconnects_instead_of_draining_unread_rows() -> None:
+    """Early close discards the dirty protocol session without fetching remaining rows."""
+    connection = MagicMock()
+    connection.unread_result = True
+    connection._cnx = None
+    cursor = MagicMock()
+    cursor.close.side_effect = RuntimeError("Unread result found")
+    driver = MagicMock(connection=connection, driver_features={})
+    source = MysqlConnectorSyncStreamSource(driver, "SELECT 1", None, 10, set())
+    source._cursor = cursor
+
+    source.close()
+
+    cursor.fetchall.assert_not_called()
+    connection.shutdown.assert_called_once_with()
+    connection.reconnect.assert_called_once_with()
+
+
+@pytest.mark.anyio
+async def test_async_stream_close_reconnects_instead_of_draining_unread_rows() -> None:
+    """Async early close replaces the dirty protocol session without fetching remaining rows."""
+    connection = MagicMock()
+    connection.unread_result = True
+    connection._cnx = None
+    connection.shutdown = AsyncMock()
+    connection.reconnect = AsyncMock()
+    cursor = MagicMock()
+    cursor.close = AsyncMock(side_effect=RuntimeError("Unread result found"))
+    driver = MagicMock(connection=connection, driver_features={})
+    source = MysqlConnectorAsyncStreamSource(driver, "SELECT 1", None, 10, set())
+    source._cursor = cursor
+
+    await source.close()
+
+    cursor.fetchall.assert_not_called()
+    connection.shutdown.assert_awaited_once_with()
+    connection.reconnect.assert_awaited_once_with()
+
+
 def test_sync_create_connection_forwards_local_infile_gate(monkeypatch: pytest.MonkeyPatch) -> None:
     """Connection creation should forward mysql-connector's local infile gate."""
     calls: list[dict[str, Any]] = []

--- a/tests/unit/adapters/test_mysqlconnector/test_config.py
+++ b/tests/unit/adapters/test_mysqlconnector/test_config.py
@@ -289,43 +289,76 @@ async def test_async_dispatch_select_stream_uses_driver_cursor_options(monkeypat
     connection.cursor.assert_awaited_once_with(prepared=True, buffered=False)
 
 
-def test_sync_stream_close_reconnects_instead_of_draining_unread_rows() -> None:
-    """Early close discards the dirty protocol session without fetching remaining rows."""
+def test_sync_stream_close_consumes_unread_rows_without_reconnecting() -> None:
+    """Early close preserves the current session and any active transaction."""
     connection = MagicMock()
     connection.unread_result = True
     connection._cnx = None
     cursor = MagicMock()
-    cursor.close.side_effect = RuntimeError("Unread result found")
     driver = MagicMock(connection=connection, driver_features={})
     source = MysqlConnectorSyncStreamSource(driver, "SELECT 1", None, 10, set())
     source._cursor = cursor
 
     source.close()
 
-    cursor.fetchall.assert_not_called()
-    connection.shutdown.assert_called_once_with()
-    connection.reconnect.assert_called_once_with()
+    connection.consume_results.assert_called_once_with()
+    cursor.close.assert_called_once_with()
+    connection.shutdown.assert_not_called()
+    connection.reconnect.assert_not_called()
+
+
+def test_sync_stream_close_closes_cursor_when_consuming_unread_rows_fails() -> None:
+    connection = MagicMock(unread_result=True, _cnx=None)
+    connection.consume_results.side_effect = RuntimeError("consume failed")
+    cursor = MagicMock()
+    source = MysqlConnectorSyncStreamSource(MagicMock(connection=connection), "SELECT 1", None, 10, set())
+    source._cursor = cursor
+
+    with pytest.raises(RuntimeError, match="consume failed"):
+        source.close()
+
+    cursor.close.assert_called_once_with()
+    connection.reconnect.assert_not_called()
 
 
 @pytest.mark.anyio
-async def test_async_stream_close_reconnects_instead_of_draining_unread_rows() -> None:
-    """Async early close replaces the dirty protocol session without fetching remaining rows."""
+async def test_async_stream_close_consumes_unread_rows_without_reconnecting() -> None:
+    """Async early close preserves the current session and active transaction."""
     connection = MagicMock()
     connection.unread_result = True
     connection._cnx = None
+    connection.consume_results = AsyncMock()
     connection.shutdown = AsyncMock()
     connection.reconnect = AsyncMock()
     cursor = MagicMock()
-    cursor.close = AsyncMock(side_effect=RuntimeError("Unread result found"))
+    cursor.close = AsyncMock()
     driver = MagicMock(connection=connection, driver_features={})
     source = MysqlConnectorAsyncStreamSource(driver, "SELECT 1", None, 10, set())
     source._cursor = cursor
 
     await source.close()
 
-    cursor.fetchall.assert_not_called()
-    connection.shutdown.assert_awaited_once_with()
-    connection.reconnect.assert_awaited_once_with()
+    connection.consume_results.assert_awaited_once_with()
+    cursor.close.assert_awaited_once_with()
+    connection.shutdown.assert_not_awaited()
+    connection.reconnect.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_async_stream_close_closes_cursor_when_consuming_unread_rows_fails() -> None:
+    connection = MagicMock(unread_result=True, _cnx=None)
+    connection.consume_results = AsyncMock(side_effect=RuntimeError("consume failed"))
+    connection.reconnect = AsyncMock()
+    cursor = MagicMock()
+    cursor.close = AsyncMock()
+    source = MysqlConnectorAsyncStreamSource(MagicMock(connection=connection), "SELECT 1", None, 10, set())
+    source._cursor = cursor
+
+    with pytest.raises(RuntimeError, match="consume failed"):
+        await source.close()
+
+    cursor.close.assert_awaited_once_with()
+    connection.reconnect.assert_not_awaited()
 
 
 def test_sync_create_connection_forwards_local_infile_gate(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/adapters/test_oracledb/test_config.py
+++ b/tests/unit/adapters/test_oracledb/test_config.py
@@ -138,7 +138,7 @@ def test_oracle_config_finite_options_use_literals_and_driver_enums() -> None:
     }
     assert set(get_args(_unwrap_not_required(driver_feature_hints["events_backend"]))) == {
         "aq",
-        "table_queue",
+        "poll_queue",
         "txeventq",
     }
 

--- a/tests/unit/driver/test_stream.py
+++ b/tests/unit/driver/test_stream.py
@@ -35,6 +35,7 @@ class FakeSyncSource:
         self.start_calls = 0
         self.fetch_calls = 0
         self.close_calls = 0
+        self.close_errors: list[bool] = []
 
     def start(self) -> None:
         self.start_calls += 1
@@ -47,6 +48,7 @@ class FakeSyncSource:
 
     def close(self, error: bool = False) -> None:
         self.close_calls += 1
+        self.close_errors.append(error)
 
 
 class FakeAsyncSource:
@@ -57,6 +59,7 @@ class FakeAsyncSource:
         self.start_calls = 0
         self.fetch_calls = 0
         self.close_calls = 0
+        self.close_errors: list[bool] = []
 
     async def start(self) -> None:
         self.start_calls += 1
@@ -69,6 +72,7 @@ class FakeAsyncSource:
 
     async def close(self, error: bool = False) -> None:
         self.close_calls += 1
+        self.close_errors.append(error)
 
 
 # --------------------------------------------------------------------------- #
@@ -149,6 +153,7 @@ def test_sync_context_manager_normal_exit_closes() -> None:
     with _sync_stream(source) as stream:
         assert next(iter(stream)) == {"id": 0}
     assert source.close_calls == 1
+    assert source.close_errors == [False]
 
 
 def test_sync_context_manager_exception_exit_closes() -> None:
@@ -156,6 +161,7 @@ def test_sync_context_manager_exception_exit_closes() -> None:
     with pytest.raises(ValueError, match="boom"), _sync_stream(source):
         raise ValueError("boom")
     assert source.close_calls == 1
+    assert source.close_errors == [True]
 
 
 # --------------------------------------------------------------------------- #
@@ -237,6 +243,7 @@ async def test_async_context_manager_normal_exit_closes() -> None:
     async with _async_stream(source) as stream:
         assert await stream.__aiter__().__anext__() == {"id": 0}
     assert source.close_calls == 1
+    assert source.close_errors == [False]
 
 
 async def test_async_context_manager_exception_exit_closes() -> None:
@@ -245,6 +252,7 @@ async def test_async_context_manager_exception_exit_closes() -> None:
         async with _async_stream(source):
             raise ValueError("boom")
     assert source.close_calls == 1
+    assert source.close_errors == [True]
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/driver/test_stream.py
+++ b/tests/unit/driver/test_stream.py
@@ -164,6 +164,18 @@ def test_sync_context_manager_exception_exit_closes() -> None:
     assert source.close_errors == [True]
 
 
+def test_sync_close_does_not_retry_when_source_raises_type_error() -> None:
+    class RaisingClose(FakeSyncSource):
+        def close(self, error: bool = False) -> None:
+            super().close(error=error)
+            raise TypeError("close boom")
+
+    source = RaisingClose([])
+    _sync_stream(source).close()
+
+    assert source.close_calls == 1
+
+
 # --------------------------------------------------------------------------- #
 # AsyncRowStream
 # --------------------------------------------------------------------------- #
@@ -253,6 +265,18 @@ async def test_async_context_manager_exception_exit_closes() -> None:
             raise ValueError("boom")
     assert source.close_calls == 1
     assert source.close_errors == [True]
+
+
+async def test_async_close_does_not_retry_when_source_raises_type_error() -> None:
+    class RaisingClose(FakeAsyncSource):
+        async def close(self, error: bool = False) -> None:
+            await super().close(error=error)
+            raise TypeError("close boom")
+
+    source = RaisingClose([])
+    await _async_stream(source).aclose()
+
+    assert source.close_calls == 1
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/driver/test_stream.py
+++ b/tests/unit/driver/test_stream.py
@@ -45,7 +45,7 @@ class FakeSyncSource:
             return self._chunks.pop(0)
         return []
 
-    def close(self) -> None:
+    def close(self, error: bool = False) -> None:
         self.close_calls += 1
 
 
@@ -67,7 +67,7 @@ class FakeAsyncSource:
             return self._chunks.pop(0)
         return []
 
-    async def close(self) -> None:
+    async def close(self, error: bool = False) -> None:
         self.close_calls += 1
 
 

--- a/tests/unit/driver/test_stream.py
+++ b/tests/unit/driver/test_stream.py
@@ -176,6 +176,26 @@ def test_sync_close_does_not_retry_when_source_raises_type_error() -> None:
     assert source.close_calls == 1
 
 
+def test_sync_close_supports_legacy_no_argument_source() -> None:
+    class LegacyCloseSource:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        def start(self) -> None:
+            pass
+
+        def fetch_chunk(self) -> "list[dict[str, Any]]":
+            return []
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    source = LegacyCloseSource()
+    _sync_stream(source).close()
+
+    assert source.close_calls == 1
+
+
 # --------------------------------------------------------------------------- #
 # AsyncRowStream
 # --------------------------------------------------------------------------- #
@@ -274,6 +294,26 @@ async def test_async_close_does_not_retry_when_source_raises_type_error() -> Non
             raise TypeError("close boom")
 
     source = RaisingClose([])
+    await _async_stream(source).aclose()
+
+    assert source.close_calls == 1
+
+
+async def test_async_close_supports_legacy_no_argument_source() -> None:
+    class LegacyCloseSource:
+        def __init__(self) -> None:
+            self.close_calls = 0
+
+        async def start(self) -> None:
+            pass
+
+        async def fetch_chunk(self) -> "list[dict[str, Any]]":
+            return []
+
+        async def close(self) -> None:
+            self.close_calls += 1
+
+    source = LegacyCloseSource()
     await _async_stream(source).aclose()
 
     assert source.close_calls == 1

--- a/tests/unit/extensions/test_events/test_backend_factories.py
+++ b/tests/unit/extensions/test_events/test_backend_factories.py
@@ -4,32 +4,32 @@
 import pytest
 
 
-def test_asyncpg_factory_listen_notify_backend() -> None:
-    """Asyncpg factory creates listen_notify backend."""
+def test_asyncpg_factory_notify_backend() -> None:
+    """Asyncpg factory creates the transient notification backend."""
     pytest.importorskip("asyncpg")
     from sqlspec.adapters.asyncpg.config import AsyncpgConfig
     from sqlspec.adapters.asyncpg.events.backend import AsyncpgEventsBackend, create_event_backend
 
     config = AsyncpgConfig(connection_config={"dsn": "postgresql://localhost/test"})
-    backend = create_event_backend(config, "listen_notify", {})
+    backend = create_event_backend(config, "notify", {})
 
     assert isinstance(backend, AsyncpgEventsBackend)
-    assert backend.backend_name == "listen_notify"
+    assert backend.backend_name == "notify"
     assert backend.supports_sync is False
     assert backend.supports_async is True
 
 
-def test_asyncpg_factory_listen_notify_durable_backend() -> None:
+def test_asyncpg_factory_notify_queue_backend() -> None:
     """Asyncpg factory creates hybrid durable backend."""
     pytest.importorskip("asyncpg")
     from sqlspec.adapters.asyncpg.config import AsyncpgConfig
     from sqlspec.adapters.asyncpg.events.backend import AsyncpgHybridEventsBackend, create_event_backend
 
     config = AsyncpgConfig(connection_config={"dsn": "postgresql://localhost/test"})
-    backend = create_event_backend(config, "listen_notify_durable", {})
+    backend = create_event_backend(config, "notify_queue", {})
 
     assert isinstance(backend, AsyncpgHybridEventsBackend)
-    assert backend.backend_name == "listen_notify_durable"
+    assert backend.backend_name == "notify_queue"
 
 
 def test_asyncpg_factory_unknown_backend_returns_none() -> None:
@@ -51,36 +51,34 @@ def test_asyncpg_factory_passes_extension_settings() -> None:
     from sqlspec.adapters.asyncpg.events.backend import AsyncpgHybridEventsBackend, create_event_backend
 
     config = AsyncpgConfig(connection_config={"dsn": "postgresql://localhost/test"})
-    backend = create_event_backend(
-        config, "listen_notify_durable", {"queue_table": "custom_queue", "lease_seconds": 60}
-    )
+    backend = create_event_backend(config, "notify_queue", {"queue_table": "custom_queue", "lease_seconds": 60})
     assert isinstance(backend, AsyncpgHybridEventsBackend)
     assert backend._queue._table_name == "custom_queue"
     assert backend._queue._lease_seconds == 60
 
 
-def test_psycopg_factory_listen_notify_async() -> None:
-    """Psycopg factory creates listen_notify backend for async config."""
+def test_psycopg_factory_notify_async() -> None:
+    """Psycopg factory creates the notification backend for async config."""
     pytest.importorskip("psycopg")
     from sqlspec.adapters.psycopg.config import PsycopgAsyncConfig
     from sqlspec.adapters.psycopg.events.backend import PsycopgAsyncEventsBackend, create_event_backend
 
     config = PsycopgAsyncConfig(connection_config={"dbname": "test"})
-    backend = create_event_backend(config, "listen_notify", {})
+    backend = create_event_backend(config, "notify", {})
 
     assert isinstance(backend, PsycopgAsyncEventsBackend)
     assert backend.supports_sync is False
     assert backend.supports_async is True
 
 
-def test_psycopg_factory_listen_notify_sync() -> None:
-    """Psycopg factory creates listen_notify backend for sync config."""
+def test_psycopg_factory_notify_sync() -> None:
+    """Psycopg factory creates the notification backend for sync config."""
     pytest.importorskip("psycopg")
     from sqlspec.adapters.psycopg.config import PsycopgSyncConfig
     from sqlspec.adapters.psycopg.events.backend import PsycopgSyncEventsBackend, create_event_backend
 
     config = PsycopgSyncConfig(connection_config={"dbname": "test"})
-    backend = create_event_backend(config, "listen_notify", {})
+    backend = create_event_backend(config, "notify", {})
 
     assert isinstance(backend, PsycopgSyncEventsBackend)
 
@@ -92,10 +90,10 @@ def test_psycopg_factory_hybrid_backend() -> None:
     from sqlspec.adapters.psycopg.events.backend import PsycopgAsyncHybridEventsBackend, create_event_backend
 
     config = PsycopgAsyncConfig(connection_config={"dbname": "test"})
-    backend = create_event_backend(config, "listen_notify_durable", {})
+    backend = create_event_backend(config, "notify_queue", {})
 
     assert isinstance(backend, PsycopgAsyncHybridEventsBackend)
-    assert backend.backend_name == "listen_notify_durable"
+    assert backend.backend_name == "notify_queue"
 
 
 def test_psycopg_factory_unknown_returns_none() -> None:
@@ -110,17 +108,17 @@ def test_psycopg_factory_unknown_returns_none() -> None:
     assert backend is None
 
 
-def test_psqlpy_factory_listen_notify_backend() -> None:
-    """Psqlpy factory creates listen_notify backend."""
+def test_psqlpy_factory_notify_backend() -> None:
+    """Psqlpy factory creates the transient notification backend."""
     pytest.importorskip("psqlpy")
     from sqlspec.adapters.psqlpy.config import PsqlpyConfig
     from sqlspec.adapters.psqlpy.events.backend import PsqlpyEventsBackend, create_event_backend
 
     config = PsqlpyConfig(connection_config={"dsn": "postgresql://localhost/test"})
-    backend = create_event_backend(config, "listen_notify", {})
+    backend = create_event_backend(config, "notify", {})
 
     assert isinstance(backend, PsqlpyEventsBackend)
-    assert backend.backend_name == "listen_notify"
+    assert backend.backend_name == "notify"
     assert backend.supports_sync is False
     assert backend.supports_async is True
 
@@ -132,10 +130,10 @@ def test_psqlpy_factory_hybrid_backend() -> None:
     from sqlspec.adapters.psqlpy.events.backend import PsqlpyHybridEventsBackend, create_event_backend
 
     config = PsqlpyConfig(connection_config={"dsn": "postgresql://localhost/test"})
-    backend = create_event_backend(config, "listen_notify_durable", {})
+    backend = create_event_backend(config, "notify_queue", {})
 
     assert isinstance(backend, PsqlpyHybridEventsBackend)
-    assert backend.backend_name == "listen_notify_durable"
+    assert backend.backend_name == "notify_queue"
 
 
 def test_psqlpy_factory_hybrid_passes_settings() -> None:
@@ -145,9 +143,7 @@ def test_psqlpy_factory_hybrid_passes_settings() -> None:
     from sqlspec.adapters.psqlpy.events.backend import PsqlpyHybridEventsBackend, create_event_backend
 
     config = PsqlpyConfig(connection_config={"dsn": "postgresql://localhost/test"})
-    backend = create_event_backend(
-        config, "listen_notify_durable", {"queue_table": "custom_events", "lease_seconds": 45}
-    )
+    backend = create_event_backend(config, "notify_queue", {"queue_table": "custom_events", "lease_seconds": 45})
     assert isinstance(backend, PsqlpyHybridEventsBackend)
     assert backend._queue._table_name == "custom_events"
     assert backend._queue._lease_seconds == 45
@@ -214,7 +210,7 @@ def test_oracle_factory_unknown_returns_none() -> None:
     from sqlspec.adapters.oracledb.events.backend import create_event_backend
 
     config = OracleSyncConfig(connection_config={"dsn": "localhost/xe"})
-    backend = create_event_backend(config, "listen_notify", {})
+    backend = create_event_backend(config, "notify", {})
 
     assert backend is None
 
@@ -469,7 +465,7 @@ def test_asyncpg_hybrid_backend_has_shutdown() -> None:
     from sqlspec.adapters.asyncpg.events.backend import create_event_backend
 
     config = AsyncpgConfig(connection_config={"dsn": "postgresql://localhost/test"})
-    backend = create_event_backend(config, "listen_notify_durable", {})
+    backend = create_event_backend(config, "notify_queue", {})
     assert backend is not None
     assert hasattr(backend, "shutdown")
     assert callable(backend.shutdown)
@@ -497,7 +493,7 @@ async def test_asyncpg_hybrid_backend_shutdown_idempotent() -> None:
     from sqlspec.adapters.asyncpg.events.backend import create_event_backend
 
     config = AsyncpgConfig(connection_config={"dsn": "postgresql://localhost/test"})
-    backend = create_event_backend(config, "listen_notify_durable", {})
+    backend = create_event_backend(config, "notify_queue", {})
     assert backend is not None
     await backend.shutdown()
     await backend.shutdown()
@@ -523,7 +519,7 @@ def test_psycopg_hybrid_backend_has_shutdown() -> None:
     from sqlspec.adapters.psycopg.events.backend import create_event_backend
 
     config = PsycopgAsyncConfig(connection_config={"dbname": "test"})
-    backend = create_event_backend(config, "listen_notify_durable", {})
+    backend = create_event_backend(config, "notify_queue", {})
     assert backend is not None
     assert hasattr(backend, "shutdown")
     assert callable(backend.shutdown)
@@ -551,7 +547,7 @@ async def test_psycopg_hybrid_backend_shutdown_idempotent() -> None:
     from sqlspec.adapters.psycopg.events.backend import PsycopgAsyncHybridEventsBackend, create_event_backend
 
     config = PsycopgAsyncConfig(connection_config={"dbname": "test"})
-    backend = create_event_backend(config, "listen_notify_durable", {})
+    backend = create_event_backend(config, "notify_queue", {})
     assert isinstance(backend, PsycopgAsyncHybridEventsBackend)
     await backend.shutdown()
     await backend.shutdown()
@@ -577,7 +573,7 @@ def test_psqlpy_hybrid_backend_has_shutdown() -> None:
     from sqlspec.adapters.psqlpy.events.backend import create_event_backend
 
     config = PsqlpyConfig(connection_config={"dsn": "postgresql://localhost/test"})
-    backend = create_event_backend(config, "listen_notify_durable", {})
+    backend = create_event_backend(config, "notify_queue", {})
     assert backend is not None
     assert hasattr(backend, "shutdown")
     assert callable(backend.shutdown)
@@ -605,7 +601,7 @@ async def test_psqlpy_hybrid_backend_shutdown_idempotent() -> None:
     from sqlspec.adapters.psqlpy.events.backend import create_event_backend
 
     config = PsqlpyConfig(connection_config={"dsn": "postgresql://localhost/test"})
-    backend = create_event_backend(config, "listen_notify_durable", {})
+    backend = create_event_backend(config, "notify_queue", {})
     assert backend is not None
     await backend.shutdown()
     await backend.shutdown()

--- a/tests/unit/extensions/test_events/test_channel_extended.py
+++ b/tests/unit/extensions/test_events/test_channel_extended.py
@@ -59,12 +59,58 @@ def test_event_channel_backend_name_poll_queue(tmp_path) -> None:
     assert channel._backend_name == "poll_queue"
 
 
-def test_event_channel_backend_fallback_warning(tmp_path) -> None:
-    """EventChannel falls back to poll_queue for unavailable backends."""
+def test_event_channel_rejects_unknown_backend(tmp_path) -> None:
+    """Unknown backend names must not silently change delivery semantics."""
     config = SqliteConfig(
         connection_config={"database": str(tmp_path / "test.db")},
         extension_config={"events": {"backend": "nonexistent_backend"}},
     )
+    with pytest.raises(ImproperConfigurationError, match="Unknown event backend"):
+        SyncEventChannel(config)
+
+
+@pytest.mark.parametrize(
+    ("retired", "replacement"),
+    (("listen_notify", "notify"), ("listen_notify_durable", "notify_queue"), ("table_queue", "poll_queue")),
+)
+def test_event_channel_rejects_retired_backend_with_migration_guidance(
+    tmp_path, retired: str, replacement: str
+) -> None:
+    """Retired backend names fail explicitly with their canonical replacement."""
+    config = SqliteConfig(
+        connection_config={"database": str(tmp_path / "test.db")}, extension_config={"events": {"backend": retired}}
+    )
+
+    with pytest.raises(ImproperConfigurationError, match=rf"use '{replacement}'"):
+        SyncEventChannel(config)
+
+
+def test_event_channel_honors_driver_feature_backend(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """Adapter driver features select the backend when extension config does not."""
+    selected: list[str | None] = []
+
+    def capture_backend(config: Any, backend_name: str | None, settings: dict[str, Any], adapter_name: str) -> None:
+        selected.append(backend_name)
+
+    monkeypatch.setattr("sqlspec.extensions.events._channel.load_native_backend", capture_backend)
+    config = SqliteConfig(
+        connection_config={"database": str(tmp_path / "test.db")}, driver_features={"events_backend": "notify"}
+    )
+
+    channel = SyncEventChannel(config)
+
+    assert channel._backend_name == "poll_queue"
+    assert selected == ["notify"]
+
+
+def test_event_extension_backend_takes_precedence_over_driver_feature(tmp_path) -> None:
+    """The extension setting is the primary event transport selector."""
+    config = SqliteConfig(
+        connection_config={"database": str(tmp_path / "test.db")},
+        driver_features={"events_backend": "listen_notify"},
+        extension_config={"events": {"backend": "poll_queue"}},
+    )
+
     channel = SyncEventChannel(config)
 
     assert channel._backend_name == "poll_queue"

--- a/tests/unit/extensions/test_events/test_channel_extended.py
+++ b/tests/unit/extensions/test_events/test_channel_extended.py
@@ -51,23 +51,23 @@ def test_event_channel_custom_poll_interval(tmp_path) -> None:
     assert channel._poll_interval_default == 0.5
 
 
-def test_event_channel_backend_name_table_queue(tmp_path) -> None:
-    """EventChannel defaults to table_queue backend."""
+def test_event_channel_backend_name_poll_queue(tmp_path) -> None:
+    """EventChannel defaults to the durable polling queue backend."""
     config = SqliteConfig(connection_config={"database": str(tmp_path / "test.db")})
     channel = SyncEventChannel(config)
 
-    assert channel._backend_name == "table_queue"
+    assert channel._backend_name == "poll_queue"
 
 
 def test_event_channel_backend_fallback_warning(tmp_path) -> None:
-    """EventChannel falls back to table_queue for unavailable backends."""
+    """EventChannel falls back to poll_queue for unavailable backends."""
     config = SqliteConfig(
         connection_config={"database": str(tmp_path / "test.db")},
         extension_config={"events": {"backend": "nonexistent_backend"}},
     )
     channel = SyncEventChannel(config)
 
-    assert channel._backend_name == "table_queue"
+    assert channel._backend_name == "poll_queue"
 
 
 def test_sync_event_channel_is_sync_class(tmp_path) -> None:
@@ -198,12 +198,12 @@ def test_event_channel_resolve_adapter_name_non_sqlspec_module(tmp_path) -> None
     assert result is None
 
 
-def test_event_channel_load_native_backend_table_queue_returns_none(tmp_path) -> None:
-    """load_native_backend returns None for table_queue backend name."""
+def test_event_channel_load_native_backend_poll_queue_returns_none(tmp_path) -> None:
+    """load_native_backend returns None for poll_queue backend name."""
     from sqlspec.extensions.events import load_native_backend
 
     config = SqliteConfig(connection_config={"database": str(tmp_path / "test.db")})
-    result = load_native_backend(config, "table_queue", {})
+    result = load_native_backend(config, "poll_queue", {})
 
     assert result is None
 
@@ -234,7 +234,7 @@ def test_load_native_backend_uses_pre_resolved_adapter_name(monkeypatch: pytest.
     CustomConfig.__module__ = "myapp.database.config"
     monkeypatch.setattr("sqlspec.extensions.events._channel.importlib.import_module", fake_import_module)
 
-    result = load_native_backend(CustomConfig(), "listen_notify", {}, adapter_name="sqlite")
+    result = load_native_backend(CustomConfig(), "notify", {}, adapter_name="sqlite")
 
     assert result is None
     assert imported_modules == ["sqlspec.adapters.sqlite.events.backend"]

--- a/tests/unit/extensions/test_events/test_events_config.py
+++ b/tests/unit/extensions/test_events/test_events_config.py
@@ -1,6 +1,18 @@
 """Configuration-related tests for extension auto-migration inclusion."""
 
+from typing import get_args, get_type_hints
+
 from sqlspec.adapters.sqlite import SqliteConfig
+from sqlspec.config import EventsConfig
+
+
+def test_events_backend_literal_uses_canonical_transport_names() -> None:
+    """The SQLSpec selector excludes the Litestar Queues-only polling mode."""
+
+    backend_hint = get_type_hints(EventsConfig)["backend"]
+    backend_literal = get_args(backend_hint)[0]
+
+    assert set(get_args(backend_literal)) == {"notify", "notify_queue", "poll_queue", "aq", "txeventq"}
 
 
 def test_events_extension_auto_includes_migrations(tmp_path) -> None:
@@ -36,7 +48,7 @@ def test_exclude_extensions_prevents_auto_inclusion(tmp_path) -> None:
     config = SqliteConfig(
         connection_config={"database": str(tmp_path / "events_skip.db")},
         migration_config={"script_location": "migrations", "exclude_extensions": ["events"]},
-        extension_config={"events": {"backend": "listen_notify"}},
+        extension_config={"events": {"backend": "notify"}},
     )
 
     include_extensions = config.migration_config.get("include_extensions")
@@ -107,7 +119,7 @@ def test_multiple_extensions_auto_include_migrations(tmp_path) -> None:
         extension_config={
             "litestar": {"session_table": True},  # Needs session_table for migrations
             "adk": {},
-            "events": {"backend": "table_queue"},
+            "events": {"backend": "poll_queue"},
         },
     )
 
@@ -124,7 +136,7 @@ def test_exclude_extensions_partial(tmp_path) -> None:
     config = SqliteConfig(
         connection_config={"database": str(tmp_path / "partial.db")},
         migration_config={"script_location": "migrations", "exclude_extensions": ["events"]},
-        extension_config={"litestar": {"session_table": True}, "events": {"backend": "listen_notify"}},
+        extension_config={"litestar": {"session_table": True}, "events": {"backend": "notify"}},
     )
 
     include_extensions = config.migration_config.get("include_extensions")

--- a/tests/unit/extensions/test_events/test_events_config.py
+++ b/tests/unit/extensions/test_events/test_events_config.py
@@ -1,6 +1,10 @@
 """Configuration-related tests for extension auto-migration inclusion."""
 
+import importlib
+from pathlib import Path
 from typing import get_args, get_type_hints
+
+import pytest
 
 from sqlspec.adapters.sqlite import SqliteConfig
 from sqlspec.config import EventsConfig
@@ -13,6 +17,40 @@ def test_events_backend_literal_uses_canonical_transport_names() -> None:
     backend_literal = get_args(backend_hint)[0]
 
     assert set(get_args(backend_literal)) == {"notify", "notify_queue", "poll_queue", "aq", "txeventq"}
+
+_POSTGRES_DRIVER_FEATURES = (
+    ("sqlspec.adapters.asyncpg.config", "AsyncpgDriverFeatures"),
+    ("sqlspec.adapters.psycopg.config", "PsycopgDriverFeatures"),
+    ("sqlspec.adapters.psqlpy.config", "PsqlpyDriverFeatures"),
+)
+_POSTGRES_EVENT_BACKENDS = {"notify", "notify_queue", "poll_queue"}
+_RETIRED_EVENT_BACKENDS = ("listen_notify", "listen_notify_durable", "table_queue")
+
+
+@pytest.mark.parametrize(("module_name", "features_name"), _POSTGRES_DRIVER_FEATURES)
+def test_postgres_driver_feature_event_backends_are_canonical_literals(module_name: str, features_name: str) -> None:
+    """PostgreSQL adapter feature typing exposes only canonical event transports."""
+    module = importlib.import_module(module_name)
+    features = getattr(module, features_name)
+    annotation = features.__annotations__["events_backend"]
+    literal = get_args(annotation)[0]
+
+    assert set(get_args(literal)) == _POSTGRES_EVENT_BACKENDS
+
+
+def test_active_event_config_prose_uses_canonical_transport_names() -> None:
+    """Active adapter config and event reference docs do not advertise retired names."""
+    project_root = Path(__file__).parents[4]
+    paths = [*project_root.glob("sqlspec/adapters/*/config.py"), project_root / "docs/reference/extensions/events.rst"]
+
+    violations = {
+        str(path.relative_to(project_root)): retired
+        for path in paths
+        for retired in _RETIRED_EVENT_BACKENDS
+        if retired in path.read_text(encoding="utf-8")
+    }
+
+    assert violations == {}
 
 
 def test_events_extension_auto_includes_migrations(tmp_path) -> None:

--- a/tests/unit/extensions/test_events/test_events_config.py
+++ b/tests/unit/extensions/test_events/test_events_config.py
@@ -14,9 +14,11 @@ def test_events_backend_literal_uses_canonical_transport_names() -> None:
     """The SQLSpec selector excludes the Litestar Queues-only polling mode."""
 
     backend_hint = get_type_hints(EventsConfig)["backend"]
-    backend_literal = get_args(backend_hint)[0]
+    backend_args = get_args(backend_hint)
+    backend_values = get_args(backend_args[0]) if len(backend_args) == 1 and get_args(backend_args[0]) else backend_args
 
-    assert set(get_args(backend_literal)) == {"notify", "notify_queue", "poll_queue", "aq", "txeventq"}
+    assert set(backend_values) == {"notify", "notify_queue", "poll_queue", "aq", "txeventq"}
+
 
 _POSTGRES_DRIVER_FEATURES = (
     ("sqlspec.adapters.asyncpg.config", "AsyncpgDriverFeatures"),

--- a/tests/unit/extensions/test_events/test_queue.py
+++ b/tests/unit/extensions/test_events/test_queue.py
@@ -19,8 +19,8 @@ def test_table_event_queue_classes_are_final_with_classvar_flags() -> None:
     assert SyncTableEventQueue.supports_async is False
     assert AsyncTableEventQueue.supports_sync is False
     assert AsyncTableEventQueue.supports_async is True
-    assert SyncTableEventQueue.backend_name == "table_queue"
-    assert AsyncTableEventQueue.backend_name == "table_queue"
+    assert SyncTableEventQueue.backend_name == "poll_queue"
+    assert AsyncTableEventQueue.backend_name == "poll_queue"
 
 
 def test_table_event_queue_default_table_name(tmp_path) -> None:
@@ -327,7 +327,7 @@ def test_parse_event_timestamp_none() -> None:
 
 def test_sync_table_event_queue_backend_name() -> None:
     """SyncTableEventQueue has correct backend_name."""
-    assert SyncTableEventQueue.backend_name == "table_queue"
+    assert SyncTableEventQueue.backend_name == "poll_queue"
 
 
 def test_sync_table_event_queue_supports_sync() -> None:


### PR DESCRIPTION
## Summary

- align bounded row-stream cleanup and transaction behavior across adapters
- consolidate Arrow fallback behavior and adapter contract cleanup
- define canonical event transports: `notify`, `notify_queue`, `poll_queue`, `aq`, and `txeventq`
- add typed adapter event configuration and accurate durable-delivery documentation

## Review fixes

- context-manager failures roll back and cleanup `TypeError` is not retried
- legacy duck-typed stream sources with `close()` still clean up correctly
- mysql-connector early close consumes unread rows without replacing an active transaction session
- retired event names fail explicitly with canonical migration guidance rather than silently selecting polling
- adapter `events_backend` features are honored when extension configuration does not override them
- native event fixtures remain collected and Python 3.14 type introspection remains supported

## Stack

This is the base PR for #635, which contains listener lifecycle, batching, polling/recovery, and final transport documentation.

## Validation

- focused stream, Arrow, event, mysql-connector, and configuration tests
- Ruff, mypy, and pyright
- full GitHub unit/integration matrix on Python 3.10-3.14
- docs, source distribution, pure wheel, MyPyC wheel, and package integrity checks

All GitHub checks are green.