### PR TITLE
feat: improve event transport throughput

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,22 @@ Unreleased
   ``poll_queue``, ``aq``, and ``txeventq``. Retired transport names now raise
   an explicit configuration error with the canonical replacement.
 
+**Added:**
+
+* Added sync and async event-channel ``publish_many()`` APIs. Batch-capable
+  implementations preserve input order and publish a grouped call in one
+  transaction; custom backends retain an ordered single-event fallback.
+* Added ``event_poll_interval`` for durable event reconciliation, independently
+  of native listener wakeups. ``poll_interval`` remains a compatibility input.
+
+**Changed:**
+
+* PostgreSQL listeners now hold one dedicated long-lived connection while
+  publishers use short pooled sessions. Native PostgreSQL batch publication
+  reuses one publisher transaction per grouped call.
+* ``notify_queue`` batch publication now bulk-inserts durable rows and sends one
+  compact wakeup marker per channel rather than one notification per event.
+
 **Fixed:**
 
 * Event channels now honor adapter ``events_backend`` driver features when no
@@ -33,11 +49,16 @@ Unreleased
   reconnecting underneath an active transaction.
 * Public row streams continue to clean up duck-typed sources whose ``close()``
   method uses the original no-argument contract.
+* Durable notification queues now drain all rows represented by a batch marker,
+  suppress duplicate markers, and recover missed markers through periodic
+  durable reconciliation.
 
 **Docs:**
 
 * Expanded the data dictionary guide with capability vocabulary, support
   matrix, DDL/dependency guidance, and safe system-metadata opt-in behavior.
+* Documented event transport delivery semantics, adapter support, connection
+  ownership, batch behavior, and polling recovery.
 
 v0.54.0 - SQL processing correctness and cleanup
 ------------------------------------------------------------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -52,6 +52,12 @@ Unreleased
 * Durable notification queues now drain all rows represented by a batch marker,
   suppress duplicate markers, and recover missed markers through periodic
   durable reconciliation.
+* Durable batch publication now preserves input delivery order, rolls back row
+  inserts when marker publication fails, and drains all recovered rows after a
+  lost marker without another native wait per event.
+* Event listener shutdown now cancels async waits concurrently and bounds sync
+  thread joins. Empty table queues do not poll faster than
+  ``event_poll_interval``.
 
 **Docs:**
 

--- a/docs/reference/extensions/events.rst
+++ b/docs/reference/extensions/events.rst
@@ -46,6 +46,12 @@ backend owns its own listener hub that:
 * Serializes subscribe / unsubscribe under a lock so concurrent callers
   cannot race on driver-level statements that share the connection.
 
+The listener lease is held for the backend lifetime. Publishers use separate,
+short-lived pooled sessions, so a shared PostgreSQL pool must configure
+``max_size >= 2``: one connection for the listener and at least one for
+publication. Native backend construction rejects a configured pool of size one
+instead of allowing publication to deadlock behind the listener.
+
 The Oracle native backends (``aq`` and
 ``txeventq``) use an analogous pattern: a per-channel
 queue-handle cache backed by a single dedicated session per backend instance.

--- a/docs/reference/extensions/events.rst
+++ b/docs/reference/extensions/events.rst
@@ -27,6 +27,43 @@ adapter ``driver_features["events_backend"]`` value is used only when the
 extension setting is absent. Retired transport names fail with an explicit
 canonical replacement instead of silently changing delivery semantics.
 
+.. list-table:: Adapter support
+   :header-rows: 1
+
+   * - Adapter family
+     - Available transports
+     - Default
+   * - PostgreSQL (``asyncpg``, ``psycopg``, ``psqlpy``)
+     - ``notify``, ``notify_queue``, ``poll_queue``
+     - ``notify``
+   * - Oracle
+     - ``poll_queue``, ``aq``, ``txeventq``
+     - ``poll_queue``
+   * - Other database adapters
+     - ``poll_queue``
+     - ``poll_queue``
+
+Configure the transport and durable reconciliation cadence independently:
+
+.. code-block:: python
+
+    from sqlspec.adapters.asyncpg import AsyncpgConfig
+
+    config = AsyncpgConfig(
+        connection_config={"dsn": "postgresql://...", "max_size": 5},
+        extension_config={
+            "events": {
+                "backend": "notify_queue",
+                "event_poll_interval": 1.0,
+            }
+        },
+    )
+
+``event_poll_interval`` controls how often durable transports reconcile the
+queue when no native wakeup arrives. The older ``poll_interval`` setting is a
+compatibility input; ``event_poll_interval`` takes precedence when both are
+provided.
+
 ``polling`` is not a SQLSpec backend name. Litestar Queues uses it for the
 fallback worker mode where no push wakeup transport is available and the
 worker waits for its configured polling interval.
@@ -61,6 +98,31 @@ the caller's polling cadence is respected.
 
 ``ack`` / ``nack`` semantics are unchanged. ``notify`` remains
 fire-and-forget; ``notify_queue`` acknowledges through the durable table queue.
+
+Batch publication and recovery
+==============================
+
+Both :class:`~sqlspec.extensions.events.AsyncEventChannel` and
+:class:`~sqlspec.extensions.events.SyncEventChannel` provide
+``publish_many(events)``. Each item is a
+``(channel, payload, metadata)`` tuple, and the returned event IDs preserve
+input order. Batch-capable implementations commit each grouped call atomically.
+Backends without ``publish_many``, including the current Oracle native
+transports, use an ordered single-event fallback; that fallback is not atomic
+across the batch.
+
+``poll_queue`` bulk-inserts the independent event rows with one publisher
+session and transaction. PostgreSQL ``notify`` publishes the normal per-event
+notification envelopes in one publisher transaction, so each notification
+keeps its existing payload and size limit.
+
+For PostgreSQL ``notify_queue``, SQLSpec bulk-inserts all durable rows and then
+emits one compact marker per channel in the same transaction. A marker contains
+only ``marker_id`` and ``batch_size``; it is a wakeup hint, not a batch event
+envelope or source of truth. A consumer uses that marker to drain the queued
+rows without waiting for another notification. Duplicate markers are ignored,
+and a missing marker is recovered by durable reconciliation on
+``event_poll_interval``.
 
 Oracle native event backends
 ============================
@@ -204,6 +266,8 @@ Utility Functions
 .. autofunction:: sqlspec.extensions.events.load_native_backend
 
 .. autofunction:: sqlspec.extensions.events.resolve_poll_interval
+
+.. autofunction:: sqlspec.extensions.events.resolve_event_poll_interval
 
 .. autofunction:: sqlspec.extensions.events.normalize_event_channel_name
 

--- a/docs/reference/extensions/events.rst
+++ b/docs/reference/extensions/events.rst
@@ -47,10 +47,11 @@ backend owns its own listener hub that:
   cannot race on driver-level statements that share the connection.
 
 The listener lease is held for the backend lifetime. Publishers use separate,
-short-lived pooled sessions, so a shared PostgreSQL pool must configure
-``max_size >= 2``: one connection for the listener and at least one for
-publication. Native backend construction rejects a configured pool of size one
-instead of allowing publication to deadlock behind the listener.
+short-lived pooled sessions, so a shared PostgreSQL pool must configure at
+least two connections: ``max_size >= 2`` for asyncpg/psycopg and
+``max_db_pool_size >= 2`` for psqlpy. Native backend construction rejects a
+configured pool of size one instead of allowing publication to deadlock behind
+the listener.
 
 The Oracle native backends (``aq`` and
 ``txeventq``) use an analogous pattern: a per-channel

--- a/sqlspec/adapters/asyncpg/events/_hub.py
+++ b/sqlspec/adapters/asyncpg/events/_hub.py
@@ -11,12 +11,13 @@ notifications into one queue per consumer task.
 
 import asyncio
 import contextlib
-from typing import TYPE_CHECKING, Any
+import logging
+from typing import TYPE_CHECKING, Any, cast
 from weakref import WeakKeyDictionary
 
 from sqlspec.exceptions import EventChannelError
 from sqlspec.extensions.events import normalize_event_channel_name
-from sqlspec.utils.logging import get_logger
+from sqlspec.utils.logging import get_logger, log_with_context
 from sqlspec.utils.type_guards import has_add_listener
 
 if TYPE_CHECKING:
@@ -33,6 +34,7 @@ class AsyncpgListenerHub:
     """Per-channel persistent listener for asyncpg-based event backends."""
 
     __slots__ = (
+        "_backend_name",
         "_callbacks",
         "_config",
         "_connection",
@@ -43,7 +45,8 @@ class AsyncpgListenerHub:
         "_shutting_down",
     )
 
-    def __init__(self, config: "AsyncpgConfig") -> None:
+    def __init__(self, config: "AsyncpgConfig", backend_name: str = "notify") -> None:
+        self._backend_name = backend_name
         self._config = config
         self._lock = asyncio.Lock()
         self._queues: dict[str, WeakKeyDictionary[asyncio.Task[Any], asyncio.Queue[str]]] = {}
@@ -97,6 +100,8 @@ class AsyncpgListenerHub:
     async def dequeue(self, channel: str, poll_interval: float) -> "str | None":
         if channel not in self._queues:
             await self.subscribe(channel)
+        async with self._lock:
+            await self._ensure_connection_locked()
         queue = self._get_consumer_queue(channel)
         if queue is None:
             return None
@@ -130,6 +135,7 @@ class AsyncpgListenerHub:
         if connection_cm is not None:
             with contextlib.suppress(Exception):
                 await connection_cm.__aexit__(None, None, None)
+            _record_listener_lifecycle(self._config, self._backend_name, "release")
         self._shutting_down = False
 
     def is_subscribed(self, channel: str) -> bool:
@@ -150,8 +156,15 @@ class AsyncpgListenerHub:
         return queue
 
     async def _ensure_connection_locked(self) -> None:
-        if self._connection is not None:
+        if self._connection is not None and not self._connection.is_closed():
             return
+        reconnecting = self._connection_cm is not None
+        if self._connection_cm is not None:
+            with contextlib.suppress(Exception):
+                await self._connection_cm.__aexit__(None, None, None)
+            _record_listener_lifecycle(self._config, self._backend_name, "release")
+            self._connection = None
+            self._connection_cm = None
         connection_cm = self._config.provide_connection()
         connection = await connection_cm.__aenter__()
         if connection is None or not has_add_listener(connection):
@@ -161,6 +174,22 @@ class AsyncpgListenerHub:
             raise EventChannelError(msg)
         self._connection_cm = connection_cm
         self._connection = connection
+        listener_connection = cast("Any", connection)
+        try:
+            for channel, callback in self._callbacks.items():
+                validated = normalize_event_channel_name(channel)
+                await listener_connection.execute(f"LISTEN {validated}")
+                await listener_connection.add_listener(channel, callback)
+        except Exception:
+            self._connection = None
+            self._connection_cm = None
+            with contextlib.suppress(Exception):
+                await connection_cm.__aexit__(None, None, None)
+            raise
+        _record_listener_lifecycle(self._config, self._backend_name, "acquire")
+        if reconnecting:
+            _record_listener_lifecycle(self._config, self._backend_name, "reconnect")
+        _record_listener_lifecycle(self._config, self._backend_name, "ready")
         self._register_pool_destroying()
 
     def _register_pool_destroying(self) -> None:
@@ -179,3 +208,16 @@ class AsyncpgListenerHub:
             return
         for queue in list(queues.values()):
             queue.put_nowait(payload)
+
+
+def _record_listener_lifecycle(config: "AsyncpgConfig", backend_name: str, status: str) -> None:
+    config.get_observability_runtime().increment_metric(f"events.listener.{status}")
+    log_with_context(
+        logger,
+        logging.DEBUG,
+        "event.listener.connection",
+        adapter_name="asyncpg",
+        backend_name=backend_name,
+        connection_role="listener",
+        status=status,
+    )

--- a/sqlspec/adapters/asyncpg/events/backend.py
+++ b/sqlspec/adapters/asyncpg/events/backend.py
@@ -28,12 +28,48 @@ __all__ = ("AsyncpgEventsBackend", "AsyncpgHybridEventsBackend", "create_event_b
 
 logger = get_logger("sqlspec.events.postgres")
 _MIN_LISTENER_POOL_SIZE = 2
+_MAX_SEEN_MARKERS = 1_024
+
+
+class _MarkerDrainState:
+    __slots__ = ("_pending", "_seen")
+
+    def __init__(self) -> None:
+        self._pending: dict[str, int] = {}
+        self._seen: dict[tuple[str, str], None] = {}
+
+    def take(self, channel: str) -> bool:
+        pending = self._pending.get(channel, 0)
+        if pending <= 0:
+            return False
+        if pending == 1:
+            self._pending.pop(channel, None)
+        else:
+            self._pending[channel] = pending - 1
+        return True
+
+    def register(self, channel: str, marker_id: "str | None", batch_size: int) -> "tuple[bool, bool]":
+        is_new = marker_id is None or (channel, marker_id) not in self._seen
+        if is_new:
+            if marker_id is not None:
+                if len(self._seen) >= _MAX_SEEN_MARKERS:
+                    self._seen.pop(next(iter(self._seen)))
+                self._seen[(channel, marker_id)] = None
+            self._pending[channel] = self._pending.get(channel, 0) + max(batch_size, 1)
+        return is_new, self.take(channel)
+
+    def clear(self, channel: str) -> None:
+        self._pending.pop(channel, None)
+
+    def reset(self) -> None:
+        self._pending.clear()
+        self._seen.clear()
 
 
 class AsyncpgHybridEventsBackend:
     """Hybrid backend combining durable queue with LISTEN/NOTIFY wakeups."""
 
-    __slots__ = ("_config", "_hub", "_queue", "_runtime")
+    __slots__ = ("_config", "_hub", "_marker_state", "_queue", "_runtime")
 
     supports_sync = False
     supports_async = True
@@ -46,6 +82,7 @@ class AsyncpgHybridEventsBackend:
         self._config = config
         self._runtime = config.get_observability_runtime()
         self._queue = queue
+        self._marker_state = _MarkerDrainState()
         self._hub: AsyncpgListenerHub | None = None
         log_with_context(
             logger,
@@ -87,7 +124,11 @@ class AsyncpgHybridEventsBackend:
                 "created_at": now,
             })
             marker_counts[channel] = marker_counts.get(channel, 0) + 1
-        markers = [(channel, to_json({"batch_size": count})) for channel, count in marker_counts.items()]
+        marker_id = uuid4().hex
+        markers = [
+            (channel, to_json({"batch_size": count, "marker_id": marker_id}))
+            for channel, count in marker_counts.items()
+        ]
         self._runtime.increment_metric("events.publisher.session")
         async with self._config.provide_session() as driver:
             await driver.execute_many(
@@ -100,16 +141,30 @@ class AsyncpgHybridEventsBackend:
         return event_ids
 
     async def dequeue(self, channel: str, poll_interval: float) -> EventMessage | None:
+        if self._marker_state.take(channel):
+            return await self._dequeue_hinted(channel)
         hub = self._ensure_hub()
-        payload = await hub.dequeue(channel, poll_interval)
-        if payload is None:
-            return await self._queue.dequeue(channel)
-        event_id = _extract_event_id(payload)
-        if event_id is not None:
-            event = await self._queue.dequeue_by_event_id(event_id)
-            if event is not None:
-                return event
-        return await self._queue.dequeue(channel)
+        while True:
+            payload = await hub.dequeue(channel, poll_interval)
+            if payload is None:
+                return await self._dequeue_reconciled(channel)
+            self._queue._reset_empty_poll_delay(channel)
+            self._runtime.increment_metric("events.listener.wakeup")
+            batch_size = _extract_batch_size(payload)
+            is_new, should_drain = self._marker_state.register(channel, _extract_marker_id(payload), batch_size)
+            if is_new and batch_size > 1:
+                self._runtime.increment_metric("events.marker.coalesced", batch_size - 1)
+            if not should_drain:
+                self._runtime.increment_metric("events.marker.duplicate")
+                continue
+            event_id = _extract_event_id(payload)
+            if event_id is not None:
+                event = await self._queue.dequeue_by_event_id(event_id)
+                if event is not None:
+                    self._runtime.increment_metric("events.marker.drain")
+                    _record_dequeue_result(self._runtime, event)
+                    return event
+            return await self._dequeue_hinted(channel)
 
     async def ack(self, event_id: str) -> None:
         await self._queue.ack(event_id)
@@ -121,14 +176,37 @@ class AsyncpgHybridEventsBackend:
 
     async def shutdown(self) -> None:
         hub = self._hub
-        if hub is not None:
-            self._hub = None
-            await hub.shutdown()
+        try:
+            if hub is not None:
+                self._hub = None
+                await hub.shutdown()
+        finally:
+            self._marker_state.reset()
 
     def _ensure_hub(self) -> AsyncpgListenerHub:
         if self._hub is None:
             self._hub = AsyncpgListenerHub(self._config, self.backend_name)
         return self._hub
+
+    async def _dequeue_hinted(self, channel: str) -> EventMessage | None:
+        event = await self._queue.dequeue(channel)
+        if event is None:
+            self._marker_state.clear(channel)
+            self._runtime.increment_metric("events.marker.shortfall")
+            return None
+        self._runtime.increment_metric("events.marker.drain")
+        _record_dequeue_result(self._runtime, event)
+        return event
+
+    async def _dequeue_reconciled(self, channel: str) -> EventMessage | None:
+        self._runtime.increment_metric("events.poll.fallback")
+        event = await self._queue.dequeue(channel)
+        if event is None:
+            self._runtime.increment_metric("events.listener.timeout")
+            return None
+        self._runtime.increment_metric("events.marker.miss")
+        _record_dequeue_result(self._runtime, event)
+        return event
 
     async def _publish_durable(
         self, channel: str, event_id: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None"
@@ -142,7 +220,7 @@ class AsyncpgHybridEventsBackend:
                         "event_id": event_id,
                         "channel": channel,
                         "payload_json": to_json(payload),
-                        "metadata_json": to_json(metadata) if metadata else None,
+                        "metadata_json": to_json(metadata) if metadata is not None else None,
                         "status": "pending",
                         "available_at": now,
                         "lease_expires_at": None,
@@ -215,8 +293,12 @@ class AsyncpgEventsBackend:
         hub = self._ensure_hub()
         payload = await hub.dequeue(channel, poll_interval)
         if payload is None:
+            self._runtime.increment_metric("events.listener.timeout")
             return None
-        return decode_notify_payload(channel, payload)
+        self._runtime.increment_metric("events.listener.wakeup")
+        event = decode_notify_payload(channel, payload)
+        _record_dequeue_result(self._runtime, event)
+        return event
 
     async def ack(self, _event_id: str) -> None:
         self._runtime.increment_metric("events.ack")
@@ -275,3 +357,30 @@ def _extract_event_id(payload: "str | None") -> "str | None":
         event_id = raw.get("event_id")
         return event_id if isinstance(event_id, str) else None
     return None
+
+
+def _extract_batch_size(payload: "str | None") -> int:
+    if not payload:
+        return 0
+    raw = from_json(payload)
+    if isinstance(raw, dict):
+        batch_size = raw.get("batch_size")
+        return batch_size if isinstance(batch_size, int) else 0
+    return 0
+
+
+def _extract_marker_id(payload: "str | None") -> "str | None":
+    if not payload:
+        return None
+    raw = from_json(payload)
+    if isinstance(raw, dict):
+        marker_id = raw.get("marker_id", raw.get("event_id"))
+        return marker_id if isinstance(marker_id, str) else None
+    return None
+
+
+def _record_dequeue_result(runtime: Any, event: "EventMessage | None") -> None:
+    if event is None:
+        return
+    latency_ms = max(0.0, (datetime.now(timezone.utc) - event.created_at).total_seconds() * 1000)
+    runtime.record_metric("events.dequeue.latency_ms", latency_ms)

--- a/sqlspec/adapters/asyncpg/events/backend.py
+++ b/sqlspec/adapters/asyncpg/events/backend.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 __all__ = ("AsyncpgEventsBackend", "AsyncpgHybridEventsBackend", "create_event_backend")
 
 logger = get_logger("sqlspec.events.postgres")
+_MIN_LISTENER_POOL_SIZE = 2
 
 
 class AsyncpgHybridEventsBackend:
@@ -55,6 +56,7 @@ class AsyncpgHybridEventsBackend:
         )
 
     async def publish(self, channel: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None" = None) -> str:
+        self._runtime.increment_metric("events.publisher.session")
         event_id = uuid4().hex
         await self._publish_durable(channel, event_id, payload, metadata)
         self._runtime.increment_metric("events.publish.native")
@@ -88,7 +90,7 @@ class AsyncpgHybridEventsBackend:
 
     def _ensure_hub(self) -> AsyncpgListenerHub:
         if self._hub is None:
-            self._hub = AsyncpgListenerHub(self._config)
+            self._hub = AsyncpgListenerHub(self._config, self.backend_name)
         return self._hub
 
     async def _publish_durable(
@@ -144,6 +146,7 @@ class AsyncpgEventsBackend:
         )
 
     async def publish(self, channel: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None" = None) -> str:
+        self._runtime.increment_metric("events.publisher.session")
         event_id = uuid4().hex
         async with self._config.provide_session() as driver:
             await driver.execute(
@@ -174,7 +177,7 @@ class AsyncpgEventsBackend:
 
     def _ensure_hub(self) -> AsyncpgListenerHub:
         if self._hub is None:
-            self._hub = AsyncpgListenerHub(self._config)
+            self._hub = AsyncpgListenerHub(self._config, self.backend_name)
         return self._hub
 
 
@@ -182,6 +185,8 @@ def create_event_backend(
     config: "AsyncpgConfig", backend_name: str, extension_settings: "dict[str, Any]"
 ) -> AsyncpgEventsBackend | AsyncpgHybridEventsBackend | None:
     """EventChannel factory for the native backend."""
+    if backend_name in {"notify", "notify_queue"}:
+        _validate_listener_pool_capacity(config)
     match backend_name:
         case "notify":
             try:
@@ -198,6 +203,16 @@ def create_event_backend(
                 return None
         case _:
             return None
+
+
+def _validate_listener_pool_capacity(config: "AsyncpgConfig") -> None:
+    max_size = config.connection_config.get("max_size")
+    if max_size is not None and max_size < _MIN_LISTENER_POOL_SIZE:
+        msg = (
+            f"{type(config).__name__} native event listeners require "
+            f"pool max_size >= {_MIN_LISTENER_POOL_SIZE}"
+        )
+        raise ImproperConfigurationError(msg)
 
 
 def _extract_event_id(payload: "str | None") -> "str | None":

--- a/sqlspec/adapters/asyncpg/events/backend.py
+++ b/sqlspec/adapters/asyncpg/events/backend.py
@@ -20,6 +20,8 @@ from sqlspec.utils.serializers import from_json, to_json
 from sqlspec.utils.uuids import uuid4
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from sqlspec.adapters.asyncpg.config import AsyncpgConfig
 
 __all__ = ("AsyncpgEventsBackend", "AsyncpgHybridEventsBackend", "create_event_backend")
@@ -61,6 +63,41 @@ class AsyncpgHybridEventsBackend:
         await self._publish_durable(channel, event_id, payload, metadata)
         self._runtime.increment_metric("events.publish.native")
         return event_id
+
+    async def publish_many(self, events: "Sequence[tuple[str, dict[str, Any], dict[str, Any] | None]]") -> list[str]:
+        """Persist a batch and publish one compact wakeup marker per channel."""
+        if not events:
+            return []
+        now = datetime.now(timezone.utc)
+        event_ids: list[str] = []
+        records: list[dict[str, Any]] = []
+        marker_counts: dict[str, int] = {}
+        for channel, payload, metadata in events:
+            event_id = uuid4().hex
+            event_ids.append(event_id)
+            records.append({
+                "event_id": event_id,
+                "channel": channel,
+                "payload_json": to_json(payload),
+                "metadata_json": to_json(metadata) if metadata is not None else None,
+                "status": "pending",
+                "available_at": now,
+                "lease_expires_at": None,
+                "attempts": 0,
+                "created_at": now,
+            })
+            marker_counts[channel] = marker_counts.get(channel, 0) + 1
+        markers = [(channel, to_json({"batch_size": count})) for channel, count in marker_counts.items()]
+        self._runtime.increment_metric("events.publisher.session")
+        async with self._config.provide_session() as driver:
+            await driver.execute_many(
+                self._queue._insert_statement, records, statement_config=self._queue._statement_config
+            )
+            await driver.execute_many("SELECT pg_notify($1, $2)", markers)
+            await driver.commit()
+        self._runtime.increment_metric("events.publisher.statement", 2)
+        self._runtime.increment_metric("events.publish.native", len(records))
+        return event_ids
 
     async def dequeue(self, channel: str, poll_interval: float) -> EventMessage | None:
         hub = self._ensure_hub()
@@ -156,6 +193,24 @@ class AsyncpgEventsBackend:
         self._runtime.increment_metric("events.publish.native")
         return event_id
 
+    async def publish_many(self, events: "Sequence[tuple[str, dict[str, Any], dict[str, Any] | None]]") -> list[str]:
+        """Publish unchanged per-event envelopes through one producer session."""
+        if not events:
+            return []
+        event_ids: list[str] = []
+        parameters: list[tuple[str, str]] = []
+        for channel, payload, metadata in events:
+            event_id = uuid4().hex
+            event_ids.append(event_id)
+            parameters.append((channel, encode_notify_payload(event_id, payload, metadata)))
+        self._runtime.increment_metric("events.publisher.session")
+        async with self._config.provide_session() as driver:
+            await driver.execute_many("SELECT pg_notify($1, $2)", parameters)
+            await driver.commit()
+        self._runtime.increment_metric("events.publisher.statement")
+        self._runtime.increment_metric("events.publish.native", len(parameters))
+        return event_ids
+
     async def dequeue(self, channel: str, poll_interval: float) -> EventMessage | None:
         hub = self._ensure_hub()
         payload = await hub.dequeue(channel, poll_interval)
@@ -208,10 +263,7 @@ def create_event_backend(
 def _validate_listener_pool_capacity(config: "AsyncpgConfig") -> None:
     max_size = config.connection_config.get("max_size")
     if max_size is not None and max_size < _MIN_LISTENER_POOL_SIZE:
-        msg = (
-            f"{type(config).__name__} native event listeners require "
-            f"pool max_size >= {_MIN_LISTENER_POOL_SIZE}"
-        )
+        msg = f"{type(config).__name__} native event listeners require pool max_size >= {_MIN_LISTENER_POOL_SIZE}"
         raise ImproperConfigurationError(msg)
 
 

--- a/sqlspec/adapters/asyncpg/events/backend.py
+++ b/sqlspec/adapters/asyncpg/events/backend.py
@@ -32,13 +32,16 @@ _MAX_SEEN_MARKERS = 1_024
 
 
 class _MarkerDrainState:
-    __slots__ = ("_pending", "_seen")
+    __slots__ = ("_pending", "_recovering", "_seen")
 
     def __init__(self) -> None:
         self._pending: dict[str, int] = {}
+        self._recovering: set[str] = set()
         self._seen: dict[tuple[str, str], None] = {}
 
     def take(self, channel: str) -> bool:
+        if channel in self._recovering:
+            return True
         pending = self._pending.get(channel, 0)
         if pending <= 0:
             return False
@@ -58,11 +61,18 @@ class _MarkerDrainState:
             self._pending[channel] = self._pending.get(channel, 0) + max(batch_size, 1)
         return is_new, self.take(channel)
 
+    def begin_recovery(self, channel: str) -> None:
+        if channel not in self._recovering and len(self._recovering) >= _MAX_SEEN_MARKERS:
+            self._recovering.pop()
+        self._recovering.add(channel)
+
     def clear(self, channel: str) -> None:
         self._pending.pop(channel, None)
+        self._recovering.discard(channel)
 
     def reset(self) -> None:
         self._pending.clear()
+        self._recovering.clear()
         self._seen.clear()
 
 
@@ -105,24 +115,9 @@ class AsyncpgHybridEventsBackend:
         """Persist a batch and publish one compact wakeup marker per channel."""
         if not events:
             return []
-        now = datetime.now(timezone.utc)
-        event_ids: list[str] = []
-        records: list[dict[str, Any]] = []
+        event_ids, records = self._queue._batch_insert_parameters(events)
         marker_counts: dict[str, int] = {}
-        for channel, payload, metadata in events:
-            event_id = uuid4().hex
-            event_ids.append(event_id)
-            records.append({
-                "event_id": event_id,
-                "channel": channel,
-                "payload_json": to_json(payload),
-                "metadata_json": to_json(metadata) if metadata is not None else None,
-                "status": "pending",
-                "available_at": now,
-                "lease_expires_at": None,
-                "attempts": 0,
-                "created_at": now,
-            })
+        for channel, _payload, _metadata in events:
             marker_counts[channel] = marker_counts.get(channel, 0) + 1
         marker_id = uuid4().hex
         markers = [
@@ -131,10 +126,15 @@ class AsyncpgHybridEventsBackend:
         ]
         self._runtime.increment_metric("events.publisher.session")
         async with self._config.provide_session() as driver:
-            await driver.execute_many(
-                self._queue._insert_statement, records, statement_config=self._queue._statement_config
-            )
-            await driver.execute_many("SELECT pg_notify($1, $2)", markers)
+            await driver.begin()
+            try:
+                await driver.execute_many(
+                    self._queue._insert_statement, records, statement_config=self._queue._statement_config
+                )
+                await driver.execute_many("SELECT pg_notify($1, $2)", markers)
+            except BaseException:
+                await driver.rollback()
+                raise
             await driver.commit()
         self._runtime.increment_metric("events.publisher.statement", 2)
         self._runtime.increment_metric("events.publish.native", len(records))
@@ -204,6 +204,7 @@ class AsyncpgHybridEventsBackend:
         if event is None:
             self._runtime.increment_metric("events.listener.timeout")
             return None
+        self._marker_state.begin_recovery(channel)
         self._runtime.increment_metric("events.marker.miss")
         _record_dequeue_result(self._runtime, event)
         return event
@@ -283,7 +284,12 @@ class AsyncpgEventsBackend:
             parameters.append((channel, encode_notify_payload(event_id, payload, metadata)))
         self._runtime.increment_metric("events.publisher.session")
         async with self._config.provide_session() as driver:
-            await driver.execute_many("SELECT pg_notify($1, $2)", parameters)
+            await driver.begin()
+            try:
+                await driver.execute_many("SELECT pg_notify($1, $2)", parameters)
+            except BaseException:
+                await driver.rollback()
+                raise
             await driver.commit()
         self._runtime.increment_metric("events.publisher.statement")
         self._runtime.increment_metric("events.publish.native", len(parameters))

--- a/sqlspec/adapters/psqlpy/events/_hub.py
+++ b/sqlspec/adapters/psqlpy/events/_hub.py
@@ -12,13 +12,14 @@ other's callbacks mid-iteration.
 
 import asyncio
 import contextlib
+import logging
 from typing import TYPE_CHECKING, Any, cast
 from weakref import WeakKeyDictionary
 
 from sqlspec.core import SQL
 from sqlspec.extensions.events import normalize_event_channel_name
 from sqlspec.protocols import NotificationProtocol
-from sqlspec.utils.logging import get_logger
+from sqlspec.utils.logging import get_logger, log_with_context
 from sqlspec.utils.uuids import uuid4
 
 if TYPE_CHECKING:
@@ -74,6 +75,7 @@ class PsqlpyListenerHub:
     """Per-channel persistent listener for psqlpy event backends."""
 
     __slots__ = (
+        "_backend_name",
         "_callbacks",
         "_config",
         "_listener",
@@ -85,7 +87,8 @@ class PsqlpyListenerHub:
         "_shutting_down",
     )
 
-    def __init__(self, config: "PsqlpyConfig") -> None:
+    def __init__(self, config: "PsqlpyConfig", backend_name: str = "notify") -> None:
+        self._backend_name = backend_name
         self._config = config
         self._lock = asyncio.Lock()
         self._queues: dict[str, WeakKeyDictionary[asyncio.Task[Any], asyncio.Queue[str]]] = {}
@@ -123,6 +126,7 @@ class PsqlpyListenerHub:
             msg = "PsqlpyListenerHub.dequeue requires an active asyncio task"
             raise RuntimeError(msg)
         async with self._lock:
+            await self._ensure_listener_locked()
             if channel not in self._queues:
                 queue = await self._subscribe_locked(channel, consumer_task=task, ready_timeout=poll_interval)
             else:
@@ -156,6 +160,7 @@ class PsqlpyListenerHub:
                     listener.abort_listen()
             with contextlib.suppress(Exception):
                 await listener.shutdown()
+            _record_listener_lifecycle(self._config, self._backend_name, "release")
         self._shutting_down = False
 
     def is_subscribed(self, channel: str) -> bool:
@@ -207,12 +212,38 @@ class PsqlpyListenerHub:
         return consumer_queue
 
     async def _ensure_listener_locked(self) -> "PsqlpyListener":
-        if self._listener is not None:
+        if self._listener is not None and self._listener.is_started:
             return cast("PsqlpyListener", self._listener)
+        previous_listener = self._listener
+        reconnecting = previous_listener is not None
+        if previous_listener is not None:
+            if self._listener_started:
+                with contextlib.suppress(Exception):
+                    previous_listener.abort_listen()
+            with contextlib.suppress(Exception):
+                await previous_listener.shutdown()
+            _record_listener_lifecycle(self._config, self._backend_name, "release")
+            self._listener = None
+            self._listener_started = False
         pool = await self._config.provide_pool()
         listener = pool.listener()
         await listener.startup()
         self._listener = listener
+        try:
+            for channel, callback in self._callbacks.items():
+                await listener.add_callback(channel=channel, callback=callback.__call__)
+        except Exception:
+            self._listener = None
+            with contextlib.suppress(Exception):
+                await listener.shutdown()
+            raise
+        if self._callbacks:
+            listener.listen()
+            self._listener_started = True
+        _record_listener_lifecycle(self._config, self._backend_name, "acquire")
+        if reconnecting:
+            _record_listener_lifecycle(self._config, self._backend_name, "reconnect")
+        _record_listener_lifecycle(self._config, self._backend_name, "ready")
         self._register_pool_destroying()
         return listener
 
@@ -254,3 +285,16 @@ class PsqlpyListenerHub:
             return
         for queue in list(queues.values()):
             queue.put_nowait(payload)
+
+
+def _record_listener_lifecycle(config: "PsqlpyConfig", backend_name: str, status: str) -> None:
+    config.get_observability_runtime().increment_metric(f"events.listener.{status}")
+    log_with_context(
+        logger,
+        logging.DEBUG,
+        "event.listener.connection",
+        adapter_name="psqlpy",
+        backend_name=backend_name,
+        connection_role="listener",
+        status=status,
+    )

--- a/sqlspec/adapters/psqlpy/events/backend.py
+++ b/sqlspec/adapters/psqlpy/events/backend.py
@@ -21,6 +21,8 @@ from sqlspec.utils.serializers import from_json, to_json
 from sqlspec.utils.uuids import uuid4
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from sqlspec.adapters.psqlpy.config import PsqlpyConfig
 
 __all__ = ("PsqlpyEventsBackend", "PsqlpyHybridEventsBackend", "create_event_backend")
@@ -66,6 +68,24 @@ class PsqlpyEventsBackend:
             await driver.commit()
         self._runtime.increment_metric("events.publish.native")
         return event_id
+
+    async def publish_many(self, events: "Sequence[tuple[str, dict[str, Any], dict[str, Any] | None]]") -> list[str]:
+        """Publish unchanged per-event envelopes through one producer session."""
+        if not events:
+            return []
+        event_ids: list[str] = []
+        parameters: list[tuple[str, str]] = []
+        for channel, payload, metadata in events:
+            event_id = uuid4().hex
+            event_ids.append(event_id)
+            parameters.append((channel, encode_notify_payload(event_id, payload, metadata)))
+        self._runtime.increment_metric("events.publisher.session")
+        async with self._config.provide_session() as driver:
+            await driver.execute_many("SELECT pg_notify($1, $2)", parameters)
+            await driver.commit()
+        self._runtime.increment_metric("events.publisher.statement")
+        self._runtime.increment_metric("events.publish.native", len(parameters))
+        return event_ids
 
     async def dequeue(self, channel: str, poll_interval: float) -> EventMessage | None:
         hub = self._ensure_hub()
@@ -125,6 +145,41 @@ class PsqlpyHybridEventsBackend:
         await self._publish_durable(channel, event_id, payload, metadata)
         self._runtime.increment_metric("events.publish.native")
         return event_id
+
+    async def publish_many(self, events: "Sequence[tuple[str, dict[str, Any], dict[str, Any] | None]]") -> list[str]:
+        """Persist a batch and publish one compact wakeup marker per channel."""
+        if not events:
+            return []
+        now = datetime.now(timezone.utc)
+        event_ids: list[str] = []
+        records: list[dict[str, Any]] = []
+        marker_counts: dict[str, int] = {}
+        for channel, payload, metadata in events:
+            event_id = uuid4().hex
+            event_ids.append(event_id)
+            records.append({
+                "event_id": event_id,
+                "channel": channel,
+                "payload_json": to_json(payload),
+                "metadata_json": to_json(metadata) if metadata is not None else None,
+                "status": "pending",
+                "available_at": now,
+                "lease_expires_at": None,
+                "attempts": 0,
+                "created_at": now,
+            })
+            marker_counts[channel] = marker_counts.get(channel, 0) + 1
+        markers = [(channel, to_json({"batch_size": count})) for channel, count in marker_counts.items()]
+        self._runtime.increment_metric("events.publisher.session")
+        async with self._config.provide_session() as driver:
+            await driver.execute_many(
+                self._queue._insert_statement, records, statement_config=self._queue._statement_config
+            )
+            await driver.execute_many("SELECT pg_notify($1, $2)", markers)
+            await driver.commit()
+        self._runtime.increment_metric("events.publisher.statement", 2)
+        self._runtime.increment_metric("events.publish.native", len(records))
+        return event_ids
 
     async def dequeue(self, channel: str, poll_interval: float) -> EventMessage | None:
         hub = self._ensure_hub()
@@ -209,8 +264,7 @@ def _validate_listener_pool_capacity(config: "PsqlpyConfig") -> None:
     max_size = config.connection_config.get("max_db_pool_size")
     if max_size is not None and max_size < _MIN_LISTENER_POOL_SIZE:
         msg = (
-            f"{type(config).__name__} native event listeners require "
-            f"pool max_db_pool_size >= {_MIN_LISTENER_POOL_SIZE}"
+            f"{type(config).__name__} native event listeners require pool max_db_pool_size >= {_MIN_LISTENER_POOL_SIZE}"
         )
         raise ImproperConfigurationError(msg)
 

--- a/sqlspec/adapters/psqlpy/events/backend.py
+++ b/sqlspec/adapters/psqlpy/events/backend.py
@@ -27,6 +27,7 @@ __all__ = ("PsqlpyEventsBackend", "PsqlpyHybridEventsBackend", "create_event_bac
 
 
 logger = get_logger("sqlspec.events.psqlpy")
+_MIN_LISTENER_POOL_SIZE = 2
 
 
 class PsqlpyEventsBackend:
@@ -56,6 +57,7 @@ class PsqlpyEventsBackend:
         )
 
     async def publish(self, channel: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None" = None) -> str:
+        self._runtime.increment_metric("events.publisher.session")
         event_id = uuid4().hex
         async with self._config.provide_session() as driver:
             await driver.execute_script(
@@ -86,7 +88,7 @@ class PsqlpyEventsBackend:
 
     def _ensure_hub(self) -> PsqlpyListenerHub:
         if self._hub is None:
-            self._hub = PsqlpyListenerHub(self._config)
+            self._hub = PsqlpyListenerHub(self._config, self.backend_name)
         return self._hub
 
 
@@ -118,6 +120,7 @@ class PsqlpyHybridEventsBackend:
         )
 
     async def publish(self, channel: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None" = None) -> str:
+        self._runtime.increment_metric("events.publisher.session")
         event_id = uuid4().hex
         await self._publish_durable(channel, event_id, payload, metadata)
         self._runtime.increment_metric("events.publish.native")
@@ -151,7 +154,7 @@ class PsqlpyHybridEventsBackend:
 
     def _ensure_hub(self) -> PsqlpyListenerHub:
         if self._hub is None:
-            self._hub = PsqlpyListenerHub(self._config)
+            self._hub = PsqlpyListenerHub(self._config, self.backend_name)
         return self._hub
 
     async def _publish_durable(
@@ -184,6 +187,8 @@ def create_event_backend(
     config: "PsqlpyConfig", backend_name: str, extension_settings: "dict[str, Any]"
 ) -> PsqlpyEventsBackend | PsqlpyHybridEventsBackend | None:
     """EventChannel factory for the native psqlpy backend."""
+    if backend_name in {"notify", "notify_queue"}:
+        _validate_listener_pool_capacity(config)
     match backend_name:
         case "notify":
             try:
@@ -198,6 +203,16 @@ def create_event_backend(
                 return None
         case _:
             return None
+
+
+def _validate_listener_pool_capacity(config: "PsqlpyConfig") -> None:
+    max_size = config.connection_config.get("max_size")
+    if max_size is not None and max_size < _MIN_LISTENER_POOL_SIZE:
+        msg = (
+            f"{type(config).__name__} native event listeners require "
+            f"pool max_size >= {_MIN_LISTENER_POOL_SIZE}"
+        )
+        raise ImproperConfigurationError(msg)
 
 
 def _extract_event_id(payload: "str | None") -> "str | None":

--- a/sqlspec/adapters/psqlpy/events/backend.py
+++ b/sqlspec/adapters/psqlpy/events/backend.py
@@ -206,11 +206,11 @@ def create_event_backend(
 
 
 def _validate_listener_pool_capacity(config: "PsqlpyConfig") -> None:
-    max_size = config.connection_config.get("max_size")
+    max_size = config.connection_config.get("max_db_pool_size")
     if max_size is not None and max_size < _MIN_LISTENER_POOL_SIZE:
         msg = (
             f"{type(config).__name__} native event listeners require "
-            f"pool max_size >= {_MIN_LISTENER_POOL_SIZE}"
+            f"pool max_db_pool_size >= {_MIN_LISTENER_POOL_SIZE}"
         )
         raise ImproperConfigurationError(msg)
 

--- a/sqlspec/adapters/psqlpy/events/backend.py
+++ b/sqlspec/adapters/psqlpy/events/backend.py
@@ -311,8 +311,8 @@ class PsqlpyHybridEventsBackend:
                     {
                         "event_id": event_id,
                         "channel": channel,
-                        "payload_json": to_json(payload),
-                        "metadata_json": to_json(metadata) if metadata is not None else None,
+                        "payload_json": payload,
+                        "metadata_json": metadata,
                         "status": "pending",
                         "available_at": now,
                         "lease_expires_at": None,

--- a/sqlspec/adapters/psqlpy/events/backend.py
+++ b/sqlspec/adapters/psqlpy/events/backend.py
@@ -30,6 +30,42 @@ __all__ = ("PsqlpyEventsBackend", "PsqlpyHybridEventsBackend", "create_event_bac
 
 logger = get_logger("sqlspec.events.psqlpy")
 _MIN_LISTENER_POOL_SIZE = 2
+_MAX_SEEN_MARKERS = 1_024
+
+
+class _MarkerDrainState:
+    __slots__ = ("_pending", "_seen")
+
+    def __init__(self) -> None:
+        self._pending: dict[str, int] = {}
+        self._seen: dict[tuple[str, str], None] = {}
+
+    def take(self, channel: str) -> bool:
+        pending = self._pending.get(channel, 0)
+        if pending <= 0:
+            return False
+        if pending == 1:
+            self._pending.pop(channel, None)
+        else:
+            self._pending[channel] = pending - 1
+        return True
+
+    def register(self, channel: str, marker_id: "str | None", batch_size: int) -> "tuple[bool, bool]":
+        is_new = marker_id is None or (channel, marker_id) not in self._seen
+        if is_new:
+            if marker_id is not None:
+                if len(self._seen) >= _MAX_SEEN_MARKERS:
+                    self._seen.pop(next(iter(self._seen)))
+                self._seen[(channel, marker_id)] = None
+            self._pending[channel] = self._pending.get(channel, 0) + max(batch_size, 1)
+        return is_new, self.take(channel)
+
+    def clear(self, channel: str) -> None:
+        self._pending.pop(channel, None)
+
+    def reset(self) -> None:
+        self._pending.clear()
+        self._seen.clear()
 
 
 class PsqlpyEventsBackend:
@@ -91,8 +127,12 @@ class PsqlpyEventsBackend:
         hub = self._ensure_hub()
         payload = await hub.dequeue(channel, poll_interval)
         if payload is None:
+            self._runtime.increment_metric("events.listener.timeout")
             return None
-        return decode_notify_payload(channel, payload)
+        self._runtime.increment_metric("events.listener.wakeup")
+        event = decode_notify_payload(channel, payload)
+        _record_dequeue_result(self._runtime, event)
+        return event
 
     async def ack(self, _event_id: str) -> None:
         self._runtime.increment_metric("events.ack")
@@ -115,7 +155,7 @@ class PsqlpyEventsBackend:
 class PsqlpyHybridEventsBackend:
     """Durable hybrid backend combining queue storage with LISTEN/NOTIFY wakeups."""
 
-    __slots__ = ("_config", "_hub", "_queue", "_runtime")
+    __slots__ = ("_config", "_hub", "_marker_state", "_queue", "_runtime")
 
     supports_sync = False
     supports_async = True
@@ -128,6 +168,7 @@ class PsqlpyHybridEventsBackend:
         self._config = config
         self._queue = queue
         self._runtime = config.get_observability_runtime()
+        self._marker_state = _MarkerDrainState()
         self._hub: PsqlpyListenerHub | None = None
         log_with_context(
             logger,
@@ -169,7 +210,11 @@ class PsqlpyHybridEventsBackend:
                 "created_at": now,
             })
             marker_counts[channel] = marker_counts.get(channel, 0) + 1
-        markers = [(channel, to_json({"batch_size": count})) for channel, count in marker_counts.items()]
+        marker_id = uuid4().hex
+        markers = [
+            (channel, to_json({"batch_size": count, "marker_id": marker_id}))
+            for channel, count in marker_counts.items()
+        ]
         self._runtime.increment_metric("events.publisher.session")
         async with self._config.provide_session() as driver:
             await driver.execute_many(
@@ -182,16 +227,50 @@ class PsqlpyHybridEventsBackend:
         return event_ids
 
     async def dequeue(self, channel: str, poll_interval: float) -> EventMessage | None:
+        if self._marker_state.take(channel):
+            return await self._dequeue_hinted(channel)
         hub = self._ensure_hub()
-        payload = await hub.dequeue(channel, poll_interval)
-        if payload is None:
-            return await self._queue.dequeue(channel)
-        event_id = _extract_event_id(payload)
-        if event_id is not None:
-            event = await self._queue.dequeue_by_event_id(event_id)
-            if event is not None:
-                return event
-        return await self._queue.dequeue(channel)
+        while True:
+            payload = await hub.dequeue(channel, poll_interval)
+            if payload is None:
+                return await self._dequeue_reconciled(channel)
+            self._queue._reset_empty_poll_delay(channel)
+            self._runtime.increment_metric("events.listener.wakeup")
+            batch_size = _extract_batch_size(payload)
+            is_new, should_drain = self._marker_state.register(channel, _extract_marker_id(payload), batch_size)
+            if is_new and batch_size > 1:
+                self._runtime.increment_metric("events.marker.coalesced", batch_size - 1)
+            if not should_drain:
+                self._runtime.increment_metric("events.marker.duplicate")
+                continue
+            event_id = _extract_event_id(payload)
+            if event_id is not None:
+                event = await self._queue.dequeue_by_event_id(event_id)
+                if event is not None:
+                    self._runtime.increment_metric("events.marker.drain")
+                    _record_dequeue_result(self._runtime, event)
+                    return event
+            return await self._dequeue_hinted(channel)
+
+    async def _dequeue_hinted(self, channel: str) -> EventMessage | None:
+        event = await self._queue.dequeue(channel)
+        if event is None:
+            self._marker_state.clear(channel)
+            self._runtime.increment_metric("events.marker.shortfall")
+            return None
+        self._runtime.increment_metric("events.marker.drain")
+        _record_dequeue_result(self._runtime, event)
+        return event
+
+    async def _dequeue_reconciled(self, channel: str) -> EventMessage | None:
+        self._runtime.increment_metric("events.poll.fallback")
+        event = await self._queue.dequeue(channel)
+        if event is None:
+            self._runtime.increment_metric("events.listener.timeout")
+            return None
+        self._runtime.increment_metric("events.marker.miss")
+        _record_dequeue_result(self._runtime, event)
+        return event
 
     async def ack(self, event_id: str) -> None:
         await self._queue.ack(event_id)
@@ -203,9 +282,12 @@ class PsqlpyHybridEventsBackend:
 
     async def shutdown(self) -> None:
         hub = self._hub
-        if hub is not None:
-            self._hub = None
-            await hub.shutdown()
+        try:
+            if hub is not None:
+                self._hub = None
+                await hub.shutdown()
+        finally:
+            self._marker_state.reset()
 
     def _ensure_hub(self) -> PsqlpyListenerHub:
         if self._hub is None:
@@ -223,8 +305,8 @@ class PsqlpyHybridEventsBackend:
                     {
                         "event_id": event_id,
                         "channel": channel,
-                        "payload_json": payload,
-                        "metadata_json": metadata,
+                        "payload_json": to_json(payload),
+                        "metadata_json": to_json(metadata) if metadata is not None else None,
                         "status": "pending",
                         "available_at": now,
                         "lease_expires_at": None,
@@ -277,3 +359,30 @@ def _extract_event_id(payload: "str | None") -> "str | None":
         event_id = raw.get("event_id")
         return event_id if isinstance(event_id, str) else None
     return None
+
+
+def _extract_batch_size(payload: "str | None") -> int:
+    if not payload:
+        return 0
+    raw = from_json(payload)
+    if isinstance(raw, dict):
+        batch_size = raw.get("batch_size")
+        return batch_size if isinstance(batch_size, int) else 0
+    return 0
+
+
+def _extract_marker_id(payload: "str | None") -> "str | None":
+    if not payload:
+        return None
+    raw = from_json(payload)
+    if isinstance(raw, dict):
+        marker_id = raw.get("marker_id", raw.get("event_id"))
+        return marker_id if isinstance(marker_id, str) else None
+    return None
+
+
+def _record_dequeue_result(runtime: Any, event: "EventMessage | None") -> None:
+    if event is None:
+        return
+    latency_ms = max(0.0, (datetime.now(timezone.utc) - event.created_at).total_seconds() * 1000)
+    runtime.record_metric("events.dequeue.latency_ms", latency_ms)

--- a/sqlspec/adapters/psqlpy/events/backend.py
+++ b/sqlspec/adapters/psqlpy/events/backend.py
@@ -34,13 +34,16 @@ _MAX_SEEN_MARKERS = 1_024
 
 
 class _MarkerDrainState:
-    __slots__ = ("_pending", "_seen")
+    __slots__ = ("_pending", "_recovering", "_seen")
 
     def __init__(self) -> None:
         self._pending: dict[str, int] = {}
+        self._recovering: set[str] = set()
         self._seen: dict[tuple[str, str], None] = {}
 
     def take(self, channel: str) -> bool:
+        if channel in self._recovering:
+            return True
         pending = self._pending.get(channel, 0)
         if pending <= 0:
             return False
@@ -60,11 +63,18 @@ class _MarkerDrainState:
             self._pending[channel] = self._pending.get(channel, 0) + max(batch_size, 1)
         return is_new, self.take(channel)
 
+    def begin_recovery(self, channel: str) -> None:
+        if channel not in self._recovering and len(self._recovering) >= _MAX_SEEN_MARKERS:
+            self._recovering.pop()
+        self._recovering.add(channel)
+
     def clear(self, channel: str) -> None:
         self._pending.pop(channel, None)
+        self._recovering.discard(channel)
 
     def reset(self) -> None:
         self._pending.clear()
+        self._recovering.clear()
         self._seen.clear()
 
 
@@ -117,7 +127,12 @@ class PsqlpyEventsBackend:
             parameters.append((channel, encode_notify_payload(event_id, payload, metadata)))
         self._runtime.increment_metric("events.publisher.session")
         async with self._config.provide_session() as driver:
-            await driver.execute_many("SELECT pg_notify($1, $2)", parameters)
+            await driver.begin()
+            try:
+                await driver.execute_many("SELECT pg_notify($1, $2)", parameters)
+            except BaseException:
+                await driver.rollback()
+                raise
             await driver.commit()
         self._runtime.increment_metric("events.publisher.statement")
         self._runtime.increment_metric("events.publish.native", len(parameters))
@@ -191,24 +206,9 @@ class PsqlpyHybridEventsBackend:
         """Persist a batch and publish one compact wakeup marker per channel."""
         if not events:
             return []
-        now = datetime.now(timezone.utc)
-        event_ids: list[str] = []
-        records: list[dict[str, Any]] = []
+        event_ids, records = self._queue._batch_insert_parameters(events)
         marker_counts: dict[str, int] = {}
-        for channel, payload, metadata in events:
-            event_id = uuid4().hex
-            event_ids.append(event_id)
-            records.append({
-                "event_id": event_id,
-                "channel": channel,
-                "payload_json": to_json(payload),
-                "metadata_json": to_json(metadata) if metadata is not None else None,
-                "status": "pending",
-                "available_at": now,
-                "lease_expires_at": None,
-                "attempts": 0,
-                "created_at": now,
-            })
+        for channel, _payload, _metadata in events:
             marker_counts[channel] = marker_counts.get(channel, 0) + 1
         marker_id = uuid4().hex
         markers = [
@@ -217,10 +217,15 @@ class PsqlpyHybridEventsBackend:
         ]
         self._runtime.increment_metric("events.publisher.session")
         async with self._config.provide_session() as driver:
-            await driver.execute_many(
-                self._queue._insert_statement, records, statement_config=self._queue._statement_config
-            )
-            await driver.execute_many("SELECT pg_notify($1, $2)", markers)
+            await driver.begin()
+            try:
+                await driver.execute_many(
+                    self._queue._insert_statement, records, statement_config=self._queue._statement_config
+                )
+                await driver.execute_many("SELECT pg_notify($1, $2)", markers)
+            except BaseException:
+                await driver.rollback()
+                raise
             await driver.commit()
         self._runtime.increment_metric("events.publisher.statement", 2)
         self._runtime.increment_metric("events.publish.native", len(records))
@@ -268,6 +273,7 @@ class PsqlpyHybridEventsBackend:
         if event is None:
             self._runtime.increment_metric("events.listener.timeout")
             return None
+        self._marker_state.begin_recovery(channel)
         self._runtime.increment_metric("events.marker.miss")
         _record_dequeue_result(self._runtime, event)
         return event

--- a/sqlspec/adapters/psycopg/events/_hub.py
+++ b/sqlspec/adapters/psycopg/events/_hub.py
@@ -17,6 +17,7 @@ import threading
 from typing import TYPE_CHECKING, Any
 from weakref import WeakKeyDictionary
 
+from sqlspec.adapters.psycopg._typing import PsycopgComposed, PsycopgIdentifier, PsycopgSQL
 from sqlspec.exceptions import ImproperConfigurationError
 from sqlspec.extensions.events import normalize_event_channel_name
 from sqlspec.utils.logging import get_logger, log_with_context
@@ -69,12 +70,11 @@ class PsycopgAsyncListenerHub:
             if channel in self._queues:
                 return
             await self._ensure_connection_locked()
-            validated = normalize_event_channel_name(channel)
             connection = self._connection
             assert connection is not None
             self._queues[channel] = WeakKeyDictionary()
             try:
-                await connection.execute(f"LISTEN {validated}")
+                await connection.execute(_listen_statement(channel))
             except Exception:
                 self._queues.pop(channel, None)
                 raise
@@ -87,9 +87,8 @@ class PsycopgAsyncListenerHub:
             connection = self._connection
             if connection is None:
                 return
-            validated = normalize_event_channel_name(channel)
             with contextlib.suppress(Exception):
-                await connection.execute(f"UNLISTEN {validated}")
+                await connection.execute(_unlisten_statement(channel))
 
     async def dequeue(self, channel: str, poll_interval: float) -> "str | None":
         if channel not in self._queues:
@@ -124,9 +123,8 @@ class PsycopgAsyncListenerHub:
                 await pump_task
         if connection is not None:
             for channel in channels:
-                validated = normalize_event_channel_name(channel)
                 with contextlib.suppress(Exception):
-                    await connection.execute(f"UNLISTEN {validated}")
+                    await connection.execute(_unlisten_statement(channel))
         if connection_cm is not None:
             with contextlib.suppress(Exception):
                 await connection_cm.__aexit__(None, None, None)
@@ -186,8 +184,7 @@ class PsycopgAsyncListenerHub:
         self._connection = connection
         try:
             for channel in self._queues:
-                validated = normalize_event_channel_name(channel)
-                await connection.execute(f"LISTEN {validated}")
+                await connection.execute(_listen_statement(channel))
         except Exception:
             self._connection = None
             self._connection_cm = None
@@ -453,12 +450,10 @@ class PsycopgSyncListenerHub:
                 return
             try:
                 if op == "listen":
-                    validated = normalize_event_channel_name(channel)
-                    connection.execute(f"LISTEN {validated}")
+                    connection.execute(_listen_statement(channel))
                 elif op == "unlisten":
-                    validated = normalize_event_channel_name(channel)
                     with contextlib.suppress(Exception):
-                        connection.execute(f"UNLISTEN {validated}")
+                        connection.execute(_unlisten_statement(channel))
                 elif op == "stop":
                     stopping.set()
             finally:
@@ -488,3 +483,13 @@ def _record_listener_lifecycle(
         mode="async" if is_async else "sync",
         status=status,
     )
+
+
+def _listen_statement(channel: str) -> PsycopgComposed:
+    validated = normalize_event_channel_name(channel)
+    return PsycopgSQL("LISTEN {}").format(PsycopgIdentifier(validated))
+
+
+def _unlisten_statement(channel: str) -> PsycopgComposed:
+    validated = normalize_event_channel_name(channel)
+    return PsycopgSQL("UNLISTEN {}").format(PsycopgIdentifier(validated))

--- a/sqlspec/adapters/psycopg/events/_hub.py
+++ b/sqlspec/adapters/psycopg/events/_hub.py
@@ -11,6 +11,7 @@ queue (psycopg sync connections are not thread-safe).
 
 import asyncio
 import contextlib
+import logging
 import queue as stdlib_queue
 import threading
 from typing import TYPE_CHECKING, Any
@@ -18,7 +19,7 @@ from weakref import WeakKeyDictionary
 
 from sqlspec.exceptions import ImproperConfigurationError
 from sqlspec.extensions.events import normalize_event_channel_name
-from sqlspec.utils.logging import get_logger
+from sqlspec.utils.logging import get_logger, log_with_context
 
 if TYPE_CHECKING:
     from sqlspec.adapters.psycopg.config import PsycopgAsyncConfig, PsycopgSyncConfig
@@ -36,6 +37,7 @@ class PsycopgAsyncListenerHub:
     """Async psycopg persistent listener hub."""
 
     __slots__ = (
+        "_backend_name",
         "_config",
         "_connection",
         "_connection_cm",
@@ -47,7 +49,8 @@ class PsycopgAsyncListenerHub:
         "_stopping",
     )
 
-    def __init__(self, config: "PsycopgAsyncConfig") -> None:
+    def __init__(self, config: "PsycopgAsyncConfig", backend_name: str = "notify") -> None:
+        self._backend_name = backend_name
         self._config = config
         self._lock = asyncio.Lock()
         self._queues: dict[str, WeakKeyDictionary[asyncio.Task[Any], asyncio.Queue[str]]] = {}
@@ -91,6 +94,8 @@ class PsycopgAsyncListenerHub:
     async def dequeue(self, channel: str, poll_interval: float) -> "str | None":
         if channel not in self._queues:
             await self.subscribe(channel)
+        async with self._lock:
+            await self._ensure_connection_locked()
         queue = self._get_consumer_queue(channel)
         if queue is None:
             return None
@@ -125,6 +130,7 @@ class PsycopgAsyncListenerHub:
         if connection_cm is not None:
             with contextlib.suppress(Exception):
                 await connection_cm.__aexit__(None, None, None)
+            _record_listener_lifecycle(self._config, self._backend_name, "release", is_async=True)
         self._shutting_down = False
         self._stopping = False
 
@@ -146,8 +152,27 @@ class PsycopgAsyncListenerHub:
         return queue
 
     async def _ensure_connection_locked(self) -> None:
-        if self._connection is not None:
+        if (
+            self._connection is not None
+            and not self._connection.closed
+            and self._pump_task is not None
+            and not self._pump_task.done()
+        ):
             return
+        reconnecting = self._connection_cm is not None
+        if self._pump_task is not None:
+            self._stopping = True
+            self._pump_task.cancel()
+            with contextlib.suppress(BaseException):
+                await self._pump_task
+        if self._connection_cm is not None:
+            with contextlib.suppress(Exception):
+                await self._connection_cm.__aexit__(None, None, None)
+            _record_listener_lifecycle(self._config, self._backend_name, "release", is_async=True)
+        self._connection = None
+        self._connection_cm = None
+        self._pump_task = None
+        self._stopping = False
         connection_cm = self._config.provide_connection()
         connection = await connection_cm.__aenter__()
         if connection is None:
@@ -159,7 +184,21 @@ class PsycopgAsyncListenerHub:
             await connection.set_autocommit(True)
         self._connection_cm = connection_cm
         self._connection = connection
+        try:
+            for channel in self._queues:
+                validated = normalize_event_channel_name(channel)
+                await connection.execute(f"LISTEN {validated}")
+        except Exception:
+            self._connection = None
+            self._connection_cm = None
+            with contextlib.suppress(Exception):
+                await connection_cm.__aexit__(None, None, None)
+            raise
         self._pump_task = asyncio.create_task(self._pump())
+        _record_listener_lifecycle(self._config, self._backend_name, "acquire", is_async=True)
+        if reconnecting:
+            _record_listener_lifecycle(self._config, self._backend_name, "reconnect", is_async=True)
+        _record_listener_lifecycle(self._config, self._backend_name, "ready", is_async=True)
         self._register_pool_destroying()
 
     def _register_pool_destroying(self) -> None:
@@ -211,6 +250,7 @@ class PsycopgSyncListenerHub:
     """
 
     __slots__ = (
+        "_backend_name",
         "_command_queue",
         "_config",
         "_connection",
@@ -223,7 +263,8 @@ class PsycopgSyncListenerHub:
         "_worker_thread",
     )
 
-    def __init__(self, config: "PsycopgSyncConfig") -> None:
+    def __init__(self, config: "PsycopgSyncConfig", backend_name: str = "notify") -> None:
+        self._backend_name = backend_name
         self._config = config
         self._lock = threading.Lock()
         self._queues: dict[str, WeakKeyDictionary[threading.Thread, stdlib_queue.Queue[str]]] = {}
@@ -260,6 +301,8 @@ class PsycopgSyncListenerHub:
     def dequeue(self, channel: str, poll_interval: float) -> "str | None":
         if channel not in self._queues:
             self.subscribe(channel)
+        with self._lock:
+            self._ensure_connection_locked()
         queue = self._get_consumer_queue(channel)
         if queue is None:
             return None
@@ -291,7 +334,10 @@ class PsycopgSyncListenerHub:
         if connection_cm is not None:
             with contextlib.suppress(Exception):
                 connection_cm.__exit__(None, None, None)
+            _record_listener_lifecycle(self._config, self._backend_name, "release", is_async=False)
         self._connection = None
+        self._stopping = threading.Event()
+        self._command_queue = stdlib_queue.Queue()
         self._shutting_down = False
 
     def is_subscribed(self, channel: str) -> bool:
@@ -310,8 +356,29 @@ class PsycopgSyncListenerHub:
             return queue
 
     def _ensure_connection_locked(self) -> None:
-        if self._connection is not None:
+        if (
+            self._connection is not None
+            and not self._connection.closed
+            and self._worker_thread is not None
+            and self._worker_thread.is_alive()
+        ):
             return
+        previous_thread = self._worker_thread
+        previous_connection_cm = self._connection_cm
+        reconnecting = previous_connection_cm is not None
+        if previous_thread is not None:
+            self._stopping.set()
+            with contextlib.suppress(Exception):
+                previous_thread.join(timeout=3.0)
+        if previous_connection_cm is not None:
+            with contextlib.suppress(Exception):
+                previous_connection_cm.__exit__(None, None, None)
+            _record_listener_lifecycle(self._config, self._backend_name, "release", is_async=False)
+        self._connection = None
+        self._connection_cm = None
+        self._worker_thread = None
+        self._stopping = threading.Event()
+        self._command_queue = stdlib_queue.Queue()
         connection_cm = self._config.provide_connection()
         connection = connection_cm.__enter__()
         if connection is None:
@@ -322,8 +389,19 @@ class PsycopgSyncListenerHub:
         connection.autocommit = True
         self._connection_cm = connection_cm
         self._connection = connection
-        self._worker_thread = threading.Thread(target=self._worker, name="psycopg-sync-event-worker", daemon=True)
+        self._worker_thread = threading.Thread(
+            target=self._worker,
+            args=(self._stopping, self._command_queue),
+            name="psycopg-sync-event-worker",
+            daemon=True,
+        )
         self._worker_thread.start()
+        for channel in self._queues:
+            self._submit("listen", channel)
+        _record_listener_lifecycle(self._config, self._backend_name, "acquire", is_async=False)
+        if reconnecting:
+            _record_listener_lifecycle(self._config, self._backend_name, "reconnect", is_async=False)
+        _record_listener_lifecycle(self._config, self._backend_name, "ready", is_async=False)
         self._register_pool_destroying()
 
     def _register_pool_destroying(self) -> None:
@@ -341,29 +419,36 @@ class PsycopgSyncListenerHub:
         self._command_queue.put((op, channel, done))
         done.wait(timeout=timeout)
 
-    def _worker(self) -> None:
+    def _worker(
+        self, stopping: threading.Event, command_queue: "stdlib_queue.Queue[tuple[str, str, threading.Event]]"
+    ) -> None:
         connection = self._connection
         if connection is None:
             return
-        while not self._stopping.is_set():
-            self._drain_commands(connection)
-            if self._stopping.is_set():
+        while not stopping.is_set():
+            self._drain_commands(connection, command_queue, stopping)
+            if stopping.is_set():
                 return
             try:
                 for notify in connection.notifies(timeout=_PUMP_TIMEOUT, stop_after=_PUMP_BATCH):
-                    if self._stopping.is_set():
+                    if stopping.is_set():
                         return
                     self._dispatch(notify.channel, notify.payload)
             except Exception as exc:  # pragma: no cover
-                if self._stopping.is_set() or getattr(connection, "closed", False):
+                if stopping.is_set() or getattr(connection, "closed", False):
                     return
                 logger.warning("psycopg sync notify worker error: %s", exc)
-                self._stopping.wait(timeout=0.25)
+                stopping.wait(timeout=0.25)
 
-    def _drain_commands(self, connection: Any) -> None:
+    def _drain_commands(
+        self,
+        connection: Any,
+        command_queue: "stdlib_queue.Queue[tuple[str, str, threading.Event]]",
+        stopping: threading.Event,
+    ) -> None:
         while True:
             try:
-                op, channel, done = self._command_queue.get_nowait()
+                op, channel, done = command_queue.get_nowait()
             except stdlib_queue.Empty:
                 return
             try:
@@ -375,7 +460,7 @@ class PsycopgSyncListenerHub:
                     with contextlib.suppress(Exception):
                         connection.execute(f"UNLISTEN {validated}")
                 elif op == "stop":
-                    self._stopping.set()
+                    stopping.set()
             finally:
                 done.set()
 
@@ -387,3 +472,19 @@ class PsycopgSyncListenerHub:
             targets = list(queues.values())
         for queue in targets:
             queue.put_nowait(payload)
+
+
+def _record_listener_lifecycle(
+    config: "PsycopgAsyncConfig | PsycopgSyncConfig", backend_name: str, status: str, *, is_async: bool
+) -> None:
+    config.get_observability_runtime().increment_metric(f"events.listener.{status}")
+    log_with_context(
+        logger,
+        logging.DEBUG,
+        "event.listener.connection",
+        adapter_name="psycopg",
+        backend_name=backend_name,
+        connection_role="listener",
+        mode="async" if is_async else "sync",
+        status=status,
+    )

--- a/sqlspec/adapters/psycopg/events/backend.py
+++ b/sqlspec/adapters/psycopg/events/backend.py
@@ -21,6 +21,8 @@ from sqlspec.utils.serializers import from_json, to_json
 from sqlspec.utils.uuids import uuid4
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from sqlspec.adapters.psycopg.config import PsycopgAsyncConfig, PsycopgSyncConfig
 
 __all__ = (
@@ -77,6 +79,24 @@ class PsycopgSyncEventsBackend:
             driver.commit()
         self._runtime.increment_metric("events.publish.native")
         return event_id
+
+    def publish_many(self, events: "Sequence[tuple[str, dict[str, Any], dict[str, Any] | None]]") -> list[str]:
+        """Publish unchanged per-event envelopes through one producer session."""
+        if not events:
+            return []
+        event_ids: list[str] = []
+        parameters: list[dict[str, str]] = []
+        for channel, payload, metadata in events:
+            event_id = uuid4().hex
+            event_ids.append(event_id)
+            parameters.append({"channel": channel, "payload": encode_notify_payload(event_id, payload, metadata)})
+        self._runtime.increment_metric("events.publisher.session")
+        with self._config.provide_session() as driver:
+            driver.execute_many("SELECT pg_notify(:channel, :payload)", parameters)
+            driver.commit()
+        self._runtime.increment_metric("events.publisher.statement")
+        self._runtime.increment_metric("events.publish.native", len(parameters))
+        return event_ids
 
     def dequeue(self, channel: str, poll_interval: float) -> EventMessage | None:
         hub = self._ensure_hub()
@@ -136,6 +156,24 @@ class PsycopgAsyncEventsBackend:
             await driver.commit()
         self._runtime.increment_metric("events.publish.native")
         return event_id
+
+    async def publish_many(self, events: "Sequence[tuple[str, dict[str, Any], dict[str, Any] | None]]") -> list[str]:
+        """Publish unchanged per-event envelopes through one producer session."""
+        if not events:
+            return []
+        event_ids: list[str] = []
+        parameters: list[dict[str, str]] = []
+        for channel, payload, metadata in events:
+            event_id = uuid4().hex
+            event_ids.append(event_id)
+            parameters.append({"channel": channel, "payload": encode_notify_payload(event_id, payload, metadata)})
+        self._runtime.increment_metric("events.publisher.session")
+        async with self._config.provide_session() as driver:
+            await driver.execute_many("SELECT pg_notify(:channel, :payload)", parameters)
+            await driver.commit()
+        self._runtime.increment_metric("events.publisher.statement")
+        self._runtime.increment_metric("events.publish.native", len(parameters))
+        return event_ids
 
     async def dequeue(self, channel: str, poll_interval: float) -> EventMessage | None:
         hub = self._ensure_hub()
@@ -198,6 +236,41 @@ class PsycopgSyncHybridEventsBackend:
         self._publish_durable(channel, event_id, payload, metadata)
         self._runtime.increment_metric("events.publish.native")
         return event_id
+
+    def publish_many(self, events: "Sequence[tuple[str, dict[str, Any], dict[str, Any] | None]]") -> list[str]:
+        """Persist a batch and publish one compact wakeup marker per channel."""
+        if not events:
+            return []
+        now = datetime.now(timezone.utc)
+        event_ids: list[str] = []
+        records: list[dict[str, Any]] = []
+        marker_counts: dict[str, int] = {}
+        for channel, payload, metadata in events:
+            event_id = uuid4().hex
+            event_ids.append(event_id)
+            records.append({
+                "event_id": event_id,
+                "channel": channel,
+                "payload_json": to_json(payload),
+                "metadata_json": to_json(metadata) if metadata is not None else None,
+                "status": "pending",
+                "available_at": now,
+                "lease_expires_at": None,
+                "attempts": 0,
+                "created_at": now,
+            })
+            marker_counts[channel] = marker_counts.get(channel, 0) + 1
+        markers = [
+            {"channel": channel, "payload": to_json({"batch_size": count})} for channel, count in marker_counts.items()
+        ]
+        self._runtime.increment_metric("events.publisher.session")
+        with self._config.provide_session() as driver:
+            driver.execute_many(self._queue._insert_statement, records, statement_config=self._queue._statement_config)
+            driver.execute_many("SELECT pg_notify(:channel, :payload)", markers)
+            driver.commit()
+        self._runtime.increment_metric("events.publisher.statement", 2)
+        self._runtime.increment_metric("events.publish.native", len(records))
+        return event_ids
 
     def dequeue(self, channel: str, poll_interval: float) -> EventMessage | None:
         hub = self._ensure_hub()
@@ -288,6 +361,43 @@ class PsycopgAsyncHybridEventsBackend:
         await self._publish_durable(channel, event_id, payload, metadata)
         self._runtime.increment_metric("events.publish.native")
         return event_id
+
+    async def publish_many(self, events: "Sequence[tuple[str, dict[str, Any], dict[str, Any] | None]]") -> list[str]:
+        """Persist a batch and publish one compact wakeup marker per channel."""
+        if not events:
+            return []
+        now = datetime.now(timezone.utc)
+        event_ids: list[str] = []
+        records: list[dict[str, Any]] = []
+        marker_counts: dict[str, int] = {}
+        for channel, payload, metadata in events:
+            event_id = uuid4().hex
+            event_ids.append(event_id)
+            records.append({
+                "event_id": event_id,
+                "channel": channel,
+                "payload_json": to_json(payload),
+                "metadata_json": to_json(metadata) if metadata is not None else None,
+                "status": "pending",
+                "available_at": now,
+                "lease_expires_at": None,
+                "attempts": 0,
+                "created_at": now,
+            })
+            marker_counts[channel] = marker_counts.get(channel, 0) + 1
+        markers = [
+            {"channel": channel, "payload": to_json({"batch_size": count})} for channel, count in marker_counts.items()
+        ]
+        self._runtime.increment_metric("events.publisher.session")
+        async with self._config.provide_session() as driver:
+            await driver.execute_many(
+                self._queue._insert_statement, records, statement_config=self._queue._statement_config
+            )
+            await driver.execute_many("SELECT pg_notify(:channel, :payload)", markers)
+            await driver.commit()
+        self._runtime.increment_metric("events.publisher.statement", 2)
+        self._runtime.increment_metric("events.publish.native", len(records))
+        return event_ids
 
     async def dequeue(self, channel: str, poll_interval: float) -> EventMessage | None:
         hub = self._ensure_hub()
@@ -398,10 +508,7 @@ def create_event_backend(
 def _validate_listener_pool_capacity(config: "PsycopgAsyncConfig | PsycopgSyncConfig") -> None:
     max_size = config.connection_config.get("max_size")
     if max_size is not None and max_size < _MIN_LISTENER_POOL_SIZE:
-        msg = (
-            f"{type(config).__name__} native event listeners require "
-            f"pool max_size >= {_MIN_LISTENER_POOL_SIZE}"
-        )
+        msg = f"{type(config).__name__} native event listeners require pool max_size >= {_MIN_LISTENER_POOL_SIZE}"
         raise ImproperConfigurationError(msg)
 
 

--- a/sqlspec/adapters/psycopg/events/backend.py
+++ b/sqlspec/adapters/psycopg/events/backend.py
@@ -32,6 +32,7 @@ __all__ = (
 )
 
 logger = get_logger("sqlspec.events.psycopg")
+_MIN_LISTENER_POOL_SIZE = 2
 
 
 class PsycopgSyncEventsBackend:
@@ -64,6 +65,7 @@ class PsycopgSyncEventsBackend:
         )
 
     def publish(self, channel: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None" = None) -> str:
+        self._runtime.increment_metric("events.publisher.session")
         event_id = uuid4().hex
         with self._config.provide_session() as driver:
             driver.execute(
@@ -97,7 +99,7 @@ class PsycopgSyncEventsBackend:
 
     def _ensure_hub(self) -> PsycopgSyncListenerHub:
         if self._hub is None:
-            self._hub = PsycopgSyncListenerHub(self._config)
+            self._hub = PsycopgSyncListenerHub(self._config, self.backend_name)
         return self._hub
 
 
@@ -122,6 +124,7 @@ class PsycopgAsyncEventsBackend:
         self._hub: PsycopgAsyncListenerHub | None = None
 
     async def publish(self, channel: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None" = None) -> str:
+        self._runtime.increment_metric("events.publisher.session")
         event_id = uuid4().hex
         async with self._config.provide_session() as driver:
             await driver.execute(
@@ -155,7 +158,7 @@ class PsycopgAsyncEventsBackend:
 
     def _ensure_hub(self) -> PsycopgAsyncListenerHub:
         if self._hub is None:
-            self._hub = PsycopgAsyncListenerHub(self._config)
+            self._hub = PsycopgAsyncListenerHub(self._config, self.backend_name)
         return self._hub
 
 
@@ -190,6 +193,7 @@ class PsycopgSyncHybridEventsBackend:
         )
 
     def publish(self, channel: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None" = None) -> str:
+        self._runtime.increment_metric("events.publisher.session")
         event_id = uuid4().hex
         self._publish_durable(channel, event_id, payload, metadata)
         self._runtime.increment_metric("events.publish.native")
@@ -223,7 +227,7 @@ class PsycopgSyncHybridEventsBackend:
 
     def _ensure_hub(self) -> PsycopgSyncListenerHub:
         if self._hub is None:
-            self._hub = PsycopgSyncListenerHub(self._config)
+            self._hub = PsycopgSyncListenerHub(self._config, self.backend_name)
         return self._hub
 
     def _publish_durable(
@@ -279,6 +283,7 @@ class PsycopgAsyncHybridEventsBackend:
         self._hub: PsycopgAsyncListenerHub | None = None
 
     async def publish(self, channel: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None" = None) -> str:
+        self._runtime.increment_metric("events.publisher.session")
         event_id = uuid4().hex
         await self._publish_durable(channel, event_id, payload, metadata)
         self._runtime.increment_metric("events.publish.native")
@@ -312,7 +317,7 @@ class PsycopgAsyncHybridEventsBackend:
 
     def _ensure_hub(self) -> PsycopgAsyncListenerHub:
         if self._hub is None:
-            self._hub = PsycopgAsyncListenerHub(self._config)
+            self._hub = PsycopgAsyncListenerHub(self._config, self.backend_name)
         return self._hub
 
     async def _publish_durable(
@@ -356,6 +361,8 @@ def create_event_backend(
     | None
 ):
     """EventChannel factory for the native psycopg backend."""
+    if backend_name in {"notify", "notify_queue"}:
+        _validate_listener_pool_capacity(config)
     is_async = config.is_async
     match (backend_name, is_async):
         case ("notify", False):
@@ -386,6 +393,16 @@ def create_event_backend(
                 return None
         case _:
             return None
+
+
+def _validate_listener_pool_capacity(config: "PsycopgAsyncConfig | PsycopgSyncConfig") -> None:
+    max_size = config.connection_config.get("max_size")
+    if max_size is not None and max_size < _MIN_LISTENER_POOL_SIZE:
+        msg = (
+            f"{type(config).__name__} native event listeners require "
+            f"pool max_size >= {_MIN_LISTENER_POOL_SIZE}"
+        )
+        raise ImproperConfigurationError(msg)
 
 
 def _extract_event_id(payload: "str | None") -> "str | None":

--- a/sqlspec/adapters/psycopg/events/backend.py
+++ b/sqlspec/adapters/psycopg/events/backend.py
@@ -2,6 +2,7 @@
 """Psycopg LISTEN/NOTIFY and hybrid event backends."""
 
 import logging
+import threading
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, cast
 
@@ -35,6 +36,50 @@ __all__ = (
 
 logger = get_logger("sqlspec.events.psycopg")
 _MIN_LISTENER_POOL_SIZE = 2
+_MAX_SEEN_MARKERS = 1_024
+
+
+class _MarkerDrainState:
+    __slots__ = ("_lock", "_pending", "_seen")
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._pending: dict[str, int] = {}
+        self._seen: dict[tuple[str, str], None] = {}
+
+    def take(self, channel: str) -> bool:
+        with self._lock:
+            return self._take_locked(channel)
+
+    def register(self, channel: str, marker_id: "str | None", batch_size: int) -> "tuple[bool, bool]":
+        with self._lock:
+            is_new = marker_id is None or (channel, marker_id) not in self._seen
+            if is_new:
+                if marker_id is not None:
+                    if len(self._seen) >= _MAX_SEEN_MARKERS:
+                        self._seen.pop(next(iter(self._seen)))
+                    self._seen[(channel, marker_id)] = None
+                self._pending[channel] = self._pending.get(channel, 0) + max(batch_size, 1)
+            return is_new, self._take_locked(channel)
+
+    def clear(self, channel: str) -> None:
+        with self._lock:
+            self._pending.pop(channel, None)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._pending.clear()
+            self._seen.clear()
+
+    def _take_locked(self, channel: str) -> bool:
+        pending = self._pending.get(channel, 0)
+        if pending <= 0:
+            return False
+        if pending == 1:
+            self._pending.pop(channel, None)
+        else:
+            self._pending[channel] = pending - 1
+        return True
 
 
 class PsycopgSyncEventsBackend:
@@ -102,8 +147,12 @@ class PsycopgSyncEventsBackend:
         hub = self._ensure_hub()
         payload = hub.dequeue(channel, poll_interval)
         if payload is None:
+            self._runtime.increment_metric("events.listener.timeout")
             return None
-        return decode_notify_payload(channel, payload)
+        self._runtime.increment_metric("events.listener.wakeup")
+        event = decode_notify_payload(channel, payload)
+        _record_dequeue_result(self._runtime, event)
+        return event
 
     def ack(self, _event_id: str) -> None:
         self._runtime.increment_metric("events.ack")
@@ -179,8 +228,12 @@ class PsycopgAsyncEventsBackend:
         hub = self._ensure_hub()
         payload = await hub.dequeue(channel, poll_interval)
         if payload is None:
+            self._runtime.increment_metric("events.listener.timeout")
             return None
-        return decode_notify_payload(channel, payload)
+        self._runtime.increment_metric("events.listener.wakeup")
+        event = decode_notify_payload(channel, payload)
+        _record_dequeue_result(self._runtime, event)
+        return event
 
     async def ack(self, _event_id: str) -> None:
         self._runtime.increment_metric("events.ack")
@@ -203,7 +256,7 @@ class PsycopgAsyncEventsBackend:
 class PsycopgSyncHybridEventsBackend:
     """Durable hybrid backend for sync psycopg adapters."""
 
-    __slots__ = ("_config", "_hub", "_queue", "_runtime")
+    __slots__ = ("_config", "_hub", "_marker_state", "_queue", "_runtime")
 
     supports_sync = True
     supports_async = False
@@ -219,6 +272,7 @@ class PsycopgSyncHybridEventsBackend:
         self._config = config
         self._queue = queue
         self._runtime = config.get_observability_runtime()
+        self._marker_state = _MarkerDrainState()
         self._hub: PsycopgSyncListenerHub | None = None
         log_with_context(
             logger,
@@ -260,8 +314,10 @@ class PsycopgSyncHybridEventsBackend:
                 "created_at": now,
             })
             marker_counts[channel] = marker_counts.get(channel, 0) + 1
+        marker_id = uuid4().hex
         markers = [
-            {"channel": channel, "payload": to_json({"batch_size": count})} for channel, count in marker_counts.items()
+            {"channel": channel, "payload": to_json({"batch_size": count, "marker_id": marker_id})}
+            for channel, count in marker_counts.items()
         ]
         self._runtime.increment_metric("events.publisher.session")
         with self._config.provide_session() as driver:
@@ -273,16 +329,30 @@ class PsycopgSyncHybridEventsBackend:
         return event_ids
 
     def dequeue(self, channel: str, poll_interval: float) -> EventMessage | None:
+        if self._marker_state.take(channel):
+            return self._dequeue_hinted(channel)
         hub = self._ensure_hub()
-        payload = hub.dequeue(channel, poll_interval)
-        if payload is None:
-            return self._queue.dequeue(channel)
-        event_id = _extract_event_id(payload)
-        if event_id is not None:
-            event = self._queue.dequeue_by_event_id(event_id)
-            if event is not None:
-                return event
-        return self._queue.dequeue(channel)
+        while True:
+            payload = hub.dequeue(channel, poll_interval)
+            if payload is None:
+                return self._dequeue_reconciled(channel)
+            self._queue._reset_empty_poll_delay(channel)
+            self._runtime.increment_metric("events.listener.wakeup")
+            batch_size = _extract_batch_size(payload)
+            is_new, should_drain = self._marker_state.register(channel, _extract_marker_id(payload), batch_size)
+            if is_new and batch_size > 1:
+                self._runtime.increment_metric("events.marker.coalesced", batch_size - 1)
+            if not should_drain:
+                self._runtime.increment_metric("events.marker.duplicate")
+                continue
+            event_id = _extract_event_id(payload)
+            if event_id is not None:
+                event = self._queue.dequeue_by_event_id(event_id)
+                if event is not None:
+                    self._runtime.increment_metric("events.marker.drain")
+                    _record_dequeue_result(self._runtime, event)
+                    return event
+            return self._dequeue_hinted(channel)
 
     def ack(self, event_id: str) -> None:
         self._queue.ack(event_id)
@@ -294,14 +364,37 @@ class PsycopgSyncHybridEventsBackend:
 
     def shutdown(self) -> None:
         hub = self._hub
-        if hub is not None:
-            self._hub = None
-            hub.shutdown()
+        try:
+            if hub is not None:
+                self._hub = None
+                hub.shutdown()
+        finally:
+            self._marker_state.reset()
 
     def _ensure_hub(self) -> PsycopgSyncListenerHub:
         if self._hub is None:
             self._hub = PsycopgSyncListenerHub(self._config, self.backend_name)
         return self._hub
+
+    def _dequeue_hinted(self, channel: str) -> EventMessage | None:
+        event = self._queue.dequeue(channel)
+        if event is None:
+            self._marker_state.clear(channel)
+            self._runtime.increment_metric("events.marker.shortfall")
+            return None
+        self._runtime.increment_metric("events.marker.drain")
+        _record_dequeue_result(self._runtime, event)
+        return event
+
+    def _dequeue_reconciled(self, channel: str) -> EventMessage | None:
+        self._runtime.increment_metric("events.poll.fallback")
+        event = self._queue.dequeue(channel)
+        if event is None:
+            self._runtime.increment_metric("events.listener.timeout")
+            return None
+        self._runtime.increment_metric("events.marker.miss")
+        _record_dequeue_result(self._runtime, event)
+        return event
 
     def _publish_durable(
         self, channel: str, event_id: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None"
@@ -315,7 +408,7 @@ class PsycopgSyncHybridEventsBackend:
                         "event_id": event_id,
                         "channel": channel,
                         "payload_json": to_json(payload),
-                        "metadata_json": to_json(metadata) if metadata else None,
+                        "metadata_json": to_json(metadata) if metadata is not None else None,
                         "status": "pending",
                         "available_at": now,
                         "lease_expires_at": None,
@@ -337,7 +430,7 @@ class PsycopgSyncHybridEventsBackend:
 class PsycopgAsyncHybridEventsBackend:
     """Durable hybrid backend for async psycopg adapters."""
 
-    __slots__ = ("_config", "_hub", "_queue", "_runtime")
+    __slots__ = ("_config", "_hub", "_marker_state", "_queue", "_runtime")
 
     supports_sync = False
     supports_async = True
@@ -353,6 +446,7 @@ class PsycopgAsyncHybridEventsBackend:
         self._config = config
         self._queue = queue
         self._runtime = config.get_observability_runtime()
+        self._marker_state = _MarkerDrainState()
         self._hub: PsycopgAsyncListenerHub | None = None
 
     async def publish(self, channel: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None" = None) -> str:
@@ -385,8 +479,10 @@ class PsycopgAsyncHybridEventsBackend:
                 "created_at": now,
             })
             marker_counts[channel] = marker_counts.get(channel, 0) + 1
+        marker_id = uuid4().hex
         markers = [
-            {"channel": channel, "payload": to_json({"batch_size": count})} for channel, count in marker_counts.items()
+            {"channel": channel, "payload": to_json({"batch_size": count, "marker_id": marker_id})}
+            for channel, count in marker_counts.items()
         ]
         self._runtime.increment_metric("events.publisher.session")
         async with self._config.provide_session() as driver:
@@ -400,16 +496,30 @@ class PsycopgAsyncHybridEventsBackend:
         return event_ids
 
     async def dequeue(self, channel: str, poll_interval: float) -> EventMessage | None:
+        if self._marker_state.take(channel):
+            return await self._dequeue_hinted(channel)
         hub = self._ensure_hub()
-        payload = await hub.dequeue(channel, poll_interval)
-        if payload is None:
-            return await self._queue.dequeue(channel)
-        event_id = _extract_event_id(payload)
-        if event_id is not None:
-            event = await self._queue.dequeue_by_event_id(event_id)
-            if event is not None:
-                return event
-        return await self._queue.dequeue(channel)
+        while True:
+            payload = await hub.dequeue(channel, poll_interval)
+            if payload is None:
+                return await self._dequeue_reconciled(channel)
+            self._queue._reset_empty_poll_delay(channel)
+            self._runtime.increment_metric("events.listener.wakeup")
+            batch_size = _extract_batch_size(payload)
+            is_new, should_drain = self._marker_state.register(channel, _extract_marker_id(payload), batch_size)
+            if is_new and batch_size > 1:
+                self._runtime.increment_metric("events.marker.coalesced", batch_size - 1)
+            if not should_drain:
+                self._runtime.increment_metric("events.marker.duplicate")
+                continue
+            event_id = _extract_event_id(payload)
+            if event_id is not None:
+                event = await self._queue.dequeue_by_event_id(event_id)
+                if event is not None:
+                    self._runtime.increment_metric("events.marker.drain")
+                    _record_dequeue_result(self._runtime, event)
+                    return event
+            return await self._dequeue_hinted(channel)
 
     async def ack(self, event_id: str) -> None:
         await self._queue.ack(event_id)
@@ -421,14 +531,37 @@ class PsycopgAsyncHybridEventsBackend:
 
     async def shutdown(self) -> None:
         hub = self._hub
-        if hub is not None:
-            self._hub = None
-            await hub.shutdown()
+        try:
+            if hub is not None:
+                self._hub = None
+                await hub.shutdown()
+        finally:
+            self._marker_state.reset()
 
     def _ensure_hub(self) -> PsycopgAsyncListenerHub:
         if self._hub is None:
             self._hub = PsycopgAsyncListenerHub(self._config, self.backend_name)
         return self._hub
+
+    async def _dequeue_hinted(self, channel: str) -> EventMessage | None:
+        event = await self._queue.dequeue(channel)
+        if event is None:
+            self._marker_state.clear(channel)
+            self._runtime.increment_metric("events.marker.shortfall")
+            return None
+        self._runtime.increment_metric("events.marker.drain")
+        _record_dequeue_result(self._runtime, event)
+        return event
+
+    async def _dequeue_reconciled(self, channel: str) -> EventMessage | None:
+        self._runtime.increment_metric("events.poll.fallback")
+        event = await self._queue.dequeue(channel)
+        if event is None:
+            self._runtime.increment_metric("events.listener.timeout")
+            return None
+        self._runtime.increment_metric("events.marker.miss")
+        _record_dequeue_result(self._runtime, event)
+        return event
 
     async def _publish_durable(
         self, channel: str, event_id: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None"
@@ -442,7 +575,7 @@ class PsycopgAsyncHybridEventsBackend:
                         "event_id": event_id,
                         "channel": channel,
                         "payload_json": to_json(payload),
-                        "metadata_json": to_json(metadata) if metadata else None,
+                        "metadata_json": to_json(metadata) if metadata is not None else None,
                         "status": "pending",
                         "available_at": now,
                         "lease_expires_at": None,
@@ -520,3 +653,30 @@ def _extract_event_id(payload: "str | None") -> "str | None":
         event_id = raw.get("event_id")
         return event_id if isinstance(event_id, str) else None
     return None
+
+
+def _extract_batch_size(payload: "str | None") -> int:
+    if not payload:
+        return 0
+    raw = from_json(payload)
+    if isinstance(raw, dict):
+        batch_size = raw.get("batch_size")
+        return batch_size if isinstance(batch_size, int) else 0
+    return 0
+
+
+def _extract_marker_id(payload: "str | None") -> "str | None":
+    if not payload:
+        return None
+    raw = from_json(payload)
+    if isinstance(raw, dict):
+        marker_id = raw.get("marker_id", raw.get("event_id"))
+        return marker_id if isinstance(marker_id, str) else None
+    return None
+
+
+def _record_dequeue_result(runtime: Any, event: "EventMessage | None") -> None:
+    if event is None:
+        return
+    latency_ms = max(0.0, (datetime.now(timezone.utc) - event.created_at).total_seconds() * 1000)
+    runtime.record_metric("events.dequeue.latency_ms", latency_ms)

--- a/sqlspec/adapters/psycopg/events/backend.py
+++ b/sqlspec/adapters/psycopg/events/backend.py
@@ -40,11 +40,12 @@ _MAX_SEEN_MARKERS = 1_024
 
 
 class _MarkerDrainState:
-    __slots__ = ("_lock", "_pending", "_seen")
+    __slots__ = ("_lock", "_pending", "_recovering", "_seen")
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._pending: dict[str, int] = {}
+        self._recovering: set[str] = set()
         self._seen: dict[tuple[str, str], None] = {}
 
     def take(self, channel: str) -> bool:
@@ -62,16 +63,26 @@ class _MarkerDrainState:
                 self._pending[channel] = self._pending.get(channel, 0) + max(batch_size, 1)
             return is_new, self._take_locked(channel)
 
+    def begin_recovery(self, channel: str) -> None:
+        with self._lock:
+            if channel not in self._recovering and len(self._recovering) >= _MAX_SEEN_MARKERS:
+                self._recovering.pop()
+            self._recovering.add(channel)
+
     def clear(self, channel: str) -> None:
         with self._lock:
             self._pending.pop(channel, None)
+            self._recovering.discard(channel)
 
     def reset(self) -> None:
         with self._lock:
             self._pending.clear()
+            self._recovering.clear()
             self._seen.clear()
 
     def _take_locked(self, channel: str) -> bool:
+        if channel in self._recovering:
+            return True
         pending = self._pending.get(channel, 0)
         if pending <= 0:
             return False
@@ -137,8 +148,17 @@ class PsycopgSyncEventsBackend:
             parameters.append({"channel": channel, "payload": encode_notify_payload(event_id, payload, metadata)})
         self._runtime.increment_metric("events.publisher.session")
         with self._config.provide_session() as driver:
-            driver.execute_many("SELECT pg_notify(:channel, :payload)", parameters)
-            driver.commit()
+            was_autocommit = bool(getattr(driver.connection, "autocommit", False))
+            driver.begin()
+            try:
+                driver.execute_many("SELECT pg_notify(:channel, :payload)", parameters)
+                driver.commit()
+            except BaseException:
+                driver.rollback()
+                raise
+            finally:
+                if was_autocommit:
+                    driver.connection.autocommit = True
         self._runtime.increment_metric("events.publisher.statement")
         self._runtime.increment_metric("events.publish.native", len(parameters))
         return event_ids
@@ -218,8 +238,17 @@ class PsycopgAsyncEventsBackend:
             parameters.append({"channel": channel, "payload": encode_notify_payload(event_id, payload, metadata)})
         self._runtime.increment_metric("events.publisher.session")
         async with self._config.provide_session() as driver:
-            await driver.execute_many("SELECT pg_notify(:channel, :payload)", parameters)
-            await driver.commit()
+            was_autocommit = bool(getattr(driver.connection, "autocommit", False))
+            await driver.begin()
+            try:
+                await driver.execute_many("SELECT pg_notify(:channel, :payload)", parameters)
+                await driver.commit()
+            except BaseException:
+                await driver.rollback()
+                raise
+            finally:
+                if was_autocommit:
+                    await driver.connection.set_autocommit(True)
         self._runtime.increment_metric("events.publisher.statement")
         self._runtime.increment_metric("events.publish.native", len(parameters))
         return event_ids
@@ -295,24 +324,9 @@ class PsycopgSyncHybridEventsBackend:
         """Persist a batch and publish one compact wakeup marker per channel."""
         if not events:
             return []
-        now = datetime.now(timezone.utc)
-        event_ids: list[str] = []
-        records: list[dict[str, Any]] = []
+        event_ids, records = self._queue._batch_insert_parameters(events)
         marker_counts: dict[str, int] = {}
-        for channel, payload, metadata in events:
-            event_id = uuid4().hex
-            event_ids.append(event_id)
-            records.append({
-                "event_id": event_id,
-                "channel": channel,
-                "payload_json": to_json(payload),
-                "metadata_json": to_json(metadata) if metadata is not None else None,
-                "status": "pending",
-                "available_at": now,
-                "lease_expires_at": None,
-                "attempts": 0,
-                "created_at": now,
-            })
+        for channel, _payload, _metadata in events:
             marker_counts[channel] = marker_counts.get(channel, 0) + 1
         marker_id = uuid4().hex
         markers = [
@@ -321,9 +335,20 @@ class PsycopgSyncHybridEventsBackend:
         ]
         self._runtime.increment_metric("events.publisher.session")
         with self._config.provide_session() as driver:
-            driver.execute_many(self._queue._insert_statement, records, statement_config=self._queue._statement_config)
-            driver.execute_many("SELECT pg_notify(:channel, :payload)", markers)
-            driver.commit()
+            was_autocommit = bool(getattr(driver.connection, "autocommit", False))
+            driver.begin()
+            try:
+                driver.execute_many(
+                    self._queue._insert_statement, records, statement_config=self._queue._statement_config
+                )
+                driver.execute_many("SELECT pg_notify(:channel, :payload)", markers)
+                driver.commit()
+            except BaseException:
+                driver.rollback()
+                raise
+            finally:
+                if was_autocommit:
+                    driver.connection.autocommit = True
         self._runtime.increment_metric("events.publisher.statement", 2)
         self._runtime.increment_metric("events.publish.native", len(records))
         return event_ids
@@ -392,6 +417,7 @@ class PsycopgSyncHybridEventsBackend:
         if event is None:
             self._runtime.increment_metric("events.listener.timeout")
             return None
+        self._marker_state.begin_recovery(channel)
         self._runtime.increment_metric("events.marker.miss")
         _record_dequeue_result(self._runtime, event)
         return event
@@ -460,24 +486,9 @@ class PsycopgAsyncHybridEventsBackend:
         """Persist a batch and publish one compact wakeup marker per channel."""
         if not events:
             return []
-        now = datetime.now(timezone.utc)
-        event_ids: list[str] = []
-        records: list[dict[str, Any]] = []
+        event_ids, records = self._queue._batch_insert_parameters(events)
         marker_counts: dict[str, int] = {}
-        for channel, payload, metadata in events:
-            event_id = uuid4().hex
-            event_ids.append(event_id)
-            records.append({
-                "event_id": event_id,
-                "channel": channel,
-                "payload_json": to_json(payload),
-                "metadata_json": to_json(metadata) if metadata is not None else None,
-                "status": "pending",
-                "available_at": now,
-                "lease_expires_at": None,
-                "attempts": 0,
-                "created_at": now,
-            })
+        for channel, _payload, _metadata in events:
             marker_counts[channel] = marker_counts.get(channel, 0) + 1
         marker_id = uuid4().hex
         markers = [
@@ -486,11 +497,20 @@ class PsycopgAsyncHybridEventsBackend:
         ]
         self._runtime.increment_metric("events.publisher.session")
         async with self._config.provide_session() as driver:
-            await driver.execute_many(
-                self._queue._insert_statement, records, statement_config=self._queue._statement_config
-            )
-            await driver.execute_many("SELECT pg_notify(:channel, :payload)", markers)
-            await driver.commit()
+            was_autocommit = bool(getattr(driver.connection, "autocommit", False))
+            await driver.begin()
+            try:
+                await driver.execute_many(
+                    self._queue._insert_statement, records, statement_config=self._queue._statement_config
+                )
+                await driver.execute_many("SELECT pg_notify(:channel, :payload)", markers)
+                await driver.commit()
+            except BaseException:
+                await driver.rollback()
+                raise
+            finally:
+                if was_autocommit:
+                    await driver.connection.set_autocommit(True)
         self._runtime.increment_metric("events.publisher.statement", 2)
         self._runtime.increment_metric("events.publish.native", len(records))
         return event_ids
@@ -559,6 +579,7 @@ class PsycopgAsyncHybridEventsBackend:
         if event is None:
             self._runtime.increment_metric("events.listener.timeout")
             return None
+        self._marker_state.begin_recovery(channel)
         self._runtime.increment_metric("events.marker.miss")
         _record_dequeue_result(self._runtime, event)
         return event

--- a/sqlspec/config.py
+++ b/sqlspec/config.py
@@ -560,7 +560,10 @@ class EventsConfig(TypedDict):
     """Retention window for acknowledged events before cleanup. Defaults to 86400 (24 hours)."""
 
     poll_interval: NotRequired[float]
-    """Default poll interval in seconds for event consumers. Defaults to 1.0."""
+    """Compatibility alias for event_poll_interval. Defaults to 1.0."""
+
+    event_poll_interval: NotRequired[float]
+    """Durable event reconciliation interval in seconds. Takes precedence over poll_interval."""
 
     select_for_update: NotRequired[bool]
     """Use SELECT FOR UPDATE locking when claiming events. Defaults to False."""

--- a/sqlspec/extensions/events/__init__.py
+++ b/sqlspec/extensions/events/__init__.py
@@ -6,6 +6,7 @@ from sqlspec.extensions.events._channel import (
     SyncEventChannel,
     SyncEventListener,
     load_native_backend,
+    resolve_event_poll_interval,
     resolve_poll_interval,
 )
 from sqlspec.extensions.events._hints import EventRuntimeHints, get_runtime_hints, resolve_adapter_name
@@ -47,5 +48,6 @@ __all__ = (
     "normalize_queue_table_name",
     "parse_event_timestamp",
     "resolve_adapter_name",
+    "resolve_event_poll_interval",
     "resolve_poll_interval",
 )

--- a/sqlspec/extensions/events/_channel.py
+++ b/sqlspec/extensions/events/_channel.py
@@ -5,8 +5,9 @@ import importlib
 import inspect
 import logging
 import threading
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator, Iterator, Sequence
 from dataclasses import dataclass
+from time import perf_counter
 from typing import TYPE_CHECKING, Any, cast
 
 from sqlspec.exceptions import ImproperConfigurationError, MissingDependencyError
@@ -441,6 +442,50 @@ class SyncEventChannel:
         )
         return event_id
 
+    def publish_many(self, events: "Sequence[tuple[str, dict[str, Any], dict[str, Any] | None]]") -> list[str]:
+        """Publish independent events in one grouped operation when supported.
+
+        Backend-native implementations are atomic per grouped call. A backend
+        without ``publish_many`` uses an ordered single-event fallback, which is
+        not atomic across the full batch.
+        """
+        normalized = [
+            (normalize_event_channel_name(channel), payload, metadata) for channel, payload, metadata in events
+        ]
+        if not normalized:
+            return []
+        if not self._backend.supports_sync:
+            msg = "Current events backend does not support sync publishing"
+            raise ImproperConfigurationError(msg)
+        started_at = perf_counter()
+        span = _start_event_span(self._runtime, "publish_many", self._backend_name, self._adapter_name, mode="sync")
+        publish_many = getattr(cast("Any", self._backend), "publish_many", None)
+        try:
+            if publish_many is None:
+                self._runtime.increment_metric("events.publish.batch_fallback")
+                event_ids = [
+                    self._backend.publish(channel, payload, metadata) for channel, payload, metadata in normalized
+                ]
+            else:
+                event_ids = cast("list[str]", publish_many(normalized))
+        except Exception as error:
+            _end_event_span(self._runtime, span, error=error)
+            raise
+        _end_event_span(self._runtime, span, result="published")
+        self._runtime.increment_metric("events.publish.batch")
+        self._runtime.increment_metric("events.publish.batch_size", len(normalized))
+        self._runtime.record_metric("events.publish.batch_latency_ms", (perf_counter() - started_at) * 1000)
+        log_with_context(
+            logger,
+            logging.DEBUG,
+            "event.publish_batch",
+            adapter_name=self._adapter_name,
+            backend_name=self._backend_name,
+            batch_size=len(normalized),
+            mode="sync",
+        )
+        return event_ids
+
     def iter_events(self, channel: str, *, poll_interval: float | None = None) -> Iterator[EventMessage]:
         """Yield events as they become available."""
         channel = normalize_event_channel_name(channel)
@@ -670,6 +715,50 @@ class AsyncEventChannel:
             mode="async",
         )
         return event_id
+
+    async def publish_many(self, events: "Sequence[tuple[str, dict[str, Any], dict[str, Any] | None]]") -> list[str]:
+        """Publish independent events in one grouped operation when supported.
+
+        Backend-native implementations are atomic per grouped call. A backend
+        without ``publish_many`` uses an ordered single-event fallback, which is
+        not atomic across the full batch.
+        """
+        normalized = [
+            (normalize_event_channel_name(channel), payload, metadata) for channel, payload, metadata in events
+        ]
+        if not normalized:
+            return []
+        if not self._backend.supports_async:
+            msg = "Current events backend does not support async publishing"
+            raise ImproperConfigurationError(msg)
+        started_at = perf_counter()
+        span = _start_event_span(self._runtime, "publish_many", self._backend_name, self._adapter_name, mode="async")
+        publish_many = getattr(cast("Any", self._backend), "publish_many", None)
+        try:
+            if publish_many is None:
+                self._runtime.increment_metric("events.publish.batch_fallback")
+                event_ids = [
+                    await self._backend.publish(channel, payload, metadata) for channel, payload, metadata in normalized
+                ]
+            else:
+                event_ids = cast("list[str]", await publish_many(normalized))
+        except Exception as error:
+            _end_event_span(self._runtime, span, error=error)
+            raise
+        _end_event_span(self._runtime, span, result="published")
+        self._runtime.increment_metric("events.publish.batch")
+        self._runtime.increment_metric("events.publish.batch_size", len(normalized))
+        self._runtime.record_metric("events.publish.batch_latency_ms", (perf_counter() - started_at) * 1000)
+        log_with_context(
+            logger,
+            logging.DEBUG,
+            "event.publish_batch",
+            adapter_name=self._adapter_name,
+            backend_name=self._backend_name,
+            batch_size=len(normalized),
+            mode="async",
+        )
+        return event_ids
 
     def iter_events(self, channel: str, *, poll_interval: float | None = None) -> AsyncIterator[EventMessage]:
         """Yield events as they become available."""

--- a/sqlspec/extensions/events/_channel.py
+++ b/sqlspec/extensions/events/_channel.py
@@ -32,6 +32,7 @@ __all__ = (
     "SyncEventChannel",
     "SyncEventListener",
     "load_native_backend",
+    "resolve_event_poll_interval",
     "resolve_poll_interval",
 )
 
@@ -79,6 +80,19 @@ def resolve_poll_interval(poll_interval: "float | None", default: float) -> floa
         msg = "poll_interval must be greater than zero"
         raise ImproperConfigurationError(msg)
     return poll_interval
+
+
+def resolve_event_poll_interval(
+    event_poll_interval: "float | None", poll_interval: "float | None", default: float
+) -> float:
+    """Resolve the event reconciliation interval with compatibility precedence."""
+    resolved = event_poll_interval if event_poll_interval is not None else poll_interval
+    if resolved is None:
+        resolved = default
+    if resolved <= 0:
+        msg = "event_poll_interval must be greater than zero"
+        raise ImproperConfigurationError(msg)
+    return resolved
 
 
 def _resolve_event_type(payload: "dict[str, Any]", metadata: "dict[str, Any] | None") -> "str | None":
@@ -374,6 +388,7 @@ class SyncEventChannel:
         "_backend",
         "_backend_name",
         "_config",
+        "_event_poll_interval",
         "_listeners",
         "_poll_interval_default",
         "_runtime",
@@ -388,7 +403,10 @@ class SyncEventChannel:
         extension_settings: dict[str, Any] = dict(config.extension_config.get("events", {}))
         self._adapter_name = resolve_adapter_name(config)
         hints = get_runtime_hints(self._adapter_name, config)
-        self._poll_interval_default = float(extension_settings.get("poll_interval") or hints.poll_interval)
+        self._event_poll_interval = resolve_event_poll_interval(
+            extension_settings.get("event_poll_interval"), extension_settings.get("poll_interval"), hints.poll_interval
+        )
+        self._poll_interval_default = self._event_poll_interval
         queue_backend = build_queue_backend(config, extension_settings, adapter_name=self._adapter_name, hints=hints)
         backend_name = _resolve_backend_name(config, extension_settings, self._adapter_name)
         native_backend = load_native_backend(config, backend_name, extension_settings, adapter_name=self._adapter_name)
@@ -414,6 +432,16 @@ class SyncEventChannel:
         self._config = config
         self._backend_name = backend_label
         self._runtime = config.get_observability_runtime()
+        self._runtime.record_metric("events.poll.interval", self._event_poll_interval)
+        self._runtime.increment_metric(f"events.backend.{self._backend_name}.resolved")
+        log_with_context(
+            logger,
+            logging.DEBUG,
+            "event.configure",
+            adapter_name=self._adapter_name,
+            backend_name=self._backend_name,
+            event_poll_interval=self._event_poll_interval,
+        )
         self._listeners: dict[str, SyncEventListener] = {}
 
     def publish(self, channel: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None" = None) -> str:
@@ -486,13 +514,15 @@ class SyncEventChannel:
         )
         return event_ids
 
-    def iter_events(self, channel: str, *, poll_interval: float | None = None) -> Iterator[EventMessage]:
+    def iter_events(
+        self, channel: str, *, event_poll_interval: float | None = None, poll_interval: float | None = None
+    ) -> Iterator[EventMessage]:
         """Yield events as they become available."""
         channel = normalize_event_channel_name(channel)
         if not self._backend.supports_sync:
             msg = "Current events backend does not support sync consumption"
             raise ImproperConfigurationError(msg)
-        interval = resolve_poll_interval(poll_interval, self._poll_interval_default)
+        interval = resolve_event_poll_interval(event_poll_interval, poll_interval, self._event_poll_interval)
         return _SyncEventIterator(
             backend=self._backend,
             runtime=self._runtime,
@@ -503,14 +533,20 @@ class SyncEventChannel:
         )
 
     def listen(
-        self, channel: str, handler: "SyncEventHandler", *, poll_interval: float | None = None, auto_ack: bool = True
+        self,
+        channel: str,
+        handler: "SyncEventHandler",
+        *,
+        event_poll_interval: float | None = None,
+        poll_interval: float | None = None,
+        auto_ack: bool = True,
     ) -> SyncEventListener:
         """Start a background thread that invokes handler for each event."""
         channel = normalize_event_channel_name(channel)
         if not self._backend.supports_sync:
             msg = "Current events backend does not support sync listeners"
             raise ImproperConfigurationError(msg)
-        interval = resolve_poll_interval(poll_interval, self._poll_interval_default)
+        interval = resolve_event_poll_interval(event_poll_interval, poll_interval, self._event_poll_interval)
         listener_id = uuid4().hex
         stop_event = threading.Event()
         thread = threading.Thread(
@@ -580,6 +616,7 @@ class SyncEventChannel:
 
     def shutdown(self) -> None:
         """Shutdown the event channel and release backend resources."""
+        started_at = perf_counter()
         span = _start_event_span(self._runtime, "shutdown", self._backend_name, self._adapter_name, mode="sync")
         try:
             for listener_id in list(self._listeners):
@@ -588,6 +625,8 @@ class SyncEventChannel:
         except Exception as error:
             _end_event_span(self._runtime, span, error=error)
             raise
+        finally:
+            self._runtime.record_metric("events.shutdown.duration_ms", (perf_counter() - started_at) * 1000)
         _end_event_span(self._runtime, span, result="shutdown")
         self._runtime.increment_metric("events.shutdown")
 
@@ -646,6 +685,7 @@ class AsyncEventChannel:
         "_backend",
         "_backend_name",
         "_config",
+        "_event_poll_interval",
         "_listeners",
         "_poll_interval_default",
         "_runtime",
@@ -660,7 +700,10 @@ class AsyncEventChannel:
         extension_settings: dict[str, Any] = dict(config.extension_config.get("events", {}))
         self._adapter_name = resolve_adapter_name(config)
         hints = get_runtime_hints(self._adapter_name, config)
-        self._poll_interval_default = float(extension_settings.get("poll_interval") or hints.poll_interval)
+        self._event_poll_interval = resolve_event_poll_interval(
+            extension_settings.get("event_poll_interval"), extension_settings.get("poll_interval"), hints.poll_interval
+        )
+        self._poll_interval_default = self._event_poll_interval
         queue_backend = build_queue_backend(config, extension_settings, adapter_name=self._adapter_name, hints=hints)
         backend_name = _resolve_backend_name(config, extension_settings, self._adapter_name)
         native_backend = load_native_backend(config, backend_name, extension_settings, adapter_name=self._adapter_name)
@@ -686,6 +729,16 @@ class AsyncEventChannel:
         self._config = config
         self._backend_name = backend_label
         self._runtime = config.get_observability_runtime()
+        self._runtime.record_metric("events.poll.interval", self._event_poll_interval)
+        self._runtime.increment_metric(f"events.backend.{self._backend_name}.resolved")
+        log_with_context(
+            logger,
+            logging.DEBUG,
+            "event.configure",
+            adapter_name=self._adapter_name,
+            backend_name=self._backend_name,
+            event_poll_interval=self._event_poll_interval,
+        )
         self._listeners: dict[str, AsyncEventListener] = {}
 
     async def publish(self, channel: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None" = None) -> str:
@@ -760,13 +813,15 @@ class AsyncEventChannel:
         )
         return event_ids
 
-    def iter_events(self, channel: str, *, poll_interval: float | None = None) -> AsyncIterator[EventMessage]:
+    def iter_events(
+        self, channel: str, *, event_poll_interval: float | None = None, poll_interval: float | None = None
+    ) -> AsyncIterator[EventMessage]:
         """Yield events as they become available."""
         channel = normalize_event_channel_name(channel)
         if not self._backend.supports_async:
             msg = "Current events backend does not support async consumption"
             raise ImproperConfigurationError(msg)
-        interval = resolve_poll_interval(poll_interval, self._poll_interval_default)
+        interval = resolve_event_poll_interval(event_poll_interval, poll_interval, self._event_poll_interval)
         return _AsyncEventIterator(
             backend=self._backend,
             runtime=self._runtime,
@@ -781,6 +836,7 @@ class AsyncEventChannel:
         channel: str,
         handler: "AsyncEventHandler | SyncEventHandler",
         *,
+        event_poll_interval: float | None = None,
         poll_interval: float | None = None,
         auto_ack: bool = True,
     ) -> AsyncEventListener:
@@ -791,7 +847,7 @@ class AsyncEventChannel:
             raise ImproperConfigurationError(msg)
         loop = asyncio.get_running_loop()
         stop_event = asyncio.Event()
-        interval = resolve_poll_interval(poll_interval, self._poll_interval_default)
+        interval = resolve_event_poll_interval(event_poll_interval, poll_interval, self._event_poll_interval)
         listener_id = uuid4().hex
         task = loop.create_task(self._run_listener(listener_id, channel, handler, stop_event, interval, auto_ack))
         listener = AsyncEventListener(listener_id, channel, task, stop_event, interval)
@@ -857,6 +913,7 @@ class AsyncEventChannel:
 
     async def shutdown(self) -> None:
         """Shutdown the event channel and release backend resources."""
+        started_at = perf_counter()
         span = _start_event_span(self._runtime, "shutdown", self._backend_name, self._adapter_name, mode="async")
         try:
             for listener_id in list(self._listeners):
@@ -865,6 +922,8 @@ class AsyncEventChannel:
         except Exception as error:
             _end_event_span(self._runtime, span, error=error)
             raise
+        finally:
+            self._runtime.record_metric("events.shutdown.duration_ms", (perf_counter() - started_at) * 1000)
         _end_event_span(self._runtime, span, result="shutdown")
         self._runtime.increment_metric("events.shutdown")
 

--- a/sqlspec/extensions/events/_channel.py
+++ b/sqlspec/extensions/events/_channel.py
@@ -6,6 +6,7 @@ import inspect
 import logging
 import threading
 from collections.abc import AsyncIterator, Iterator, Sequence
+from contextlib import suppress
 from dataclasses import dataclass
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, cast
@@ -37,6 +38,7 @@ __all__ = (
 )
 
 logger = get_logger("sqlspec.events.channel")
+_LISTENER_SHUTDOWN_TIMEOUT = 0.5
 
 
 @dataclass(slots=True)
@@ -53,6 +55,8 @@ class AsyncEventListener:
         """Signal the listener to stop and await task completion."""
         self.stop_event.set()
         if not self.task.done():
+            self.task.cancel()
+        with suppress(asyncio.CancelledError):
             await self.task
 
 
@@ -69,7 +73,7 @@ class SyncEventListener:
     def stop(self) -> None:
         """Signal the listener to stop and join the thread."""
         self.stop_event.set()
-        self.thread.join()
+        self.thread.join(timeout=_LISTENER_SHUTDOWN_TIMEOUT)
 
 
 def resolve_poll_interval(poll_interval: "float | None", default: float) -> float:
@@ -618,15 +622,21 @@ class SyncEventChannel:
         """Shutdown the event channel and release backend resources."""
         started_at = perf_counter()
         span = _start_event_span(self._runtime, "shutdown", self._backend_name, self._adapter_name, mode="sync")
+        listeners = list(self._listeners.values())
+        self._listeners.clear()
+        for listener in listeners:
+            listener.stop_event.set()
         try:
-            for listener_id in list(self._listeners):
-                self.stop_listener(listener_id)
             self._backend.shutdown()
         except Exception as error:
             _end_event_span(self._runtime, span, error=error)
             raise
         finally:
+            deadline = started_at + _LISTENER_SHUTDOWN_TIMEOUT
+            for listener in listeners:
+                listener.thread.join(timeout=max(deadline - perf_counter(), 0.0))
             self._runtime.record_metric("events.shutdown.duration_ms", (perf_counter() - started_at) * 1000)
+        self._runtime.increment_metric("events.listener.stop", len(listeners))
         _end_event_span(self._runtime, span, result="shutdown")
         self._runtime.increment_metric("events.shutdown")
 
@@ -915,15 +925,17 @@ class AsyncEventChannel:
         """Shutdown the event channel and release backend resources."""
         started_at = perf_counter()
         span = _start_event_span(self._runtime, "shutdown", self._backend_name, self._adapter_name, mode="async")
+        listeners = list(self._listeners.values())
+        self._listeners.clear()
         try:
-            for listener_id in list(self._listeners):
-                await self.stop_listener(listener_id)
+            await asyncio.gather(*(listener.stop() for listener in listeners))
             await self._backend.shutdown()
         except Exception as error:
             _end_event_span(self._runtime, span, error=error)
             raise
         finally:
             self._runtime.record_metric("events.shutdown.duration_ms", (perf_counter() - started_at) * 1000)
+        self._runtime.increment_metric("events.listener.stop", len(listeners))
         _end_event_span(self._runtime, span, result="shutdown")
         self._runtime.increment_metric("events.shutdown")
 

--- a/sqlspec/extensions/events/_protocols.py
+++ b/sqlspec/extensions/events/_protocols.py
@@ -3,6 +3,8 @@
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from sqlspec.extensions.events._models import EventMessage
 
 __all__ = ("AsyncEventBackendProtocol", "AsyncEventHandler", "SyncEventBackendProtocol", "SyncEventHandler")
@@ -42,6 +44,15 @@ class AsyncEventBackendProtocol(Protocol):
 
         Returns:
             The event ID.
+        """
+        ...
+
+    async def publish_many(self, events: "Sequence[tuple[str, dict[str, Any], dict[str, Any] | None]]") -> list[str]:
+        """Publish independent events as one grouped backend operation.
+
+        Implementations with native batching must preserve input order in the
+        returned event IDs. Backends without native batching are invoked through
+        the event channel's single-event fallback.
         """
         ...
 
@@ -98,6 +109,15 @@ class SyncEventBackendProtocol(Protocol):
 
         Returns:
             The event ID.
+        """
+        ...
+
+    def publish_many(self, events: "Sequence[tuple[str, dict[str, Any], dict[str, Any] | None]]") -> list[str]:
+        """Publish independent events as one grouped backend operation.
+
+        Implementations with native batching must preserve input order in the
+        returned event IDs. Backends without native batching are invoked through
+        the event channel's single-event fallback.
         """
         ...
 

--- a/sqlspec/extensions/events/_queue.py
+++ b/sqlspec/extensions/events/_queue.py
@@ -33,7 +33,6 @@ _PENDING_STATUS = "pending"
 _LEASED_STATUS = "leased"
 _ACKED_STATUS = "acked"
 _DEFAULT_TABLE = "sqlspec_event_queue"
-_INITIAL_EMPTY_POLL_BACKOFF = 0.05
 _MAX_EMPTY_POLL_CHANNELS = 1_024
 
 
@@ -100,7 +99,7 @@ class _BaseTableEventQueue:
     def _select_sql(self, select_for_update: bool, skip_locked: bool) -> str:
         top_clause = "TOP 1 " if self._uses_tsql_limit() else ""
         limit_clause = "" if self._uses_oracle_locking_select(select_for_update) else self._row_limit_clause()
-        base = f"SELECT {top_clause}event_id, channel, payload_json, metadata_json, attempts, available_at, lease_expires_at, created_at FROM {self._table_name} WHERE channel = :channel AND available_at <= :available_cutoff AND (status = :pending_status OR (status = :leased_status AND (lease_expires_at IS NULL OR lease_expires_at <= :lease_cutoff))) ORDER BY created_at ASC"
+        base = f"SELECT {top_clause}event_id, channel, payload_json, metadata_json, attempts, available_at, lease_expires_at, created_at FROM {self._table_name} WHERE channel = :channel AND available_at <= :available_cutoff AND (status = :pending_status OR (status = :leased_status AND (lease_expires_at IS NULL OR lease_expires_at <= :lease_cutoff))) ORDER BY created_at ASC, event_id ASC"
         locking_clause = ""
         if select_for_update:
             locking_clause = " FOR UPDATE"
@@ -133,8 +132,8 @@ class _BaseTableEventQueue:
             return 0.0
         if channel not in self._empty_poll_delays and len(self._empty_poll_delays) >= _MAX_EMPTY_POLL_CHANNELS:
             self._empty_poll_delays.pop(next(iter(self._empty_poll_delays)))
-        delay = min(self._empty_poll_delays.get(channel, _INITIAL_EMPTY_POLL_BACKOFF), poll_interval)
-        self._empty_poll_delays[channel] = min(delay * 2, poll_interval)
+        delay = poll_interval
+        self._empty_poll_delays[channel] = delay
         self._runtime.record_metric("events.poll.backoff", delay)
         return delay
 
@@ -185,7 +184,7 @@ class _BaseTableEventQueue:
         now = cls._utcnow()
         event_ids: list[str] = []
         records: list[dict[str, Any]] = []
-        for channel, payload, metadata in events:
+        for index, (channel, payload, metadata) in enumerate(events):
             event_id = uuid4().hex
             event_ids.append(event_id)
             records.append({
@@ -197,7 +196,7 @@ class _BaseTableEventQueue:
                 "available_at": now,
                 "lease_expires_at": None,
                 "attempts": 0,
-                "created_at": now,
+                "created_at": now + timedelta(microseconds=index),
             })
         return event_ids, records
 

--- a/sqlspec/extensions/events/_queue.py
+++ b/sqlspec/extensions/events/_queue.py
@@ -14,10 +14,11 @@ from sqlspec.extensions.events._models import EventMessage
 from sqlspec.extensions.events._names import normalize_queue_table_name
 from sqlspec.extensions.events._payload import parse_event_timestamp
 from sqlspec.utils.logging import get_logger
-from sqlspec.utils.serializers import from_json
+from sqlspec.utils.serializers import from_json, to_json
 from sqlspec.utils.uuids import uuid4
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from contextlib import AbstractAsyncContextManager, AbstractContextManager
 
     from sqlspec.config import DatabaseConfigProtocol
@@ -160,6 +161,29 @@ class _BaseTableEventQueue:
     def _utcnow() -> "datetime":
         return datetime.now(timezone.utc)
 
+    @classmethod
+    def _batch_insert_parameters(
+        cls, events: "Sequence[tuple[str, dict[str, Any], dict[str, Any] | None]]"
+    ) -> "tuple[list[str], list[dict[str, Any]]]":
+        now = cls._utcnow()
+        event_ids: list[str] = []
+        records: list[dict[str, Any]] = []
+        for channel, payload, metadata in events:
+            event_id = uuid4().hex
+            event_ids.append(event_id)
+            records.append({
+                "event_id": event_id,
+                "channel": channel,
+                "payload_json": to_json(payload),
+                "metadata_json": to_json(metadata) if metadata is not None else None,
+                "status": _PENDING_STATUS,
+                "available_at": now,
+                "lease_expires_at": None,
+                "attempts": 0,
+                "created_at": now,
+            })
+        return event_ids, records
+
     @staticmethod
     def _claim_verified(row: "dict[str, Any] | None", leased_until: "datetime") -> bool:
         """Confirm claim ownership by matching the stored lease against the claimer's token.
@@ -242,6 +266,21 @@ class SyncTableEventQueue(_BaseTableEventQueue):
         )
         self._runtime.increment_metric("events.publish")
         return event_id
+
+    def publish_many(self, events: "Sequence[tuple[str, dict[str, Any], dict[str, Any] | None]]") -> list[str]:
+        """Bulk-insert independent events in one transaction."""
+        if not events:
+            return []
+        event_ids, records = self._batch_insert_parameters(events)
+        with cast(
+            "AbstractContextManager[SyncDriverAdapterBase]", self._config.provide_session(transaction=True)
+        ) as driver:
+            driver.execute_many(self._insert_statement, records, statement_config=self._statement_config)
+            driver.commit()
+        self._runtime.increment_metric("events.publisher.session")
+        self._runtime.increment_metric("events.publisher.statement")
+        self._runtime.increment_metric("events.publish", len(records))
+        return event_ids
 
     def dequeue(self, channel: str, poll_interval: float | None = None) -> "EventMessage | None":
         attempt = 0
@@ -449,6 +488,21 @@ class AsyncTableEventQueue(_BaseTableEventQueue):
         )
         self._runtime.increment_metric("events.publish")
         return event_id
+
+    async def publish_many(self, events: "Sequence[tuple[str, dict[str, Any], dict[str, Any] | None]]") -> list[str]:
+        """Bulk-insert independent events in one transaction."""
+        if not events:
+            return []
+        event_ids, records = self._batch_insert_parameters(events)
+        async with cast(
+            "AbstractAsyncContextManager[AsyncDriverAdapterBase]", self._config.provide_session(transaction=True)
+        ) as driver:
+            await driver.execute_many(self._insert_statement, records, statement_config=self._statement_config)
+            await driver.commit()
+        self._runtime.increment_metric("events.publisher.session")
+        self._runtime.increment_metric("events.publisher.statement")
+        self._runtime.increment_metric("events.publish", len(records))
+        return event_ids
 
     async def dequeue(self, channel: str, poll_interval: float | None = None) -> "EventMessage | None":
         attempt = 0

--- a/sqlspec/extensions/events/_queue.py
+++ b/sqlspec/extensions/events/_queue.py
@@ -33,6 +33,8 @@ _PENDING_STATUS = "pending"
 _LEASED_STATUS = "leased"
 _ACKED_STATUS = "acked"
 _DEFAULT_TABLE = "sqlspec_event_queue"
+_INITIAL_EMPTY_POLL_BACKOFF = 0.05
+_MAX_EMPTY_POLL_CHANNELS = 1_024
 
 
 class _BaseTableEventQueue:
@@ -44,6 +46,7 @@ class _BaseTableEventQueue:
         "_claim_statement",
         "_config",
         "_dialect",
+        "_empty_poll_delays",
         "_insert_statement",
         "_lease_seconds",
         "_max_claim_attempts",
@@ -71,6 +74,7 @@ class _BaseTableEventQueue:
         self._statement_config = config.statement_config
         self._runtime = config.get_observability_runtime()
         self._dialect = str(self._statement_config.dialect or "").lower() if self._statement_config else ""
+        self._empty_poll_delays: dict[str, float] = {}
         self._table_name = normalize_queue_table_name(queue_table or _DEFAULT_TABLE)
         self._lease_seconds = lease_seconds or 30
         self._retention_seconds = retention_seconds or 86_400
@@ -123,6 +127,19 @@ class _BaseTableEventQueue:
     def _uses_oracle_locking_select(self, select_for_update: bool | None = None) -> bool:
         locking_enabled = self._select_for_update if select_for_update is None else select_for_update
         return bool(locking_enabled) and "oracle" in self._dialect
+
+    def _next_empty_poll_delay(self, channel: str, poll_interval: "float | None") -> float:
+        if poll_interval is None or poll_interval <= 0:
+            return 0.0
+        if channel not in self._empty_poll_delays and len(self._empty_poll_delays) >= _MAX_EMPTY_POLL_CHANNELS:
+            self._empty_poll_delays.pop(next(iter(self._empty_poll_delays)))
+        delay = min(self._empty_poll_delays.get(channel, _INITIAL_EMPTY_POLL_BACKOFF), poll_interval)
+        self._empty_poll_delays[channel] = min(delay * 2, poll_interval)
+        self._runtime.record_metric("events.poll.backoff", delay)
+        return delay
+
+    def _reset_empty_poll_delay(self, channel: str) -> None:
+        self._empty_poll_delays.pop(channel, None)
 
     def _claim_sql(self) -> str:
         return f"UPDATE {self._table_name} SET status = :claimed_status, lease_expires_at = :lease_expires_at, attempts = attempts + 1 WHERE event_id = :event_id AND (status = :pending_status OR (status = :leased_status AND (lease_expires_at IS NULL OR lease_expires_at <= :lease_reentry_cutoff)))"
@@ -289,14 +306,19 @@ class SyncTableEventQueue(_BaseTableEventQueue):
             if self._select_for_update:
                 event = self._claim_locked_candidate(channel)
                 if event is not None:
+                    self._reset_empty_poll_delay(channel)
                     return event
-                if poll_interval is not None and poll_interval > 0:
-                    time.sleep(poll_interval)
+                self._runtime.increment_metric("events.poll.empty")
+                delay = self._next_empty_poll_delay(channel, poll_interval)
+                if delay > 0:
+                    time.sleep(delay)
                 return None
             row = self._fetch_candidate(channel)
             if row is None:
-                if poll_interval is not None and poll_interval > 0:
-                    time.sleep(poll_interval)
+                self._runtime.increment_metric("events.poll.empty")
+                delay = self._next_empty_poll_delay(channel, poll_interval)
+                if delay > 0:
+                    time.sleep(delay)
                 return None
             now = self._utcnow()
             leased_until = now + timedelta(seconds=self._lease_seconds)
@@ -314,6 +336,7 @@ class SyncTableEventQueue(_BaseTableEventQueue):
             if not claimed:
                 claimed = self._claim_verified(self._fetch_by_event_id(row["event_id"]), leased_until)
             if claimed:
+                self._reset_empty_poll_delay(channel)
                 return self._hydrate_event(row, leased_until)
         return None
 
@@ -337,7 +360,9 @@ class SyncTableEventQueue(_BaseTableEventQueue):
         if not claimed:
             claimed = self._claim_verified(self._fetch_by_event_id(row["event_id"]), leased_until)
         if claimed:
-            return self._hydrate_event(row, leased_until)
+            event = self._hydrate_event(row, leased_until)
+            self._reset_empty_poll_delay(event.channel)
+            return event
         return None
 
     def ack(self, event_id: str) -> None:
@@ -359,6 +384,7 @@ class SyncTableEventQueue(_BaseTableEventQueue):
 
     def _fetch_candidate(self, channel: str) -> "dict[str, Any] | None":
         current_time = self._utcnow()
+        self._runtime.increment_metric("events.poll.query")
         with cast("AbstractContextManager[SyncDriverAdapterBase]", self._config.provide_session()) as driver:
             return driver.select_one_or_none(
                 # SQL allocation here is intentional: DB round-trip dominates by >=100x,
@@ -511,14 +537,19 @@ class AsyncTableEventQueue(_BaseTableEventQueue):
             if self._select_for_update:
                 event = await self._claim_locked_candidate(channel)
                 if event is not None:
+                    self._reset_empty_poll_delay(channel)
                     return event
-                if poll_interval is not None and poll_interval > 0:
-                    await asyncio.sleep(poll_interval)
+                self._runtime.increment_metric("events.poll.empty")
+                delay = self._next_empty_poll_delay(channel, poll_interval)
+                if delay > 0:
+                    await asyncio.sleep(delay)
                 return None
             row = await self._fetch_candidate(channel)
             if row is None:
-                if poll_interval is not None and poll_interval > 0:
-                    await asyncio.sleep(poll_interval)
+                self._runtime.increment_metric("events.poll.empty")
+                delay = self._next_empty_poll_delay(channel, poll_interval)
+                if delay > 0:
+                    await asyncio.sleep(delay)
                 return None
             now = self._utcnow()
             leased_until = now + timedelta(seconds=self._lease_seconds)
@@ -536,6 +567,7 @@ class AsyncTableEventQueue(_BaseTableEventQueue):
             if not claimed:
                 claimed = self._claim_verified(await self._fetch_by_event_id(row["event_id"]), leased_until)
             if claimed:
+                self._reset_empty_poll_delay(channel)
                 return self._hydrate_event(row, leased_until)
         return None
 
@@ -559,7 +591,9 @@ class AsyncTableEventQueue(_BaseTableEventQueue):
         if not claimed:
             claimed = self._claim_verified(await self._fetch_by_event_id(row["event_id"]), leased_until)
         if claimed:
-            return self._hydrate_event(row, leased_until)
+            event = self._hydrate_event(row, leased_until)
+            self._reset_empty_poll_delay(event.channel)
+            return event
         return None
 
     async def ack(self, event_id: str) -> None:
@@ -581,6 +615,7 @@ class AsyncTableEventQueue(_BaseTableEventQueue):
 
     async def _fetch_candidate(self, channel: str) -> "dict[str, Any] | None":
         current_time = self._utcnow()
+        self._runtime.increment_metric("events.poll.query")
         async with cast(
             "AbstractAsyncContextManager[AsyncDriverAdapterBase]", self._config.provide_session()
         ) as driver:

--- a/sqlspec/extensions/events/_queue.py
+++ b/sqlspec/extensions/events/_queue.py
@@ -14,7 +14,7 @@ from sqlspec.extensions.events._models import EventMessage
 from sqlspec.extensions.events._names import normalize_queue_table_name
 from sqlspec.extensions.events._payload import parse_event_timestamp
 from sqlspec.utils.logging import get_logger
-from sqlspec.utils.serializers import from_json, to_json
+from sqlspec.utils.serializers import from_json
 from sqlspec.utils.uuids import uuid4
 
 if TYPE_CHECKING:
@@ -190,8 +190,8 @@ class _BaseTableEventQueue:
             records.append({
                 "event_id": event_id,
                 "channel": channel,
-                "payload_json": to_json(payload),
-                "metadata_json": to_json(metadata) if metadata is not None else None,
+                "payload_json": payload,
+                "metadata_json": metadata,
                 "status": _PENDING_STATUS,
                 "available_at": now,
                 "lease_expires_at": None,

--- a/sqlspec/extensions/litestar/channels.py
+++ b/sqlspec/extensions/litestar/channels.py
@@ -11,7 +11,7 @@ from litestar.channels.backends.base import ChannelsBackend
 from sqlspec.utils.logging import get_logger
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Iterable
+    from collections.abc import AsyncGenerator, Iterable, Sequence
 
     from sqlspec.extensions.events import AsyncEventChannel
 
@@ -64,8 +64,21 @@ class SQLSpecChannelsBackend(ChannelsBackend):
         await self._event_channel.shutdown()
 
     async def publish(self, data: bytes, channels: "Iterable[str]") -> None:
-        payload = {"data_b64": base64.b64encode(data).decode("ascii")}
-        events = [(self._db_channel_name(channel), payload, None) for channel in channels]
+        await self.publish_many((data,), channels)
+
+    async def publish_many(self, data: "Sequence[bytes]", channels: "Iterable[str]") -> None:
+        """Publish independent payloads through one event-channel batch.
+
+        Args:
+            data: Ordered payloads to publish.
+            channels: Litestar channel names that receive each payload.
+        """
+        db_channels = [self._db_channel_name(channel) for channel in channels]
+        events = [
+            (db_channel, {"data_b64": base64.b64encode(payload).decode("ascii")}, None)
+            for payload in data
+            for db_channel in db_channels
+        ]
         await self._event_channel.publish_many(events)
 
     async def subscribe(self, channels: "Iterable[str]") -> None:

--- a/sqlspec/extensions/litestar/channels.py
+++ b/sqlspec/extensions/litestar/channels.py
@@ -65,9 +65,8 @@ class SQLSpecChannelsBackend(ChannelsBackend):
 
     async def publish(self, data: bytes, channels: "Iterable[str]") -> None:
         payload = {"data_b64": base64.b64encode(data).decode("ascii")}
-        for channel in channels:
-            db_channel = self._db_channel_name(channel)
-            await self._event_channel.publish(db_channel, payload)
+        events = [(self._db_channel_name(channel), payload, None) for channel in channels]
+        await self._event_channel.publish_many(events)
 
     async def subscribe(self, channels: "Iterable[str]") -> None:
         for channel in channels:

--- a/tests/integration/adapters/asyncpg/extensions/events/test_listen_notify.py
+++ b/tests/integration/adapters/asyncpg/extensions/events/test_listen_notify.py
@@ -66,12 +66,24 @@ async def test_asyncpg_hybrid_listen_notify_durable(postgres_service: "Any", tmp
         event_id = await channel.publish("alerts", {"action": "hybrid_async"})
         await _wait_for_message(received)
 
+    batch_ids = await channel.publish_many([
+        ("alerts", {"index": 1}, None),
+        ("alerts", {"index": 2}, {"source": "batch"}),
+    ])
+    for _ in range(_MAX_POLL_ATTEMPTS):
+        if len(received) >= 3:
+            break
+        await asyncio.sleep(_POLL_INTERVAL)
+
     await channel.stop_listener(listener.id)
 
-    assert received, "listener did not receive message"
+    assert len(received) >= 3, "listener did not receive the single event and complete batch"
     message = received[0]
     assert message.event_id == event_id
     assert message.payload["action"] == "hybrid_async"
+    assert [message.event_id for message in received[1:3]] == batch_ids
+    assert [message.payload["index"] for message in received[1:3]] == [1, 2]
+    assert received[2].metadata == {"source": "batch"}
 
     await channel.shutdown()
     if config.connection_instance:

--- a/tests/integration/adapters/psqlpy/extensions/events/test_listen_notify.py
+++ b/tests/integration/adapters/psqlpy/extensions/events/test_listen_notify.py
@@ -100,12 +100,24 @@ async def test_psqlpy_listen_notify_hybrid(postgres_service: "Any", tmp_path) ->
             if received:
                 break
             await asyncio.sleep(0.05)
+
+        batch_ids = await channel.publish_many([
+            ("alerts", {"index": 1}, None),
+            ("alerts", {"index": 2}, {"source": "batch"}),
+        ])
+        for _ in range(200):
+            if len(received) >= 3:
+                break
+            await asyncio.sleep(0.05)
         await channel.stop_listener(listener.id)
 
-        assert received, "listener did not receive message"
+        assert len(received) >= 3, "listener did not receive the single event and complete batch"
         message = received[0]
         assert message.event_id == event_id
         assert message.payload["action"] == "hybrid"
+        assert [message.event_id for message in received[1:3]] == batch_ids
+        assert [message.payload["index"] for message in received[1:3]] == [1, 2]
+        assert received[2].metadata == {"source": "batch"}
     finally:
         backend = getattr(channel, "_backend", None)
         if backend and hasattr(backend, "shutdown"):

--- a/tests/integration/adapters/psycopg/extensions/events/test_listen_notify.py
+++ b/tests/integration/adapters/psycopg/extensions/events/test_listen_notify.py
@@ -172,10 +172,22 @@ async def test_psycopg_async_hybrid_listen_notify_durable(postgres_service: "Any
         if received:
             break
         await asyncio.sleep(0.05)
+
+    batch_ids = await channel.publish_many([
+        ("alerts", {"index": 1}, None),
+        ("alerts", {"index": 2}, {"source": "batch"}),
+    ])
+    for _ in range(200):
+        if len(received) >= 3:
+            break
+        await asyncio.sleep(0.05)
     await channel.stop_listener(listener.id)
 
-    assert received, "listener did not receive message"
+    assert len(received) >= 3, "listener did not receive the single event and complete batch"
     message = received[0]
 
     assert message.event_id == event_id
     assert message.payload["action"] == "hybrid-async"
+    assert [message.event_id for message in received[1:3]] == batch_ids
+    assert [message.payload["index"] for message in received[1:3]] == [1, 2]
+    assert received[2].metadata == {"source": "batch"}

--- a/tests/integration/extensions/events/test_native_concurrency.py
+++ b/tests/integration/extensions/events/test_native_concurrency.py
@@ -22,11 +22,12 @@ import asyncio
 import contextlib
 import importlib
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 from sqlspec import SQLSpec
+from sqlspec.extensions.events import AsyncEventChannel
 
 pytestmark = pytest.mark.xdist_group("postgres")
 
@@ -229,7 +230,8 @@ async def test_native_publish_many_preserves_individual_envelopes(postgres_servi
         await asyncio.sleep(_SUBSCRIBE_WAIT)
         events = [(channel_name, {"index": index}, {"source": "batch"}) for index in range(_EXPECTED_DELIVERIES)]
 
-        event_ids = await channel.publish_many(events)
+        async_channel = cast("AsyncEventChannel", channel)
+        event_ids = await async_channel.publish_many(events)
         await _drain(received, _EXPECTED_DELIVERIES, watch_tasks=(listener.task,))
 
         assert len(received) == _EXPECTED_DELIVERIES

--- a/tests/integration/extensions/events/test_native_concurrency.py
+++ b/tests/integration/extensions/events/test_native_concurrency.py
@@ -204,6 +204,43 @@ async def test_native_concurrent_same_channel_peers(postgres_service: Any, backe
         await _cleanup(channel, config)
 
 
+@pytest.mark.postgres
+@pytest.mark.parametrize("backend_key", sorted(_FACTORIES))
+async def test_native_publish_many_preserves_individual_envelopes(postgres_service: Any, backend_key: str) -> None:
+    """A native batch uses one producer flush without changing subscriber envelopes."""
+    factory = _import_or_skip(backend_key)
+    try:
+        config = factory(postgres_service)
+    except ImportError:  # pragma: no cover - driver absent
+        pytest.skip(f"driver for {backend_key} not installed")
+
+    spec = SQLSpec()
+    spec.add_config(config)
+    channel = spec.event_channel(config)
+    received: list[Any] = []
+
+    async def _handler(message: Any) -> None:
+        received.append(message)
+
+    channel_name = f"batch_{backend_key}"
+    listener = None
+    try:
+        listener = channel.listen(channel_name, _handler, poll_interval=_POLL_INTERVAL)
+        await asyncio.sleep(_SUBSCRIBE_WAIT)
+        events = [(channel_name, {"index": index}, {"source": "batch"}) for index in range(_EXPECTED_DELIVERIES)]
+
+        event_ids = await channel.publish_many(events)
+        await _drain(received, _EXPECTED_DELIVERIES, watch_tasks=(listener.task,))
+
+        assert len(received) == _EXPECTED_DELIVERIES
+        assert [message.event_id for message in received] == event_ids
+        assert [message.payload["index"] for message in received] == list(range(_EXPECTED_DELIVERIES))
+        assert all(message.metadata == {"source": "batch"} for message in received)
+    finally:
+        await _safe_stop(channel, listener)
+        await _cleanup(channel, config)
+
+
 async def _safe_stop(channel: Any, *listeners: Any) -> None:
     for listener in listeners:
         if listener is None:

--- a/tests/integration/extensions/litestar/test_channels_backend.py
+++ b/tests/integration/extensions/litestar/test_channels_backend.py
@@ -71,3 +71,18 @@ async def test_litestar_channels_backend_groups_multi_channel_publish() -> None:
         backend._db_channel_name("gamma"),
     ]
     assert {event[1]["data_b64"] for event in event_channel.batches[0]} == {"cGF5bG9hZA=="}
+
+
+async def test_litestar_channels_backend_groups_multiple_payloads_and_channels() -> None:
+    event_channel = _RecordingEventChannel()
+    backend = SQLSpecChannelsBackend(cast("Any", event_channel), channel_prefix="litestar")
+
+    await backend.publish_many((b"first", b"second"), (channel for channel in ("alpha", "beta")))
+
+    assert len(event_channel.batches) == 1
+    assert [(event[0], event[1]["data_b64"]) for event in event_channel.batches[0]] == [
+        (backend._db_channel_name("alpha"), "Zmlyc3Q="),
+        (backend._db_channel_name("beta"), "Zmlyc3Q="),
+        (backend._db_channel_name("alpha"), "c2Vjb25k"),
+        (backend._db_channel_name("beta"), "c2Vjb25k"),
+    ]

--- a/tests/integration/extensions/litestar/test_channels_backend.py
+++ b/tests/integration/extensions/litestar/test_channels_backend.py
@@ -18,6 +18,15 @@ async def _next_event(subscriber: "Any") -> bytes:
     raise RuntimeError(msg)
 
 
+class _RecordingEventChannel:
+    def __init__(self) -> None:
+        self.batches: list[list[tuple[str, dict[str, str], None]]] = []
+
+    async def publish_many(self, events: "list[tuple[str, dict[str, str], None]]") -> list[str]:
+        self.batches.append(events)
+        return [f"event-{index}" for index in range(len(events))]
+
+
 async def test_litestar_channels_backend_database_roundtrip(tmp_path: "Any") -> None:
     migrations = tmp_path / "migrations"
     migrations.mkdir()
@@ -46,3 +55,19 @@ async def test_litestar_channels_backend_database_roundtrip(tmp_path: "Any") -> 
             await plugin.unsubscribe(subscriber)
 
         await config.close_pool()
+
+
+async def test_litestar_channels_backend_groups_multi_channel_publish() -> None:
+    event_channel = _RecordingEventChannel()
+    backend = SQLSpecChannelsBackend(cast("Any", event_channel), channel_prefix="litestar")
+
+    await backend.publish(b"payload", (channel for channel in ("alpha", "beta", "gamma")))
+
+    assert len(event_channel.batches) == 1
+    assert len(event_channel.batches[0]) == 3
+    assert [event[0] for event in event_channel.batches[0]] == [
+        backend._db_channel_name("alpha"),
+        backend._db_channel_name("beta"),
+        backend._db_channel_name("gamma"),
+    ]
+    assert {event[1]["data_b64"] for event in event_channel.batches[0]} == {"cGF5bG9hZA=="}

--- a/tests/integration/extensions/litestar/test_channels_backend.py
+++ b/tests/integration/extensions/litestar/test_channels_backend.py
@@ -52,6 +52,11 @@ async def test_litestar_channels_backend_database_roundtrip(tmp_path: "Any") -> 
             decoded = msgspec.json.decode(payload)
             assert decoded["action"] == "hello"
 
+            await backend.publish_many((b"first", b"second"), ("notifications",))
+            first = await asyncio.wait_for(_next_event(subscriber), timeout=3.0)
+            second = await asyncio.wait_for(_next_event(subscriber), timeout=3.0)
+            assert (first, second) == (b"first", b"second")
+
             await plugin.unsubscribe(subscriber)
 
         await config.close_pool()

--- a/tests/unit/extensions/test_events/test_backend_factories.py
+++ b/tests/unit/extensions/test_events/test_backend_factories.py
@@ -30,6 +30,7 @@ def test_asyncpg_factory_notify_queue_backend() -> None:
 
     assert isinstance(backend, AsyncpgHybridEventsBackend)
     assert backend.backend_name == "notify_queue"
+    assert backend._ensure_hub()._backend_name == "notify_queue"
 
 
 def test_asyncpg_factory_unknown_backend_returns_none() -> None:
@@ -42,6 +43,19 @@ def test_asyncpg_factory_unknown_backend_returns_none() -> None:
     backend = create_event_backend(config, "unknown_backend", {})
 
     assert backend is None
+
+
+def test_asyncpg_factory_rejects_single_connection_listener_pool() -> None:
+    """Asyncpg native listeners reserve capacity for a publisher session."""
+    pytest.importorskip("asyncpg")
+    from sqlspec.adapters.asyncpg.config import AsyncpgConfig
+    from sqlspec.adapters.asyncpg.events.backend import create_event_backend
+    from sqlspec.exceptions import ImproperConfigurationError
+
+    config = AsyncpgConfig(connection_config={"dsn": "postgresql://localhost/test", "max_size": 1})
+
+    with pytest.raises(ImproperConfigurationError, match="max_size >= 2"):
+        create_event_backend(config, "notify", {})
 
 
 def test_asyncpg_factory_passes_extension_settings() -> None:
@@ -94,6 +108,7 @@ def test_psycopg_factory_hybrid_backend() -> None:
 
     assert isinstance(backend, PsycopgAsyncHybridEventsBackend)
     assert backend.backend_name == "notify_queue"
+    assert backend._ensure_hub()._backend_name == "notify_queue"
 
 
 def test_psycopg_factory_unknown_returns_none() -> None:
@@ -106,6 +121,19 @@ def test_psycopg_factory_unknown_returns_none() -> None:
     backend = create_event_backend(config, "unknown_backend", {})
 
     assert backend is None
+
+
+def test_psycopg_factory_rejects_single_connection_listener_pool() -> None:
+    """Psycopg native listeners reserve capacity for a publisher session."""
+    pytest.importorskip("psycopg")
+    from sqlspec.adapters.psycopg.config import PsycopgAsyncConfig
+    from sqlspec.adapters.psycopg.events.backend import create_event_backend
+    from sqlspec.exceptions import ImproperConfigurationError
+
+    config = PsycopgAsyncConfig(connection_config={"dbname": "test", "max_size": 1})
+
+    with pytest.raises(ImproperConfigurationError, match="max_size >= 2"):
+        create_event_backend(config, "notify", {})
 
 
 def test_psqlpy_factory_notify_backend() -> None:
@@ -134,6 +162,7 @@ def test_psqlpy_factory_hybrid_backend() -> None:
 
     assert isinstance(backend, PsqlpyHybridEventsBackend)
     assert backend.backend_name == "notify_queue"
+    assert backend._ensure_hub()._backend_name == "notify_queue"
 
 
 def test_psqlpy_factory_hybrid_passes_settings() -> None:
@@ -159,6 +188,19 @@ def test_psqlpy_factory_unknown_returns_none() -> None:
     backend = create_event_backend(config, "unknown_backend", {})
 
     assert backend is None
+
+
+def test_psqlpy_factory_rejects_single_connection_listener_pool() -> None:
+    """Psqlpy native listeners reserve capacity for a publisher session."""
+    pytest.importorskip("psqlpy")
+    from sqlspec.adapters.psqlpy.config import PsqlpyConfig
+    from sqlspec.adapters.psqlpy.events.backend import create_event_backend
+    from sqlspec.exceptions import ImproperConfigurationError
+
+    config = PsqlpyConfig(connection_config={"dsn": "postgresql://localhost/test", "max_size": 1})
+
+    with pytest.raises(ImproperConfigurationError, match="max_size >= 2"):
+        create_event_backend(config, "notify", {})
 
 
 def test_oracle_factory_aq_backend() -> None:

--- a/tests/unit/extensions/test_events/test_backend_factories.py
+++ b/tests/unit/extensions/test_events/test_backend_factories.py
@@ -197,9 +197,9 @@ def test_psqlpy_factory_rejects_single_connection_listener_pool() -> None:
     from sqlspec.adapters.psqlpy.events.backend import create_event_backend
     from sqlspec.exceptions import ImproperConfigurationError
 
-    config = PsqlpyConfig(connection_config={"dsn": "postgresql://localhost/test", "max_size": 1})
+    config = PsqlpyConfig(connection_config={"dsn": "postgresql://localhost/test", "max_db_pool_size": 1})
 
-    with pytest.raises(ImproperConfigurationError, match="max_size >= 2"):
+    with pytest.raises(ImproperConfigurationError, match="max_db_pool_size >= 2"):
         create_event_backend(config, "notify", {})
 
 

--- a/tests/unit/extensions/test_events/test_batch_publish.py
+++ b/tests/unit/extensions/test_events/test_batch_publish.py
@@ -12,7 +12,7 @@ from sqlspec.core import StatementConfig
 from sqlspec.exceptions import EventChannelError
 from sqlspec.extensions.events import AsyncEventChannel, AsyncTableEventQueue, SyncEventChannel, SyncTableEventQueue
 from sqlspec.observability import ObservabilityRuntime
-from sqlspec.utils.serializers import from_json
+from sqlspec.utils.serializers import from_json, to_json
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -182,7 +182,11 @@ async def test_async_event_channel_publish_many_finishes_error_span(tmp_path: An
 class _SyncDriver:
     def __init__(self) -> None:
         self.commits = 0
+        self.execute_calls: list[Any] = []
         self.execute_many_calls: list[tuple[Any, list[dict[str, Any]], Any]] = []
+
+    def execute(self, statement: Any) -> None:
+        self.execute_calls.append(statement)
 
     def execute_many(self, statement: Any, parameters: Any, *, statement_config: Any = None) -> None:
         self.execute_many_calls.append((statement, list(parameters), statement_config))
@@ -194,7 +198,14 @@ class _SyncDriver:
 class _AsyncDriver:
     def __init__(self) -> None:
         self.commits = 0
+        self.execute_calls: list[Any] = []
         self.execute_many_calls: list[tuple[Any, list[dict[str, Any]], Any]] = []
+
+    async def execute(self, statement: Any) -> None:
+        self.execute_calls.append(statement)
+
+    async def execute_script(self, statement: Any) -> None:
+        self.execute_calls.append(statement)
 
     async def execute_many(self, statement: Any, parameters: Any, *, statement_config: Any = None) -> None:
         self.execute_many_calls.append((statement, list(parameters), statement_config))
@@ -438,8 +449,33 @@ async def test_async_postgres_hybrid_publish_many_bulk_inserts_and_marks_each_ch
     assert len(config.driver.execute_many_calls) == 2
     assert [len(call[1]) for call in config.driver.execute_many_calls] == [1_000, 2]
     assert [record["event_id"] for record in config.driver.execute_many_calls[0][1]] == ids
-    assert _notify_channels(config.driver.execute_many_calls[1][1]) == ["channel_0", "channel_1"]
+    marker_parameters = config.driver.execute_many_calls[1][1]
+    assert _notify_channels(marker_parameters) == ["channel_0", "channel_1"]
+    assert _notify_batch_markers(marker_parameters) == [500, 500]
     assert config.driver.commits == 1
+
+
+@pytest.mark.parametrize(
+    "config_type,backend_factory",
+    [
+        (_AsyncpgConfig, _asyncpg_hybrid_backend),
+        (_PsycopgAsyncConfig, _psycopg_async_hybrid_backend),
+        (_PsqlpyConfig, _psqlpy_hybrid_backend),
+    ],
+)
+async def test_async_postgres_hybrid_single_and_batch_preserve_empty_metadata(
+    config_type: Any, backend_factory: Any
+) -> None:
+    single_config = config_type()
+    single_backend = backend_factory(single_config)
+    await single_backend.publish("events", {"value": 1}, {})
+
+    batch_config = config_type()
+    batch_backend = backend_factory(batch_config)
+    await batch_backend.publish_many([("events", {"value": 1}, {})])
+
+    assert single_config.driver.execute_calls[0].parameters["metadata_json"] == to_json({})
+    assert batch_config.driver.execute_many_calls[0][1][0]["metadata_json"] == to_json({})
 
 
 def test_psycopg_sync_hybrid_publish_many_bulk_inserts_and_marks_each_channel_once() -> None:
@@ -456,8 +492,26 @@ def test_psycopg_sync_hybrid_publish_many_bulk_inserts_and_marks_each_channel_on
     assert len(config.driver.execute_many_calls) == 2
     assert [len(call[1]) for call in config.driver.execute_many_calls] == [1_000, 2]
     assert [record["event_id"] for record in config.driver.execute_many_calls[0][1]] == ids
-    assert _notify_channels(config.driver.execute_many_calls[1][1]) == ["channel_0", "channel_1"]
+    marker_parameters = config.driver.execute_many_calls[1][1]
+    assert _notify_channels(marker_parameters) == ["channel_0", "channel_1"]
+    assert _notify_batch_markers(marker_parameters) == [500, 500]
     assert config.driver.commits == 1
+
+
+def test_psycopg_sync_hybrid_single_and_batch_preserve_empty_metadata() -> None:
+    pytest.importorskip("psycopg")
+    from sqlspec.adapters.psycopg.events.backend import PsycopgSyncHybridEventsBackend
+
+    single_config = _PsycopgSyncConfig()
+    single_backend = PsycopgSyncHybridEventsBackend(single_config, _HybridQueue())  # type: ignore[arg-type]
+    single_backend.publish("events", {"value": 1}, {})
+
+    batch_config = _PsycopgSyncConfig()
+    batch_backend = PsycopgSyncHybridEventsBackend(batch_config, _HybridQueue())  # type: ignore[arg-type]
+    batch_backend.publish_many([("events", {"value": 1}, {})])
+
+    assert single_config.driver.execute_calls[0].parameters["metadata_json"] == to_json({})
+    assert batch_config.driver.execute_many_calls[0][1][0]["metadata_json"] == to_json({})
 
 
 def _notify_event_ids(parameters: "list[Any]") -> list[str]:
@@ -477,3 +531,20 @@ def _notify_channels(parameters: "list[Any]") -> list[str]:
         parameters_row["channel"] if isinstance(parameters_row, dict) else parameters_row[0]
         for parameters_row in parameters
     ]
+
+
+def _notify_batch_markers(parameters: "list[Any]") -> list[int]:
+    batch_sizes: list[int] = []
+    marker_ids: set[str] = set()
+    for parameters_row in parameters:
+        payload = parameters_row["payload"] if isinstance(parameters_row, dict) else parameters_row[1]
+        decoded = from_json(payload)
+        assert isinstance(decoded, dict)
+        batch_size = decoded.get("batch_size")
+        marker_id = decoded.get("marker_id")
+        assert isinstance(batch_size, int)
+        assert isinstance(marker_id, str)
+        batch_sizes.append(batch_size)
+        marker_ids.add(marker_id)
+    assert len(marker_ids) == 1
+    return batch_sizes

--- a/tests/unit/extensions/test_events/test_batch_publish.py
+++ b/tests/unit/extensions/test_events/test_batch_publish.py
@@ -1,0 +1,373 @@
+# pyright: reportPrivateUsage=false
+"""Batch publication contract tests for event channels and backends."""
+
+from contextlib import asynccontextmanager, contextmanager
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+
+from sqlspec.adapters.aiosqlite import AiosqliteConfig
+from sqlspec.adapters.sqlite import SqliteConfig
+from sqlspec.core import StatementConfig
+from sqlspec.exceptions import EventChannelError
+from sqlspec.extensions.events import AsyncEventChannel, AsyncTableEventQueue, SyncEventChannel, SyncTableEventQueue
+from sqlspec.observability import ObservabilityRuntime
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+def _events(count: int = 1_000) -> "list[tuple[str, dict[str, Any], dict[str, Any] | None]]":
+    return [(f"channel_{index % 2}", {"index": index}, {"source": "batch"}) for index in range(count)]
+
+
+class _SyncFallbackBackend:
+    backend_name = "sync-fallback"
+    supports_sync = True
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict[str, Any], dict[str, Any] | None]] = []
+
+    def publish(self, channel: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None" = None) -> str:
+        self.published.append((channel, payload, metadata))
+        return f"event-{len(self.published)}"
+
+
+class _AsyncFallbackBackend:
+    backend_name = "async-fallback"
+    supports_async = True
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict[str, Any], dict[str, Any] | None]] = []
+
+    async def publish(self, channel: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None" = None) -> str:
+        self.published.append((channel, payload, metadata))
+        return f"event-{len(self.published)}"
+
+
+class _AsyncBatchBackend(_AsyncFallbackBackend):
+    def __init__(self) -> None:
+        super().__init__()
+        self.batches: list[list[tuple[str, dict[str, Any], dict[str, Any] | None]]] = []
+
+    async def publish_many(self, events: "list[tuple[str, dict[str, Any], dict[str, Any] | None]]") -> list[str]:
+        self.batches.append(events)
+        return [f"batch-{index}" for index in range(len(events))]
+
+
+def test_sync_event_channel_publish_many_falls_back_after_prevalidation(tmp_path: Any) -> None:
+    backend = _SyncFallbackBackend()
+    channel = SyncEventChannel(SqliteConfig(connection_config={"database": str(tmp_path / "sync.db")}))
+    channel._backend = backend  # type: ignore[assignment]
+    channel._backend_name = backend.backend_name
+
+    ids = channel.publish_many([("first", {"index": 1}, None), ("second", {"index": 2}, {"x": 1})])
+
+    assert ids == ["event-1", "event-2"]
+    assert [event[0] for event in backend.published] == ["first", "second"]
+    backend.published.clear()
+    with pytest.raises(EventChannelError, match="Invalid events channel name"):
+        channel.publish_many([("valid", {}, None), ("invalid-channel", {}, None)])
+    assert backend.published == []
+
+
+async def test_async_event_channel_publish_many_falls_back_and_empty_is_noop(tmp_path: Any) -> None:
+    backend = _AsyncFallbackBackend()
+    channel = AsyncEventChannel(AiosqliteConfig(connection_config={"database": str(tmp_path / "async.db")}))
+    channel._backend = backend  # type: ignore[assignment]
+    channel._backend_name = backend.backend_name
+
+    assert await channel.publish_many([]) == []
+    ids = await channel.publish_many([("first", {"index": 1}, None), ("second", {"index": 2}, None)])
+
+    assert ids == ["event-1", "event-2"]
+    assert [event[0] for event in backend.published] == ["first", "second"]
+    snapshot = channel._runtime.metrics_snapshot()
+    assert snapshot["AiosqliteConfig.events.publish.batch_fallback"] == pytest.approx(1.0)
+
+
+async def test_async_event_channel_publish_many_prefers_backend_batch(tmp_path: Any) -> None:
+    backend = _AsyncBatchBackend()
+    channel = AsyncEventChannel(AiosqliteConfig(connection_config={"database": str(tmp_path / "native.db")}))
+    channel._backend = backend  # type: ignore[assignment]
+    channel._backend_name = backend.backend_name
+    events = [("first", {"index": 1}, None), ("second", {"index": 2}, None)]
+
+    ids = await channel.publish_many(events)
+
+    assert ids == ["batch-0", "batch-1"]
+    assert backend.batches == [events]
+    assert backend.published == []
+
+
+class _SyncDriver:
+    def __init__(self) -> None:
+        self.commits = 0
+        self.execute_many_calls: list[tuple[Any, list[dict[str, Any]], Any]] = []
+
+    def execute_many(self, statement: Any, parameters: Any, *, statement_config: Any = None) -> None:
+        self.execute_many_calls.append((statement, list(parameters), statement_config))
+
+    def commit(self) -> None:
+        self.commits += 1
+
+
+class _AsyncDriver:
+    def __init__(self) -> None:
+        self.commits = 0
+        self.execute_many_calls: list[tuple[Any, list[dict[str, Any]], Any]] = []
+
+    async def execute_many(self, statement: Any, parameters: Any, *, statement_config: Any = None) -> None:
+        self.execute_many_calls.append((statement, list(parameters), statement_config))
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+
+class _SyncQueueConfig:
+    is_async = False
+
+    def __init__(self) -> None:
+        self.driver = _SyncDriver()
+        self.sessions = 0
+        self.statement_config = StatementConfig(dialect="sqlite")
+        self.runtime = ObservabilityRuntime(config_name="SyncBatchConfig")
+
+    def get_observability_runtime(self) -> ObservabilityRuntime:
+        return self.runtime
+
+    @contextmanager
+    def provide_session(self, **_: Any) -> Any:
+        self.sessions += 1
+        yield self.driver
+
+
+class _AsyncQueueConfig:
+    is_async = True
+
+    def __init__(self) -> None:
+        self.driver = _AsyncDriver()
+        self.sessions = 0
+        self.statement_config = StatementConfig(dialect="sqlite")
+        self.runtime = ObservabilityRuntime(config_name="AsyncBatchConfig")
+
+    def get_observability_runtime(self) -> ObservabilityRuntime:
+        return self.runtime
+
+    @asynccontextmanager
+    async def provide_session(self, **_: Any) -> "AsyncIterator[Any]":
+        self.sessions += 1
+        yield self.driver
+
+
+def test_sync_table_queue_publish_many_uses_one_session_statement_and_commit() -> None:
+    config = _SyncQueueConfig()
+    queue = SyncTableEventQueue(config)  # type: ignore[arg-type]
+
+    ids = queue.publish_many(_events())
+
+    assert len(ids) == 1_000
+    assert len(set(ids)) == 1_000
+    assert config.sessions == 1
+    assert len(config.driver.execute_many_calls) == 1
+    assert len(config.driver.execute_many_calls[0][1]) == 1_000
+    assert config.driver.commits == 1
+
+
+async def test_async_table_queue_publish_many_uses_one_session_statement_and_commit() -> None:
+    config = _AsyncQueueConfig()
+    queue = AsyncTableEventQueue(config)  # type: ignore[arg-type]
+
+    ids = await queue.publish_many(_events())
+
+    assert len(ids) == 1_000
+    assert len(set(ids)) == 1_000
+    assert config.sessions == 1
+    assert len(config.driver.execute_many_calls) == 1
+    assert len(config.driver.execute_many_calls[0][1]) == 1_000
+    assert config.driver.commits == 1
+
+
+class _NativeAsyncConfig:
+    is_async = True
+
+    def __init__(self) -> None:
+        self.connection_config: dict[str, Any] = {}
+        self.driver = _AsyncDriver()
+        self.sessions = 0
+        self.runtime = ObservabilityRuntime(config_name=type(self).__name__)
+
+    def get_observability_runtime(self) -> ObservabilityRuntime:
+        return self.runtime
+
+    @asynccontextmanager
+    async def provide_session(self, **_: Any) -> "AsyncIterator[Any]":
+        self.sessions += 1
+        yield self.driver
+
+
+class _AsyncpgConfig(_NativeAsyncConfig):
+    pass
+
+
+class _PsycopgAsyncConfig(_NativeAsyncConfig):
+    pass
+
+
+class _PsqlpyConfig(_NativeAsyncConfig):
+    pass
+
+
+_AsyncpgConfig.__module__ = "sqlspec.adapters.asyncpg.config"
+_PsycopgAsyncConfig.__module__ = "sqlspec.adapters.psycopg.config"
+_PsqlpyConfig.__module__ = "sqlspec.adapters.psqlpy.config"
+
+
+class _NativeSyncConfig:
+    is_async = False
+
+    def __init__(self) -> None:
+        self.connection_config: dict[str, Any] = {}
+        self.driver = _SyncDriver()
+        self.sessions = 0
+        self.runtime = ObservabilityRuntime(config_name=type(self).__name__)
+
+    def get_observability_runtime(self) -> ObservabilityRuntime:
+        return self.runtime
+
+    @contextmanager
+    def provide_session(self, **_: Any) -> Any:
+        self.sessions += 1
+        yield self.driver
+
+
+class _PsycopgSyncConfig(_NativeSyncConfig):
+    pass
+
+
+_PsycopgSyncConfig.__module__ = "sqlspec.adapters.psycopg.config"
+
+
+class _HybridQueue:
+    _insert_statement = "INSERT INTO sqlspec_event_queue VALUES (:event_id)"
+    _statement_config = StatementConfig(dialect="postgres")
+
+
+def _asyncpg_notify_backend(config: Any) -> Any:
+    pytest.importorskip("asyncpg")
+    from sqlspec.adapters.asyncpg.events.backend import AsyncpgEventsBackend
+
+    return AsyncpgEventsBackend(config)
+
+
+def _psycopg_async_notify_backend(config: Any) -> Any:
+    pytest.importorskip("psycopg")
+    from sqlspec.adapters.psycopg.events.backend import PsycopgAsyncEventsBackend
+
+    return PsycopgAsyncEventsBackend(config)
+
+
+def _psqlpy_notify_backend(config: Any) -> Any:
+    pytest.importorskip("psqlpy")
+    from sqlspec.adapters.psqlpy.events.backend import PsqlpyEventsBackend
+
+    return PsqlpyEventsBackend(config)
+
+
+@pytest.mark.parametrize(
+    "config_type,backend_factory",
+    [
+        (_AsyncpgConfig, _asyncpg_notify_backend),
+        (_PsycopgAsyncConfig, _psycopg_async_notify_backend),
+        (_PsqlpyConfig, _psqlpy_notify_backend),
+    ],
+)
+async def test_async_postgres_notify_publish_many_uses_one_session_and_batch_statement(
+    config_type: Any, backend_factory: Any
+) -> None:
+    config = config_type()
+    backend = backend_factory(config)
+
+    ids = await backend.publish_many(_events())
+
+    assert len(ids) == 1_000
+    assert config.sessions == 1
+    assert len(config.driver.execute_many_calls) == 1
+    assert len(config.driver.execute_many_calls[0][1]) == 1_000
+    assert config.driver.commits == 1
+
+
+def test_psycopg_sync_notify_publish_many_uses_one_session_and_batch_statement() -> None:
+    pytest.importorskip("psycopg")
+    from sqlspec.adapters.psycopg.events.backend import PsycopgSyncEventsBackend
+
+    config = _PsycopgSyncConfig()
+    backend = PsycopgSyncEventsBackend(config)  # type: ignore[arg-type]
+
+    ids = backend.publish_many(_events())
+
+    assert len(ids) == 1_000
+    assert config.sessions == 1
+    assert len(config.driver.execute_many_calls) == 1
+    assert len(config.driver.execute_many_calls[0][1]) == 1_000
+    assert config.driver.commits == 1
+
+
+def _asyncpg_hybrid_backend(config: Any) -> Any:
+    pytest.importorskip("asyncpg")
+    from sqlspec.adapters.asyncpg.events.backend import AsyncpgHybridEventsBackend
+
+    return AsyncpgHybridEventsBackend(config, cast("Any", _HybridQueue()))
+
+
+def _psycopg_async_hybrid_backend(config: Any) -> Any:
+    pytest.importorskip("psycopg")
+    from sqlspec.adapters.psycopg.events.backend import PsycopgAsyncHybridEventsBackend
+
+    return PsycopgAsyncHybridEventsBackend(config, cast("Any", _HybridQueue()))
+
+
+def _psqlpy_hybrid_backend(config: Any) -> Any:
+    pytest.importorskip("psqlpy")
+    from sqlspec.adapters.psqlpy.events.backend import PsqlpyHybridEventsBackend
+
+    return PsqlpyHybridEventsBackend(config, cast("Any", _HybridQueue()))
+
+
+@pytest.mark.parametrize(
+    "config_type,backend_factory",
+    [
+        (_AsyncpgConfig, _asyncpg_hybrid_backend),
+        (_PsycopgAsyncConfig, _psycopg_async_hybrid_backend),
+        (_PsqlpyConfig, _psqlpy_hybrid_backend),
+    ],
+)
+async def test_async_postgres_hybrid_publish_many_bulk_inserts_and_marks_each_channel_once(
+    config_type: Any, backend_factory: Any
+) -> None:
+    config = config_type()
+    backend = backend_factory(config)
+
+    ids = await backend.publish_many(_events())
+
+    assert len(ids) == 1_000
+    assert config.sessions == 1
+    assert len(config.driver.execute_many_calls) == 2
+    assert [len(call[1]) for call in config.driver.execute_many_calls] == [1_000, 2]
+    assert config.driver.commits == 1
+
+
+def test_psycopg_sync_hybrid_publish_many_bulk_inserts_and_marks_each_channel_once() -> None:
+    pytest.importorskip("psycopg")
+    from sqlspec.adapters.psycopg.events.backend import PsycopgSyncHybridEventsBackend
+
+    config = _PsycopgSyncConfig()
+    backend = PsycopgSyncHybridEventsBackend(config, _HybridQueue())  # type: ignore[arg-type]
+
+    ids = backend.publish_many(_events())
+
+    assert len(ids) == 1_000
+    assert config.sessions == 1
+    assert len(config.driver.execute_many_calls) == 2
+    assert [len(call[1]) for call in config.driver.execute_many_calls] == [1_000, 2]
+    assert config.driver.commits == 1

--- a/tests/unit/extensions/test_events/test_batch_publish.py
+++ b/tests/unit/extensions/test_events/test_batch_publish.py
@@ -12,6 +12,7 @@ from sqlspec.core import StatementConfig
 from sqlspec.exceptions import EventChannelError
 from sqlspec.extensions.events import AsyncEventChannel, AsyncTableEventQueue, SyncEventChannel, SyncTableEventQueue
 from sqlspec.observability import ObservabilityRuntime
+from sqlspec.utils.serializers import from_json
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -53,6 +54,52 @@ class _AsyncBatchBackend(_AsyncFallbackBackend):
     async def publish_many(self, events: "list[tuple[str, dict[str, Any], dict[str, Any] | None]]") -> list[str]:
         self.batches.append(events)
         return [f"batch-{index}" for index in range(len(events))]
+
+
+class _RaisingSyncBatchBackend(_SyncFallbackBackend):
+    def publish_many(self, _events: Any) -> list[str]:
+        msg = "sync batch failed"
+        raise RuntimeError(msg)
+
+
+class _RaisingAsyncBatchBackend(_AsyncFallbackBackend):
+    async def publish_many(self, _events: Any) -> list[str]:
+        msg = "async batch failed"
+        raise RuntimeError(msg)
+
+
+class _RecordingSpan:
+    def __init__(self) -> None:
+        self.closed = False
+        self.error: Exception | None = None
+
+    def end(self) -> None:
+        self.closed = True
+
+    def record_exception(self, error: Exception) -> None:
+        self.error = error
+
+    def set_attribute(self, _name: str, _value: Any) -> None:
+        return None
+
+
+class _RecordingSpanManager:
+    is_enabled = True
+
+    def __init__(self) -> None:
+        self.started: list[_RecordingSpan] = []
+        self.finished: list[_RecordingSpan] = []
+
+    def start_span(self, _name: str, _attributes: "dict[str, Any]") -> _RecordingSpan:
+        span = _RecordingSpan()
+        self.started.append(span)
+        return span
+
+    def end_span(self, span: _RecordingSpan, error: "Exception | None" = None) -> None:
+        if error is not None:
+            span.record_exception(error)
+        span.end()
+        self.finished.append(span)
 
 
 def test_sync_event_channel_publish_many_falls_back_after_prevalidation(tmp_path: Any) -> None:
@@ -98,6 +145,38 @@ async def test_async_event_channel_publish_many_prefers_backend_batch(tmp_path: 
     assert ids == ["batch-0", "batch-1"]
     assert backend.batches == [events]
     assert backend.published == []
+
+
+def test_sync_event_channel_publish_many_finishes_error_span(tmp_path: Any) -> None:
+    backend = _RaisingSyncBatchBackend()
+    channel = SyncEventChannel(SqliteConfig(connection_config={"database": str(tmp_path / "sync_error.db")}))
+    channel._backend = backend  # type: ignore[assignment]
+    span_manager = _RecordingSpanManager()
+    channel._runtime.span_manager = cast("Any", span_manager)
+
+    with pytest.raises(RuntimeError, match="sync batch failed"):
+        channel.publish_many([("events", {}, None)])
+
+    assert len(span_manager.started) == 1
+    assert span_manager.finished == span_manager.started
+    assert span_manager.finished[0].closed is True
+    assert isinstance(span_manager.finished[0].error, RuntimeError)
+
+
+async def test_async_event_channel_publish_many_finishes_error_span(tmp_path: Any) -> None:
+    backend = _RaisingAsyncBatchBackend()
+    channel = AsyncEventChannel(AiosqliteConfig(connection_config={"database": str(tmp_path / "async_error.db")}))
+    channel._backend = backend  # type: ignore[assignment]
+    span_manager = _RecordingSpanManager()
+    channel._runtime.span_manager = cast("Any", span_manager)
+
+    with pytest.raises(RuntimeError, match="async batch failed"):
+        await channel.publish_many([("events", {}, None)])
+
+    assert len(span_manager.started) == 1
+    assert span_manager.finished == span_manager.started
+    assert span_manager.finished[0].closed is True
+    assert isinstance(span_manager.finished[0].error, RuntimeError)
 
 
 class _SyncDriver:
@@ -171,6 +250,7 @@ def test_sync_table_queue_publish_many_uses_one_session_statement_and_commit() -
     assert config.sessions == 1
     assert len(config.driver.execute_many_calls) == 1
     assert len(config.driver.execute_many_calls[0][1]) == 1_000
+    assert [record["event_id"] for record in config.driver.execute_many_calls[0][1]] == ids
     assert config.driver.commits == 1
 
 
@@ -185,6 +265,7 @@ async def test_async_table_queue_publish_many_uses_one_session_statement_and_com
     assert config.sessions == 1
     assert len(config.driver.execute_many_calls) == 1
     assert len(config.driver.execute_many_calls[0][1]) == 1_000
+    assert [record["event_id"] for record in config.driver.execute_many_calls[0][1]] == ids
     assert config.driver.commits == 1
 
 
@@ -294,6 +375,7 @@ async def test_async_postgres_notify_publish_many_uses_one_session_and_batch_sta
     assert config.sessions == 1
     assert len(config.driver.execute_many_calls) == 1
     assert len(config.driver.execute_many_calls[0][1]) == 1_000
+    assert _notify_event_ids(config.driver.execute_many_calls[0][1]) == ids
     assert config.driver.commits == 1
 
 
@@ -310,6 +392,7 @@ def test_psycopg_sync_notify_publish_many_uses_one_session_and_batch_statement()
     assert config.sessions == 1
     assert len(config.driver.execute_many_calls) == 1
     assert len(config.driver.execute_many_calls[0][1]) == 1_000
+    assert _notify_event_ids(config.driver.execute_many_calls[0][1]) == ids
     assert config.driver.commits == 1
 
 
@@ -354,6 +437,8 @@ async def test_async_postgres_hybrid_publish_many_bulk_inserts_and_marks_each_ch
     assert config.sessions == 1
     assert len(config.driver.execute_many_calls) == 2
     assert [len(call[1]) for call in config.driver.execute_many_calls] == [1_000, 2]
+    assert [record["event_id"] for record in config.driver.execute_many_calls[0][1]] == ids
+    assert _notify_channels(config.driver.execute_many_calls[1][1]) == ["channel_0", "channel_1"]
     assert config.driver.commits == 1
 
 
@@ -370,4 +455,25 @@ def test_psycopg_sync_hybrid_publish_many_bulk_inserts_and_marks_each_channel_on
     assert config.sessions == 1
     assert len(config.driver.execute_many_calls) == 2
     assert [len(call[1]) for call in config.driver.execute_many_calls] == [1_000, 2]
+    assert [record["event_id"] for record in config.driver.execute_many_calls[0][1]] == ids
+    assert _notify_channels(config.driver.execute_many_calls[1][1]) == ["channel_0", "channel_1"]
     assert config.driver.commits == 1
+
+
+def _notify_event_ids(parameters: "list[Any]") -> list[str]:
+    event_ids: list[str] = []
+    for parameters_row in parameters:
+        payload = parameters_row["payload"] if isinstance(parameters_row, dict) else parameters_row[1]
+        decoded = from_json(payload)
+        assert isinstance(decoded, dict)
+        event_id = decoded.get("event_id")
+        assert isinstance(event_id, str)
+        event_ids.append(event_id)
+    return event_ids
+
+
+def _notify_channels(parameters: "list[Any]") -> list[str]:
+    return [
+        parameters_row["channel"] if isinstance(parameters_row, dict) else parameters_row[0]
+        for parameters_row in parameters
+    ]

--- a/tests/unit/extensions/test_events/test_batch_publish.py
+++ b/tests/unit/extensions/test_events/test_batch_publish.py
@@ -573,8 +573,9 @@ async def test_async_postgres_hybrid_single_and_batch_preserve_empty_metadata(
     batch_backend = backend_factory(batch_config)
     await batch_backend.publish_many([("events", {"value": 1}, {})])
 
-    assert single_config.driver.execute_calls[0].parameters["metadata_json"] == to_json({})
-    assert batch_config.driver.execute_many_calls[0][1][0]["metadata_json"] == to_json({})
+    expected_single_metadata = {} if config_type is _PsqlpyConfig else to_json({})
+    assert single_config.driver.execute_calls[0].parameters["metadata_json"] == expected_single_metadata
+    assert batch_config.driver.execute_many_calls[0][1][0]["metadata_json"] == {}
 
 
 def test_psycopg_sync_hybrid_publish_many_bulk_inserts_and_marks_each_channel_once() -> None:
@@ -630,7 +631,7 @@ def test_psycopg_sync_hybrid_single_and_batch_preserve_empty_metadata() -> None:
     batch_backend.publish_many([("events", {"value": 1}, {})])
 
     assert single_config.driver.execute_calls[0].parameters["metadata_json"] == to_json({})
-    assert batch_config.driver.execute_many_calls[0][1][0]["metadata_json"] == to_json({})
+    assert batch_config.driver.execute_many_calls[0][1][0]["metadata_json"] == {}
 
 
 def _notify_event_ids(parameters: "list[Any]") -> list[str]:

--- a/tests/unit/extensions/test_events/test_batch_publish.py
+++ b/tests/unit/extensions/test_events/test_batch_publish.py
@@ -2,6 +2,7 @@
 """Batch publication contract tests for event channels and backends."""
 
 from contextlib import asynccontextmanager, contextmanager
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
@@ -181,25 +182,54 @@ async def test_async_event_channel_publish_many_finishes_error_span(tmp_path: An
 
 class _SyncDriver:
     def __init__(self) -> None:
+        self.begins = 0
         self.commits = 0
+        self.rollbacks = 0
+        self.connection = SimpleNamespace(autocommit=False)
+        self.fail_execute_many_call: int | None = None
         self.execute_calls: list[Any] = []
         self.execute_many_calls: list[tuple[Any, list[dict[str, Any]], Any]] = []
+
+    def begin(self) -> None:
+        self.begins += 1
+        self.connection.autocommit = False
 
     def execute(self, statement: Any) -> None:
         self.execute_calls.append(statement)
 
     def execute_many(self, statement: Any, parameters: Any, *, statement_config: Any = None) -> None:
         self.execute_many_calls.append((statement, list(parameters), statement_config))
+        if self.fail_execute_many_call == len(self.execute_many_calls):
+            raise RuntimeError("marker publish failed")
 
     def commit(self) -> None:
         self.commits += 1
 
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+class _AsyncConnection:
+    def __init__(self) -> None:
+        self.autocommit = False
+
+    async def set_autocommit(self, value: bool) -> None:
+        self.autocommit = value
+
 
 class _AsyncDriver:
     def __init__(self) -> None:
+        self.begins = 0
         self.commits = 0
+        self.rollbacks = 0
+        self.connection = _AsyncConnection()
+        self.fail_execute_many_call: int | None = None
         self.execute_calls: list[Any] = []
         self.execute_many_calls: list[tuple[Any, list[dict[str, Any]], Any]] = []
+
+    async def begin(self) -> None:
+        self.begins += 1
+        self.connection.autocommit = False
 
     async def execute(self, statement: Any) -> None:
         self.execute_calls.append(statement)
@@ -209,9 +239,14 @@ class _AsyncDriver:
 
     async def execute_many(self, statement: Any, parameters: Any, *, statement_config: Any = None) -> None:
         self.execute_many_calls.append((statement, list(parameters), statement_config))
+        if self.fail_execute_many_call == len(self.execute_many_calls):
+            raise RuntimeError("marker publish failed")
 
     async def commit(self) -> None:
         self.commits += 1
+
+    async def rollback(self) -> None:
+        self.rollbacks += 1
 
 
 class _SyncQueueConfig:
@@ -344,6 +379,10 @@ class _HybridQueue:
     _insert_statement = "INSERT INTO sqlspec_event_queue VALUES (:event_id)"
     _statement_config = StatementConfig(dialect="postgres")
 
+    @staticmethod
+    def _batch_insert_parameters(events: Any) -> Any:
+        return SyncTableEventQueue._batch_insert_parameters(events)
+
 
 def _asyncpg_notify_backend(config: Any) -> Any:
     pytest.importorskip("asyncpg")
@@ -387,7 +426,30 @@ async def test_async_postgres_notify_publish_many_uses_one_session_and_batch_sta
     assert len(config.driver.execute_many_calls) == 1
     assert len(config.driver.execute_many_calls[0][1]) == 1_000
     assert _notify_event_ids(config.driver.execute_many_calls[0][1]) == ids
+    assert config.driver.begins == 1
     assert config.driver.commits == 1
+    assert config.driver.rollbacks == 0
+
+
+@pytest.mark.parametrize(
+    "config_type,backend_factory",
+    [
+        (_AsyncpgConfig, _asyncpg_notify_backend),
+        (_PsycopgAsyncConfig, _psycopg_async_notify_backend),
+        (_PsqlpyConfig, _psqlpy_notify_backend),
+    ],
+)
+async def test_async_postgres_notify_batch_failure_rolls_back(config_type: Any, backend_factory: Any) -> None:
+    config = config_type()
+    config.driver.fail_execute_many_call = 1
+    backend = backend_factory(config)
+
+    with pytest.raises(RuntimeError, match="marker publish failed"):
+        await backend.publish_many(_events(4))
+
+    assert config.driver.begins == 1
+    assert config.driver.commits == 0
+    assert config.driver.rollbacks == 1
 
 
 def test_psycopg_sync_notify_publish_many_uses_one_session_and_batch_statement() -> None:
@@ -404,7 +466,9 @@ def test_psycopg_sync_notify_publish_many_uses_one_session_and_batch_statement()
     assert len(config.driver.execute_many_calls) == 1
     assert len(config.driver.execute_many_calls[0][1]) == 1_000
     assert _notify_event_ids(config.driver.execute_many_calls[0][1]) == ids
+    assert config.driver.begins == 1
     assert config.driver.commits == 1
+    assert config.driver.rollbacks == 0
 
 
 def _asyncpg_hybrid_backend(config: Any) -> Any:
@@ -452,7 +516,42 @@ async def test_async_postgres_hybrid_publish_many_bulk_inserts_and_marks_each_ch
     marker_parameters = config.driver.execute_many_calls[1][1]
     assert _notify_channels(marker_parameters) == ["channel_0", "channel_1"]
     assert _notify_batch_markers(marker_parameters) == [500, 500]
+    assert config.driver.begins == 1
     assert config.driver.commits == 1
+    assert config.driver.rollbacks == 0
+
+
+@pytest.mark.parametrize(
+    "config_type,backend_factory",
+    [
+        (_AsyncpgConfig, _asyncpg_hybrid_backend),
+        (_PsycopgAsyncConfig, _psycopg_async_hybrid_backend),
+        (_PsqlpyConfig, _psqlpy_hybrid_backend),
+    ],
+)
+async def test_async_postgres_hybrid_marker_failure_rolls_back_batch(config_type: Any, backend_factory: Any) -> None:
+    config = config_type()
+    config.driver.fail_execute_many_call = 2
+    backend = backend_factory(config)
+
+    with pytest.raises(RuntimeError, match="marker publish failed"):
+        await backend.publish_many(_events(4))
+
+    assert config.driver.begins == 1
+    assert config.driver.commits == 0
+    assert config.driver.rollbacks == 1
+
+
+async def test_psycopg_async_hybrid_marker_failure_restores_autocommit() -> None:
+    config = _PsycopgAsyncConfig()
+    config.driver.connection.autocommit = True
+    config.driver.fail_execute_many_call = 2
+    backend = _psycopg_async_hybrid_backend(config)
+
+    with pytest.raises(RuntimeError, match="marker publish failed"):
+        await backend.publish_many(_events(4))
+
+    assert config.driver.connection.autocommit is True
 
 
 @pytest.mark.parametrize(
@@ -495,7 +594,27 @@ def test_psycopg_sync_hybrid_publish_many_bulk_inserts_and_marks_each_channel_on
     marker_parameters = config.driver.execute_many_calls[1][1]
     assert _notify_channels(marker_parameters) == ["channel_0", "channel_1"]
     assert _notify_batch_markers(marker_parameters) == [500, 500]
+    assert config.driver.begins == 1
     assert config.driver.commits == 1
+    assert config.driver.rollbacks == 0
+
+
+def test_psycopg_sync_hybrid_marker_failure_rolls_back_batch_and_restores_autocommit() -> None:
+    pytest.importorskip("psycopg")
+    from sqlspec.adapters.psycopg.events.backend import PsycopgSyncHybridEventsBackend
+
+    config = _PsycopgSyncConfig()
+    config.driver.connection.autocommit = True
+    config.driver.fail_execute_many_call = 2
+    backend = PsycopgSyncHybridEventsBackend(config, _HybridQueue())  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError, match="marker publish failed"):
+        backend.publish_many(_events(4))
+
+    assert config.driver.begins == 1
+    assert config.driver.commits == 0
+    assert config.driver.rollbacks == 1
+    assert config.driver.connection.autocommit is True
 
 
 def test_psycopg_sync_hybrid_single_and_batch_preserve_empty_metadata() -> None:

--- a/tests/unit/extensions/test_events/test_channel.py
+++ b/tests/unit/extensions/test_events/test_channel.py
@@ -64,6 +64,35 @@ def test_event_channel_publish_and_ack_sync(tmp_path) -> None:
     assert snapshot.get("SqliteConfig.events.ack") == pytest.approx(1.0)
 
 
+def test_event_channel_publish_many_sync_roundtrip(tmp_path) -> None:
+    """A grouped table-queue publish preserves every independent event envelope."""
+    migrations_dir = tmp_path / "migrations_batch_sync"
+    migrations_dir.mkdir()
+    config = SqliteConfig(
+        connection_config={"database": str(tmp_path / "events_batch_sync.db")},
+        migration_config={"script_location": str(migrations_dir), "include_extensions": ["events"]},
+    )
+    SyncMigrationCommands(config).upgrade()
+    channel = SyncEventChannel(config)
+    events = [("notifications", {"index": index}, {"source": "batch"}) for index in range(20)]
+
+    event_ids = channel.publish_many(events)
+    iterator = channel.iter_events("notifications", poll_interval=0.01)
+    messages = [next(iterator) for _ in events]
+    for message in messages:
+        channel.ack(message.event_id)
+
+    assert {message.event_id for message in messages} == set(event_ids)
+    assert {message.payload["index"] for message in messages} == set(range(20))
+    assert all(message.metadata == {"source": "batch"} for message in messages)
+    with config.provide_session() as driver:
+        acknowledged = driver.select_value(
+            "SELECT COUNT(*) FROM sqlspec_event_queue WHERE status = :status", {"status": "acked"}
+        )
+    assert acknowledged == 20
+    config.close_pool()
+
+
 async def test_event_channel_async_iteration(tmp_path) -> None:
     """Async adapters can publish and drain events via the iterator helper."""
     migrations_dir = tmp_path / "migrations"
@@ -90,6 +119,35 @@ async def test_event_channel_async_iteration(tmp_path) -> None:
             "SELECT status FROM sqlspec_event_queue WHERE event_id = :event_id", {"event_id": event_id}
         )
     assert row["status"] == "acked"
+    await config.close_pool()
+
+
+async def test_event_channel_publish_many_async_roundtrip(tmp_path) -> None:
+    """The async table queue consumes and acknowledges every grouped event."""
+    migrations_dir = tmp_path / "migrations_batch_async"
+    migrations_dir.mkdir()
+    config = AiosqliteConfig(
+        connection_config={"database": str(tmp_path / "events_batch_async.db")},
+        migration_config={"script_location": str(migrations_dir), "include_extensions": ["events"]},
+    )
+    await AsyncMigrationCommands(config).upgrade()
+    channel = AsyncEventChannel(config)
+    events = [("notifications", {"index": index}, None) for index in range(20)]
+
+    event_ids = await channel.publish_many(events)
+    iterator = channel.iter_events("notifications", poll_interval=0.01)
+    messages = [await iterator.__anext__() for _ in events]
+    await iterator.aclose()
+    for message in messages:
+        await channel.ack(message.event_id)
+
+    assert {message.event_id for message in messages} == set(event_ids)
+    assert {message.payload["index"] for message in messages} == set(range(20))
+    async with config.provide_session() as driver:
+        acknowledged = await driver.select_value(
+            "SELECT COUNT(*) FROM sqlspec_event_queue WHERE status = :status", {"status": "acked"}
+        )
+    assert acknowledged == 20
     await config.close_pool()
 
 

--- a/tests/unit/extensions/test_events/test_channel_extended.py
+++ b/tests/unit/extensions/test_events/test_channel_extended.py
@@ -51,6 +51,22 @@ def test_event_channel_custom_poll_interval(tmp_path) -> None:
     assert channel._poll_interval_default == 0.5
 
 
+def test_event_channel_event_poll_interval_takes_precedence(tmp_path) -> None:
+    """The explicit event interval wins over the legacy poll_interval input."""
+    config = SqliteConfig(
+        connection_config={"database": str(tmp_path / "event_poll.db")},
+        extension_config={"events": {"event_poll_interval": 2.5, "poll_interval": 0.1}},
+    )
+
+    channel = SyncEventChannel(config)
+
+    assert channel._event_poll_interval == 2.5
+    assert channel._poll_interval_default == 2.5
+    snapshot = channel._runtime.metrics_snapshot()
+    assert snapshot["SqliteConfig.events.poll.interval"] == pytest.approx(2.5)
+    assert snapshot["SqliteConfig.events.backend.poll_queue.resolved"] == pytest.approx(1.0)
+
+
 def test_event_channel_backend_name_poll_queue(tmp_path) -> None:
     """EventChannel defaults to the durable polling queue backend."""
     config = SqliteConfig(connection_config={"database": str(tmp_path / "test.db")})
@@ -198,6 +214,22 @@ def test_event_channel_resolve_poll_interval_negative_raises(tmp_path) -> None:
 
     with pytest.raises(ImproperConfigurationError, match="poll_interval must be greater than zero"):
         resolve_poll_interval(-1.0, 1.0)
+
+
+def test_event_channel_resolve_event_poll_interval_precedence() -> None:
+    """New setting, compatibility input, and adapter hint have deterministic precedence."""
+    from sqlspec.extensions.events import resolve_event_poll_interval
+
+    assert resolve_event_poll_interval(2.0, 0.1, 1.0) == 2.0
+    assert resolve_event_poll_interval(None, 0.1, 1.0) == 0.1
+    assert resolve_event_poll_interval(None, None, 1.0) == 1.0
+
+
+def test_event_channel_resolve_event_poll_interval_rejects_non_positive() -> None:
+    from sqlspec.extensions.events import resolve_event_poll_interval
+
+    with pytest.raises(ImproperConfigurationError, match="event_poll_interval must be greater than zero"):
+        resolve_event_poll_interval(0, None, 1.0)
 
 
 def test_event_channel_backend_supports_sync(tmp_path) -> None:

--- a/tests/unit/extensions/test_events/test_channel_extended.py
+++ b/tests/unit/extensions/test_events/test_channel_extended.py
@@ -2,6 +2,7 @@
 """Extended unit tests for EventChannel configuration and backend selection."""
 
 import asyncio
+import threading
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
@@ -9,7 +10,7 @@ import pytest
 from sqlspec import ObservabilityRuntime
 from sqlspec.adapters.sqlite import SqliteConfig
 from sqlspec.exceptions import EventChannelError, ImproperConfigurationError
-from sqlspec.extensions.events import AsyncEventChannel, SyncEventChannel
+from sqlspec.extensions.events import AsyncEventChannel, AsyncEventListener, SyncEventChannel, SyncEventListener
 
 if TYPE_CHECKING:
     from sqlspec.config import AsyncDatabaseConfig, SyncDatabaseConfig
@@ -31,6 +32,33 @@ def test_event_channel_adapter_name_resolution(tmp_path) -> None:
     channel = SyncEventChannel(config)
 
     assert channel._adapter_name == "sqlite"
+
+
+async def test_async_event_listener_stop_cancels_blocked_wait() -> None:
+    stop_event = asyncio.Event()
+    task = asyncio.create_task(asyncio.Event().wait())
+    listener = AsyncEventListener("listener", "events", task, stop_event, 60.0)
+
+    await asyncio.wait_for(listener.stop(), timeout=0.1)
+
+    assert stop_event.is_set()
+    assert task.cancelled()
+
+
+def test_sync_event_listener_stop_uses_bounded_join(monkeypatch: pytest.MonkeyPatch) -> None:
+    blocker = threading.Event()
+    thread = threading.Thread(target=blocker.wait, daemon=True)
+    thread.start()
+    stop_event = threading.Event()
+    listener = SyncEventListener("listener", "events", thread, stop_event, 60.0)
+    monkeypatch.setattr("sqlspec.extensions.events._channel._LISTENER_SHUTDOWN_TIMEOUT", 0.01)
+
+    listener.stop()
+
+    assert stop_event.is_set()
+    assert thread.is_alive()
+    blocker.set()
+    thread.join(timeout=0.1)
 
 
 def test_event_channel_default_poll_interval(tmp_path) -> None:

--- a/tests/unit/extensions/test_events/test_listener_hubs.py
+++ b/tests/unit/extensions/test_events/test_listener_hubs.py
@@ -20,20 +20,41 @@ from sqlspec.extensions.events import EventMessage
 
 
 class _AsyncConnectionContext:
-    def __init__(self, connection: Any) -> None:
+    def __init__(self, connection: Any, tracker: Any | None = None) -> None:
         self.connection = connection
+        self.tracker = tracker
 
     async def __aenter__(self) -> Any:
+        if self.tracker is not None:
+            self.tracker.connection_enters += 1
         return self.connection
 
     async def __aexit__(self, *_exc_info: object) -> None:
-        return None
+        if self.tracker is not None:
+            self.tracker.connection_exits += 1
+
+
+class _SyncConnectionContext:
+    def __init__(self, connection: Any, tracker: Any) -> None:
+        self.connection = connection
+        self.tracker = tracker
+
+    def __enter__(self) -> Any:
+        self.tracker.connection_enters += 1
+        return self.connection
+
+    def __exit__(self, *_exc_info: object) -> None:
+        self.tracker.connection_exits += 1
 
 
 class _AsyncpgConnection:
     def __init__(self) -> None:
         self.callbacks: dict[str, Any] = {}
         self.executed: list[str] = []
+        self.closed = False
+
+    def is_closed(self) -> bool:
+        return self.closed
 
     async def execute(self, statement: str) -> None:
         self.executed.append(statement)
@@ -47,22 +68,26 @@ class _AsyncpgConnection:
 
 class _StubRuntime:
     def __init__(self) -> None:
+        self.metrics: list[str] = []
         self.registered: list[tuple[str, Any]] = []
 
-    def increment_metric(self, _metric: str) -> None:
-        return None
+    def increment_metric(self, metric: str) -> None:
+        self.metrics.append(metric)
 
     def register_lifecycle_hook(self, event: str, callback: Any) -> None:
         self.registered.append((event, callback))
 
 
 class _AsyncpgConfig:
-    def __init__(self, connection: _AsyncpgConnection) -> None:
-        self.connection = connection
+    def __init__(self, connection: _AsyncpgConnection, *replacement_connections: _AsyncpgConnection) -> None:
+        self.connections = [connection, *replacement_connections]
+        self.connection_enters = 0
+        self.connection_exits = 0
         self._runtime = _StubRuntime()
 
     def provide_connection(self) -> _AsyncConnectionContext:
-        return _AsyncConnectionContext(self.connection)
+        connection = self.connections[min(self.connection_enters, len(self.connections) - 1)]
+        return _AsyncConnectionContext(connection, self)
 
     def get_observability_runtime(self) -> _StubRuntime:
         return self._runtime
@@ -77,9 +102,15 @@ class _PsqlpyListener:
         self.listen_count = 0
         self.abort_count = 0
         self.emitted: list[tuple[str, str]] = []
+        self.shutdown_count = 0
+        self.started = False
+
+    @property
+    def is_started(self) -> bool:
+        return self.started
 
     async def startup(self) -> None:
-        pass
+        self.started = True
 
     async def add_callback(self, *, channel: str, callback: Any) -> None:
         self.callbacks[channel] = callback
@@ -104,21 +135,25 @@ class _PsqlpyListener:
         self.abort_count += 1
 
     async def shutdown(self) -> None:
-        pass
+        self.shutdown_count += 1
+        self.started = False
 
 
 class _PsqlpyPool:
-    def __init__(self, listener_handle: _PsqlpyListener | None = None) -> None:
-        self.listener_handle = listener_handle or _PsqlpyListener()
+    def __init__(self, listener_handle: _PsqlpyListener, *replacement_listeners: _PsqlpyListener) -> None:
+        self.listener_handles = [listener_handle, *replacement_listeners]
+        self.listener_calls = 0
 
     def listener(self) -> _PsqlpyListener:
-        return self.listener_handle
+        listener = self.listener_handles[min(self.listener_calls, len(self.listener_handles) - 1)]
+        self.listener_calls += 1
+        return listener
 
 
 class _PsqlpyConfig:
-    def __init__(self, listener_handle: _PsqlpyListener | None = None) -> None:
+    def __init__(self, listener_handle: _PsqlpyListener | None = None, *replacement_listeners: _PsqlpyListener) -> None:
         self.listener_handle = listener_handle or _PsqlpyListener()
-        self.pool = _PsqlpyPool(self.listener_handle)
+        self.pool = _PsqlpyPool(self.listener_handle, *replacement_listeners)
         self._runtime = _StubRuntime()
 
     async def provide_pool(self) -> _PsqlpyPool:
@@ -158,6 +193,7 @@ class _PsqlpySession:
 class _PsycopgAsyncConnection:
     def __init__(self) -> None:
         self.executed: list[str] = []
+        self.closed = False
 
     async def execute(self, statement: str) -> None:
         self.executed.append(statement)
@@ -177,12 +213,45 @@ class _PsycopgAsyncConnection:
 
 
 class _PsycopgAsyncConfig:
-    def __init__(self, connection: _PsycopgAsyncConnection) -> None:
-        self.connection = connection
+    def __init__(self, connection: _PsycopgAsyncConnection, *replacement_connections: _PsycopgAsyncConnection) -> None:
+        self.connections = [connection, *replacement_connections]
+        self.connection_enters = 0
+        self.connection_exits = 0
         self._runtime = _StubRuntime()
 
     def provide_connection(self) -> _AsyncConnectionContext:
-        return _AsyncConnectionContext(self.connection)
+        connection = self.connections[min(self.connection_enters, len(self.connections) - 1)]
+        return _AsyncConnectionContext(connection, self)
+
+    def get_observability_runtime(self) -> _StubRuntime:
+        return self._runtime
+
+
+class _PsycopgSyncConnection:
+    def __init__(self) -> None:
+        self.autocommit = False
+        self.closed = False
+        self.executed: list[str] = []
+
+    def execute(self, statement: str) -> None:
+        self.executed.append(statement)
+
+    def notifies(self, *, timeout: float, stop_after: int) -> list[Any]:
+        _ = stop_after
+        threading.Event().wait(timeout)
+        return []
+
+
+class _PsycopgSyncConfig:
+    def __init__(self, connection: _PsycopgSyncConnection, *replacement_connections: _PsycopgSyncConnection) -> None:
+        self.connections = [connection, *replacement_connections]
+        self.connection_enters = 0
+        self.connection_exits = 0
+        self._runtime = _StubRuntime()
+
+    def provide_connection(self) -> _SyncConnectionContext:
+        connection = self.connections[min(self.connection_enters, len(self.connections) - 1)]
+        return _SyncConnectionContext(connection, self)
 
     def get_observability_runtime(self) -> _StubRuntime:
         return self._runtime
@@ -283,6 +352,43 @@ async def test_asyncpg_listener_hub_broadcasts_to_same_channel_consumers() -> No
     await hub.shutdown()
 
 
+async def test_async_listener_hubs_acquire_one_listener_resource_for_many_channels() -> None:
+    asyncpg_config = _AsyncpgConfig(_AsyncpgConnection())
+    asyncpg_hub = AsyncpgListenerHub(asyncpg_config)  # type: ignore[arg-type]
+    psycopg_config = _PsycopgAsyncConfig(_PsycopgAsyncConnection())
+    psycopg_hub = PsycopgAsyncListenerHub(psycopg_config)  # type: ignore[arg-type]
+    psqlpy_config = _PsqlpyConfig()
+    psqlpy_hub = PsqlpyListenerHub(psqlpy_config)  # type: ignore[arg-type]
+
+    await asyncpg_hub.subscribe("alerts")
+    await asyncpg_hub.subscribe("metrics")
+    await psycopg_hub.subscribe("alerts")
+    await psycopg_hub.subscribe("metrics")
+    await psqlpy_hub.subscribe("alerts")
+    await psqlpy_hub.subscribe("metrics")
+
+    assert asyncpg_config.connection_enters == 1
+    assert psycopg_config.connection_enters == 1
+    assert psqlpy_config.pool.listener_calls == 1
+
+    await asyncpg_hub.shutdown()
+    await psycopg_hub.shutdown()
+    await psqlpy_hub.shutdown()
+
+
+def test_psycopg_sync_listener_hub_acquires_one_listener_resource_for_many_channels() -> None:
+    config = _PsycopgSyncConfig(_PsycopgSyncConnection())
+    hub = PsycopgSyncListenerHub(config)  # type: ignore[arg-type]
+
+    hub.subscribe("alerts")
+    hub.subscribe("metrics")
+
+    assert config.connection_enters == 1
+
+    hub.shutdown()
+    assert config.connection_exits == 1
+
+
 async def test_psqlpy_listener_hub_broadcasts_to_same_channel_consumers() -> None:
     payload = "payload-1"
     hub = PsqlpyListenerHub(_PsqlpyConfig())  # type: ignore[arg-type]
@@ -351,6 +457,26 @@ async def test_psqlpy_listener_hub_rearms_for_new_channels() -> None:
     await hub.shutdown()
 
 
+async def test_psqlpy_listener_hub_reconnects_and_releases_listener_handles() -> None:
+    first = _PsqlpyListener()
+    replacement = _PsqlpyListener()
+    config = _PsqlpyConfig(first, replacement)
+    hub = PsqlpyListenerHub(config)  # type: ignore[arg-type]
+
+    await hub.subscribe("alerts")
+    first.started = False
+
+    assert await hub.dequeue("alerts", 0.01) is None
+    assert config.pool.listener_calls == 2
+    assert first.shutdown_count == 1
+    assert "alerts" in replacement.callbacks
+    assert "events.listener.reconnect" in config.get_observability_runtime().metrics
+
+    await hub.shutdown()
+    assert replacement.shutdown_count == 1
+    assert config.get_observability_runtime().metrics.count("events.listener.release") == 2
+
+
 async def test_psycopg_async_listener_hub_broadcasts_to_same_channel_consumers() -> None:
     payload = "payload-1"
     connection = _PsycopgAsyncConnection()
@@ -371,10 +497,50 @@ async def test_psycopg_async_listener_hub_broadcasts_to_same_channel_consumers()
     await hub.shutdown()
 
 
+async def test_asyncpg_listener_hub_reconnects_and_releases_listener_contexts() -> None:
+    first = _AsyncpgConnection()
+    replacement = _AsyncpgConnection()
+    config = _AsyncpgConfig(first, replacement)
+    hub = AsyncpgListenerHub(config)  # type: ignore[arg-type]
+
+    await hub.subscribe("alerts")
+    first.closed = True
+
+    assert await hub.dequeue("alerts", 0.01) is None
+    assert config.connection_enters == 2
+    assert config.connection_exits == 1
+    assert "alerts" in replacement.callbacks
+    assert "events.listener.reconnect" in config.get_observability_runtime().metrics
+
+    await hub.shutdown()
+    assert config.connection_exits == 2
+    assert config.get_observability_runtime().metrics.count("events.listener.release") == 2
+
+
+async def test_psycopg_async_listener_hub_reconnects_and_releases_listener_contexts() -> None:
+    first = _PsycopgAsyncConnection()
+    replacement = _PsycopgAsyncConnection()
+    config = _PsycopgAsyncConfig(first, replacement)
+    hub = PsycopgAsyncListenerHub(config)  # type: ignore[arg-type]
+
+    await hub.subscribe("alerts")
+    first.closed = True
+
+    assert await hub.dequeue("alerts", 0.01) is None
+    assert config.connection_enters == 2
+    assert config.connection_exits == 1
+    assert "LISTEN alerts" in replacement.executed
+    assert "events.listener.reconnect" in config.get_observability_runtime().metrics
+
+    await hub.shutdown()
+    assert config.connection_exits == 2
+    assert config.get_observability_runtime().metrics.count("events.listener.release") == 2
+
+
 def test_psycopg_sync_listener_hub_broadcasts_to_same_channel_consumers() -> None:
     payload = "payload-1"
-    hub = PsycopgSyncListenerHub(object())  # type: ignore[arg-type]
-    hub._queues["alerts"] = WeakKeyDictionary()
+    hub = PsycopgSyncListenerHub(_PsycopgSyncConfig(_PsycopgSyncConnection()))  # type: ignore[arg-type]
+    hub.subscribe("alerts")
     results: list[str | None] = []
 
     def receive_once() -> None:
@@ -391,6 +557,27 @@ def test_psycopg_sync_listener_hub_broadcasts_to_same_channel_consumers() -> Non
     thread_b.join(timeout=1.0)
 
     assert results == [payload, payload]
+    hub.shutdown()
+
+
+def test_psycopg_sync_listener_hub_reconnects_and_releases_listener_contexts() -> None:
+    first = _PsycopgSyncConnection()
+    replacement = _PsycopgSyncConnection()
+    config = _PsycopgSyncConfig(first, replacement)
+    hub = PsycopgSyncListenerHub(config)  # type: ignore[arg-type]
+
+    hub.subscribe("alerts")
+    first.closed = True
+
+    assert hub.dequeue("alerts", 0.01) is None
+    assert config.connection_enters == 2
+    assert config.connection_exits == 1
+    assert "LISTEN alerts" in replacement.executed
+    assert "events.listener.reconnect" in config.get_observability_runtime().metrics
+
+    hub.shutdown()
+    assert config.connection_exits == 2
+    assert config.get_observability_runtime().metrics.count("events.listener.release") == 2
 
 
 async def test_asyncpg_hybrid_dequeue_polls_durable_queue_after_notify_timeout() -> None:

--- a/tests/unit/extensions/test_events/test_listener_hubs.py
+++ b/tests/unit/extensions/test_events/test_listener_hubs.py
@@ -12,10 +12,17 @@ from weakref import WeakKeyDictionary
 import pytest
 
 from sqlspec.adapters.asyncpg.events._hub import AsyncpgListenerHub
-from sqlspec.adapters.asyncpg.events.backend import AsyncpgHybridEventsBackend
+from sqlspec.adapters.asyncpg.events.backend import AsyncpgEventsBackend, AsyncpgHybridEventsBackend
 from sqlspec.adapters.oracledb.events import _hub as oracle_hub
 from sqlspec.adapters.psqlpy.events._hub import PsqlpyListenerHub
+from sqlspec.adapters.psqlpy.events.backend import PsqlpyEventsBackend, PsqlpyHybridEventsBackend
 from sqlspec.adapters.psycopg.events._hub import PsycopgAsyncListenerHub, PsycopgSyncListenerHub
+from sqlspec.adapters.psycopg.events.backend import (
+    PsycopgAsyncEventsBackend,
+    PsycopgAsyncHybridEventsBackend,
+    PsycopgSyncEventsBackend,
+    PsycopgSyncHybridEventsBackend,
+)
 from sqlspec.extensions.events import EventMessage
 
 
@@ -195,8 +202,8 @@ class _PsycopgAsyncConnection:
         self.executed: list[str] = []
         self.closed = False
 
-    async def execute(self, statement: str) -> None:
-        self.executed.append(statement)
+    async def execute(self, statement: Any) -> None:
+        self.executed.append(statement.as_string())
 
     async def set_autocommit(self, value: bool) -> None:
         _ = value
@@ -233,8 +240,8 @@ class _PsycopgSyncConnection:
         self.closed = False
         self.executed: list[str] = []
 
-    def execute(self, statement: str) -> None:
-        self.executed.append(statement)
+    def execute(self, statement: Any) -> None:
+        self.executed.append(statement.as_string())
 
     def notifies(self, *, timeout: float, stop_after: int) -> list[Any]:
         _ = stop_after
@@ -258,20 +265,97 @@ class _PsycopgSyncConfig:
 
 
 class _Runtime:
-    def increment_metric(self, _metric: str) -> None:
-        return None
+    def __init__(self) -> None:
+        self.metrics: list[tuple[str, float]] = []
+
+    def increment_metric(self, metric: str, amount: float = 1.0) -> None:
+        self.metrics.append((metric, amount))
+
+    def record_metric(self, metric: str, value: float) -> None:
+        self.metrics.append((metric, value))
 
 
 class _HybridConfig:
     is_async = True
 
+    def __init__(self) -> None:
+        self.runtime = _Runtime()
+
     def get_observability_runtime(self) -> _Runtime:
-        return _Runtime()
+        return self.runtime
+
+
+class _PsycopgHybridConfig(_HybridConfig):
+    pass
+
+
+class _PsqlpyHybridConfig(_HybridConfig):
+    pass
+
+
+class _AsyncpgNativeConfig(_HybridConfig):
+    pass
+
+
+class _PsycopgNativeConfig(_HybridConfig):
+    pass
+
+
+class _PsqlpyNativeConfig(_HybridConfig):
+    pass
+
+
+class _PsycopgSyncNativeConfig(_HybridConfig):
+    is_async = False
+
+
+_PsycopgHybridConfig.__module__ = "sqlspec.adapters.psycopg.config"
+_PsqlpyHybridConfig.__module__ = "sqlspec.adapters.psqlpy.config"
+_AsyncpgNativeConfig.__module__ = "sqlspec.adapters.asyncpg.config"
+_PsycopgNativeConfig.__module__ = "sqlspec.adapters.psycopg.config"
+_PsqlpyNativeConfig.__module__ = "sqlspec.adapters.psqlpy.config"
+_PsycopgSyncNativeConfig.__module__ = "sqlspec.adapters.psycopg.config"
 
 
 class _TimeoutHub:
     async def dequeue(self, _channel: str, _poll_interval: float) -> None:
         return None
+
+
+class _SyncTimeoutHub:
+    def dequeue(self, _channel: str, _poll_interval: float) -> None:
+        return None
+
+
+class _MarkerHub:
+    def __init__(self, batch_size: int = 1) -> None:
+        self.batch_size = batch_size
+        self.dequeue_calls = 0
+
+    async def dequeue(self, _channel: str, _poll_interval: float) -> str:
+        self.dequeue_calls += 1
+        return f'{{"batch_size":{self.batch_size},"marker_id":"marker-1"}}'
+
+
+class _SyncMarkerHub:
+    def __init__(self, batch_size: int = 1) -> None:
+        self.batch_size = batch_size
+        self.dequeue_calls = 0
+
+    def dequeue(self, _channel: str, _poll_interval: float) -> str:
+        self.dequeue_calls += 1
+        return f'{{"batch_size":{self.batch_size},"marker_id":"marker-1"}}'
+
+
+class _SequenceMarkerHub:
+    def __init__(self, payloads: list[str]) -> None:
+        self.payloads = iter(payloads)
+        self.dequeue_calls = 0
+
+    async def dequeue(self, _channel: str, _poll_interval: float) -> str:
+        self.dequeue_calls += 1
+        await asyncio.sleep(0)
+        return next(self.payloads)
 
 
 class _QueueFallback:
@@ -288,13 +372,50 @@ class _QueueFallback:
             created_at=now,
         )
         self.dequeue_calls: list[tuple[str, float | None]] = []
+        self.reset_calls: list[str] = []
 
-    async def dequeue(self, channel: str, poll_interval: float | None = None) -> EventMessage:
+    async def dequeue(self, channel: str, poll_interval: float | None = None) -> EventMessage | None:
         self.dequeue_calls.append((channel, poll_interval))
         return self.event
 
     async def dequeue_by_event_id(self, _event_id: str) -> None:
         return None
+
+    def _reset_empty_poll_delay(self, channel: str) -> None:
+        self.reset_calls.append(channel)
+
+
+class _EmptyQueueFallback(_QueueFallback):
+    async def dequeue(self, channel: str, poll_interval: float | None = None) -> None:
+        self.dequeue_calls.append((channel, poll_interval))
+        return
+
+
+class _SyncQueueFallback:
+    def __init__(self) -> None:
+        now = datetime.now(timezone.utc)
+        self.event = EventMessage(
+            event_id="event-1",
+            channel="alerts",
+            payload={"ok": True},
+            metadata=None,
+            attempts=0,
+            available_at=now,
+            lease_expires_at=None,
+            created_at=now,
+        )
+        self.dequeue_calls: list[tuple[str, float | None]] = []
+        self.reset_calls: list[str] = []
+
+    def dequeue(self, channel: str, poll_interval: float | None = None) -> EventMessage:
+        self.dequeue_calls.append((channel, poll_interval))
+        return self.event
+
+    def dequeue_by_event_id(self, _event_id: str) -> None:
+        return None
+
+    def _reset_empty_poll_delay(self, channel: str) -> None:
+        self.reset_calls.append(channel)
 
 
 class _Options:
@@ -370,6 +491,7 @@ async def test_async_listener_hubs_acquire_one_listener_resource_for_many_channe
     assert asyncpg_config.connection_enters == 1
     assert psycopg_config.connection_enters == 1
     assert psqlpy_config.pool.listener_calls == 1
+    assert psycopg_config.connections[0].executed[:2] == ['LISTEN "alerts"', 'LISTEN "metrics"']
 
     await asyncpg_hub.shutdown()
     await psycopg_hub.shutdown()
@@ -529,7 +651,7 @@ async def test_psycopg_async_listener_hub_reconnects_and_releases_listener_conte
     assert await hub.dequeue("alerts", 0.01) is None
     assert config.connection_enters == 2
     assert config.connection_exits == 1
-    assert "LISTEN alerts" in replacement.executed
+    assert 'LISTEN "alerts"' in replacement.executed
     assert "events.listener.reconnect" in config.get_observability_runtime().metrics
 
     await hub.shutdown()
@@ -572,7 +694,7 @@ def test_psycopg_sync_listener_hub_reconnects_and_releases_listener_contexts() -
     assert hub.dequeue("alerts", 0.01) is None
     assert config.connection_enters == 2
     assert config.connection_exits == 1
-    assert "LISTEN alerts" in replacement.executed
+    assert 'LISTEN "alerts"' in replacement.executed
     assert "events.listener.reconnect" in config.get_observability_runtime().metrics
 
     hub.shutdown()
@@ -581,14 +703,145 @@ def test_psycopg_sync_listener_hub_reconnects_and_releases_listener_contexts() -
 
 
 async def test_asyncpg_hybrid_dequeue_polls_durable_queue_after_notify_timeout() -> None:
+    config = _HybridConfig()
+    await _assert_dropped_marker_recovers(
+        AsyncpgHybridEventsBackend(config, _QueueFallback()),  # type: ignore[arg-type]
+        config,
+    )
+
+
+async def test_psycopg_hybrid_dequeue_polls_durable_queue_after_notify_timeout() -> None:
+    pytest.importorskip("psycopg")
+    from sqlspec.adapters.psycopg.events.backend import PsycopgAsyncHybridEventsBackend
+
+    config = _PsycopgHybridConfig()
+    await _assert_dropped_marker_recovers(
+        PsycopgAsyncHybridEventsBackend(config, _QueueFallback()),  # type: ignore[arg-type]
+        config,
+    )
+
+
+async def test_psqlpy_hybrid_dequeue_polls_durable_queue_after_notify_timeout() -> None:
+    pytest.importorskip("psqlpy")
+    from sqlspec.adapters.psqlpy.events.backend import PsqlpyHybridEventsBackend
+
+    config = _PsqlpyHybridConfig()
+    await _assert_dropped_marker_recovers(
+        PsqlpyHybridEventsBackend(config, _QueueFallback()),  # type: ignore[arg-type]
+        config,
+    )
+
+
+async def test_hybrid_native_marker_resets_empty_poll_backoff() -> None:
+    config = _HybridConfig()
     queue = _QueueFallback()
-    backend = AsyncpgHybridEventsBackend(_HybridConfig(), queue)  # type: ignore[arg-type]
+    backend = AsyncpgHybridEventsBackend(config, queue)  # type: ignore[arg-type]
+    backend._hub = _MarkerHub()  # type: ignore[assignment]
+
+    assert await backend.dequeue("alerts", 0.01) is queue.event
+    assert queue.reset_calls == ["alerts"]
+
+
+async def test_async_hybrid_batch_marker_drains_all_hinted_rows_without_waiting_again() -> None:
+    configs_and_backends = [
+        (_HybridConfig(), AsyncpgHybridEventsBackend),
+        (_PsycopgHybridConfig(), PsycopgAsyncHybridEventsBackend),
+        (_PsqlpyHybridConfig(), PsqlpyHybridEventsBackend),
+    ]
+    for config, backend_type in configs_and_backends:
+        queue = _QueueFallback()
+        hub = _MarkerHub(batch_size=3)
+        backend = backend_type(config, queue)  # type: ignore[arg-type,call-arg]
+        backend._hub = hub  # type: ignore[assignment]
+
+        events = [await backend.dequeue("alerts", 0.5) for _ in range(3)]
+
+        assert events == [queue.event, queue.event, queue.event]
+        assert hub.dequeue_calls == 1
+        assert queue.dequeue_calls == [("alerts", None)] * 3
+        assert not any(metric == "events.marker.miss" for metric, _amount in config.runtime.metrics)
+
+
+def test_sync_hybrid_batch_marker_drains_all_hinted_rows_without_waiting_again() -> None:
+    config = _PsycopgSyncNativeConfig()
+    queue = _SyncQueueFallback()
+    hub = _SyncMarkerHub(batch_size=3)
+    backend = PsycopgSyncHybridEventsBackend(config, queue)  # type: ignore[arg-type]
+    backend._hub = hub  # type: ignore[assignment]
+
+    events = [backend.dequeue("alerts", 0.5) for _ in range(3)]
+
+    assert events == [queue.event, queue.event, queue.event]
+    assert hub.dequeue_calls == 1
+    assert queue.dequeue_calls == [("alerts", None)] * 3
+    assert not any(metric == "events.marker.miss" for metric, _amount in config.runtime.metrics)
+
+
+async def test_hybrid_marker_dedupe_adds_overlapping_flush_counts_once() -> None:
+    config = _HybridConfig()
+    queue = _QueueFallback()
+    marker_a = '{"batch_size":2,"marker_id":"marker-a"}'
+    marker_b = '{"batch_size":2,"marker_id":"marker-b"}'
+    hub = _SequenceMarkerHub([marker_a, marker_a, marker_b, marker_b])
+    backend = AsyncpgHybridEventsBackend(config, queue)  # type: ignore[arg-type]
+    backend._hub = hub  # type: ignore[assignment]
+
+    events = await asyncio.gather(*(backend.dequeue("alerts", 0.5) for _ in range(4)))
+
+    assert events == [queue.event] * 4
+    assert hub.dequeue_calls == 4
+    assert queue.dequeue_calls == [("alerts", None)] * 4
+    assert backend._marker_state._pending == {}
+    assert list(backend._marker_state._seen) == [("alerts", "marker-a"), ("alerts", "marker-b")]
+
+
+def test_hybrid_marker_dedupe_state_is_bounded() -> None:
+    configs_and_backends = [
+        (_HybridConfig(), AsyncpgHybridEventsBackend),
+        (_PsycopgHybridConfig(), PsycopgAsyncHybridEventsBackend),
+        (_PsqlpyHybridConfig(), PsqlpyHybridEventsBackend),
+    ]
+    for config, backend_type in configs_and_backends:
+        backend = backend_type(config, _QueueFallback())  # type: ignore[arg-type,call-arg]
+        for index in range(1_025):
+            assert backend._marker_state.register("alerts", f"marker-{index}", 1) == (True, True)
+
+        assert len(backend._marker_state._seen) == 1_024
+        assert ("alerts", "marker-0") not in backend._marker_state._seen
+
+
+async def test_hybrid_backend_does_not_double_count_table_queue_empty_poll() -> None:
+    config = _HybridConfig()
+    backend = AsyncpgHybridEventsBackend(config, _EmptyQueueFallback())  # type: ignore[arg-type]
     backend._hub = _TimeoutHub()  # type: ignore[assignment]
 
-    event = await backend.dequeue("alerts", 0.25)
+    assert await backend.dequeue("alerts", 0.01) is None
+    assert not any(metric == "events.poll.empty" for metric, _amount in config.runtime.metrics)
+    assert not any(metric == "events.marker.miss" for metric, _amount in config.runtime.metrics)
+    assert ("events.listener.timeout", 1.0) in config.runtime.metrics
 
-    assert event is queue.event
-    assert queue.dequeue_calls == [("alerts", None)]
+
+async def test_async_native_notify_timeout_records_empty_wait() -> None:
+    configs_and_backends = [
+        (_AsyncpgNativeConfig(), AsyncpgEventsBackend),
+        (_PsycopgNativeConfig(), PsycopgAsyncEventsBackend),
+        (_PsqlpyNativeConfig(), PsqlpyEventsBackend),
+    ]
+    for config, backend_type in configs_and_backends:
+        backend = backend_type(config)  # type: ignore[arg-type,call-arg]
+        backend._hub = _TimeoutHub()  # type: ignore[assignment]
+
+        assert await backend.dequeue("alerts", 0.01) is None
+        assert ("events.listener.timeout", 1.0) in config.runtime.metrics
+
+
+def test_sync_native_notify_timeout_records_empty_wait() -> None:
+    config = _PsycopgSyncNativeConfig()
+    backend = PsycopgSyncEventsBackend(config)  # type: ignore[arg-type]
+    backend._hub = _SyncTimeoutHub()  # type: ignore[assignment]
+
+    assert backend.dequeue("alerts", 0.01) is None
+    assert ("events.listener.timeout", 1.0) in config.runtime.metrics
 
 
 def test_oracle_aq_options_round_subsecond_wait_up_to_one_second() -> None:
@@ -662,3 +915,17 @@ async def test_psycopg_async_hub_registers_pool_destroying_hook_after_subscribe(
     assert len(registered) == 1
     assert registered[0][0] == "on_pool_destroying"
     await hub.shutdown()
+
+
+async def _assert_dropped_marker_recovers(backend: Any, config: _HybridConfig) -> None:
+    queue = backend._queue
+    backend._hub = _TimeoutHub()
+
+    event = await backend.dequeue("alerts", 0.25)
+
+    assert event is queue.event
+    assert queue.dequeue_calls == [("alerts", None)]
+    metric_names = [name for name, _ in config.runtime.metrics]
+    assert "events.marker.miss" in metric_names
+    assert "events.poll.fallback" in metric_names
+    assert "events.dequeue.latency_ms" in metric_names

--- a/tests/unit/extensions/test_events/test_listener_hubs.py
+++ b/tests/unit/extensions/test_events/test_listener_hubs.py
@@ -318,8 +318,11 @@ _PsycopgSyncNativeConfig.__module__ = "sqlspec.adapters.psycopg.config"
 
 
 class _TimeoutHub:
+    def __init__(self) -> None:
+        self.dequeue_calls = 0
+
     async def dequeue(self, _channel: str, _poll_interval: float) -> None:
-        return None
+        self.dequeue_calls += 1
 
 
 class _SyncTimeoutHub:
@@ -389,6 +392,16 @@ class _EmptyQueueFallback(_QueueFallback):
     async def dequeue(self, channel: str, poll_interval: float | None = None) -> None:
         self.dequeue_calls.append((channel, poll_interval))
         return
+
+
+class _RecoveringQueueFallback(_QueueFallback):
+    def __init__(self) -> None:
+        super().__init__()
+        self._remaining: list[EventMessage | None] = [self.event, self.event, None]
+
+    async def dequeue(self, channel: str, poll_interval: float | None = None) -> EventMessage | None:
+        self.dequeue_calls.append((channel, poll_interval))
+        return self._remaining.pop(0)
 
 
 class _SyncQueueFallback:
@@ -705,7 +718,7 @@ def test_psycopg_sync_listener_hub_reconnects_and_releases_listener_contexts() -
 async def test_asyncpg_hybrid_dequeue_polls_durable_queue_after_notify_timeout() -> None:
     config = _HybridConfig()
     await _assert_dropped_marker_recovers(
-        AsyncpgHybridEventsBackend(config, _QueueFallback()),  # type: ignore[arg-type]
+        AsyncpgHybridEventsBackend(config, _RecoveringQueueFallback()),  # type: ignore[arg-type]
         config,
     )
 
@@ -716,7 +729,7 @@ async def test_psycopg_hybrid_dequeue_polls_durable_queue_after_notify_timeout()
 
     config = _PsycopgHybridConfig()
     await _assert_dropped_marker_recovers(
-        PsycopgAsyncHybridEventsBackend(config, _QueueFallback()),  # type: ignore[arg-type]
+        PsycopgAsyncHybridEventsBackend(config, _RecoveringQueueFallback()),  # type: ignore[arg-type]
         config,
     )
 
@@ -727,7 +740,7 @@ async def test_psqlpy_hybrid_dequeue_polls_durable_queue_after_notify_timeout() 
 
     config = _PsqlpyHybridConfig()
     await _assert_dropped_marker_recovers(
-        PsqlpyHybridEventsBackend(config, _QueueFallback()),  # type: ignore[arg-type]
+        PsqlpyHybridEventsBackend(config, _RecoveringQueueFallback()),  # type: ignore[arg-type]
         config,
     )
 
@@ -919,12 +932,18 @@ async def test_psycopg_async_hub_registers_pool_destroying_hook_after_subscribe(
 
 async def _assert_dropped_marker_recovers(backend: Any, config: _HybridConfig) -> None:
     queue = backend._queue
-    backend._hub = _TimeoutHub()
+    hub = _TimeoutHub()
+    backend._hub = hub
 
-    event = await backend.dequeue("alerts", 0.25)
+    first = await backend.dequeue("alerts", 0.25)
+    second = await backend.dequeue("alerts", 0.25)
+    exhausted = await backend.dequeue("alerts", 0.25)
 
-    assert event is queue.event
-    assert queue.dequeue_calls == [("alerts", None)]
+    assert first is queue.event
+    assert second is queue.event
+    assert exhausted is None
+    assert hub.dequeue_calls == 1
+    assert queue.dequeue_calls == [("alerts", None), ("alerts", None), ("alerts", None)]
     metric_names = [name for name, _ in config.runtime.metrics]
     assert "events.marker.miss" in metric_names
     assert "events.poll.fallback" in metric_names

--- a/tests/unit/extensions/test_events/test_queue.py
+++ b/tests/unit/extensions/test_events/test_queue.py
@@ -56,7 +56,7 @@ def test_sync_table_queue_empty_poll_backoff_is_bounded_and_resets(
     assert queue.dequeue("alerts", 0.08) is not None
     assert queue.dequeue("alerts", 0.08) is None
 
-    assert sleeps == [0.05, 0.08, 0.01, 0.05]
+    assert sleeps == [0.08, 0.08, 0.01, 0.08]
 
 
 async def test_async_table_queue_empty_poll_backoff_is_bounded_and_resets(
@@ -88,7 +88,7 @@ async def test_async_table_queue_empty_poll_backoff_is_bounded_and_resets(
     assert await queue.dequeue("alerts", 0.08) is not None
     assert await queue.dequeue("alerts", 0.08) is None
 
-    assert sleeps == [0.05, 0.08, 0.01, 0.05]
+    assert sleeps == [0.08, 0.08, 0.01, 0.08]
 
 
 def test_table_queue_empty_poll_backoff_state_is_bounded(tmp_path: Any) -> None:
@@ -100,6 +100,16 @@ def test_table_queue_empty_poll_backoff_state_is_bounded(tmp_path: Any) -> None:
 
     assert len(queue._empty_poll_delays) == 1_024
     assert "channel-0" not in queue._empty_poll_delays
+
+
+def test_table_queue_batch_records_have_deterministic_created_order() -> None:
+    _, records = SyncTableEventQueue._batch_insert_parameters([
+        ("events", {"index": index}, None) for index in range(3)
+    ])
+
+    created_at = [record["created_at"] for record in records]
+    assert created_at == sorted(created_at)
+    assert len(set(created_at)) == 3
 
 
 def test_table_event_queue_default_table_name(tmp_path) -> None:

--- a/tests/unit/extensions/test_events/test_queue.py
+++ b/tests/unit/extensions/test_events/test_queue.py
@@ -2,6 +2,7 @@
 """Unit tests for SyncTableEventQueue and AsyncTableEventQueue."""
 
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 
@@ -10,6 +11,20 @@ from sqlspec.core import StatementConfig
 from sqlspec.core.parameters import structural_fingerprint
 from sqlspec.exceptions import EventChannelError
 from sqlspec.extensions.events import AsyncTableEventQueue, EventMessage, SyncTableEventQueue, parse_event_timestamp
+
+
+def _event_row(event_id: str = "event-1") -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    return {
+        "event_id": event_id,
+        "channel": "alerts",
+        "payload_json": {"ok": True},
+        "metadata_json": None,
+        "attempts": 0,
+        "available_at": now,
+        "lease_expires_at": None,
+        "created_at": now,
+    }
 
 
 def test_table_event_queue_classes_are_final_with_classvar_flags() -> None:
@@ -21,6 +36,70 @@ def test_table_event_queue_classes_are_final_with_classvar_flags() -> None:
     assert AsyncTableEventQueue.supports_async is True
     assert SyncTableEventQueue.backend_name == "poll_queue"
     assert AsyncTableEventQueue.backend_name == "poll_queue"
+
+
+def test_sync_table_queue_empty_poll_backoff_is_bounded_and_resets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    config = SqliteConfig(connection_config={"database": str(tmp_path / "sync-backoff.db")})
+    queue = SyncTableEventQueue(config)
+    rows = iter([None, None, None, _event_row(), None])
+    sleeps: list[float] = []
+
+    monkeypatch.setattr(SyncTableEventQueue, "_fetch_candidate", lambda *_args: next(rows))
+    monkeypatch.setattr(SyncTableEventQueue, "_execute", lambda *_args, **_kwargs: 1)
+    monkeypatch.setattr("sqlspec.extensions.events._queue.time.sleep", sleeps.append)
+
+    assert queue.dequeue("alerts", 0.08) is None
+    assert queue.dequeue("alerts", 0.08) is None
+    assert queue.dequeue("alerts", 0.01) is None
+    assert queue.dequeue("alerts", 0.08) is not None
+    assert queue.dequeue("alerts", 0.08) is None
+
+    assert sleeps == [0.05, 0.08, 0.01, 0.05]
+
+
+async def test_async_table_queue_empty_poll_backoff_is_bounded_and_resets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    from sqlspec.adapters.aiosqlite import AiosqliteConfig
+
+    config = AiosqliteConfig(connection_config={"database": str(tmp_path / "async-backoff.db")})
+    queue = AsyncTableEventQueue(config)
+    rows = iter([None, None, None, _event_row(), None])
+    sleeps: list[float] = []
+
+    async def _fetch_candidate(*_args: Any) -> dict[str, Any] | None:
+        return next(rows)
+
+    async def _execute(*_args: Any, **_kwargs: Any) -> int:
+        return 1
+
+    async def _sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(AsyncTableEventQueue, "_fetch_candidate", _fetch_candidate)
+    monkeypatch.setattr(AsyncTableEventQueue, "_execute", _execute)
+    monkeypatch.setattr("sqlspec.extensions.events._queue.asyncio.sleep", _sleep)
+
+    assert await queue.dequeue("alerts", 0.08) is None
+    assert await queue.dequeue("alerts", 0.08) is None
+    assert await queue.dequeue("alerts", 0.01) is None
+    assert await queue.dequeue("alerts", 0.08) is not None
+    assert await queue.dequeue("alerts", 0.08) is None
+
+    assert sleeps == [0.05, 0.08, 0.01, 0.05]
+
+
+def test_table_queue_empty_poll_backoff_state_is_bounded(tmp_path: Any) -> None:
+    config = SqliteConfig(connection_config={"database": str(tmp_path / "bounded-backoff.db")})
+    queue = SyncTableEventQueue(config)
+
+    for index in range(1_025):
+        queue._next_empty_poll_delay(f"channel-{index}", 0.1)
+
+    assert len(queue._empty_poll_delays) == 1_024
+    assert "channel-0" not in queue._empty_poll_delays
 
 
 def test_table_event_queue_default_table_name(tmp_path) -> None:

--- a/tests/unit/extensions/test_events/test_queue.py
+++ b/tests/unit/extensions/test_events/test_queue.py
@@ -103,13 +103,15 @@ def test_table_queue_empty_poll_backoff_state_is_bounded(tmp_path: Any) -> None:
 
 
 def test_table_queue_batch_records_have_deterministic_created_order() -> None:
-    _, records = SyncTableEventQueue._batch_insert_parameters([
-        ("events", {"index": index}, None) for index in range(3)
-    ])
+    payloads = [{"index": index} for index in range(3)]
+    metadata = {"source": "test"}
+    _, records = SyncTableEventQueue._batch_insert_parameters([("events", payload, metadata) for payload in payloads])
 
     created_at = [record["created_at"] for record in records]
     assert created_at == sorted(created_at)
     assert len(set(created_at)) == 3
+    assert [record["payload_json"] for record in records] == payloads
+    assert all(record["metadata_json"] is metadata for record in records)
 
 
 def test_table_event_queue_default_table_name(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- dedicate one long-lived listener resource per native backend instance while publishers use short pooled sessions
- add typed sync/async `publish_many()` with ordered IDs, explicit grouped transactions, and an ordered fallback
- bulk-insert durable rows and emit one compact `{marker_id, batch_size}` wakeup marker per channel atomically
- recover missing markers through independent `event_poll_interval` reconciliation and immediately drain every recovered row
- cancel async listener waits concurrently, bound sync joins, and prevent table polling faster than the configured interval
- preserve durable batch delivery order and add `SQLSpecChannelsBackend.publish_many(data, channels)` for consumer integration
- document canonical transport semantics, adapter support, connection ownership, and recovery behavior

## Integration

This PR targeted `main` directly after #633 and #634 merged. Its event-only commits were rebased onto merge commit `ff0b8cb51`, so the final branch validates the consolidated C4 contracts and lazy-typing implementation together.

## Correctness notes

Durable rows are the source of truth. Native markers are wakeup hints, not batch envelopes. Row insertion and marker publication share one explicit transaction, marker publication failure rolls back the rows, duplicate markers are suppressed, and one reconciliation timeout enters drain mode until the queue is empty. Durable transports remain competing-consumer queues rather than browser fan-out.

JSON payloads and metadata remain native values through batch parameter preparation so adapter-specific encoders receive the same input shape as single-event publication.

## Validation

- listener lifecycle and native backend factory tests
- 1,000-event batch, ordering, transaction rollback, autocommit restoration, session/statement count, empty/fallback, marker loss/duplication, polling, and metadata tests
- real asyncpg, psqlpy, and psycopg PostgreSQL integration coverage for single-plus-batch IDs, delivery order, payloads, and metadata
- SQLite durable order and Litestar channel integrations
- focused event suite, Ruff, mypy, pyright, docs, and docs linkcheck
- full GitHub quality, docs, Python 3.10-3.14 unit/integration, source/wheel, MyPyC, and package-integrity checks pass
