### PR TITLE
perf: defer optional typing imports

### DIFF
--- a/docs/reference/typing.rst
+++ b/docs/reference/typing.rst
@@ -7,6 +7,29 @@ SQLSpec.
 
 .. currentmodule:: sqlspec.typing
 
+Optional dependency exports
+===========================
+
+The :mod:`sqlspec.typing` and :mod:`sqlspec._typing` modules resolve heavy
+optional-dependency symbols lazily. Importing :mod:`sqlspec` does not import
+Pydantic, Litestar, PyArrow, pandas, Polars, OpenTelemetry, or Prometheus.
+Accessing one of their exported symbols imports its dependency on first use and
+caches the resolved object::
+
+   import sqlspec.typing as sqlspec_typing
+
+   arrow_table_type = sqlspec_typing.ArrowTable  # Imports PyArrow here.
+
+When an optional dependency is not installed, the same access returns a stable
+typed shim. Repeated access returns the identical real object or shim, preserving
+annotation and runtime identity behavior. Features that require the dependency
+still raise the normal missing-dependency error when enabled.
+
+``msgspec`` remains eager because its core types and conversion functions are
+used throughout result mapping and serialization. ``orjson`` also remains on
+the existing eager path; both have a small measured import cost compared with
+the deferred integrations.
+
 Metadata Types
 ==============
 

--- a/sqlspec/_typing.py
+++ b/sqlspec/_typing.py
@@ -10,7 +10,7 @@ import enum
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, ClassVar, Final, Literal, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, ClassVar, Final, Literal, Protocol, cast, runtime_checkable
 
 from typing_extensions import Self, TypeVar, dataclass_transform
 
@@ -21,6 +21,28 @@ from sqlspec.utils.module_loader import (
     module_available,
     resolve_optional_attr,
 )
+
+if TYPE_CHECKING:
+    from attrs import AttrsInstance
+    from attrs import asdict as attrs_asdict
+    from attrs import define as attrs_define
+    from attrs import field as attrs_field
+    from attrs import fields as attrs_fields
+    from attrs import has as attrs_has
+    from cattrs import structure as cattrs_structure
+    from cattrs import unstructure as cattrs_unstructure
+    from litestar.dto.data_structures import DTOData
+    from numpy import ndarray as NumpyArray  # noqa: N812
+    from opentelemetry import trace
+    from opentelemetry.trace import Span, Status, StatusCode, Tracer
+    from pandas import DataFrame as PandasDataFrame
+    from polars import DataFrame as PolarsDataFrame
+    from prometheus_client import Counter, Gauge, Histogram
+    from pyarrow import RecordBatch as ArrowRecordBatch
+    from pyarrow import RecordBatchReader as ArrowRecordBatchReader
+    from pyarrow import Schema as ArrowSchema
+    from pyarrow import Table as ArrowTable
+    from pydantic import BaseModel, FailFast, TypeAdapter
 
 __all__ = (
     "ALLOYDB_CONNECTOR_INSTALLED",
@@ -514,7 +536,7 @@ class NumpyArrayStub(Protocol):
 _NUMPY_ARRAY_SHIM = NumpyArrayStub
 
 
-class Span:
+class _SpanShim:
     def set_attribute(self, key: str, value: Any) -> None:
         return None
 
@@ -540,11 +562,12 @@ class Span:
         return None
 
 
-_SPAN_SHIM = Span
-del Span
+_SPAN_SHIM = _SpanShim
+_SPAN_SHIM.__name__ = "Span"
+_SPAN_SHIM.__qualname__ = "Span"
 
 
-class Tracer:
+class _TracerShim:
     def start_span(
         self,
         name: str,
@@ -555,12 +578,13 @@ class Tracer:
         start_time: Any = None,
         record_exception: bool = True,
         set_status_on_exception: bool = True,
-    ) -> "_SPAN_SHIM":
-        return _SPAN_SHIM()  # type: ignore[abstract]
+    ) -> "_SpanShim":
+        return _SPAN_SHIM()
 
 
-_TRACER_SHIM = Tracer
-del Tracer
+_TRACER_SHIM = _TracerShim
+_TRACER_SHIM.__name__ = "Tracer"
+_TRACER_SHIM.__qualname__ = "Tracer"
 
 
 class _TraceModule:
@@ -570,8 +594,8 @@ class _TraceModule:
         instrumenting_library_version: "str | None" = None,
         schema_url: "str | None" = None,
         tracer_provider: Any = None,
-    ) -> "_TRACER_SHIM":
-        return _TRACER_SHIM()  # type: ignore[abstract] # pragma: no cover
+    ) -> "_TracerShim":
+        return _TRACER_SHIM()  # pragma: no cover
 
     def get_tracer_provider(self) -> Any:  # pragma: no cover
         return None
@@ -620,31 +644,34 @@ class _MetricInstance:
         return None
 
 
-class Counter(_Metric):  # type: ignore[no-redef]
+class _CounterShim(_Metric):
     def labels(self, *labelvalues: str, **labelkwargs: str) -> "_MetricInstance":
         return _MetricInstance()  # pragma: no cover
 
 
-_COUNTER_SHIM = Counter
-del Counter
+_COUNTER_SHIM = _CounterShim
+_COUNTER_SHIM.__name__ = "Counter"
+_COUNTER_SHIM.__qualname__ = "Counter"
 
 
-class Gauge(_Metric):  # type: ignore[no-redef]
+class _GaugeShim(_Metric):
     def labels(self, *labelvalues: str, **labelkwargs: str) -> "_MetricInstance":
         return _MetricInstance()  # pragma: no cover
 
 
-_GAUGE_SHIM = Gauge
-del Gauge
+_GAUGE_SHIM = _GaugeShim
+_GAUGE_SHIM.__name__ = "Gauge"
+_GAUGE_SHIM.__qualname__ = "Gauge"
 
 
-class Histogram(_Metric):  # type: ignore[no-redef]
+class _HistogramShim(_Metric):
     def labels(self, *labelvalues: str, **labelkwargs: str) -> "_MetricInstance":
         return _MetricInstance()  # pragma: no cover
 
 
-_HISTOGRAM_SHIM = Histogram
-del Histogram
+_HISTOGRAM_SHIM = _HistogramShim
+_HISTOGRAM_SHIM.__name__ = "Histogram"
+_HISTOGRAM_SHIM.__qualname__ = "Histogram"
 
 
 ATTRS_INSTALLED = dependency_flag("attrs")
@@ -679,14 +706,6 @@ _ATTRS_FIELDS_SHIM = attrs_fields_stub
 _ATTRS_HAS_SHIM = attrs_has_stub
 _CATTRS_STRUCTURE_SHIM = cattrs_structure_stub
 _CATTRS_UNSTRUCTURE_SHIM = cattrs_unstructure_stub
-_ARROW_TABLE_SHIM = ArrowTableResult
-_ARROW_RECORD_BATCH_SHIM = ArrowRecordBatchResult
-_ARROW_SCHEMA_SHIM = ArrowSchemaProtocol
-_ARROW_RECORD_BATCH_READER_SHIM = ArrowRecordBatchReaderProtocol
-_PANDAS_DATAFRAME_SHIM = PandasDataFrameProtocol
-_POLARS_DATAFRAME_SHIM = PolarsDataFrameProtocol
-_NUMPY_ARRAY_SHIM = NumpyArrayStub
-
 _LAZY_EXPORTS: "dict[str, tuple[str, str, Any]]" = {
     "ArrowRecordBatch": ("pyarrow", "RecordBatch", _ARROW_RECORD_BATCH_SHIM),
     "ArrowRecordBatchReader": ("pyarrow", "RecordBatchReader", _ARROW_RECORD_BATCH_READER_SHIM),

--- a/sqlspec/_typing.py
+++ b/sqlspec/_typing.py
@@ -705,7 +705,11 @@ _ATTRS_FIELD_SHIM = attrs_field_stub
 _ATTRS_FIELDS_SHIM = attrs_fields_stub
 _ATTRS_HAS_SHIM = attrs_has_stub
 _CATTRS_STRUCTURE_SHIM = cattrs_structure_stub
+_CATTRS_STRUCTURE_SHIM.__name__ = "cattrs_structure"
+_CATTRS_STRUCTURE_SHIM.__qualname__ = "cattrs_structure"
 _CATTRS_UNSTRUCTURE_SHIM = cattrs_unstructure_stub
+_CATTRS_UNSTRUCTURE_SHIM.__name__ = "cattrs_unstructure"
+_CATTRS_UNSTRUCTURE_SHIM.__qualname__ = "cattrs_unstructure"
 _LAZY_EXPORTS: "dict[str, tuple[str, str | None, Any]]" = {
     "ArrowRecordBatch": ("pyarrow", "RecordBatch", _ARROW_RECORD_BATCH_SHIM),
     "ArrowRecordBatchReader": ("pyarrow", "RecordBatchReader", _ARROW_RECORD_BATCH_READER_SHIM),

--- a/sqlspec/_typing.py
+++ b/sqlspec/_typing.py
@@ -706,7 +706,7 @@ _ATTRS_FIELDS_SHIM = attrs_fields_stub
 _ATTRS_HAS_SHIM = attrs_has_stub
 _CATTRS_STRUCTURE_SHIM = cattrs_structure_stub
 _CATTRS_UNSTRUCTURE_SHIM = cattrs_unstructure_stub
-_LAZY_EXPORTS: "dict[str, tuple[str, str, Any]]" = {
+_LAZY_EXPORTS: "dict[str, tuple[str, str | None, Any]]" = {
     "ArrowRecordBatch": ("pyarrow", "RecordBatch", _ARROW_RECORD_BATCH_SHIM),
     "ArrowRecordBatchReader": ("pyarrow", "RecordBatchReader", _ARROW_RECORD_BATCH_READER_SHIM),
     "ArrowSchema": ("pyarrow", "Schema", _ARROW_SCHEMA_SHIM),
@@ -733,7 +733,7 @@ _LAZY_EXPORTS: "dict[str, tuple[str, str, Any]]" = {
     "attrs_has": ("attrs", "has", _ATTRS_HAS_SHIM),
     "cattrs_structure": ("cattrs", "structure", _CATTRS_STRUCTURE_SHIM),
     "cattrs_unstructure": ("cattrs", "unstructure", _CATTRS_UNSTRUCTURE_SHIM),
-    "trace": ("opentelemetry", "trace", _TRACE_SHIM),
+    "trace": ("opentelemetry.trace", None, _TRACE_SHIM),
 }
 
 

--- a/sqlspec/_typing.py
+++ b/sqlspec/_typing.py
@@ -14,7 +14,13 @@ from typing import Any, ClassVar, Final, Literal, Protocol, cast, runtime_checka
 
 from typing_extensions import Self, TypeVar, dataclass_transform
 
-from sqlspec.utils.module_loader import dependency_flag, import_optional, import_optional_attr, module_available
+from sqlspec.utils.module_loader import (
+    dependency_flag,
+    import_optional,
+    import_optional_attr,
+    module_available,
+    resolve_optional_attr,
+)
 
 __all__ = (
     "ALLOYDB_CONNECTOR_INSTALLED",
@@ -198,20 +204,6 @@ class FailFastStub:
     fail_fast: bool = True
 
 
-# Try to import real implementations at runtime
-try:
-    from pydantic import BaseModel as _RealBaseModel
-    from pydantic import FailFast as _RealFailFast
-    from pydantic import TypeAdapter as _RealTypeAdapter
-
-    BaseModel = _RealBaseModel
-    TypeAdapter = _RealTypeAdapter
-    FailFast = _RealFailFast
-except ImportError:
-    BaseModel = BaseModelStub  # type: ignore[assignment,misc]
-    TypeAdapter = TypeAdapterStub  # type: ignore[assignment,misc]
-    FailFast = FailFastStub  # type: ignore[assignment,misc]
-
 # Always define stub types for msgspec
 
 
@@ -304,15 +296,6 @@ class DTODataStub(Protocol[T]):
         return {}
 
 
-# Try to import real implementation at runtime
-try:
-    from litestar.dto.data_structures import DTOData as _RealDTOData  # pyright: ignore[reportUnknownVariableType]
-
-    DTOData = _RealDTOData
-except ImportError:
-    DTOData = DTODataStub  # type: ignore[assignment,misc]
-
-
 # Always define stub types for attrs
 @dataclass_transform()
 class AttrsInstanceStub:
@@ -358,41 +341,14 @@ def attrs_has_stub(*args: Any, **kwargs: Any) -> bool:  # noqa: ARG001
     return False
 
 
-# Try to import real implementations at runtime
-try:
-    from attrs import AttrsInstance as _RealAttrsInstance  # pyright: ignore
-    from attrs import asdict as _real_attrs_asdict
-    from attrs import define as _real_attrs_define
-    from attrs import field as _real_attrs_field
-    from attrs import fields as _real_attrs_fields
-    from attrs import has as _real_attrs_has
+def cattrs_unstructure_stub(*args: Any, **kwargs: Any) -> Any:  # noqa: ARG001
+    """Placeholder implementation"""
+    return {}
 
-    AttrsInstance = _RealAttrsInstance
-    attrs_asdict = _real_attrs_asdict
-    attrs_define = _real_attrs_define
-    attrs_field = _real_attrs_field
-    attrs_fields = _real_attrs_fields
-    attrs_has = _real_attrs_has
-except ImportError:
-    AttrsInstance = AttrsInstanceStub  # type: ignore[misc]
-    attrs_asdict = attrs_asdict_stub
-    attrs_define = attrs_define_stub
-    attrs_field = attrs_field_stub
-    attrs_fields = attrs_fields_stub
-    attrs_has = attrs_has_stub  # type: ignore[assignment]
 
-try:
-    from cattrs import structure as cattrs_structure
-    from cattrs import unstructure as cattrs_unstructure
-except ImportError:
-
-    def cattrs_unstructure(*args: Any, **kwargs: Any) -> Any:  # noqa: ARG001
-        """Placeholder implementation"""
-        return {}
-
-    def cattrs_structure(*args: Any, **kwargs: Any) -> Any:  # noqa: ARG001
-        """Placeholder implementation"""
-        return {}
+def cattrs_structure_stub(*args: Any, **kwargs: Any) -> Any:  # noqa: ARG001
+    """Placeholder implementation"""
+    return {}
 
 
 class EmptyEnum(Enum):
@@ -505,16 +461,10 @@ class ArrowRecordBatchReaderProtocol(Protocol):
         ...
 
 
-try:
-    from pyarrow import RecordBatch as ArrowRecordBatch
-    from pyarrow import RecordBatchReader as ArrowRecordBatchReader
-    from pyarrow import Schema as ArrowSchema
-    from pyarrow import Table as ArrowTable
-except ImportError:
-    ArrowTable = ArrowTableResult  # type: ignore[assignment,misc]
-    ArrowRecordBatch = ArrowRecordBatchResult  # type: ignore[assignment,misc]
-    ArrowSchema = ArrowSchemaProtocol  # type: ignore[assignment,misc]
-    ArrowRecordBatchReader = ArrowRecordBatchReaderProtocol  # type: ignore[assignment,misc]
+_ARROW_TABLE_SHIM = ArrowTableResult
+_ARROW_RECORD_BATCH_SHIM = ArrowRecordBatchResult
+_ARROW_SCHEMA_SHIM = ArrowSchemaProtocol
+_ARROW_RECORD_BATCH_READER_SHIM = ArrowRecordBatchReaderProtocol
 
 
 @runtime_checkable
@@ -543,17 +493,10 @@ class PolarsDataFrameProtocol(Protocol):
         ...
 
 
-try:
-    from pandas import DataFrame as PandasDataFrame
-except ImportError:
-    PandasDataFrame = PandasDataFrameProtocol  # type: ignore[assignment,misc]
+_PANDAS_DATAFRAME_SHIM = PandasDataFrameProtocol
 
 
-try:
-    from polars import DataFrame as PolarsDataFrame
-
-except ImportError:
-    PolarsDataFrame = PolarsDataFrameProtocol  # type: ignore[assignment,misc]
+_POLARS_DATAFRAME_SHIM = PolarsDataFrameProtocol
 
 
 @runtime_checkable
@@ -568,136 +511,140 @@ class NumpyArrayStub(Protocol):
         ...
 
 
-try:
-    from numpy import ndarray as NumpyArray  # noqa: N812
-except ImportError:
-    NumpyArray = NumpyArrayStub  # type: ignore[assignment,misc]
+_NUMPY_ARRAY_SHIM = NumpyArrayStub
 
 
-try:
-    from opentelemetry import trace  # pyright: ignore[reportMissingImports, reportAssignmentType]
-    from opentelemetry.trace import (  # pyright: ignore[reportMissingImports, reportAssignmentType]
-        Span,  # pyright: ignore[reportMissingImports, reportAssignmentType]
-        Status,
-        StatusCode,
-        Tracer,  # pyright: ignore[reportMissingImports, reportAssignmentType]
-    )
-except ImportError:
-    # Define shims for when opentelemetry is not installed
+class Span:
+    def set_attribute(self, key: str, value: Any) -> None:
+        return None
 
-    class Span:  # type: ignore[no-redef]
-        def set_attribute(self, key: str, value: Any) -> None:
-            return None
+    def record_exception(
+        self,
+        exception: "Exception",
+        attributes: "Mapping[str, Any] | None" = None,
+        timestamp: "int | None" = None,
+        escaped: bool = False,
+    ) -> None:
+        return None
 
-        def record_exception(
-            self,
-            exception: "Exception",
-            attributes: "Mapping[str, Any] | None" = None,
-            timestamp: "int | None" = None,
-            escaped: bool = False,
-        ) -> None:
-            return None
+    def set_status(self, status: Any, description: "str | None" = None) -> None:
+        return None
 
-        def set_status(self, status: Any, description: "str | None" = None) -> None:
-            return None
+    def end(self, end_time: "int | None" = None) -> None:
+        return None
 
-        def end(self, end_time: "int | None" = None) -> None:
-            return None
+    def __enter__(self) -> Self:
+        return self
 
-        def __enter__(self) -> Self:
-            return self
-
-        def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
-            return None
-
-    class Tracer:  # type: ignore[no-redef]
-        def start_span(
-            self,
-            name: str,
-            context: Any = None,
-            kind: Any = None,
-            attributes: Any = None,
-            links: Any = None,
-            start_time: Any = None,
-            record_exception: bool = True,
-            set_status_on_exception: bool = True,
-        ) -> Span:
-            return Span()  # type: ignore[abstract]
-
-    class _TraceModule:
-        def get_tracer(
-            self,
-            instrumenting_module_name: str,
-            instrumenting_library_version: "str | None" = None,
-            schema_url: "str | None" = None,
-            tracer_provider: Any = None,
-        ) -> Tracer:
-            return Tracer()  # type: ignore[abstract] # pragma: no cover
-
-        def get_tracer_provider(self) -> Any:  # pragma: no cover
-            return None
-
-        TracerProvider = type(None)  # Shim for TracerProvider if needed elsewhere
-        StatusCode = type(None)  # Shim for StatusCode
-        Status = type(None)  # Shim for Status
-
-    trace = _TraceModule()  # type: ignore[assignment]
-    StatusCode = trace.StatusCode  # type: ignore[misc]
-    Status = trace.Status  # type: ignore[misc]
+    def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> None:
+        return None
 
 
-try:
-    from prometheus_client import (  # pyright: ignore[reportMissingImports, reportAssignmentType]
-        Counter,  # pyright: ignore[reportAssignmentType]
-        Gauge,  # pyright: ignore[reportAssignmentType]
-        Histogram,  # pyright: ignore[reportAssignmentType]
-    )
-except ImportError:
-    # Define shims for when prometheus_client is not installed
+_SPAN_SHIM = Span
+del Span
 
-    class _Metric:  # Base shim for metrics
-        def __init__(
-            self,
-            name: str,
-            documentation: str,
-            labelnames: tuple[str, ...] = (),
-            namespace: str = "",
-            subsystem: str = "",
-            unit: str = "",
-            registry: Any = None,
-            ejemplar_fn: Any = None,
-            buckets: Any = None,
-            **_: Any,
-        ) -> None:
-            return None
 
-        def labels(self, *labelvalues: str, **labelkwargs: str) -> "_MetricInstance":
-            return _MetricInstance()
+class Tracer:
+    def start_span(
+        self,
+        name: str,
+        context: Any = None,
+        kind: Any = None,
+        attributes: Any = None,
+        links: Any = None,
+        start_time: Any = None,
+        record_exception: bool = True,
+        set_status_on_exception: bool = True,
+    ) -> "_SPAN_SHIM":
+        return _SPAN_SHIM()  # type: ignore[abstract]
 
-    class _MetricInstance:
-        def inc(self, amount: float = 1) -> None:
-            return None
 
-        def dec(self, amount: float = 1) -> None:
-            return None
+_TRACER_SHIM = Tracer
+del Tracer
 
-        def set(self, value: float) -> None:
-            return None
 
-        def observe(self, amount: float) -> None:
-            return None
+class _TraceModule:
+    def get_tracer(
+        self,
+        instrumenting_module_name: str,
+        instrumenting_library_version: "str | None" = None,
+        schema_url: "str | None" = None,
+        tracer_provider: Any = None,
+    ) -> "_TRACER_SHIM":
+        return _TRACER_SHIM()  # type: ignore[abstract] # pragma: no cover
 
-    class Counter(_Metric):  # type: ignore[no-redef]
-        def labels(self, *labelvalues: str, **labelkwargs: str) -> _MetricInstance:
-            return _MetricInstance()  # pragma: no cover
+    def get_tracer_provider(self) -> Any:  # pragma: no cover
+        return None
 
-    class Gauge(_Metric):  # type: ignore[no-redef]
-        def labels(self, *labelvalues: str, **labelkwargs: str) -> _MetricInstance:
-            return _MetricInstance()  # pragma: no cover
+    TracerProvider = type(None)  # Shim for TracerProvider if needed elsewhere
+    StatusCode = type(None)  # Shim for StatusCode
+    Status = type(None)  # Shim for Status
 
-    class Histogram(_Metric):  # type: ignore[no-redef]
-        def labels(self, *labelvalues: str, **labelkwargs: str) -> _MetricInstance:
-            return _MetricInstance()  # pragma: no cover
+
+_TRACE_SHIM = _TraceModule()
+_STATUS_CODE_SHIM = type(None)
+_STATUS_SHIM = type(None)
+
+
+class _Metric:  # Base shim for metrics
+    def __init__(
+        self,
+        name: str,
+        documentation: str,
+        labelnames: tuple[str, ...] = (),
+        namespace: str = "",
+        subsystem: str = "",
+        unit: str = "",
+        registry: Any = None,
+        ejemplar_fn: Any = None,
+        buckets: Any = None,
+        **_: Any,
+    ) -> None:
+        return None
+
+    def labels(self, *labelvalues: str, **labelkwargs: str) -> "_MetricInstance":
+        return _MetricInstance()
+
+
+class _MetricInstance:
+    def inc(self, amount: float = 1) -> None:
+        return None
+
+    def dec(self, amount: float = 1) -> None:
+        return None
+
+    def set(self, value: float) -> None:
+        return None
+
+    def observe(self, amount: float) -> None:
+        return None
+
+
+class Counter(_Metric):  # type: ignore[no-redef]
+    def labels(self, *labelvalues: str, **labelkwargs: str) -> "_MetricInstance":
+        return _MetricInstance()  # pragma: no cover
+
+
+_COUNTER_SHIM = Counter
+del Counter
+
+
+class Gauge(_Metric):  # type: ignore[no-redef]
+    def labels(self, *labelvalues: str, **labelkwargs: str) -> "_MetricInstance":
+        return _MetricInstance()  # pragma: no cover
+
+
+_GAUGE_SHIM = Gauge
+del Gauge
+
+
+class Histogram(_Metric):  # type: ignore[no-redef]
+    def labels(self, *labelvalues: str, **labelkwargs: str) -> "_MetricInstance":
+        return _MetricInstance()  # pragma: no cover
+
+
+_HISTOGRAM_SHIM = Histogram
+del Histogram
 
 
 ATTRS_INSTALLED = dependency_flag("attrs")
@@ -719,3 +666,73 @@ PYDANTIC_INSTALLED = dependency_flag("pydantic")
 ALLOYDB_CONNECTOR_INSTALLED = dependency_flag("google.cloud.alloydb.connector")
 NANOID_INSTALLED = dependency_flag("fastnanoid")
 UUID_UTILS_INSTALLED = dependency_flag("uuid_utils")
+
+_BASE_MODEL_SHIM = BaseModelStub
+_TYPE_ADAPTER_SHIM = TypeAdapterStub
+_FAIL_FAST_SHIM = FailFastStub
+_DTO_DATA_SHIM = DTODataStub
+_ATTRS_INSTANCE_SHIM = AttrsInstanceStub
+_ATTRS_ASDICT_SHIM = attrs_asdict_stub
+_ATTRS_DEFINE_SHIM = attrs_define_stub
+_ATTRS_FIELD_SHIM = attrs_field_stub
+_ATTRS_FIELDS_SHIM = attrs_fields_stub
+_ATTRS_HAS_SHIM = attrs_has_stub
+_CATTRS_STRUCTURE_SHIM = cattrs_structure_stub
+_CATTRS_UNSTRUCTURE_SHIM = cattrs_unstructure_stub
+_ARROW_TABLE_SHIM = ArrowTableResult
+_ARROW_RECORD_BATCH_SHIM = ArrowRecordBatchResult
+_ARROW_SCHEMA_SHIM = ArrowSchemaProtocol
+_ARROW_RECORD_BATCH_READER_SHIM = ArrowRecordBatchReaderProtocol
+_PANDAS_DATAFRAME_SHIM = PandasDataFrameProtocol
+_POLARS_DATAFRAME_SHIM = PolarsDataFrameProtocol
+_NUMPY_ARRAY_SHIM = NumpyArrayStub
+
+_LAZY_EXPORTS: "dict[str, tuple[str, str, Any]]" = {
+    "ArrowRecordBatch": ("pyarrow", "RecordBatch", _ARROW_RECORD_BATCH_SHIM),
+    "ArrowRecordBatchReader": ("pyarrow", "RecordBatchReader", _ARROW_RECORD_BATCH_READER_SHIM),
+    "ArrowSchema": ("pyarrow", "Schema", _ARROW_SCHEMA_SHIM),
+    "ArrowTable": ("pyarrow", "Table", _ARROW_TABLE_SHIM),
+    "AttrsInstance": ("attrs", "AttrsInstance", _ATTRS_INSTANCE_SHIM),
+    "BaseModel": ("pydantic", "BaseModel", _BASE_MODEL_SHIM),
+    "Counter": ("prometheus_client", "Counter", _COUNTER_SHIM),
+    "DTOData": ("litestar.dto.data_structures", "DTOData", _DTO_DATA_SHIM),
+    "FailFast": ("pydantic", "FailFast", _FAIL_FAST_SHIM),
+    "Gauge": ("prometheus_client", "Gauge", _GAUGE_SHIM),
+    "Histogram": ("prometheus_client", "Histogram", _HISTOGRAM_SHIM),
+    "NumpyArray": ("numpy", "ndarray", _NUMPY_ARRAY_SHIM),
+    "PandasDataFrame": ("pandas", "DataFrame", _PANDAS_DATAFRAME_SHIM),
+    "PolarsDataFrame": ("polars", "DataFrame", _POLARS_DATAFRAME_SHIM),
+    "Span": ("opentelemetry.trace", "Span", _SPAN_SHIM),
+    "Status": ("opentelemetry.trace", "Status", _STATUS_SHIM),
+    "StatusCode": ("opentelemetry.trace", "StatusCode", _STATUS_CODE_SHIM),
+    "Tracer": ("opentelemetry.trace", "Tracer", _TRACER_SHIM),
+    "TypeAdapter": ("pydantic", "TypeAdapter", _TYPE_ADAPTER_SHIM),
+    "attrs_asdict": ("attrs", "asdict", _ATTRS_ASDICT_SHIM),
+    "attrs_define": ("attrs", "define", _ATTRS_DEFINE_SHIM),
+    "attrs_field": ("attrs", "field", _ATTRS_FIELD_SHIM),
+    "attrs_fields": ("attrs", "fields", _ATTRS_FIELDS_SHIM),
+    "attrs_has": ("attrs", "has", _ATTRS_HAS_SHIM),
+    "cattrs_structure": ("cattrs", "structure", _CATTRS_STRUCTURE_SHIM),
+    "cattrs_unstructure": ("cattrs", "unstructure", _CATTRS_UNSTRUCTURE_SHIM),
+    "trace": ("opentelemetry", "trace", _TRACE_SHIM),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve optional dependency symbols lazily on first access."""
+
+    try:
+        module_name, attr_name, fallback = _LAZY_EXPORTS[name]
+    except KeyError:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg) from None
+
+    resolved = resolve_optional_attr(module_name, attr_name, fallback)
+    globals()[name] = resolved
+    return resolved
+
+
+def __dir__() -> "list[str]":
+    """Expose the public surface for autocomplete and ``dir()``."""
+
+    return sorted(set(globals()) | set(__all__))

--- a/sqlspec/storage/backends/base.py
+++ b/sqlspec/storage/backends/base.py
@@ -11,10 +11,10 @@ from typing import TYPE_CHECKING, Any, cast
 from mypy_extensions import mypyc_attr
 from typing_extensions import Self
 
-from sqlspec.typing import ArrowRecordBatch, ArrowTable
-
 if TYPE_CHECKING:
     from types import TracebackType
+
+    from sqlspec.typing import ArrowRecordBatch, ArrowTable
 
 __all__ = (
     "AsyncArrowBatchIterator",
@@ -270,17 +270,17 @@ class ObjectStoreBase(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def read_arrow_sync(self, path: str, **kwargs: Any) -> ArrowTable:
+    def read_arrow_sync(self, path: str, **kwargs: Any) -> "ArrowTable":
         """Read Arrow table from storage synchronously."""
         raise NotImplementedError
 
     @abstractmethod
-    def write_arrow_sync(self, path: str, table: ArrowTable, **kwargs: Any) -> None:
+    def write_arrow_sync(self, path: str, table: "ArrowTable", **kwargs: Any) -> None:
         """Write Arrow table to storage synchronously."""
         raise NotImplementedError
 
     @abstractmethod
-    def stream_arrow_sync(self, pattern: str, **kwargs: Any) -> Iterator[ArrowRecordBatch]:
+    def stream_arrow_sync(self, pattern: str, **kwargs: Any) -> "Iterator[ArrowRecordBatch]":
         """Stream Arrow record batches from storage synchronously."""
         raise NotImplementedError
 
@@ -342,17 +342,17 @@ class ObjectStoreBase(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def read_arrow_async(self, path: str, **kwargs: Any) -> ArrowTable:
+    async def read_arrow_async(self, path: str, **kwargs: Any) -> "ArrowTable":
         """Read Arrow table from storage asynchronously."""
         raise NotImplementedError
 
     @abstractmethod
-    async def write_arrow_async(self, path: str, table: ArrowTable, **kwargs: Any) -> None:
+    async def write_arrow_async(self, path: str, table: "ArrowTable", **kwargs: Any) -> None:
         """Write Arrow table to storage asynchronously."""
         raise NotImplementedError
 
     # NOTE: Returns AsyncIterator directly; keep in sync with ObjectStoreProtocol.
     @abstractmethod
-    def stream_arrow_async(self, pattern: str, **kwargs: Any) -> AsyncIterator[ArrowRecordBatch]:
+    def stream_arrow_async(self, pattern: str, **kwargs: Any) -> "AsyncIterator[ArrowRecordBatch]":
         """Stream Arrow record batches from storage asynchronously."""
         raise NotImplementedError

--- a/sqlspec/storage/backends/obstore.py
+++ b/sqlspec/storage/backends/obstore.py
@@ -23,8 +23,10 @@ from sqlspec.storage.backends.base import AsyncArrowBatchIterator, AsyncObStoreS
 
 if TYPE_CHECKING:
     from obstore.store import ObjectStore
+
+    from sqlspec.typing import ArrowRecordBatch, ArrowTable
+
 from sqlspec.storage.errors import execute_sync_storage_operation
-from sqlspec.typing import ArrowRecordBatch, ArrowTable
 from sqlspec.utils.module_loader import ensure_obstore
 from sqlspec.utils.sync_tools import async_
 
@@ -404,7 +406,7 @@ class ObStoreBackend:
         except Exception:
             return False
 
-    def read_arrow_sync(self, path: "str | Path", **kwargs: Any) -> ArrowTable:
+    def read_arrow_sync(self, path: "str | Path", **kwargs: Any) -> "ArrowTable":
         """Read Arrow table using obstore synchronously."""
         pq = import_pyarrow_parquet()
         resolved_path = self._resolve_path(path)
@@ -428,7 +430,7 @@ class ObStoreBackend:
         )
         return result
 
-    def write_arrow_sync(self, path: "str | Path", table: ArrowTable, **kwargs: Any) -> None:
+    def write_arrow_sync(self, path: "str | Path", table: "ArrowTable", **kwargs: Any) -> None:
         """Write Arrow table using obstore synchronously."""
         pa = import_pyarrow()
         pq = import_pyarrow_parquet()
@@ -489,7 +491,7 @@ class ObStoreBackend:
         for chunk in result.stream(min_chunk_size=chunk_size):
             yield bytes(chunk)
 
-    def stream_arrow_sync(self, pattern: str, **kwargs: Any) -> Iterator[ArrowRecordBatch]:
+    def stream_arrow_sync(self, pattern: str, **kwargs: Any) -> "Iterator[ArrowRecordBatch]":
         """Stream Arrow record batches using obstore's native streaming synchronously.
 
         For each matching file, streams data through a buffered wrapper
@@ -792,7 +794,7 @@ class ObStoreBackend:
         else:
             return result
 
-    async def read_arrow_async(self, path: "str | Path", **kwargs: Any) -> ArrowTable:
+    async def read_arrow_async(self, path: "str | Path", **kwargs: Any) -> "ArrowTable":
         """Read Arrow table from storage asynchronously.
 
         Uses async_() with storage limiter to offload blocking PyArrow I/O to thread pool.
@@ -813,7 +815,7 @@ class ObStoreBackend:
         )
         return cast("ArrowTable", result)
 
-    async def write_arrow_async(self, path: "str | Path", table: ArrowTable, **kwargs: Any) -> None:
+    async def write_arrow_async(self, path: "str | Path", table: "ArrowTable", **kwargs: Any) -> None:
         """Write Arrow table to storage asynchronously.
 
         Uses async_() with storage limiter to offload blocking PyArrow serialization

--- a/sqlspec/typing.py
+++ b/sqlspec/typing.py
@@ -8,7 +8,7 @@ API.
 
 from collections.abc import Iterator, Mapping
 from functools import lru_cache
-from typing import Annotated, Any, Literal, Protocol, TypeAlias
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Protocol, TypeAlias
 
 from typing_extensions import TypeVar
 
@@ -50,6 +50,39 @@ from sqlspec._typing import (
     module_available,
     msgspec_fields,
 )
+
+if TYPE_CHECKING:
+    from sqlspec._typing import (
+        ArrowRecordBatch,
+        ArrowRecordBatchReader,
+        ArrowRecordBatchReaderProtocol,
+        ArrowSchema,
+        ArrowSchemaProtocol,
+        ArrowTable,
+        AttrsInstance,
+        BaseModel,
+        Counter,
+        DTOData,
+        FailFast,
+        Gauge,
+        Histogram,
+        NumpyArray,
+        PandasDataFrame,
+        PolarsDataFrame,
+        Span,
+        Status,
+        StatusCode,
+        Tracer,
+        TypeAdapter,
+        attrs_asdict,
+        attrs_define,
+        attrs_field,
+        attrs_fields,
+        attrs_has,
+        cattrs_structure,
+        cattrs_unstructure,
+        trace,
+    )
 
 __all__ = (
     "ALLOYDB_CONNECTOR_INSTALLED",
@@ -218,6 +251,8 @@ def get_type_adapter(f: "type[T]") -> Any:
     Returns:
         :class:`pydantic.TypeAdapter`[:class:`typing.TypeVar`[T]]
     """
+    type_adapter = _typing.TypeAdapter
     if PYDANTIC_USE_FAILFAST:
-        return TypeAdapter(Annotated[f, FailFast()])
-    return TypeAdapter(f)
+        fail_fast = _typing.FailFast
+        return type_adapter(Annotated[f, fail_fast()])
+    return type_adapter(f)

--- a/sqlspec/typing.py
+++ b/sqlspec/typing.py
@@ -12,6 +12,7 @@ from typing import Annotated, Any, Literal, Protocol, TypeAlias
 
 from typing_extensions import TypeVar
 
+from sqlspec import _typing
 from sqlspec._typing import (
     ALLOYDB_CONNECTOR_INSTALLED,
     ATTRS_INSTALLED,
@@ -33,50 +34,21 @@ from sqlspec._typing import (
     PYDANTIC_INSTALLED,
     UNSET,
     UUID_UTILS_INSTALLED,
-    ArrowRecordBatch,
-    ArrowRecordBatchReader,
-    ArrowRecordBatchReaderProtocol,
-    ArrowSchema,
-    ArrowSchemaProtocol,
-    ArrowTable,
-    AttrsInstance,
     AttrsInstanceStub,
-    BaseModel,
     BaseModelStub,
-    Counter,
     DataclassProtocol,
-    DTOData,
     Empty,
     EmptyEnum,
     EmptyType,
-    FailFast,
-    Gauge,
-    Histogram,
     MsgspecValidationError,
-    NumpyArray,
-    PandasDataFrame,
-    PolarsDataFrame,
-    Span,
-    Status,
-    StatusCode,
     Struct,
     StructStub,
-    Tracer,
-    TypeAdapter,
     UnsetType,
-    attrs_asdict,
-    attrs_define,
-    attrs_field,
-    attrs_fields,
-    attrs_has,
-    cattrs_structure,
-    cattrs_unstructure,
     convert,
     import_optional,
     import_optional_attr,
     module_available,
     msgspec_fields,
-    trace,
 )
 
 __all__ = (
@@ -151,6 +123,29 @@ __all__ = (
     "msgspec_fields",
     "trace",
 )
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve lazy typing exports on demand."""
+
+    if name not in __all__:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg)
+
+    try:
+        value = getattr(_typing, name)
+    except AttributeError:
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg) from None
+
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> "list[str]":
+    """Expose the public surface for autocomplete and ``dir()``."""
+
+    return sorted(set(globals()) | set(__all__))
 
 
 class DictLike(Protocol):

--- a/sqlspec/utils/module_loader.py
+++ b/sqlspec/utils/module_loader.py
@@ -8,7 +8,7 @@ module paths to filesystem paths, and ensuring optional dependencies are install
 import importlib
 from importlib.util import find_spec
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from sqlspec.exceptions import MissingDependencyError
 
@@ -147,8 +147,8 @@ def import_optional_attr(module_name: str, attr: str) -> Any:
     return getattr(module, attr, None)
 
 
-def resolve_optional_attr(module_name: str, attr: str, fallback: T) -> T:
-    """Return ``module.attr`` when available, otherwise the provided fallback.
+def resolve_optional_attr(module_name: str, attr: "str | None", fallback: T) -> T:
+    """Return an optional module or attribute, otherwise the provided fallback.
 
     Unlike :func:`import_optional_attr`, this keeps the caller-supplied shim
     object stable so module-level caches can preserve identity when the optional
@@ -156,7 +156,8 @@ def resolve_optional_attr(module_name: str, attr: str, fallback: T) -> T:
 
     Args:
         module_name: Dotted module path to import.
-        attr: Attribute name to resolve on the imported module.
+        attr: Attribute name to resolve on the imported module. Returns the
+            module itself when ``None``.
         fallback: Shim object to return when the module or attribute is missing.
 
     Returns:
@@ -166,6 +167,8 @@ def resolve_optional_attr(module_name: str, attr: str, fallback: T) -> T:
     module = import_optional(module_name)
     if module is None:
         return fallback
+    if attr is None:
+        return cast("T", module)
     resolved = getattr(module, attr, None)
     return fallback if resolved is None else resolved
 

--- a/sqlspec/utils/module_loader.py
+++ b/sqlspec/utils/module_loader.py
@@ -8,7 +8,7 @@ module paths to filesystem paths, and ensuring optional dependencies are install
 import importlib
 from importlib.util import find_spec
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from sqlspec.exceptions import MissingDependencyError
 
@@ -40,6 +40,7 @@ __all__ = (
     "module_available",
     "module_to_os_path",
     "reset_dependency_cache",
+    "resolve_optional_attr",
 )
 
 
@@ -49,6 +50,7 @@ __all__ = (
 
 _dependency_cache: "dict[str, bool]" = {}
 _optional_module_cache: "dict[str, ModuleType | None]" = {}
+T = TypeVar("T")
 
 
 def module_available(module_name: str) -> bool:
@@ -143,6 +145,29 @@ def import_optional_attr(module_name: str, attr: str) -> Any:
     if module is None:
         return None
     return getattr(module, attr, None)
+
+
+def resolve_optional_attr(module_name: str, attr: str, fallback: T) -> T:
+    """Return ``module.attr`` when available, otherwise the provided fallback.
+
+    Unlike :func:`import_optional_attr`, this keeps the caller-supplied shim
+    object stable so module-level caches can preserve identity when the optional
+    dependency is missing.
+
+    Args:
+        module_name: Dotted module path to import.
+        attr: Attribute name to resolve on the imported module.
+        fallback: Shim object to return when the module or attribute is missing.
+
+    Returns:
+        The resolved attribute or the fallback shim.
+    """
+
+    module = import_optional(module_name)
+    if module is None:
+        return fallback
+    resolved = getattr(module, attr, None)
+    return fallback if resolved is None else resolved
 
 
 class OptionalDependencyFlag:

--- a/sqlspec/utils/schema.py
+++ b/sqlspec/utils/schema.py
@@ -13,19 +13,10 @@ from typing_extensions import TypeVar
 
 from sqlspec.data_dictionary import ForeignKeyMetadata
 from sqlspec.exceptions import SQLSpecError
-from sqlspec.typing import (
-    CATTRS_INSTALLED,
-    NUMPY_INSTALLED,
-    MsgspecValidationError,
-    SchemaT,
-    attrs_asdict,
-    cattrs_structure,
-    cattrs_unstructure,
-    convert,
-    get_type_adapter,
-)
+from sqlspec.typing import CATTRS_INSTALLED, NUMPY_INSTALLED, MsgspecValidationError, SchemaT, convert, get_type_adapter
 from sqlspec.utils.dispatch import TypeDispatcher
 from sqlspec.utils.logging import get_logger
+from sqlspec.utils.module_loader import import_optional_attr
 from sqlspec.utils.serializers import from_json
 from sqlspec.utils.text import camelize, kebabize, pascalize
 from sqlspec.utils.type_guards import (
@@ -405,12 +396,15 @@ def _convert_pydantic(data: Any, schema_type: Any) -> Any:
 def _convert_attrs(data: Any, schema_type: Any) -> Any:
     """Convert data to attrs class."""
     if CATTRS_INSTALLED:
+        cattrs_structure = import_optional_attr("cattrs", "structure")
+        cattrs_unstructure = import_optional_attr("cattrs", "unstructure")
         if isinstance(data, Sequence):
             return cattrs_structure(data, list[schema_type])
         structured = cattrs_unstructure(data) if is_attrs_instance(data) else data
         return cattrs_structure(structured, schema_type)
 
     if isinstance(data, list):
+        attrs_asdict = import_optional_attr("attrs", "asdict")
         return [schema_type(**item) if is_dict(item) else schema_type(**attrs_asdict(item)) for item in data]
     return schema_type(**data) if is_dict(data) else data
 

--- a/sqlspec/utils/serializers/_json.py
+++ b/sqlspec/utils/serializers/_json.py
@@ -6,20 +6,13 @@ import enum
 import json
 import uuid as uuid_mod
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from decimal import Decimal
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path, PurePath
 from typing import Any, Final, Literal, Protocol, cast, overload
 
-from sqlspec.typing import (
-    MSGSPEC_INSTALLED,
-    NUMPY_INSTALLED,
-    ORJSON_INSTALLED,
-    PYDANTIC_INSTALLED,
-    BaseModel,
-    attrs_asdict,
-)
+from sqlspec.typing import MSGSPEC_INSTALLED, NUMPY_INSTALLED, ORJSON_INSTALLED, PYDANTIC_INSTALLED
 from sqlspec.utils.logging import get_logger
 from sqlspec.utils.module_loader import import_optional_attr
 from sqlspec.utils.type_guards import dataclass_to_dict, is_attrs_instance, is_dataclass_instance, is_msgspec_struct
@@ -115,23 +108,70 @@ def _default_type_encoders() -> "dict[type, Callable[[Any], Any]]":
 
         encoders[pgproto.UUID] = str
 
-    if NUMPY_INSTALLED:
-        import numpy as np
-
-        encoders[np.ndarray] = lambda v: v.tolist()
-        encoders[np.generic] = lambda v: v.item()
-
-    if PYDANTIC_INSTALLED:
-        encoders[BaseModel] = _dump_pydantic_model
-
     return encoders
 
 
-DEFAULT_TYPE_ENCODERS: Final["dict[type, Callable[[Any], Any]]"] = _default_type_encoders()
+class _LazyTypeEncoders(dict[type, Callable[[Any], Any]]):
+    """Load optional type keys when the public registry is first used."""
+
+    __slots__ = ("_loaded",)
+
+    def __init__(self, encoders: "dict[type, Callable[[Any], Any]]") -> None:
+        super().__init__(encoders)
+        self._loaded = False
+
+    def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        self._loaded = True
+        if NUMPY_INSTALLED:
+            ndarray = cast("type[Any]", import_optional_attr("numpy", "ndarray"))
+            generic = cast("type[Any]", import_optional_attr("numpy", "generic"))
+            dict.__setitem__(self, ndarray, lambda value: value.tolist())
+            dict.__setitem__(self, generic, lambda value: value.item())
+        if PYDANTIC_INSTALLED:
+            base_model = cast("type[Any]", import_optional_attr("pydantic", "BaseModel"))
+            dict.__setitem__(self, base_model, _dump_pydantic_model)
+
+    def __contains__(self, key: object) -> bool:
+        self._ensure_loaded()
+        return super().__contains__(key)
+
+    def __getitem__(self, key: type) -> "Callable[[Any], Any]":
+        self._ensure_loaded()
+        return super().__getitem__(key)
+
+    def __iter__(self) -> "Iterator[type]":
+        self._ensure_loaded()
+        return super().__iter__()
+
+    def __len__(self) -> int:
+        self._ensure_loaded()
+        return super().__len__()
+
+    def get(self, key: type, default: Any = None) -> Any:
+        self._ensure_loaded()
+        return super().get(key, default)
+
+    def items(self) -> "Any":
+        self._ensure_loaded()
+        return super().items()
+
+    def keys(self) -> "Any":
+        self._ensure_loaded()
+        return super().keys()
+
+    def values(self) -> "Any":
+        self._ensure_loaded()
+        return super().values()
+
+
+DEFAULT_TYPE_ENCODERS: Final["dict[type, Callable[[Any], Any]]"] = _LazyTypeEncoders(_default_type_encoders())
 _STRUCTURAL_ENCODER_CACHE: Final["dict[type[Any], StructuralEncoder | None]"] = {}
 
 
 def _dump_attrs_instance(value: Any) -> Any:
+    attrs_asdict = import_optional_attr("attrs", "asdict")
     return attrs_asdict(value, recurse=True)
 
 

--- a/sqlspec/utils/serializers/_json.py
+++ b/sqlspec/utils/serializers/_json.py
@@ -10,7 +10,10 @@ from collections.abc import Callable, Iterator, Mapping
 from decimal import Decimal
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import Path, PurePath
-from typing import Any, Final, Literal, Protocol, cast, overload
+from typing import TYPE_CHECKING, Any, Final, Literal, Protocol, cast, overload
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 from sqlspec.typing import MSGSPEC_INSTALLED, NUMPY_INSTALLED, ORJSON_INSTALLED, PYDANTIC_INSTALLED
 from sqlspec.utils.logging import get_logger
@@ -115,6 +118,7 @@ class _LazyTypeEncoders(dict[type, Callable[[Any], Any]]):
     """Load optional type keys when the public registry is first used."""
 
     __slots__ = ("_loaded",)
+    __hash__ = None
 
     def __init__(self, encoders: "dict[type, Callable[[Any], Any]]") -> None:
         super().__init__(encoders)
@@ -137,6 +141,16 @@ class _LazyTypeEncoders(dict[type, Callable[[Any], Any]]):
         self._ensure_loaded()
         return super().__contains__(key)
 
+    def __delitem__(self, key: type) -> None:
+        self._ensure_loaded()
+        super().__delitem__(key)
+
+    def __eq__(self, other: object) -> bool:
+        self._ensure_loaded()
+        if isinstance(other, _LazyTypeEncoders):
+            other._ensure_loaded()
+        return super().__eq__(other)
+
     def __getitem__(self, key: type) -> "Callable[[Any], Any]":
         self._ensure_loaded()
         return super().__getitem__(key)
@@ -149,6 +163,38 @@ class _LazyTypeEncoders(dict[type, Callable[[Any], Any]]):
         self._ensure_loaded()
         return super().__len__()
 
+    def __ne__(self, other: object) -> bool:
+        return not self == other
+
+    def __or__(self, other: "dict[Any, Any]", /) -> "dict[Any, Any]":
+        self._ensure_loaded()
+        return super().__or__(other)
+
+    def __ror__(self, other: "dict[Any, Any]", /) -> "dict[Any, Any]":
+        self._ensure_loaded()
+        return super().__ror__(other)
+
+    def __repr__(self) -> str:
+        self._ensure_loaded()
+        return super().__repr__()
+
+    def __setitem__(self, key: type, value: "Callable[[Any], Any]") -> None:
+        self._ensure_loaded()
+        super().__setitem__(key, value)
+
+    def __ior__(self, other: Any) -> "Self":  # type: ignore[misc,override]
+        self._ensure_loaded()
+        super().__ior__(other)
+        return self
+
+    def clear(self) -> None:
+        self._ensure_loaded()
+        super().clear()
+
+    def copy(self) -> "dict[type, Callable[[Any], Any]]":
+        self._ensure_loaded()
+        return super().copy()
+
     def get(self, key: type, default: Any = None) -> Any:
         self._ensure_loaded()
         return super().get(key, default)
@@ -160,6 +206,22 @@ class _LazyTypeEncoders(dict[type, Callable[[Any], Any]]):
     def keys(self) -> "Any":
         self._ensure_loaded()
         return super().keys()
+
+    def pop(self, key: type, *args: Any) -> Any:
+        self._ensure_loaded()
+        return super().pop(key, *args)
+
+    def popitem(self) -> "tuple[type, Callable[[Any], Any]]":
+        self._ensure_loaded()
+        return super().popitem()
+
+    def setdefault(self, key: type, default: Any = None) -> Any:
+        self._ensure_loaded()
+        return super().setdefault(key, default)
+
+    def update(self, *args: Any, **kwargs: Any) -> None:
+        self._ensure_loaded()
+        super().update(*args, **kwargs)
 
     def values(self) -> "Any":
         self._ensure_loaded()

--- a/sqlspec/utils/serializers/_json.py
+++ b/sqlspec/utils/serializers/_json.py
@@ -4,6 +4,7 @@ import contextlib
 import datetime
 import enum
 import json
+import threading
 import uuid as uuid_mod
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator, Mapping
@@ -117,25 +118,31 @@ def _default_type_encoders() -> "dict[type, Callable[[Any], Any]]":
 class _LazyTypeEncoders(dict[type, Callable[[Any], Any]]):
     """Load optional type keys when the public registry is first used."""
 
-    __slots__ = ("_loaded",)
+    __slots__ = ("_load_lock", "_loaded")
     __hash__ = None
 
     def __init__(self, encoders: "dict[type, Callable[[Any], Any]]") -> None:
         super().__init__(encoders)
+        self._load_lock = threading.Lock()
         self._loaded = False
 
     def _ensure_loaded(self) -> None:
         if self._loaded:
             return
-        self._loaded = True
-        if NUMPY_INSTALLED:
-            ndarray = cast("type[Any]", import_optional_attr("numpy", "ndarray"))
-            generic = cast("type[Any]", import_optional_attr("numpy", "generic"))
-            dict.__setitem__(self, ndarray, lambda value: value.tolist())
-            dict.__setitem__(self, generic, lambda value: value.item())
-        if PYDANTIC_INSTALLED:
-            base_model = cast("type[Any]", import_optional_attr("pydantic", "BaseModel"))
-            dict.__setitem__(self, base_model, _dump_pydantic_model)
+        with self._load_lock:
+            if self._loaded:
+                return
+            optional_encoders: dict[type, Callable[[Any], Any]] = {}
+            if NUMPY_INSTALLED:
+                ndarray = cast("type[Any]", import_optional_attr("numpy", "ndarray"))
+                generic = cast("type[Any]", import_optional_attr("numpy", "generic"))
+                optional_encoders[ndarray] = lambda value: value.tolist()
+                optional_encoders[generic] = lambda value: value.item()
+            if PYDANTIC_INSTALLED:
+                base_model = cast("type[Any]", import_optional_attr("pydantic", "BaseModel"))
+                optional_encoders[base_model] = _dump_pydantic_model
+            dict.update(self, optional_encoders)
+            self._loaded = True
 
     def __contains__(self, key: object) -> bool:
         self._ensure_loaded()

--- a/sqlspec/utils/serializers/_schema.py
+++ b/sqlspec/utils/serializers/_schema.py
@@ -8,8 +8,9 @@ from functools import partial
 from threading import RLock
 from typing import TYPE_CHECKING, Any, Final, cast
 
-from sqlspec.typing import MSGSPEC_INSTALLED, UNSET, ArrowReturnFormat, Empty, attrs_asdict, msgspec_fields
+from sqlspec.typing import MSGSPEC_INSTALLED, UNSET, ArrowReturnFormat, Empty, msgspec_fields
 from sqlspec.utils.arrow_helpers import convert_dict_to_arrow
+from sqlspec.utils.module_loader import import_optional_attr
 from sqlspec.utils.type_guards import (
     dataclass_to_dict,
     has_dict_attribute,
@@ -178,7 +179,8 @@ def _dump_pydantic(value: Any, *, exclude_unset: bool) -> "dict[str, Any]":
 
 
 def _dump_attrs(value: Any) -> "dict[str, Any]":
-    return attrs_asdict(value, recurse=True)
+    attrs_asdict = import_optional_attr("attrs", "asdict")
+    return cast("dict[str, Any]", attrs_asdict(value, recurse=True))
 
 
 def _dump_dict_attr(value: Any) -> "dict[str, Any]":

--- a/sqlspec/utils/type_guards.py
+++ b/sqlspec/utils/type_guards.py
@@ -5,6 +5,7 @@ understand type narrowing, replacing defensive hasattr() and duck typing pattern
 """
 
 import inspect
+import sys
 from collections.abc import Sequence
 from collections.abc import Set as AbstractSet
 from dataclasses import Field
@@ -34,12 +35,8 @@ from sqlspec.typing import (
     LITESTAR_INSTALLED,
     MSGSPEC_INSTALLED,
     PYDANTIC_INSTALLED,
-    BaseModel,
     DataclassProtocol,
-    DTOData,
     Struct,
-    attrs_fields,
-    attrs_has,
 )
 from sqlspec.utils.text import camelize, kebabize, pascalize
 
@@ -589,12 +586,16 @@ def is_pydantic_model(obj: Any) -> "TypeGuard[BaseModelStub]":
     """
     if not PYDANTIC_INSTALLED:
         return False
+    pydantic = sys.modules.get("pydantic")
+    if pydantic is None:
+        return False
+    base_model = pydantic.BaseModel
     if isinstance(obj, type):
         try:
-            return issubclass(obj, BaseModel)
+            return issubclass(obj, base_model)
         except TypeError:
             return False
-    return isinstance(obj, BaseModel)
+    return isinstance(obj, base_model)
 
 
 def is_pydantic_model_with_field(obj: Any, field_name: str) -> "TypeGuard[BaseModelStub]":
@@ -777,7 +778,12 @@ def is_attrs_instance(obj: Any) -> "TypeGuard[AttrsInstanceStub]":
     Returns:
         bool
     """
-    return bool(ATTRS_INSTALLED) and attrs_has(obj.__class__)
+    if not ATTRS_INSTALLED:
+        return False
+    from sqlspec.utils.module_loader import import_optional_attr
+
+    attrs_has = import_optional_attr("attrs", "has")
+    return bool(attrs_has(obj.__class__))
 
 
 def is_attrs_schema(cls: Any) -> "TypeGuard[type[AttrsInstanceStub]]":
@@ -789,7 +795,12 @@ def is_attrs_schema(cls: Any) -> "TypeGuard[type[AttrsInstanceStub]]":
     Returns:
         bool
     """
-    return bool(ATTRS_INSTALLED) and attrs_has(cls)
+    if not ATTRS_INSTALLED:
+        return False
+    from sqlspec.utils.module_loader import import_optional_attr
+
+    attrs_has = import_optional_attr("attrs", "has")
+    return bool(attrs_has(cls))
 
 
 def is_attrs_instance_with_field(obj: Any, field_name: str) -> "TypeGuard[AttrsInstanceStub]":
@@ -804,6 +815,9 @@ def is_attrs_instance_with_field(obj: Any, field_name: str) -> "TypeGuard[AttrsI
     """
     if not is_attrs_instance(obj):
         return False
+    from sqlspec.utils.module_loader import import_optional_attr
+
+    attrs_fields = import_optional_attr("attrs", "fields")
     return any(field.name == field_name for field in attrs_fields(obj.__class__))
 
 
@@ -819,6 +833,9 @@ def is_attrs_instance_without_field(obj: Any, field_name: str) -> "TypeGuard[Att
     """
     if not is_attrs_instance(obj):
         return False
+    from sqlspec.utils.module_loader import import_optional_attr
+
+    attrs_fields = import_optional_attr("attrs", "fields")
     return all(field.name != field_name for field in attrs_fields(obj.__class__))
 
 
@@ -951,7 +968,10 @@ def is_dto_data(v: Any) -> "TypeGuard[DTODataStub[Any]]":
     Returns:
         bool
     """
-    return bool(LITESTAR_INSTALLED) and isinstance(v, DTOData)
+    if not LITESTAR_INSTALLED:
+        return False
+    data_structures = sys.modules.get("litestar.dto.data_structures")
+    return data_structures is not None and isinstance(v, data_structures.DTOData)
 
 
 def is_expression(obj: Any) -> "TypeGuard[exp.Expr]":

--- a/tests/typing/typing_lazy_exports.py
+++ b/tests/typing/typing_lazy_exports.py
@@ -1,0 +1,43 @@
+"""Static analyzer contract for lazy optional typing exports."""
+
+from typing import TypeVar
+
+from litestar.dto.data_structures import DTOData as LitestarDTOData
+from pyarrow import Table as PyArrowTable
+from pydantic import BaseModel as PydanticBaseModel
+from typing_extensions import assert_type
+
+from sqlspec.typing import ArrowTable, BaseModel, DTOData
+
+T = TypeVar("T")
+
+
+def arrow_to_vendor(value: ArrowTable) -> PyArrowTable:
+    assert_type(value, PyArrowTable)
+    return value
+
+
+def arrow_from_vendor(value: PyArrowTable) -> ArrowTable:
+    return value
+
+
+def model_to_vendor(value: BaseModel) -> PydanticBaseModel:
+    assert_type(value, PydanticBaseModel)
+    return value
+
+
+def model_from_vendor(value: PydanticBaseModel) -> BaseModel:
+    return value
+
+
+def dto_to_vendor(value: "DTOData[T]") -> "LitestarDTOData[T]":
+    assert_type(value, LitestarDTOData[T])
+    return value
+
+
+def dto_from_vendor(value: "LitestarDTOData[T]") -> "DTOData[T]":
+    return value
+
+
+def dto_create(value: "DTOData[T]") -> T:
+    return value.create_instance()

--- a/tests/unit/test_import_time.py
+++ b/tests/unit/test_import_time.py
@@ -1,0 +1,29 @@
+"""Regression tests for import-time optional dependency leakage."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+FORBIDDEN = ("pandas", "polars", "pyarrow", "litestar", "pydantic", "prometheus_client")
+
+
+def test_import_sqlspec_does_not_import_heavy_optional_deps() -> None:
+    """Importing ``sqlspec`` in a fresh subprocess should not pull heavy optional deps."""
+    script = (
+        f"import sys, sqlspec; leaked=[name for name in {FORBIDDEN!r} if name in sys.modules]; print(','.join(leaked))"
+    )
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, check=True)
+    leaked = [name for name in result.stdout.strip().split(",") if name]
+    assert not leaked, f"import sqlspec eagerly imported: {leaked}"
+
+
+@pytest.mark.skipif(any(name in sys.modules for name in FORBIDDEN), reason="forbidden deps already preloaded")
+def test_import_sqlspec_does_not_import_heavy_optional_deps_in_process() -> None:
+    """Same-process import should also stay clean when the environment is pristine."""
+    import sqlspec  # noqa: F401
+
+    leaked = [name for name in FORBIDDEN if name in sys.modules]
+    assert not leaked, f"import sqlspec eagerly imported: {leaked}"

--- a/tests/unit/test_import_time.py
+++ b/tests/unit/test_import_time.py
@@ -1,13 +1,11 @@
 """Regression tests for import-time optional dependency leakage."""
 
-from __future__ import annotations
-
 import subprocess
 import sys
 
 import pytest
 
-FORBIDDEN = ("pandas", "polars", "pyarrow", "litestar", "pydantic", "prometheus_client")
+FORBIDDEN = ("pandas", "polars", "pyarrow", "litestar", "pydantic", "opentelemetry", "prometheus_client")
 
 
 def test_import_sqlspec_does_not_import_heavy_optional_deps() -> None:

--- a/tests/unit/test_import_time_extensions.py
+++ b/tests/unit/test_import_time_extensions.py
@@ -1,0 +1,88 @@
+"""Import-time boundaries for opt-in framework and observability extensions."""
+
+import subprocess
+import sys
+
+import pytest
+
+
+def _run_import_probe(script: str) -> "subprocess.CompletedProcess[str]":
+    return subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, check=True)
+
+
+def test_public_trace_export_resolves_real_opentelemetry_module() -> None:
+    """Direct public access should return the installed OTel trace module, not its shim."""
+    script = """
+import importlib.util
+
+if importlib.util.find_spec("opentelemetry.trace") is None:
+    print("missing")
+else:
+    import sqlspec.typing as sqlspec_typing
+    resolved = sqlspec_typing.trace
+    from opentelemetry import trace
+    assert resolved is trace
+    print("ok")
+"""
+    result = _run_import_probe(script)
+    if result.stdout.strip() == "missing":
+        pytest.skip("opentelemetry is not installed")
+    assert result.stdout.strip() == "ok"
+
+
+@pytest.mark.parametrize(
+    ("extension_module", "dependency_module", "symbols"),
+    [
+        ("sqlspec.extensions.otel", "opentelemetry", ("trace",)),
+        ("sqlspec.extensions.prometheus._observer", "prometheus_client", ("Counter", "Histogram")),
+    ],
+)
+def test_observability_extensions_resolve_real_symbols_once(
+    extension_module: str, dependency_module: str, symbols: "tuple[str, ...]"
+) -> None:
+    """Opt-in observability imports should resolve and cache real dependency symbols."""
+    script = f"""
+import importlib
+import importlib.util
+import sys
+
+if importlib.util.find_spec({dependency_module!r}) is None:
+    print("missing")
+else:
+    import sqlspec
+    assert {dependency_module!r} not in sys.modules
+    extension = importlib.import_module({extension_module!r})
+    dependency = importlib.import_module({dependency_module!r})
+    dependency_identity = sys.modules[{dependency_module!r}]
+    for symbol in {symbols!r}:
+        assert getattr(extension, symbol) is getattr(dependency, symbol)
+    assert importlib.import_module({extension_module!r}) is extension
+    assert sys.modules[{dependency_module!r}] is dependency_identity
+    print("ok")
+"""
+    result = _run_import_probe(script)
+    if result.stdout.strip() == "missing":
+        pytest.skip(f"{dependency_module} is not installed")
+    assert result.stdout.strip() == "ok"
+
+
+def test_litestar_extension_import_is_outside_bare_import_contract() -> None:
+    """Framework extensions may import their dependency after explicit opt-in."""
+    script = """
+import importlib
+import importlib.util
+import sys
+
+if importlib.util.find_spec("litestar") is None:
+    print("missing")
+else:
+    import sqlspec
+    assert "litestar" not in sys.modules
+    importlib.import_module("sqlspec.extensions.litestar")
+    assert "litestar" in sys.modules
+    print("ok")
+"""
+    result = _run_import_probe(script)
+    if result.stdout.strip() == "missing":
+        pytest.skip("litestar is not installed")
+    assert result.stdout.strip() == "ok"

--- a/tests/unit/test_typing_lazy_exports.py
+++ b/tests/unit/test_typing_lazy_exports.py
@@ -1,5 +1,6 @@
 """Regression tests for the lazy typing hubs."""
 
+import pickle
 from typing import get_args
 
 import pytest
@@ -78,6 +79,8 @@ def test_observability_fallbacks_preserve_public_class_names(monkeypatch: pytest
     assert fallback is getattr(private_typing, export_name)
     assert fallback.__name__ == export_name
     assert fallback.__qualname__ == export_name
+    assert repr(fallback) == f"<class 'sqlspec._typing.{export_name}'>"
+    assert pickle.loads(pickle.dumps(fallback)) is fallback
 
 
 def test_get_type_adapter_resolves_lazy_pydantic_exports(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_typing_lazy_exports.py
+++ b/tests/unit/test_typing_lazy_exports.py
@@ -1,0 +1,39 @@
+"""Regression tests for the lazy typing hubs."""
+
+import sqlspec.typing as public_typing
+from sqlspec import _typing as private_typing
+
+
+def test_typing_hubs_expose_all_public_names_in_dir() -> None:
+    """dir() should cover the full public surface of both typing modules."""
+    assert set(public_typing.__all__).issubset(set(dir(public_typing)))
+    assert set(private_typing.__all__).issubset(set(dir(private_typing)))
+
+
+def test_typing_hubs_resolve_all_public_exports() -> None:
+    """Every public name should be resolvable through getattr()."""
+    for name in public_typing.__all__:
+        getattr(public_typing, name)
+
+    for name in private_typing.__all__:
+        getattr(private_typing, name)
+
+
+def test_lazy_exports_cache_the_first_resolved_object(monkeypatch) -> None:
+    """First access should resolve once and subsequent accesses should reuse the cached object."""
+    sentinel = object()
+    calls: list[tuple[str, str, object]] = []
+
+    def fake_resolve(module_name: str, attr_name: str, fallback: object) -> object:
+        calls.append((module_name, attr_name, fallback))
+        return sentinel
+
+    monkeypatch.delitem(public_typing.__dict__, "BaseModel", raising=False)
+    monkeypatch.delitem(private_typing.__dict__, "BaseModel", raising=False)
+    monkeypatch.setattr(private_typing, "resolve_optional_attr", fake_resolve)
+
+    assert getattr(private_typing, "BaseModel") is sentinel
+    assert getattr(private_typing, "BaseModel") is sentinel
+    assert getattr(public_typing, "BaseModel") is sentinel
+    assert getattr(public_typing, "BaseModel") is sentinel
+    assert calls == [("pydantic", "BaseModel", private_typing.BaseModelStub)]

--- a/tests/unit/test_typing_lazy_exports.py
+++ b/tests/unit/test_typing_lazy_exports.py
@@ -1,5 +1,9 @@
 """Regression tests for the lazy typing hubs."""
 
+from typing import get_args
+
+import pytest
+
 import sqlspec.typing as public_typing
 from sqlspec import _typing as private_typing
 
@@ -37,3 +41,68 @@ def test_lazy_exports_cache_the_first_resolved_object(monkeypatch) -> None:
     assert getattr(public_typing, "BaseModel") is sentinel
     assert getattr(public_typing, "BaseModel") is sentinel
     assert calls == [("pydantic", "BaseModel", private_typing.BaseModelStub)]
+
+
+def test_lazy_exports_preserve_missing_dependency_shim_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing optional dependencies should expose one stable shim through both hubs."""
+
+    def missing_dependency(_module_name: str, _attr_name: str, fallback: object) -> object:
+        return fallback
+
+    monkeypatch.delitem(public_typing.__dict__, "ArrowTable", raising=False)
+    monkeypatch.delitem(private_typing.__dict__, "ArrowTable", raising=False)
+    monkeypatch.setattr(private_typing, "resolve_optional_attr", missing_dependency)
+
+    private_arrow_table = getattr(private_typing, "ArrowTable")
+    public_arrow_table = getattr(public_typing, "ArrowTable")
+
+    assert private_arrow_table is private_typing.ArrowTableResult
+    assert public_arrow_table is private_arrow_table
+    assert getattr(private_typing, "ArrowTable") is private_arrow_table
+    assert getattr(public_typing, "ArrowTable") is public_arrow_table
+
+
+@pytest.mark.parametrize("export_name", ("Span", "Tracer", "Counter", "Gauge", "Histogram"))
+def test_observability_fallbacks_preserve_public_class_names(
+    monkeypatch: pytest.MonkeyPatch, export_name: str
+) -> None:
+    """Laziness should not change the observable identity of fallback classes."""
+
+    def missing_dependency(_module_name: str, _attr_name: str, fallback: object) -> object:
+        return fallback
+
+    monkeypatch.delitem(public_typing.__dict__, export_name, raising=False)
+    monkeypatch.delitem(private_typing.__dict__, export_name, raising=False)
+    monkeypatch.setattr(private_typing, "resolve_optional_attr", missing_dependency)
+
+    fallback = getattr(public_typing, export_name)
+
+    assert fallback is getattr(private_typing, export_name)
+    assert fallback.__name__ == export_name
+    assert fallback.__qualname__ == export_name
+
+
+def test_get_type_adapter_resolves_lazy_pydantic_exports(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The helper should resolve lazy globals explicitly for normal and fail-fast adapters."""
+    created: list[object] = []
+
+    class FakeTypeAdapter:
+        def __init__(self, annotation: object) -> None:
+            created.append(annotation)
+
+    class FakeFailFast:
+        pass
+
+    monkeypatch.setattr(private_typing, "TypeAdapter", FakeTypeAdapter)
+    monkeypatch.setattr(private_typing, "FailFast", FakeFailFast)
+    public_typing.get_type_adapter.cache_clear()
+    monkeypatch.setattr(public_typing, "PYDANTIC_USE_FAILFAST", False)
+
+    assert isinstance(public_typing.get_type_adapter(str), FakeTypeAdapter)
+    assert created == [str]
+
+    public_typing.get_type_adapter.cache_clear()
+    monkeypatch.setattr(public_typing, "PYDANTIC_USE_FAILFAST", True)
+    assert isinstance(public_typing.get_type_adapter(int), FakeTypeAdapter)
+    assert get_args(created[-1])[0] is int
+    assert isinstance(get_args(created[-1])[1], FakeFailFast)

--- a/tests/unit/test_typing_lazy_exports.py
+++ b/tests/unit/test_typing_lazy_exports.py
@@ -83,6 +83,32 @@ def test_observability_fallbacks_preserve_public_class_names(monkeypatch: pytest
     assert pickle.loads(pickle.dumps(fallback)) is fallback
 
 
+@pytest.mark.parametrize(
+    ("export_name", "stub_name"),
+    (("cattrs_structure", "cattrs_structure_stub"), ("cattrs_unstructure", "cattrs_unstructure_stub")),
+)
+def test_cattrs_fallbacks_preserve_public_function_identity(
+    monkeypatch: pytest.MonkeyPatch, export_name: str, stub_name: str
+) -> None:
+    """Missing cattrs exports should retain their advertised function identity."""
+
+    def missing_dependency(_module_name: str, _attr_name: str, fallback: object) -> object:
+        return fallback
+
+    monkeypatch.delitem(public_typing.__dict__, export_name, raising=False)
+    monkeypatch.delitem(private_typing.__dict__, export_name, raising=False)
+    monkeypatch.delattr(private_typing, stub_name)
+    monkeypatch.setattr(private_typing, "resolve_optional_attr", missing_dependency)
+
+    fallback = getattr(public_typing, export_name)
+
+    assert fallback is getattr(private_typing, export_name)
+    assert fallback.__name__ == export_name
+    assert fallback.__qualname__ == export_name
+    assert repr(fallback).startswith(f"<function {export_name} at ")
+    assert pickle.loads(pickle.dumps(fallback)) is fallback
+
+
 def test_get_type_adapter_resolves_lazy_pydantic_exports(monkeypatch: pytest.MonkeyPatch) -> None:
     """The helper should resolve lazy globals explicitly for normal and fail-fast adapters."""
     created: list[object] = []

--- a/tests/unit/test_typing_lazy_exports.py
+++ b/tests/unit/test_typing_lazy_exports.py
@@ -63,9 +63,7 @@ def test_lazy_exports_preserve_missing_dependency_shim_identity(monkeypatch: pyt
 
 
 @pytest.mark.parametrize("export_name", ("Span", "Tracer", "Counter", "Gauge", "Histogram"))
-def test_observability_fallbacks_preserve_public_class_names(
-    monkeypatch: pytest.MonkeyPatch, export_name: str
-) -> None:
+def test_observability_fallbacks_preserve_public_class_names(monkeypatch: pytest.MonkeyPatch, export_name: str) -> None:
     """Laziness should not change the observable identity of fallback classes."""
 
     def missing_dependency(_module_name: str, _attr_name: str, fallback: object) -> object:

--- a/tests/unit/tools/test_import_time.py
+++ b/tests/unit/tools/test_import_time.py
@@ -1,0 +1,16 @@
+"""Tests for the import-time measurement helper."""
+
+import pytest
+from tools.scripts.import_time import calculate_reduction, parse_import_times
+
+
+def test_parse_import_times_extracts_cumulative_module_timings() -> None:
+    output = """
+import time:       250 |        250 |   sqlspec._typing
+import time:       500 |       1000 | sqlspec
+"""
+    assert parse_import_times(output) == {"sqlspec._typing": 250, "sqlspec": 1000}
+
+
+def test_calculate_reduction_returns_percentage() -> None:
+    assert calculate_reduction(681.0, 204.3) == pytest.approx(70.0)

--- a/tests/unit/utils/serializers/test_default_type_encoders.py
+++ b/tests/unit/utils/serializers/test_default_type_encoders.py
@@ -13,7 +13,9 @@ import ipaddress
 import json
 import subprocess
 import sys
+import threading
 import uuid
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from decimal import Decimal
 from pathlib import Path, PurePosixPath
 
@@ -104,6 +106,90 @@ else:
 """
     result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
     assert result.returncode == 0, result.stderr
+
+
+def test_registry_first_load_is_thread_safe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Concurrent first readers should wait for the complete optional registry."""
+
+    class NumpyArray:
+        pass
+
+    class NumpyGeneric:
+        pass
+
+    first_import_started = threading.Event()
+    release_first_import = threading.Event()
+    start_readers = threading.Barrier(3)
+    registry = serializer_json._LazyTypeEncoders({})
+
+    def import_optional_type(_module_name: str, attr_name: str) -> type:
+        if attr_name == "ndarray":
+            first_import_started.set()
+            if not release_first_import.wait(timeout=5):
+                pytest.fail("timed out waiting to release the first optional import")
+            return NumpyArray
+        return NumpyGeneric
+
+    def copy_registry() -> dict[type, object]:
+        start_readers.wait(timeout=5)
+        return registry.copy()
+
+    monkeypatch.setattr(serializer_json, "NUMPY_INSTALLED", True)
+    monkeypatch.setattr(serializer_json, "PYDANTIC_INSTALLED", False)
+    monkeypatch.setattr(serializer_json, "import_optional_attr", import_optional_type)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(copy_registry) for _ in range(2)]
+        start_readers.wait(timeout=5)
+        assert first_import_started.wait(timeout=5)
+        completed_before_release, _ = wait(futures, timeout=1, return_when=FIRST_COMPLETED)
+        release_first_import.set()
+        results = [future.result(timeout=5) for future in futures]
+
+    assert not completed_before_release
+    assert all(NumpyArray in result and NumpyGeneric in result for result in results)
+
+
+def test_registry_retries_after_optional_registration_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed optional registration should publish nothing and remain retryable."""
+
+    class NumpyArray:
+        pass
+
+    class NumpyGeneric:
+        pass
+
+    attempts: list[str] = []
+    fail_generic = True
+    registry = serializer_json._LazyTypeEncoders({})
+
+    def import_optional_type(_module_name: str, attr_name: str) -> type:
+        nonlocal fail_generic
+        attempts.append(attr_name)
+        if attr_name == "ndarray":
+            return NumpyArray
+        if fail_generic:
+            fail_generic = False
+            msg = "generic import failed"
+            raise ImportError(msg)
+        return NumpyGeneric
+
+    monkeypatch.setattr(serializer_json, "NUMPY_INSTALLED", True)
+    monkeypatch.setattr(serializer_json, "PYDANTIC_INSTALLED", False)
+    monkeypatch.setattr(serializer_json, "import_optional_attr", import_optional_type)
+
+    with pytest.raises(ImportError, match="generic import failed"):
+        registry.copy()
+
+    assert registry._loaded is False
+    assert dict.copy(registry) == {}
+
+    loaded = registry.copy()
+
+    assert registry._loaded is True
+    assert NumpyArray in loaded
+    assert NumpyGeneric in loaded
+    assert attempts == ["ndarray", "generic", "ndarray", "generic"]
 
 
 def test_registry_covers_required_types() -> None:

--- a/tests/unit/utils/serializers/test_default_type_encoders.py
+++ b/tests/unit/utils/serializers/test_default_type_encoders.py
@@ -11,6 +11,8 @@ import datetime
 import enum
 import ipaddress
 import json
+import subprocess
+import sys
 import uuid
 from decimal import Decimal
 from pathlib import Path, PurePosixPath
@@ -36,6 +38,72 @@ def test_registry_is_public_dict() -> None:
     for key, encoder in DEFAULT_TYPE_ENCODERS.items():
         assert isinstance(key, type)
         assert callable(encoder)
+
+
+@pytest.mark.skipif(not (PYDANTIC_INSTALLED and NUMPY_INSTALLED), reason="Pydantic and NumPy are required")
+@pytest.mark.parametrize("operation", ["copy", "unpack", "equality", "repr", "or", "ror"])
+def test_registry_dict_operations_load_optional_encoder_keys(operation: str) -> None:
+    """Ordinary dict operations should include lazy optional encoder keys on first use."""
+    script = f"""
+import numpy as np
+from pydantic import BaseModel
+
+from sqlspec.utils.serializers import DEFAULT_TYPE_ENCODERS
+
+optional_keys = (BaseModel, np.ndarray, np.generic)
+operation = {operation!r}
+if operation == "copy":
+    result = DEFAULT_TYPE_ENCODERS.copy()
+    assert all(key in result for key in optional_keys)
+elif operation == "unpack":
+    result = {{**DEFAULT_TYPE_ENCODERS}}
+    assert all(key in result for key in optional_keys)
+elif operation == "equality":
+    assert DEFAULT_TYPE_ENCODERS == DEFAULT_TYPE_ENCODERS
+    raw_registry = dict.copy(DEFAULT_TYPE_ENCODERS)
+    assert all(key in raw_registry for key in optional_keys)
+elif operation == "repr":
+    registry_repr = repr(DEFAULT_TYPE_ENCODERS)
+    assert all(key.__name__ in registry_repr for key in optional_keys)
+elif operation == "or":
+    result = DEFAULT_TYPE_ENCODERS | {{}}
+    assert all(key in result for key in optional_keys)
+else:
+    result = {{}} | DEFAULT_TYPE_ENCODERS
+    assert all(key in result for key in optional_keys)
+"""
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(not (PYDANTIC_INSTALLED and NUMPY_INSTALLED), reason="Pydantic and NumPy are required")
+@pytest.mark.parametrize("mutation", ["override", "delete", "clear"])
+def test_registry_mutations_load_optional_encoder_keys_first(mutation: str) -> None:
+    """Mutations before the first read should not overwrite or resurrect user intent."""
+    script = f"""
+import numpy as np
+from pydantic import BaseModel
+
+from sqlspec.utils.serializers import DEFAULT_TYPE_ENCODERS
+
+mutation = {mutation!r}
+if mutation == "override":
+    override = lambda value: "override"
+    DEFAULT_TYPE_ENCODERS[BaseModel] = override
+    assert DEFAULT_TYPE_ENCODERS[BaseModel] is override
+    assert np.ndarray in dict.copy(DEFAULT_TYPE_ENCODERS)
+elif mutation == "delete":
+    del DEFAULT_TYPE_ENCODERS[BaseModel]
+    assert BaseModel not in dict.copy(DEFAULT_TYPE_ENCODERS)
+    assert BaseModel not in DEFAULT_TYPE_ENCODERS
+else:
+    DEFAULT_TYPE_ENCODERS.clear()
+    assert dict.copy(DEFAULT_TYPE_ENCODERS) == {{}}
+    assert BaseModel not in DEFAULT_TYPE_ENCODERS
+    assert np.ndarray not in DEFAULT_TYPE_ENCODERS
+"""
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
 
 
 def test_registry_covers_required_types() -> None:

--- a/tests/unit/utils/serializers/test_default_type_encoders.py
+++ b/tests/unit/utils/serializers/test_default_type_encoders.py
@@ -18,6 +18,7 @@ import uuid
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from decimal import Decimal
 from pathlib import Path, PurePosixPath
+from typing import Any
 
 import pytest
 
@@ -130,7 +131,7 @@ def test_registry_first_load_is_thread_safe(monkeypatch: pytest.MonkeyPatch) -> 
             return NumpyArray
         return NumpyGeneric
 
-    def copy_registry() -> dict[type, object]:
+    def copy_registry() -> dict[type, Any]:
         start_readers.wait(timeout=5)
         return registry.copy()
 

--- a/tests/unit/utils/test_dependencies.py
+++ b/tests/unit/utils/test_dependencies.py
@@ -198,6 +198,14 @@ def test_import_optional_attr_returns_none_when_attr_missing() -> None:
     assert dependencies.import_optional_attr("json", "definitely_not_an_attr") is None
 
 
+def test_resolve_optional_attr_returns_module_when_attr_is_none() -> None:
+    """resolve_optional_attr can return an optional module directly."""
+    import json
+
+    fallback = object()
+    assert dependencies.resolve_optional_attr("json", None, fallback) is json
+
+
 def test_import_string_basic_module() -> None:
     """Test import_string with basic module import."""
     sys_module = import_string("sys")

--- a/tools/scripts/import_time.py
+++ b/tools/scripts/import_time.py
@@ -1,0 +1,87 @@
+"""Measure cold SQLSpec import time and optional-dependency leakage.
+
+Usage:
+    python tools/scripts/import_time.py --samples 5 --baseline-ms 681
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from statistics import median
+
+__all__ = ("calculate_reduction", "main", "parse_import_times")
+
+_IMPORT_TIME_PATTERN = re.compile(r"^import time:\s+\d+\s+\|\s+(\d+)\s+\|\s+(.+?)\s*$")
+_FORBIDDEN = ("pandas", "polars", "pyarrow", "litestar", "pydantic", "opentelemetry", "prometheus_client")
+
+
+def parse_import_times(output: str) -> "dict[str, int]":
+    """Extract cumulative microseconds by module from ``-X importtime`` output."""
+    timings: dict[str, int] = {}
+    for line in output.splitlines():
+        match = _IMPORT_TIME_PATTERN.match(line)
+        if match is not None:
+            timings[match.group(2)] = int(match.group(1))
+    return timings
+
+
+def calculate_reduction(baseline_ms: float, current_ms: float) -> float:
+    """Return the percentage reduction from a positive baseline."""
+    if baseline_ms <= 0:
+        msg = "baseline_ms must be greater than zero"
+        raise ValueError(msg)
+    return (baseline_ms - current_ms) / baseline_ms * 100
+
+
+def _measure_once(python: str) -> "tuple[float, float, tuple[str, ...]]":
+    probe = f"import sys, sqlspec; print(','.join(name for name in {_FORBIDDEN!r} if name in sys.modules))"
+    result = subprocess.run([python, "-X", "importtime", "-c", probe], capture_output=True, text=True, check=True)
+    timings = parse_import_times(result.stderr)
+    try:
+        total_ms = timings["sqlspec"] / 1000
+        typing_ms = timings["sqlspec._typing"] / 1000
+    except KeyError as exc:
+        msg = f"missing import-time entry for {exc.args[0]}"
+        raise RuntimeError(msg) from exc
+    leaked = tuple(name for name in result.stdout.strip().split(",") if name)
+    return total_ms, typing_ms, leaked
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--samples", type=int, default=5, help="Number of fresh interpreter samples")
+    parser.add_argument("--baseline-ms", type=float, help="Optional historical baseline for reduction reporting")
+    parser.add_argument("--python", default=sys.executable, help="Python interpreter to measure")
+    return parser
+
+
+def main() -> int:
+    """Run cold-import samples and print median timings."""
+    parser = _build_parser()
+    args = parser.parse_args()
+    if args.samples < 1:
+        parser.error("--samples must be greater than zero")
+
+    measurements = [_measure_once(args.python) for _ in range(args.samples)]
+    total_samples = [sample[0] for sample in measurements]
+    typing_samples = [sample[1] for sample in measurements]
+    leaked = sorted({name for sample in measurements for name in sample[2]})
+    total_ms = median(total_samples)
+    typing_ms = median(typing_samples)
+
+    output = [
+        f"sqlspec median: {total_ms:.3f} ms",
+        f"sqlspec._typing median: {typing_ms:.3f} ms",
+        f"samples: {', '.join(f'{sample:.3f}' for sample in total_samples)} ms",
+        f"forbidden modules: {', '.join(leaked) if leaked else 'none'}",
+    ]
+    if args.baseline_ms is not None:
+        reduction = calculate_reduction(args.baseline_ms, total_ms)
+        output.append(f"reduction from {args.baseline_ms:.3f} ms: {reduction:.2f}%")
+    sys.stdout.write("\n".join(output) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- resolve heavy optional typing exports lazily on first access
- preserve precise analyzer-visible vendor types when their extras are installed
- preserve stable runtime shims and Protocol fallbacks when optional dependencies are absent
- defer optional imports in serializers, storage, schema, and type-guard consumers
- keep `DEFAULT_TYPE_ENCODERS` fully dict-compatible with thread-safe, failure-retryable lazy registration

## Compatibility

Users do not need optional libraries installed for SQLSpec imports or runtime annotations to work. Missing dependencies resolve to stable cached shims; installed dependencies retain their precise static vendor types. In a no-extras consumer type-checking environment, optional vendor aliases resolve as `Any` because the vendor type definitions are unavailable; the explicit SQLSpec Stub and Protocol types remain available where callers need a dependency-independent contract.

Public exports, `dir()`, identity, pickle/repr behavior, cattrs fallback names, dict mutation/union behavior, and runtime type-adapter behavior are covered.

## Performance

Bare `import sqlspec` median time decreased from 681 ms to 202.467 ms (70.27%). The import regression guard confirms pandas, polars, PyArrow, Litestar, Pydantic, OpenTelemetry, and Prometheus are not imported eagerly.

## Validation

- lazy-export, fallback-shim, optional-boundary, serializer, storage, concurrency, retry, and dict-contract tests
- Ruff, mypy, pyright, docs, compiled acceptance tests, and MyPyC wheel build
- full GitHub unit/integration matrix on Python 3.10-3.14

All required GitHub checks pass on the final commit.
