### PR TITLE
fix: correct isinstance and issubclass results in compiled builds

### DIFF
--- a/sqlspec/builder/_base.py
+++ b/sqlspec/builder/_base.py
@@ -4,7 +4,7 @@ Provides abstract base classes and core functionality for SQL query builders.
 """
 
 import re
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from collections.abc import Callable, Iterable, Mapping
 from typing import Any, NoReturn, cast
 
@@ -115,7 +115,7 @@ class BuiltQuery:
         return hash((self.sql, frozenset(self.parameters.items()), self.dialect))
 
 
-class QueryBuilder(ABC):
+class QueryBuilder:
     """Abstract base class for SQL query builders.
 
     Provides common functionality for dialect handling, parameter management,

--- a/sqlspec/core/filters.py
+++ b/sqlspec/core/filters.py
@@ -18,7 +18,7 @@ Features:
     - Cacheable filter configurations
 """
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from collections import abc
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, Literal, TypeAlias
@@ -68,7 +68,7 @@ FilterTypeT = TypeVar("FilterTypeT", bound="StatementFilter")
 
 
 @mypyc_attr(allow_interpreted_subclasses=True)
-class StatementFilter(ABC):
+class StatementFilter:
     """Abstract base class for filters that can be appended to a statement."""
 
     __slots__ = ()
@@ -334,7 +334,7 @@ class OnBeforeAfterFilter(_DatetimeBoundFilter):
         return self._lower_value
 
 
-class InAnyFilter(StatementFilter, ABC, Generic[T]):
+class InAnyFilter(StatementFilter, Generic[T]):
     """Base class for collection-based filters that support ANY operations."""
 
     __slots__ = ("_field_name", "_values")
@@ -473,7 +473,7 @@ class NotAnyCollectionFilter(InAnyFilter[T]):
     _parameter_suffix: ClassVar[str] = "not_any"
 
 
-class PaginationFilter(StatementFilter, ABC):
+class PaginationFilter(StatementFilter):
     """Base class for pagination-related filters."""
 
     __slots__ = ()

--- a/sqlspec/core/result/_base.py
+++ b/sqlspec/core/result/_base.py
@@ -9,8 +9,7 @@ Classes:
     ArrowResult: Apache Arrow format results for data interchange.
 """
 
-from abc import ABC, abstractmethod
-from collections.abc import Iterable, Iterator, Sequence
+from abc import abstractmethod
 from typing import TYPE_CHECKING, Any, Final, Literal, cast, overload
 
 from mypy_extensions import mypyc_attr
@@ -42,6 +41,8 @@ from sqlspec.utils.module_loader import ensure_pandas, ensure_polars
 from sqlspec.utils.schema import to_schema
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
     from sqlspec.core.compiler import OperationType
     from sqlspec.typing import ArrowReturnFormat, ArrowTable, PandasDataFrame, PolarsDataFrame, SchemaT
 
@@ -57,7 +58,7 @@ _TWO_COLUMN_THRESHOLD: Final[int] = 2
 
 
 @mypyc_attr(allow_interpreted_subclasses=False)
-class StatementResult(ABC, Iterable[Any]):
+class StatementResult:
     """Abstract base class for SQL statement execution results.
 
     Provides a common interface for handling different types of SQL operation

--- a/sqlspec/core/splitter.py
+++ b/sqlspec/core/splitter.py
@@ -16,7 +16,7 @@ MySQL, SQLite, DuckDB, and BigQuery.
 import logging
 import re
 import threading
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from collections.abc import Callable
 from enum import Enum
 from re import Pattern
@@ -141,7 +141,7 @@ SpecialTerminatorHandler: TypeAlias = Callable[[list[Token], int], bool]
 
 
 @mypyc_attr(allow_interpreted_subclasses=False)
-class DialectConfig(ABC):
+class DialectConfig:
     """Abstract base class for SQL dialect configurations."""
 
     __slots__ = DIALECT_CONFIG_SLOTS

--- a/sqlspec/migrations/base.py
+++ b/sqlspec/migrations/base.py
@@ -1,7 +1,7 @@
 """Base classes for SQLSpec migrations."""
 
 import os
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
@@ -71,7 +71,7 @@ class AppliedMigrationRecord(TypedDict):
 
 
 @mypyc_attr(allow_interpreted_subclasses=True)
-class BaseMigrationTracker(ABC, Generic[DriverT]):
+class BaseMigrationTracker(Generic[DriverT]):
     """Base class for migration version tracking."""
 
     __slots__ = ("_output_policy", "version_table", "version_table_name", "version_table_schema")
@@ -414,7 +414,7 @@ class BaseMigrationTracker(ABC, Generic[DriverT]):
 
 
 @mypyc_attr(allow_interpreted_subclasses=True)
-class BaseMigrationCommands(ABC, Generic[ConfigT, DriverT]):
+class BaseMigrationCommands(Generic[ConfigT, DriverT]):
     """Base class for migration commands."""
 
     extension_configs: "dict[str, dict[str, Any]]"

--- a/sqlspec/migrations/loaders.py
+++ b/sqlspec/migrations/loaders.py
@@ -26,7 +26,7 @@ class MigrationLoadError(Exception):
     """Exception raised when migration loading fails."""
 
 
-class BaseMigrationLoader(abc.ABC):
+class BaseMigrationLoader:
     """Abstract base class for migration loaders."""
 
     __slots__ = ()

--- a/sqlspec/migrations/runner.py
+++ b/sqlspec/migrations/runner.py
@@ -5,7 +5,7 @@ import hashlib
 import logging
 import re
 import time
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
@@ -57,7 +57,7 @@ class _MigrationFileEntry:
         self.extension_name = extension_name
 
 
-class BaseMigrationRunner(ABC):
+class BaseMigrationRunner:
     """Base migration runner with common functionality shared between sync and async implementations."""
 
     def __init__(
@@ -485,7 +485,7 @@ class BaseMigrationRunner(ABC):
     def _resolve_default_schema(self) -> str | None:
         """Return the configured default schema for migration execution."""
         config = self.context.config if self.context else None
-        migration_config = cast("dict[str, Any]", getattr(config, "migration_config", None))
+        migration_config = cast("dict[str, Any] | None", getattr(config, "migration_config", None))
         return _resolve_default_schema(migration_config)
 
     def _resolve_use_transaction(self, migration: "LoadedMigrationMetadata", use_transaction: "bool | None") -> bool:

--- a/sqlspec/storage/backends/base.py
+++ b/sqlspec/storage/backends/base.py
@@ -4,7 +4,7 @@
 import asyncio
 import builtins
 import contextlib
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from collections.abc import AsyncIterator, Iterator
 from typing import TYPE_CHECKING, Any, cast
 
@@ -137,7 +137,7 @@ class AsyncThreadedBytesIterator:
 
 
 @mypyc_attr(allow_interpreted_subclasses=True)
-class ObjectStoreBase(ABC):
+class ObjectStoreBase:
     """Base class for storage backends.
 
     All synchronous methods follow the *_sync naming convention for consistency

--- a/sqlspec/utils/serializers/_json.py
+++ b/sqlspec/utils/serializers/_json.py
@@ -6,7 +6,7 @@ import enum
 import json
 import threading
 import uuid as uuid_mod
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from collections.abc import Callable, Iterator, Mapping
 from decimal import Decimal
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
@@ -326,7 +326,7 @@ class JSONSerializer(Protocol):
         ...
 
 
-class BaseJSONSerializer(ABC):
+class BaseJSONSerializer:
     """Base class shared by JSON serializer implementations."""
 
     __slots__ = ()


### PR DESCRIPTION
Compiled builds returned wrong answers for `isinstance` and `issubclass` on SQLSpec's own class hierarchies, and which answer you got depended on which check happened first in the process. An ordinary type check was enough to break query execution.

```python
isinstance(select, CreateIndex)   # False - an ordinary, correct check
isinstance(select, QueryBuilder)  # False - WRONG, poisoned by the line above
session.execute(select)           # AttributeError: 'Select' object has no attribute 'sql'
```

- **Cause.** mypyc builds compiled classes without running `ABCMeta.__new__` for each class, so every class in a hierarchy inherited one shared cache object. The first `isinstance`/`issubclass` result was written into that shared cache and then returned for every later check against any class in the hierarchy. All **54** abstract classes across the builder, core, migrations, storage, and serializer modules shared a single cache.
- **Fix.** Abstract bases now use plain inheritance instead of `ABC`. This removes the shared cache entirely — type checks become ordinary MRO lookups.
- **Enforcement is unchanged.** `abstractmethod` is retained, so mypy still reports `Cannot instantiate abstract class` and the type-check gate keeps enforcing implementations.
- **No runtime guard was lost.** mypyc had already disabled it: with `ABC` in place, `QueryBuilder()` constructed successfully and `__abstractmethods__` was absent. Nothing in the codebase uses virtual subclass registration.
- **Results stay iterable.** `StatementResult` no longer inherits `collections.abc.Iterable`, which carries the same metaclass. It defines `__iter__`, so `isinstance(result, Iterable)` still succeeds through the structural check.
- **Also fixes a compiled-only crash** in the migration runner, where a `cast` to a non-optional type raised `TypeError: dict object expected; got None` whenever a runner had no configuration attached. `cast` is a runtime type check under mypyc and the value is legitimately `None`.

## Scope

The defect reproduces in a twelve-line file with no SQLSpec code involved, on CPython 3.10, 3.11, 3.13 and 3.14, and is not fixed upstream. `@mypyc_attr(native_class=False)` — the documented escape hatch — is not usable here: it crashes the compiler on classes with rich comparison methods, and emits invalid C for a non-native base with native subclasses.

Interpreted behavior is unaffected; the full interpreted suite passes. Compiled builds go from 54 shared-cache classes to zero.