### PR TITLE
fix(docs): restore Mermaid theme configuration

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -412,14 +412,10 @@ html.dark .only-light {
   margin-bottom: 3em;
 }
 
-/* -----------------------------------------------------------------------------
-   Mermaid Diagrams (Dark Mode Fix)
-   ----------------------------------------------------------------------------- */
-html.dark .mermaid svg,
-html[data-theme="dark"] .mermaid svg {
-  background-color: white;
-  padding: 1em;
-  border-radius: 8px;
+/* Mermaid renders a native dark theme; Shibuya's inversion would undo it. */
+html.dark pre.mermaid > svg,
+html[data-theme="dark"] pre.mermaid > svg {
+  filter: none;
 }
 
 /* -----------------------------------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -208,19 +208,14 @@ html_sidebars = {"**": []}
 
 
 # Mermaid configuration
-mermaid_version = "11.2.0"
-mermaid_init_js = """
-mermaid.initialize({
-    startOnLoad: true,
-    theme: 'default',
-    securityLevel: 'loose',
-    flowchart: {
-        useMaxWidth: true,
-        htmlLabels: true,
-        curve: 'basis'
-    }
-});
-"""
+mermaid_version = "11.12.1"
+mermaid_light_theme = "default"
+mermaid_dark_theme = "dark"
+mermaid_init_config = {
+    "startOnLoad": False,
+    "securityLevel": "loose",
+    "flowchart": {"useMaxWidth": True, "htmlLabels": True, "curve": "basis"},
+}
 
 html_theme_options = {
     "logo_target": "/",


### PR DESCRIPTION
## Summary

- replace the removed `mermaid_init_js` setting with the supported `mermaid_init_config` API
- configure Mermaid's native light and dark themes and update the bundled Mermaid version to 11.12.1
- disable Shibuya's SVG inversion so it does not double-correct Mermaid's native dark theme

## Why

`sphinxcontrib-mermaid` 2.x no longer registers `mermaid_init_js`, so Sphinx silently ignored SQLSpec's diagram configuration. The extension already renders and re-renders native light and dark themes, while Shibuya's dark-mode filter inverted the resulting dark SVG and produced washed-out diagrams.

Closes #675
