### PR TITLE
test: debloat structural and duplicated coverage

### DIFF
--- a/tests/unit/adapters/test_aiomysql/test_load_from_arrow.py
+++ b/tests/unit/adapters/test_aiomysql/test_load_from_arrow.py
@@ -7,7 +7,6 @@ import anyio
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from sqlspec.adapters.aiomysql.core import build_insert_statement
 from sqlspec.adapters.aiomysql.driver import AiomysqlDriver
 
 _CAPS: dict[str, Any] = {
@@ -89,12 +88,6 @@ async def test_load_from_arrow_overwrite_truncates_first() -> None:
 
     assert conn._cursor.execute_calls[0] == "TRUNCATE TABLE `orders`"
     assert any(sql.startswith("LOAD DATA") for sql in conn._cursor.execute_calls)
-
-
-def test_build_insert_statement_preserves_backtick_quoted_dots() -> None:
-    statement = build_insert_statement("`analytics.db`.`orders.table`", ["id"])
-
-    assert statement == "INSERT INTO `analytics.db`.`orders.table` (`id`) VALUES (%s)"
 
 
 async def test_load_from_storage_reads_parquet_and_delegates(tmp_path: Path) -> None:

--- a/tests/unit/adapters/test_async_adapters.py
+++ b/tests/unit/adapters/test_async_adapters.py
@@ -233,27 +233,11 @@ async def test_async_driver_dispatch_statement_execution_many(aiosqlite_async_dr
 
 
 async def test_async_dispatch_no_dead_processed_state_cast(aiosqlite_async_driver: AiosqliteDriver) -> None:
-    """Async dispatch should not contain the removed get_processed_state cast."""
-    import inspect
-
-    from sqlspec.driver import _async as async_module
-
-    source = inspect.getsource(async_module.AsyncDriverAdapterBase.dispatch_statement_execution)
-    assert "get_processed_state" not in source
-
     statement = SQL("SELECT * FROM users", statement_config=aiosqlite_async_driver.statement_config)
     result = await aiosqlite_async_driver.dispatch_statement_execution(statement, aiosqlite_async_driver.connection)
 
     assert isinstance(result, SQLResult)
     assert result.operation_type == "SELECT"
-
-
-def test_async_import_structure() -> None:
-    """ProcessedState and Statement are not runtime names in _async.py."""
-    from sqlspec.driver import _async as async_module
-
-    assert not hasattr(async_module, "ProcessedState")
-    assert not hasattr(async_module, "Statement")
 
 
 async def test_async_driver_releases_pooled_statement(aiosqlite_async_driver: AiosqliteDriver) -> None:

--- a/tests/unit/adapters/test_asyncmy/test_load_from_arrow.py
+++ b/tests/unit/adapters/test_asyncmy/test_load_from_arrow.py
@@ -6,7 +6,6 @@ from typing import Any, cast
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from sqlspec.adapters.asyncmy.core import build_insert_statement
 from sqlspec.adapters.asyncmy.driver import AsyncmyDriver
 
 _CAPS: dict[str, Any] = {
@@ -69,12 +68,6 @@ async def test_load_from_arrow_overwrite_truncates_first() -> None:
 
     assert conn._cursor.execute_calls[0] == "TRUNCATE TABLE `orders`"
     assert conn._cursor.executemany_calls[0][0].startswith("INSERT INTO")
-
-
-def test_build_insert_statement_preserves_backtick_quoted_dots() -> None:
-    statement = build_insert_statement("`analytics.db`.`orders.table`", ["id"])
-
-    assert statement == "INSERT INTO `analytics.db`.`orders.table` (`id`) VALUES (%s)"
 
 
 async def test_load_from_storage_reads_parquet_and_delegates(tmp_path: Path) -> None:

--- a/tests/unit/adapters/test_bigquery/test_core.py
+++ b/tests/unit/adapters/test_bigquery/test_core.py
@@ -215,12 +215,6 @@ def test_copy_job_fields_use_real_reservation_attribute() -> None:
     assert "reservation_id" not in _COPY_JOB_FIELDS
 
 
-def test_copy_job_attribute_helper_removed() -> None:
-    import sqlspec.adapters.bigquery.core as bigquery_core
-
-    assert not hasattr(bigquery_core, "_should_copy_job_attribute")
-
-
 def test_run_query_job_passes_query_start_retry_timeout_and_job_retry() -> None:
     connection = _RecordingConnection()
     retry = build_retry(1.0)

--- a/tests/unit/adapters/test_mysql_insert_statement_contract.py
+++ b/tests/unit/adapters/test_mysql_insert_statement_contract.py
@@ -1,0 +1,22 @@
+"""Shared MySQL-family insert-statement contracts."""
+
+from collections.abc import Callable
+
+import pytest
+
+from sqlspec.adapters.aiomysql.core import build_insert_statement as build_aiomysql_insert
+from sqlspec.adapters.asyncmy.core import build_insert_statement as build_asyncmy_insert
+from sqlspec.adapters.mysqlconnector.core import build_insert_statement as build_mysqlconnector_insert
+from sqlspec.adapters.pymysql.core import build_insert_statement as build_pymysql_insert
+
+
+@pytest.mark.parametrize(
+    "build_insert_statement",
+    (build_aiomysql_insert, build_asyncmy_insert, build_mysqlconnector_insert, build_pymysql_insert),
+)
+def test_build_insert_statement_preserves_backtick_quoted_dots(
+    build_insert_statement: Callable[[str, list[str]], str],
+) -> None:
+    statement = build_insert_statement("`analytics.db`.`orders.table`", ["id"])
+
+    assert statement == "INSERT INTO `analytics.db`.`orders.table` (`id`) VALUES (%s)"

--- a/tests/unit/adapters/test_mysqlconnector/test_load_from_arrow.py
+++ b/tests/unit/adapters/test_mysqlconnector/test_load_from_arrow.py
@@ -7,7 +7,6 @@ import anyio
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from sqlspec.adapters.mysqlconnector.core import build_insert_statement
 from sqlspec.adapters.mysqlconnector.driver import MysqlConnectorAsyncDriver, MysqlConnectorSyncDriver
 
 _CAPS: dict[str, Any] = {
@@ -110,12 +109,6 @@ def test_sync_load_from_arrow_overwrite_truncates_first() -> None:
     driver.load_from_arrow("orders", pa.table({"id": [1]}), overwrite=True)
 
     assert conn._cursor.execute_calls[0] == "TRUNCATE TABLE `orders`"
-
-
-def test_build_insert_statement_preserves_backtick_quoted_dots() -> None:
-    statement = build_insert_statement("`analytics.db`.`orders.table`", ["id"])
-
-    assert statement == "INSERT INTO `analytics.db`.`orders.table` (`id`) VALUES (%s)"
 
 
 async def test_async_load_from_arrow_local_infile_writes_tsv_and_loads() -> None:

--- a/tests/unit/adapters/test_oracledb/test_oracle_version_unification.py
+++ b/tests/unit/adapters/test_oracledb/test_oracle_version_unification.py
@@ -212,14 +212,6 @@ _STORE_CLASSES = (
 
 
 def test_oracle_stores_use_shared_version_cache() -> None:
-    """Stores neither instantiate fresh dictionaries nor keep private version caches."""
-    import inspect
-
-    for module in (events_store, adk_store):
-        source = inspect.getsource(module)
-        assert "OracledbSyncDataDictionary()" not in source
-        assert "OracledbAsyncDataDictionary()" not in source
-
     for store_class in _STORE_CLASSES:
         slots = set(store_class.__slots__)
         assert "_oracle_version_info" not in slots

--- a/tests/unit/adapters/test_oracledb/test_param_types.py
+++ b/tests/unit/adapters/test_oracledb/test_param_types.py
@@ -149,12 +149,6 @@ def test_oracle_clob_value_is_mutable_via_assignment() -> None:
     assert instance.value == "second"
 
 
-def test_oracle_output_converter_dead_methods_oracle_output_converter_dead_methods_removed() -> None:
-    removed = {"convert_oracle_value", "detect_json_storage_type", "format_datetime_for_oracle", "handle_large_lob"}
-    for method_name in removed:
-        assert not hasattr(OracleOutputConverter, method_name)
-
-
 def test_oracle_output_converter_dead_methods_oracle_output_converter_reexported_from_adapter_package() -> None:
     import sqlspec.adapters.oracledb as oracledb_adapter
 

--- a/tests/unit/adapters/test_pymysql/test_load_from_arrow.py
+++ b/tests/unit/adapters/test_pymysql/test_load_from_arrow.py
@@ -6,7 +6,6 @@ from typing import Any, cast
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from sqlspec.adapters.pymysql.core import build_insert_statement
 from sqlspec.adapters.pymysql.driver import PyMysqlDriver
 
 _CAPS: dict[str, Any] = {
@@ -90,12 +89,6 @@ def test_load_from_arrow_overwrite_truncates_first() -> None:
 
     assert conn._cursor.execute_calls[0] == "TRUNCATE TABLE `orders`"
     assert any(sql.startswith("LOAD DATA") for sql in conn._cursor.execute_calls)
-
-
-def test_build_insert_statement_preserves_backtick_quoted_dots() -> None:
-    statement = build_insert_statement("`analytics.db`.`orders.table`", ["id"])
-
-    assert statement == "INSERT INTO `analytics.db`.`orders.table` (`id`) VALUES (%s)"
 
 
 def test_load_from_storage_reads_parquet_and_delegates(tmp_path: Path) -> None:

--- a/tests/unit/builder/test_ddl_builder.py
+++ b/tests/unit/builder/test_ddl_builder.py
@@ -1,7 +1,5 @@
 """Regression tests for DDL builder Wave 1 fixes."""
 
-import inspect
-
 import pytest
 from sqlglot import exp
 
@@ -76,12 +74,6 @@ def test_foreign_key_action_none_still_short_circuits_validation() -> None:
 def test_foreign_key_action_invalid_value_still_raises() -> None:
     with pytest.raises(SQLBuilderError):
         CreateTable("orders").foreign_key_constraint("user_id", "users", "id", on_delete="EXPLODE")
-
-
-def test_ddl_module_uses_pep604_annotations() -> None:
-    import sqlspec.builder._ddl as ddl_module
-
-    assert "Union" not in inspect.getsource(ddl_module)
 
 
 def test_ddl_check_constraint_check_constraint_column_expression_stores_condition_expr() -> None:

--- a/tests/unit/builder/test_sql_factory.py
+++ b/tests/unit/builder/test_sql_factory.py
@@ -1,7 +1,6 @@
 # pyright: reportAttributeAccessIssue=false
 """Unit tests for SQL factory functionality including parameter binding fixes and new features."""
 
-import importlib.util
 import math
 from collections.abc import Callable
 from typing import Any, cast
@@ -674,12 +673,6 @@ def test_case_property_returns_case_builder() -> None:
     assert hasattr(case_builder, "else_")
     assert hasattr(case_builder, "end")
     assert hasattr(case_builder, "as_")
-
-
-def test_case_implementation_has_no_duplicate_private_module() -> None:
-    """CASE stays public through sqlspec.builder without a duplicate private module."""
-    assert importlib.util.find_spec("sqlspec.builder._case") is None
-    assert Case.__module__ == "sqlspec.builder._select"
 
 
 def test_window_function_shortcuts() -> None:

--- a/tests/unit/config/test_storage_capabilities.py
+++ b/tests/unit/config/test_storage_capabilities.py
@@ -1,10 +1,8 @@
-import inspect
 from contextlib import AbstractContextManager, asynccontextmanager, contextmanager
 from typing import TYPE_CHECKING, Any
 
 import pytest
 
-import sqlspec.core.config_runtime as config_runtime_module
 from sqlspec.config import AsyncDatabaseConfig, NoPoolAsyncConfig, NoPoolSyncConfig, SyncDatabaseConfig
 from sqlspec.core import StatementConfig
 from sqlspec.core.config_runtime import (
@@ -27,13 +25,6 @@ from sqlspec.driver import (
 from tests.conftest import requires_interpreted
 
 pytestmark = requires_interpreted
-
-
-def test_config_runtime_uses_direct_core_submodule_imports() -> None:
-    source = inspect.getsource(config_runtime_module)
-    assert "from sqlspec.core.parameters import ParameterStyle, ParameterStyleConfig" in source
-    assert "from sqlspec.core.statement import StatementConfig" in source
-    assert "from sqlspec.core import ParameterStyle, ParameterStyleConfig, StatementConfig" not in source
 
 
 if TYPE_CHECKING:

--- a/tests/unit/core/test_cache.py
+++ b/tests/unit/core/test_cache.py
@@ -200,19 +200,8 @@ def test_lru_cache_initialization() -> None:
 def test_lru_cache_uses_non_reentrant_lock() -> None:
     """LRUCache methods should not depend on re-entrant locking."""
     cache = LRUCache()
-    source = inspect.getsource(LRUCache.__init__)
 
     assert isinstance(cache._lock, type(threading.Lock()))
-    assert "threading.Lock()" in source
-    assert "threading.RLock()" not in source
-
-
-def test_lru_cache_nodes_do_not_keep_write_only_access_counts() -> None:
-    """LRU cache nodes should not track unused per-node access counts."""
-    source = inspect.getsource(cache_module)
-
-    assert "access_count" not in source
-    assert "CACHE_STATS_UPDATE_INTERVAL" not in source
 
 
 def test_lru_cache_basic_operations() -> None:
@@ -888,15 +877,6 @@ def test_lru_cache_logs_include_namespace(caplog: pytest.LogCaptureFixture) -> N
     assert "cache_size" in record.__dict__["extra_fields"]
 
 
-def test_lru_cache_get_logs_outside_lock() -> None:
-    """LRUCache.get should not log or check debug state while holding the lock."""
-    source = inspect.getsource(LRUCache.get)
-    lock_body = source.split("with self._lock:", 1)[1].split("if log_event is not None:", 1)[0]
-
-    assert "logger.isEnabledFor" not in lock_body
-    assert "log_with_context" not in lock_body
-
-
 def test_lru_cache_logs_hit_with_namespace(caplog: pytest.LogCaptureFixture) -> None:
     """Test that cache hit logs include namespace."""
     import logging
@@ -976,12 +956,3 @@ def test_lru_cache_size_method_removed() -> None:
     """LRUCache should use __len__ instead of a duplicate size() method."""
 
     assert "size" not in LRUCache.__dict__
-
-
-def test_namespaced_cache_config_uses_inline_accessors() -> None:
-    """Namespaced cache config should not keep dead named accessor functions."""
-
-    source = inspect.getsource(cache_module)
-
-    assert "def _sql_cache_enabled" not in source
-    assert "lambda config: config.sql_cache_enabled" in source

--- a/tests/unit/core/test_compiler.py
+++ b/tests/unit/core/test_compiler.py
@@ -14,7 +14,6 @@ Test Coverage:
 8. Performance characteristics - Compilation speed and efficiency testing
 """
 
-import inspect
 import logging
 import threading
 from collections import OrderedDict
@@ -27,10 +26,8 @@ import sqlglot
 from sqlglot import expressions as exp
 from sqlglot.errors import ParseError
 
-import sqlspec.core.compiler as compiler_module
 from sqlspec.core import (
     CompiledSQL,
-    OperationProfile,
     OperationType,
     ParameterProcessor,
     ParameterProfile,
@@ -702,13 +699,6 @@ def test_parse_cache_entry_does_not_store_parameter_casts() -> None:
     assert len(cache_entry) == 3
 
 
-def test_ast_transformer_path_does_not_accept_unused_parse_cache_entry() -> None:
-    source = inspect.getsource(SQLProcessor._apply_ast_transformers)
-
-    assert "parse_cache_entry" not in source
-    assert not hasattr(compiler_module, "ParseCacheEntry")
-
-
 @requires_interpreted
 def test_parameter_casts_called_exactly_once_with_transformer() -> None:
     """Transformers should not trigger duplicate parameter-cast AST walks."""
@@ -1213,10 +1203,6 @@ def test_compile_with_pipeline_passes_expression() -> None:
 
 def test_c11_mypyc_native_class_pass(basic_statement_config: "StatementConfig") -> None:
     """Verify c11 native-class optimization invariants and compiler behavior."""
-    for cls in (OperationProfile, CompiledSQL, SQLProcessor):
-        source = inspect.getsource(cls)
-        assert source.startswith("@final\n@mypyc_attr(allow_interpreted_subclasses=False)\n")
-
     for name in (
         "_normalize_expression_override",
         "_unpack_parse_cache_entry",
@@ -1226,9 +1212,6 @@ def test_c11_mypyc_native_class_pass(basic_statement_config: "StatementConfig") 
         "_make_parse_cache_key",
     ):
         assert isinstance(SQLProcessor.__dict__.get(name), staticmethod)
-
-    source = inspect.getsource(SQLProcessor._compile_uncached)
-    assert "dialect_str = str(self._config.dialect)" not in source
 
     processor = SQLProcessor(basic_statement_config)
     select_result = processor.compile("SELECT * FROM users WHERE id = ?", (42,))

--- a/tests/unit/core/test_compiler.py
+++ b/tests/unit/core/test_compiler.py
@@ -19,7 +19,6 @@ import logging
 import threading
 from collections import OrderedDict
 from datetime import datetime
-from pathlib import Path
 from typing import Any, get_args
 from unittest.mock import Mock, patch
 
@@ -30,7 +29,6 @@ from sqlglot.errors import ParseError
 
 import sqlspec.core.compiler as compiler_module
 from sqlspec.core import (
-    SQL,
     CompiledSQL,
     OperationProfile,
     OperationType,
@@ -46,7 +44,7 @@ from sqlspec.core import (
 )
 from sqlspec.core.parameters import structural_fingerprint
 from sqlspec.core.parameters._processor import _make_cache_key_tuple
-from sqlspec.core.pipeline import StatementPipelineRegistry, compile_with_pipeline, reset_statement_pipeline_cache
+from sqlspec.core.pipeline import compile_with_pipeline, reset_statement_pipeline_cache
 from sqlspec.core.statement import get_default_config
 from tests.conftest import requires_interpreted
 
@@ -991,15 +989,13 @@ def test_parameter_cache_statistics(basic_statement_config: "StatementConfig") -
 
 
 def test_compiler_cache_hot_paths_use_bound_cache_flags(basic_statement_config: "StatementConfig") -> None:
-    """Compiler cache hot paths should not re-check config.enable_caching after initialization."""
+    """Compiler cache should reuse entries when only parameter values change."""
     processor = SQLProcessor(basic_statement_config)
 
     processor.compile("SELECT * FROM users WHERE id = ?", [123])
     processor.compile("SELECT * FROM users WHERE id = ?", [456])
 
     assert processor.cache_stats["hits"] == 1
-    assert "self._config.enable_caching" not in inspect.getsource(SQLProcessor.compile)
-    assert "self._config.enable_caching" not in inspect.getsource(SQLProcessor._resolve_expression)
 
 
 def test_processor_binds_parameter_config_hot_path_attrs(basic_statement_config: "StatementConfig") -> None:
@@ -1008,79 +1004,6 @@ def test_processor_binds_parameter_config_hot_path_attrs(basic_statement_config:
 
     assert processor._parameter_config is basic_statement_config.parameter_config
     assert processor._enable_parameter_type_wrapping is basic_statement_config.enable_parameter_type_wrapping
-    assert "self._config.parameter_config" not in inspect.getsource(SQLProcessor._prepare_parameters)
-    assert "self._config.parameter_config" not in inspect.getsource(SQLProcessor._finalize_compilation)
-
-
-def test_core_idiom_sweep_source_shapes() -> None:
-    """Core helpers should use mypyc-friendly staticmethods and Final constants."""
-    static_methods = {
-        SQL: ("_normalize_dialect", "_should_auto_detect_many", "_extract_filters"),
-        SQLProcessor: ("_validate_parameters",),
-        StatementPipelineRegistry: ("_fingerprint_config",),
-    }
-    for cls, names in static_methods.items():
-        for name in names:
-            assert isinstance(cls.__dict__.get(name), staticmethod)
-
-    expected_source_fragments = {
-        "sqlspec/core/compiler.py": (
-            "OPERATION_TYPE_MAP: Final[dict[type[exp.Expr], OperationType]]",
-            "COPY_OPERATION_TYPES: Final[tuple[OperationType, ...]]",
-            "COPY_FROM_OPERATION_TYPES: Final[tuple[OperationType, ...]]",
-            "COPY_TO_OPERATION_TYPES: Final[tuple[OperationType, ...]]",
-        ),
-        "sqlspec/core/statement.py": (
-            "RETURNS_ROWS_OPERATIONS: Final[frozenset[str]] = frozenset({",
-            "MODIFYING_OPERATIONS: Final[frozenset[str]] = frozenset({",
-        ),
-        "sqlspec/core/query_modifiers.py": (
-            "_TABLE_QUALIFIED_PARTS: Final[int] = 2",
-            "_DATABASE_QUALIFIED_PARTS: Final[int] = 3",
-            "_CATALOG_QUALIFIED_PARTS: Final[int] = 4",
-        ),
-        "sqlspec/core/cache.py": ("NAMESPACED_CACHE_CONFIG: Final[dict[str, tuple[",),
-        "sqlspec/core/parameters/_alignment.py": ("EXECUTE_MANY_MIN_ROWS: Final[int] = 2",),
-        "sqlspec/core/parameters/_declared.py": ("_JSON_VALUE_TYPES: Final[tuple[type, ...]]",),
-        "sqlspec/core/parameters/_processor.py": (
-            "_EXECUTE_MANY_SAMPLE_THRESHOLD: Final[int] = 10",
-            "_EXECUTE_MANY_SAMPLE_SIZE: Final[int] = 3",
-            "_OCCURRENCE_BASED_POSITIONAL_STYLES: Final[frozenset[ParameterStyle]]",
-        ),
-        "sqlspec/core/parameters/_registry.py": (
-            "_DEFAULT_JSON_SERIALIZER: Final[Callable[[Any], str]]",
-            "_DEFAULT_JSON_DESERIALIZER: Final[Callable[[str], Any]]",
-            "DRIVER_PARAMETER_PROFILES: Final[dict[str, DriverParameterProfile]]",
-        ),
-        "sqlspec/core/parameters/_types.py": (
-            "TYPED_PARAMETER_SLOTS: Final",
-            "PARAMETER_INFO_SLOTS: Final",
-            "PARAMETER_STYLE_CONFIG_SLOTS: Final",
-            "_NAMED_STYLES: Final",
-            "_POSITIONAL_STYLES: Final",
-        ),
-    }
-    for path, fragments in expected_source_fragments.items():
-        source = Path(path).read_text()
-        for fragment in fragments:
-            assert fragment in source
-
-    stripped_comments = (
-        "Optimization: Check only the first element",
-        "O(1) check instead of O(N) scan",
-        "through the interpreted serializer-selection shell",
-        "For expressions, we use a hash",
-        "Skip sort for single style",
-    )
-    for path in (
-        "sqlspec/core/statement.py",
-        "sqlspec/core/type_converter.py",
-        "sqlspec/core/filters.py",
-        "sqlspec/core/parameters/_types.py",
-    ):
-        source = Path(path).read_text()
-        for comment in stripped_comments:
-            assert comment not in source
 
 
 def test_cache_clear(basic_statement_config: "StatementConfig", sample_sql_queries: "dict[str, str]") -> None:

--- a/tests/unit/core/test_explain.py
+++ b/tests/unit/core/test_explain.py
@@ -1,7 +1,5 @@
 """Unit tests for EXPLAIN option value objects."""
 
-from pathlib import Path
-
 from sqlspec.core.explain import ExplainFormat, ExplainOptions
 
 
@@ -15,13 +13,3 @@ def test_explain_options_value_semantics() -> None:
     assert hash(options) == hash(same)
     assert repr(options) == "ExplainOptions(analyze=True, verbose=True, format='json', costs=False, buffers=True)"
     assert options.to_dict() == {"analyze": True, "verbose": True, "format": "JSON", "costs": False, "buffers": True}
-
-
-def test_explain_options_source_uses_shared_key_and_fields() -> None:
-    source = Path("sqlspec/core/explain.py").read_text()
-
-    assert "EXPLAIN_OPTION_FIELDS: Final" in source
-    assert "def _key(self)" in source
-    assert "return self._key() == other._key()" in source
-    assert "return hash(self._key())" in source
-    assert "for field_name in EXPLAIN_OPTION_FIELDS" in source

--- a/tests/unit/core/test_filters.py
+++ b/tests/unit/core/test_filters.py
@@ -63,27 +63,6 @@ def test_public_filters_alias_points_to_core_filters_module() -> None:
     assert sqlspec.filters is filters_module
 
 
-def test_filter_hierarchy_uses_shared_private_bases() -> None:
-    """Public filter classes keep their API while sharing private implementation bodies."""
-    source = Path("sqlspec/core/filters.py").read_text()
-    assert "class _DatetimeBoundFilter(StatementFilter):" in source
-    assert "class BeforeAfterFilter(_DatetimeBoundFilter):" in source
-    assert "class OnBeforeAfterFilter(_DatetimeBoundFilter):" in source
-
-    datetime_section = source.split("class _DatetimeBoundFilter", 1)[1].split("class InAnyFilter", 1)[0]
-    assert datetime_section.count("def extract_parameters(") == 1
-    assert datetime_section.count("def append_to_statement(") == 1
-
-    assert "class _TextSearchFilter(StatementFilter):" in source
-    assert "class SearchFilter(_TextSearchFilter):" in source
-    assert "class NotInSearchFilter(SearchFilter):" in source
-
-    search_section = source.split("class _TextSearchFilter", 1)[1].split("class NullFilter", 1)[0]
-    assert search_section.count("def extract_parameters(") == 1
-    assert search_section.count("def append_to_statement(") == 1
-    assert search_section.count("def get_cache_key(") == 1
-
-
 def test_filters_docs_render_inherited_members() -> None:
     """Docs include inherited members for public filters whose methods are inherited."""
     docs = Path("docs/reference/core/filters.rst").read_text()

--- a/tests/unit/core/test_filters.py
+++ b/tests/unit/core/test_filters.py
@@ -4,7 +4,6 @@ This module tests the filter system that provides dynamic WHERE clauses,
 ORDER BY, LIMIT/OFFSET, and other SQL modifications with proper parameter naming.
 """
 
-import inspect
 import tempfile
 from dataclasses import dataclass
 from datetime import datetime
@@ -304,14 +303,6 @@ def test_filter_parameter_conflict_resolution() -> None:
     new_param_keys = [k for k in result.parameters.keys() if k.startswith("name_search_") and k != "name_search"]
     assert len(new_param_keys) == 1
     assert result.parameters[new_param_keys[0]] == "%new_value%"
-
-
-def test_resolve_parameter_conflicts_binds_statement_parameters_once() -> None:
-    """Conflict resolution should avoid duplicate parameter property reads."""
-    source = inspect.getsource(StatementFilter._resolve_parameter_conflicts)
-
-    assert source.count("statement.parameters") == 1
-    assert "existing_params.update" not in source
 
 
 def test_multiple_filters_preserve_column_names() -> None:
@@ -960,12 +951,6 @@ def test_not_in_search_filter_declares_empty_slots() -> None:
     """NotInSearchFilter should not allocate an instance dict."""
 
     assert NotInSearchFilter.__slots__ == ()
-
-
-def test_dead_create_filters_api_removed() -> None:
-    """The create_filters helper was redundant with tuple()."""
-
-    assert not hasattr(filters_module, "create_filters")
 
 
 def test_not_in_collection_parameter_suffix_is_literal() -> None:

--- a/tests/unit/core/test_hashing.py
+++ b/tests/unit/core/test_hashing.py
@@ -5,7 +5,6 @@ Tests for SQL statement and expression hashing utilities used for cache key gene
 Covers all hashing functions with edge cases, performance considerations, and circular reference handling.
 """
 
-import inspect
 import math
 from typing import Any
 from unittest.mock import Mock
@@ -191,11 +190,6 @@ def test_hash_parameters_named_typed_parameters_use_direct_isinstance() -> None:
     assert hash_parameters(named_parameters={"items": typed_param}) == hash_parameters(
         named_parameters={"items": typed_param}
     )
-
-    source = inspect.getsource(hash_parameters)
-    named_loop = source.split("if named_parameters:", 1)[1].split("if original_parameters", 1)[0]
-    assert "isinstance(value, TypedParameter)" in named_loop
-    assert "is_typed_parameter(value)" not in named_loop
 
 
 def test_hash_parameters_unhashable_types() -> None:

--- a/tests/unit/core/test_parameters.py
+++ b/tests/unit/core/test_parameters.py
@@ -17,7 +17,6 @@ from collections.abc import Callable, Sequence
 from datetime import date, datetime, time
 from decimal import Decimal
 from importlib import import_module
-from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
@@ -2495,85 +2494,3 @@ def test_build_conversion_plan_called_once_execute_many_preserve_original_params
     assert converter.build_conversion_plan_calls == 1
     assert result.sql == "INSERT INTO t (a, b) VALUES ($1, $2)"
     assert result.parameters is rows
-
-
-def test_skip_groups_constant_is_module_level() -> None:
-    """Parameter validator skip groups should be hoisted out of hot paths."""
-    source = Path("sqlspec/core/parameters/_validator.py").read_text()
-    assert "_SKIP_GROUPS:" in source
-    assert "skip_groups =" not in source
-
-
-def test_converter_hot_path_uses_shared_style_sets() -> None:
-    """Parameter converter should avoid per-call cache and style-set allocations."""
-    source = Path("sqlspec/core/parameters/_converter.py").read_text()
-    assert "placeholder_text_len_cache" not in source
-    assert "_OCCURRENCE_KEYED_STYLES:" in source
-    assert "_POSITIONAL_STYLES" in source
-
-
-def test_skip_groups_constant_used_by_both_paths() -> None:
-    """Parameter extraction should keep skip groups hoisted out of the hot loop."""
-    source = Path("sqlspec/core/parameters/_validator.py").read_text()
-    assert source.count("_SKIP_GROUPS") == 2
-
-
-def test_parameter_transformer_validator_source_shapes() -> None:
-    """Parameter helpers should avoid repeated hot-path type checks."""
-    transformer_source = Path("sqlspec/core/parameters/_transformers.py").read_text()
-    null_transformer_source = transformer_source.split("class _NullPlaceholderTransformer:", 1)[1].split(
-        "@mypyc_attr", 1
-    )[0]
-    literal_transformer_source = transformer_source.split("class _PlaceholderLiteralTransformer:", 1)[1].split(
-        "def build_null_pruning_transform", 1
-    )[0]
-
-    assert "_MISSING_PARAMETER: Final" in transformer_source
-    assert null_transformer_source.count("isinstance(node, _exp.Placeholder)") == 1
-    assert '"_is_mapping", "_is_sequence"' in literal_transformer_source
-    assert "self._is_mapping = isinstance(parameters, Mapping)" in literal_transformer_source
-    assert "self._is_sequence = isinstance(parameters, Sequence)" in literal_transformer_source
-    assert "isinstance(self._parameters, Mapping)" not in literal_transformer_source
-
-    validator_source = Path("sqlspec/core/parameters/_validator.py").read_text()
-    assert isinstance(ParameterValidator.__dict__.get("_extract_parameter_style"), staticmethod)
-    assert "any(match.group(*_SKIP_GROUPS))" in validator_source
-    assert "any(match.group(group) for group in _SKIP_GROUPS)" not in validator_source
-
-
-def test_parameter_internal_consolidation_source_shapes() -> None:
-    """Parameter helpers should share internal conversion/extraction bodies."""
-    validator_source = Path("sqlspec/core/parameters/_validator.py").read_text()
-    extract_body = validator_source.split("def extract_parameters", 1)[1].split("def _extract_parameters_uncached", 1)[
-        0
-    ]
-    assert "parameters = self._extract_parameters_uncached(sql)" in extract_body
-    assert "for match in PARAMETER_REGEX.finditer(sql)" not in extract_body
-
-    processor_source = Path("sqlspec/core/parameters/_processor.py").read_text()
-    payload_body = processor_source.split("def _coerce_parameters_payload", 1)[1].split("def _make_cache_key_tuple", 1)[
-        0
-    ]
-    assert "_coerce_sequence_if_needed(seq_params" in payload_body
-    assert "_coerce_mapping_if_needed(dict_params" in payload_body
-    assert "updated_seq:" not in payload_body
-    assert "updated_mapping:" not in payload_body
-
-    transformer_source = Path("sqlspec/core/parameters/_transformers.py").read_text()
-    null_pruning_body = transformer_source.split("def replace_null_parameters_with_literals", 1)[1].split(
-        "def _create_literal_expression", 1
-    )[0]
-    assert "def _as_concrete_payload(" in transformer_source
-    assert "_as_concrete_payload(parameters)" in null_pruning_body
-    assert "list(parameters) if isinstance(parameters, list)" not in null_pruning_body
-
-
-def test_private_zero_ref_helpers_are_folded() -> None:
-    """API-invisible private helpers with no references should not linger."""
-    converter_source = Path("sqlspec/core/parameters/_converter.py").read_text()
-
-    assert "def _extract_param_value_single_style(" not in converter_source
-    assert "def _get_parameter_value(" not in converter_source
-    assert "def _normalize_named_identifier_aliases(" not in Path("sqlspec/core/parameters/_alignment.py").read_text()
-    assert "def _hash_filter_value(" not in Path("sqlspec/core/hashing.py").read_text()
-    assert "def _reset_noop(" not in Path("sqlspec/core/_pool.py").read_text()

--- a/tests/unit/core/test_pipeline.py
+++ b/tests/unit/core/test_pipeline.py
@@ -1,7 +1,6 @@
 # pyright: reportPrivateUsage = false
 """Unit tests for the shared statement pipeline registry."""
 
-from pathlib import Path
 from unittest.mock import patch
 
 import sqlspec.core.pipeline as pipeline_module
@@ -13,17 +12,6 @@ from sqlspec.core.statement import StatementConfig
 
 def test_record_pipeline_metrics_constant_is_bool() -> None:
     assert isinstance(getattr(pipeline_module, "_RECORD_PIPELINE_METRICS", None), bool)
-
-
-def test_pipeline_metrics_use_keyed_store_source_shape() -> None:
-    source = Path("sqlspec/core/pipeline.py").read_text()
-    metrics_section = source.split("class _PipelineMetrics", 1)[1].split("@mypyc_attr", 1)[0]
-
-    assert "_METRIC_KEYS: Final[tuple[str, ...]]" in source
-    assert '__slots__ = ("_values",)' in metrics_section
-    assert "self._values = dict.fromkeys(_METRIC_KEYS, 0)" in metrics_section
-    assert "return self._values.copy()" in metrics_section
-    assert "entry.update(metrics)" in source
 
 
 def test_os_getenv_not_called_during_compile() -> None:

--- a/tests/unit/core/test_result.py
+++ b/tests/unit/core/test_result.py
@@ -3,7 +3,6 @@
 import importlib.util
 import inspect
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 from unittest.mock import patch
 
@@ -938,20 +937,6 @@ def test_result_external_api_docstring_markers() -> None:
     """Dead-code policy markers identify externally callable result helpers."""
     for member in (ArrowResult.num_columns.fget, StackResult.is_arrow_result, StackResult.from_arrow_result):
         assert "External/extension API" in (inspect.getdoc(member) or "")
-
-
-def test_result_and_stack_idiom_source_shapes() -> None:
-    """Result and stack helpers should keep MyPyC-safe source shapes."""
-    result_source = Path("sqlspec/core/result/_base.py").read_text()
-    assert "return iter(arrow_table_to_pylist" in result_source
-    assert "yield from arrow_table_to_pylist" not in result_source
-    assert 'object.__getattribute__(self.result, "rows_affected")' in result_source
-    assert "_EMPTY_RESULT_STATEMENT: Final" in result_source
-    assert "_DEFAULT_DML_METADATA: Final" in result_source
-
-    stack_source = Path("sqlspec/core/stack.py").read_text()
-    assert "ALLOWED_METHODS: Final[tuple[str, ...]]" in stack_source
-    assert 'StackOperation("execute_many", normalized_statement, tuple(arguments), frozen_kwargs)' not in stack_source
 
 
 def test_arrow_result_to_pandas_with_null_values() -> None:

--- a/tests/unit/core/test_splitter.py
+++ b/tests/unit/core/test_splitter.py
@@ -1,6 +1,5 @@
 """Unit tests for SQL splitter helpers."""
 
-import inspect
 from typing import Any
 
 import pytest
@@ -31,16 +30,6 @@ DIALECT_DEFAULTS: dict[type[Any], tuple[str, set[str], set[str], set[str], set[s
     splitter_module.DuckDBDialectConfig: ("duckdb", {"BEGIN", "CASE"}, {"END"}, {";"}, set(), set()),
     splitter_module.BigQueryDialectConfig: ("bigquery", {"BEGIN", "CASE"}, {"END"}, {";"}, set(), set()),
 }
-
-
-def test_join_string_fragments_helper_removed() -> None:
-    """The one-line join helper should not remain in the splitter module."""
-
-    assert not hasattr(splitter_module, "_join_string_fragments")
-
-
-def test_splitter_private_cache_stats_helper_removed() -> None:
-    assert not hasattr(splitter_module, "get_splitter_cache_stats")
 
 
 def test_dialect_class_map_contains_expected_aliases() -> None:
@@ -85,11 +74,6 @@ def test_dialect_configs_share_eager_base_without_lazy_property_boilerplate() ->
     eager_base = getattr(splitter_module, "_EagerDialectConfig")
     for config_class in PUBLIC_DIALECT_CONFIGS:
         assert issubclass(config_class, eager_base)
-        source = inspect.getsource(config_class)
-        assert "if self._name is None" not in source
-        assert "if self._block_starters is None" not in source
-        assert "if self._block_enders is None" not in source
-        assert "if self._statement_terminators is None" not in source
 
 
 @pytest.mark.parametrize("config_class", PUBLIC_DIALECT_CONFIGS)

--- a/tests/unit/core/test_sqlcommenter.py
+++ b/tests/unit/core/test_sqlcommenter.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import inspect
 from typing import Any
 from unittest.mock import patch
 
@@ -236,11 +235,6 @@ def test_transformer_empty_attrs_noop() -> None:
 
 
 def test_transformer_factory_uses_module_level_callables() -> None:
-    source = inspect.getsource(create_sqlcommenter_statement_transformer)
-    assert "def _noop_transformer" not in source
-    assert "def _static_transformer" not in source
-    assert "def _dynamic_transformer" not in source
-
     noop_transformer = create_sqlcommenter_statement_transformer(attributes={})
     static_transformer = create_sqlcommenter_statement_transformer(attributes={"db_driver": "asyncpg"})
     dynamic_transformer = create_sqlcommenter_statement_transformer(enable_context=True)

--- a/tests/unit/core/test_statement.py
+++ b/tests/unit/core/test_statement.py
@@ -16,10 +16,8 @@ Key Test Coverage:
 
 import copy
 import importlib.util
-import inspect
 import logging
 import pickle
-from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -72,11 +70,6 @@ DEFAULT_PARAMETER_CONFIG = ParameterStyleConfig(
     default_parameter_style=ParameterStyle.QMARK, supported_parameter_styles={ParameterStyle.QMARK}
 )
 TEST_CONFIG = StatementConfig(parameter_config=DEFAULT_PARAMETER_CONFIG)
-
-
-def test_sql_private_raw_sql_helper_uses_purpose_name() -> None:
-    assert hasattr(SQL, "_materialized_raw_sql")
-    assert not hasattr(SQL, "_get_raw_sql")
 
 
 @pytest.mark.parametrize(
@@ -278,18 +271,6 @@ def test_sql_where_preserves_generated_parameter_counters() -> None:
     stmt = SQL("SELECT * FROM users").where_eq("id", 1)
     filtered = stmt.where("active = TRUE")
     assert filtered._sql_param_counters == stmt._sql_param_counters
-
-
-def test_statement_where_helpers_are_consolidated() -> None:
-    source = Path("sqlspec/core/statement.py").read_text()
-    clone_section = source.split("def _copy_with_expression", 1)[1].split("def where(", 1)[0]
-    assert "def _copy_base(" in clone_section
-    assert clone_section.count("statement_config=self._statement_config") == 1
-    assert "def _where_condition(" in source
-    assert "def _where_comparison(" in source
-    assert "def _where_sequence_membership(" in source
-    assert source.count("new_sql._named_parameters[param_name] =") == 1
-    assert source.count("safe_modify_with_cte(expression, lambda e: apply_where(e, condition))") <= 2
 
 
 def test_sql_order_by_preserves_generated_parameter_counters() -> None:
@@ -980,13 +961,6 @@ def test_sql_as_script_creates_new_instance() -> None:
     assert script_stmt is not original
     assert script_stmt._is_script is True
     assert original._is_script is False
-
-
-def test_sql_as_script_reuses_copy_base() -> None:
-    source = inspect.getsource(SQL.as_script)
-
-    assert "self._copy_base" in source
-    assert "SQL(" not in source
 
 
 def test_statement_config_public_fields_are_derived_from_slots() -> None:

--- a/tests/unit/driver/test_count_query.py
+++ b/tests/unit/driver/test_count_query.py
@@ -1,7 +1,5 @@
 """Tests for count query helpers and edge cases."""
 
-import ast
-import inspect
 import sqlite3
 from collections import UserDict
 from collections.abc import Iterator
@@ -15,7 +13,6 @@ from sqlspec import SQL
 from sqlspec.adapters.sqlite.driver import SqliteDriver
 from sqlspec.core import StatementConfig, get_default_config
 from sqlspec.driver import SyncDriverAdapterBase
-from sqlspec.driver import _common as driver_common
 from sqlspec.exceptions import ImproperConfigurationError
 from tests.conftest import requires_interpreted
 
@@ -99,16 +96,6 @@ def test_count_query_compiles_missing_expression(sqlite_driver: "SqliteDriver") 
 
     assert count_sql.expression is not None
     assert "count" in compiled_sql.lower()
-
-
-def test_pagination_names_uses_module_sqlglot_import() -> None:
-    """Pagination placeholder extraction should avoid per-call import lookups."""
-    source = inspect.getsource(driver_common._pagination_names)
-    tree = ast.parse(source)
-    imports = [node for node in ast.walk(tree) if isinstance(node, ast.Import | ast.ImportFrom)]
-
-    assert hasattr(driver_common, "sqlglot")
-    assert imports == []
 
 
 def test_count_query_with_cte_keeps_with_clause(sqlite_driver: "SqliteDriver") -> None:

--- a/tests/unit/driver/test_fetch_aliases.py
+++ b/tests/unit/driver/test_fetch_aliases.py
@@ -1,580 +1,206 @@
 # pyright: reportPrivateUsage=false
-"""Tests for fetch* method aliases in SyncDriverAdapterBase and AsyncDriverAdapterBase.
-
-Tests that all 16 fetch* methods (8 sync + 8 async) exist, have matching signatures,
-and delegate correctly to their corresponding select* methods.
-
-Uses function-based pytest approach as per AGENTS.md requirements.
-"""
+"""Tests for the fetch method compatibility aliases."""
 
 import inspect
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 
+import pytest
+
 from sqlspec.driver import AsyncDriverAdapterBase, SyncDriverAdapterBase
 from tests.conftest import requires_interpreted
 
-# Test method existence and signature equivalence
-
-
-def test_sync_fetch_method_exists() -> None:
-    """Test that fetch() method exists on SyncDriverAdapterBase."""
-    assert hasattr(SyncDriverAdapterBase, "fetch")
-    assert callable(getattr(SyncDriverAdapterBase, "fetch"))
-
-
-def test_sync_fetch_one_method_exists() -> None:
-    """Test that fetch_one() method exists on SyncDriverAdapterBase."""
-    assert hasattr(SyncDriverAdapterBase, "fetch_one")
-    assert callable(getattr(SyncDriverAdapterBase, "fetch_one"))
-
-
-def test_sync_fetch_one_or_none_method_exists() -> None:
-    """Test that fetch_one_or_none() method exists on SyncDriverAdapterBase."""
-    assert hasattr(SyncDriverAdapterBase, "fetch_one_or_none")
-    assert callable(getattr(SyncDriverAdapterBase, "fetch_one_or_none"))
-
-
-def test_sync_fetch_value_method_exists() -> None:
-    """Test that fetch_value() method exists on SyncDriverAdapterBase."""
-    assert hasattr(SyncDriverAdapterBase, "fetch_value")
-    assert callable(getattr(SyncDriverAdapterBase, "fetch_value"))
-
-
-def test_sync_fetch_value_or_none_method_exists() -> None:
-    """Test that fetch_value_or_none() method exists on SyncDriverAdapterBase."""
-    assert hasattr(SyncDriverAdapterBase, "fetch_value_or_none")
-    assert callable(getattr(SyncDriverAdapterBase, "fetch_value_or_none"))
-
-
-def test_sync_fetch_to_arrow_method_exists() -> None:
-    """Test that fetch_to_arrow() method exists on SyncDriverAdapterBase."""
-    assert hasattr(SyncDriverAdapterBase, "fetch_to_arrow")
-    assert callable(getattr(SyncDriverAdapterBase, "fetch_to_arrow"))
-
-
-def test_sync_fetch_stream_method_exists() -> None:
-    """Test that fetch_stream() method exists on SyncDriverAdapterBase."""
-    assert hasattr(SyncDriverAdapterBase, "fetch_stream")
-    assert callable(getattr(SyncDriverAdapterBase, "fetch_stream"))
-
-
-def test_sync_fetch_with_total_method_exists() -> None:
-    """Test that fetch_with_total() method exists on SyncDriverAdapterBase."""
-    assert hasattr(SyncDriverAdapterBase, "fetch_with_total")
-    assert callable(getattr(SyncDriverAdapterBase, "fetch_with_total"))
-
-
-def test_async_fetch_method_exists() -> None:
-    """Test that fetch() method exists on AsyncDriverAdapterBase."""
-    assert hasattr(AsyncDriverAdapterBase, "fetch")
-    assert callable(getattr(AsyncDriverAdapterBase, "fetch"))
-
-
-def test_async_fetch_one_method_exists() -> None:
-    """Test that fetch_one() method exists on AsyncDriverAdapterBase."""
-    assert hasattr(AsyncDriverAdapterBase, "fetch_one")
-    assert callable(getattr(AsyncDriverAdapterBase, "fetch_one"))
-
-
-def test_async_fetch_one_or_none_method_exists() -> None:
-    """Test that fetch_one_or_none() method exists on AsyncDriverAdapterBase."""
-    assert hasattr(AsyncDriverAdapterBase, "fetch_one_or_none")
-    assert callable(getattr(AsyncDriverAdapterBase, "fetch_one_or_none"))
-
-
-def test_async_fetch_value_method_exists() -> None:
-    """Test that fetch_value() method exists on AsyncDriverAdapterBase."""
-    assert hasattr(AsyncDriverAdapterBase, "fetch_value")
-    assert callable(getattr(AsyncDriverAdapterBase, "fetch_value"))
-
-
-def test_async_fetch_value_or_none_method_exists() -> None:
-    """Test that fetch_value_or_none() method exists on AsyncDriverAdapterBase."""
-    assert hasattr(AsyncDriverAdapterBase, "fetch_value_or_none")
-    assert callable(getattr(AsyncDriverAdapterBase, "fetch_value_or_none"))
-
-
-def test_async_fetch_to_arrow_method_exists() -> None:
-    """Test that fetch_to_arrow() method exists on AsyncDriverAdapterBase."""
-    assert hasattr(AsyncDriverAdapterBase, "fetch_to_arrow")
-    assert callable(getattr(AsyncDriverAdapterBase, "fetch_to_arrow"))
-
-
-def test_async_fetch_stream_method_exists() -> None:
-    """Test that fetch_stream() method exists on AsyncDriverAdapterBase."""
-    assert hasattr(AsyncDriverAdapterBase, "fetch_stream")
-    assert callable(getattr(AsyncDriverAdapterBase, "fetch_stream"))
-
-
-def test_async_fetch_with_total_method_exists() -> None:
-    """Test that fetch_with_total() method exists on AsyncDriverAdapterBase."""
-    assert hasattr(AsyncDriverAdapterBase, "fetch_with_total")
-    assert callable(getattr(AsyncDriverAdapterBase, "fetch_with_total"))
-
-
-# Test signature equivalence between fetch* and select* methods
-
-
-def test_sync_fetch_signature_matches_select() -> None:
-    """Test that fetch() signature matches select() signature."""
-    fetch_sig = inspect.signature(SyncDriverAdapterBase.fetch)
-    select_sig = inspect.signature(SyncDriverAdapterBase.select)
-
-    # Parameters should be identical
-    assert fetch_sig.parameters == select_sig.parameters
-
-
-def test_sync_fetch_one_signature_matches_select_one() -> None:
-    """Test that fetch_one() signature matches select_one() signature."""
-    fetch_sig = inspect.signature(SyncDriverAdapterBase.fetch_one)
-    select_sig = inspect.signature(SyncDriverAdapterBase.select_one)
-
-    assert fetch_sig.parameters == select_sig.parameters
-
-
-def test_sync_fetch_one_or_none_signature_matches_select_one_or_none() -> None:
-    """Test that fetch_one_or_none() signature matches select_one_or_none() signature."""
-    fetch_sig = inspect.signature(SyncDriverAdapterBase.fetch_one_or_none)
-    select_sig = inspect.signature(SyncDriverAdapterBase.select_one_or_none)
-
-    assert fetch_sig.parameters == select_sig.parameters
-
-
-def test_sync_fetch_value_signature_matches_select_value() -> None:
-    """Test that fetch_value() signature matches select_value() signature."""
-    fetch_sig = inspect.signature(SyncDriverAdapterBase.fetch_value)
-    select_sig = inspect.signature(SyncDriverAdapterBase.select_value)
-
-    assert fetch_sig.parameters == select_sig.parameters
-
-
-def test_sync_fetch_value_or_none_signature_matches_select_value_or_none() -> None:
-    """Test that fetch_value_or_none() signature matches select_value_or_none() signature."""
-    fetch_sig = inspect.signature(SyncDriverAdapterBase.fetch_value_or_none)
-    select_sig = inspect.signature(SyncDriverAdapterBase.select_value_or_none)
-
-    assert fetch_sig.parameters == select_sig.parameters
-
-
-def test_sync_fetch_to_arrow_signature_matches_select_to_arrow() -> None:
-    """Test that fetch_to_arrow() signature matches select_to_arrow() signature."""
-    fetch_sig = inspect.signature(SyncDriverAdapterBase.fetch_to_arrow)
-    select_sig = inspect.signature(SyncDriverAdapterBase.select_to_arrow)
-
-    assert fetch_sig.parameters == select_sig.parameters
-
-
-def test_sync_fetch_stream_signature_matches_select_stream() -> None:
-    """Test that fetch_stream() signature matches select_stream() signature."""
-    fetch_sig = inspect.signature(SyncDriverAdapterBase.fetch_stream)
-    select_sig = inspect.signature(SyncDriverAdapterBase.select_stream)
-
-    assert fetch_sig.parameters == select_sig.parameters
-
-
-def test_sync_fetch_with_total_signature_matches_select_with_total() -> None:
-    """Test that fetch_with_total() signature matches select_with_total() signature."""
-    fetch_sig = inspect.signature(SyncDriverAdapterBase.fetch_with_total)
-    select_sig = inspect.signature(SyncDriverAdapterBase.select_with_total)
-
-    assert fetch_sig.parameters == select_sig.parameters
-
-
-def test_async_fetch_signature_matches_select() -> None:
-    """Test that async fetch() signature matches async select() signature."""
-    fetch_sig = inspect.signature(AsyncDriverAdapterBase.fetch)
-    select_sig = inspect.signature(AsyncDriverAdapterBase.select)
-
-    assert fetch_sig.parameters == select_sig.parameters
-
-
-def test_async_fetch_one_signature_matches_select_one() -> None:
-    """Test that async fetch_one() signature matches async select_one() signature."""
-    fetch_sig = inspect.signature(AsyncDriverAdapterBase.fetch_one)
-    select_sig = inspect.signature(AsyncDriverAdapterBase.select_one)
-
-    assert fetch_sig.parameters == select_sig.parameters
-
-
-def test_async_fetch_one_or_none_signature_matches_select_one_or_none() -> None:
-    """Test that async fetch_one_or_none() signature matches async select_one_or_none() signature."""
-    fetch_sig = inspect.signature(AsyncDriverAdapterBase.fetch_one_or_none)
-    select_sig = inspect.signature(AsyncDriverAdapterBase.select_one_or_none)
-
-    assert fetch_sig.parameters == select_sig.parameters
-
-
-def test_async_fetch_value_signature_matches_select_value() -> None:
-    """Test that async fetch_value() signature matches async select_value() signature."""
-    fetch_sig = inspect.signature(AsyncDriverAdapterBase.fetch_value)
-    select_sig = inspect.signature(AsyncDriverAdapterBase.select_value)
-
-    assert fetch_sig.parameters == select_sig.parameters
-
-
-def test_async_fetch_value_or_none_signature_matches_select_value_or_none() -> None:
-    """Test that async fetch_value_or_none() signature matches async select_value_or_none() signature."""
-    fetch_sig = inspect.signature(AsyncDriverAdapterBase.fetch_value_or_none)
-    select_sig = inspect.signature(AsyncDriverAdapterBase.select_value_or_none)
-
-    assert fetch_sig.parameters == select_sig.parameters
-
-
-def test_async_fetch_to_arrow_signature_matches_select_to_arrow() -> None:
-    """Test that async fetch_to_arrow() signature matches async select_to_arrow() signature."""
-    fetch_sig = inspect.signature(AsyncDriverAdapterBase.fetch_to_arrow)
-    select_sig = inspect.signature(AsyncDriverAdapterBase.select_to_arrow)
-
-    assert fetch_sig.parameters == select_sig.parameters
-
-
-def test_async_fetch_stream_signature_matches_select_stream() -> None:
-    """Test that async fetch_stream() signature matches async select_stream() signature."""
-    fetch_sig = inspect.signature(AsyncDriverAdapterBase.fetch_stream)
-    select_sig = inspect.signature(AsyncDriverAdapterBase.select_stream)
-
-    assert fetch_sig.parameters == select_sig.parameters
-
-
-def test_async_fetch_with_total_signature_matches_select_with_total() -> None:
-    """Test that async fetch_with_total() signature matches async select_with_total() signature."""
-    fetch_sig = inspect.signature(AsyncDriverAdapterBase.fetch_with_total)
-    select_sig = inspect.signature(AsyncDriverAdapterBase.select_with_total)
-
-    assert fetch_sig.parameters == select_sig.parameters
-
-
-# Test delegation behavior using mocks
+_ALIAS_PAIRS = (
+    ("fetch", "select"),
+    ("fetch_one", "select_one"),
+    ("fetch_one_or_none", "select_one_or_none"),
+    ("fetch_value", "select_value"),
+    ("fetch_value_or_none", "select_value_or_none"),
+    ("fetch_to_arrow", "select_to_arrow"),
+    ("fetch_stream", "select_stream"),
+    ("fetch_with_total", "select_with_total"),
+)
+
+_DELEGATION_CASES = (
+    (
+        "fetch",
+        "select",
+        ("SELECT * FROM users", {"id": 1}),
+        {"schema_type": None, "statement_config": None},
+        {"schema_type": None, "statement_config": None},
+        [{"id": 1}],
+    ),
+    (
+        "fetch_one",
+        "select_one",
+        ("SELECT * FROM users WHERE id = ?", {"id": 1}),
+        {"schema_type": None, "statement_config": None},
+        {"schema_type": None, "statement_config": None},
+        {"id": 1},
+    ),
+    (
+        "fetch_one_or_none",
+        "select_one_or_none",
+        ("SELECT * FROM users WHERE id = ?", {"id": 999}),
+        {"schema_type": None, "statement_config": None},
+        {"schema_type": None, "statement_config": None},
+        None,
+    ),
+    (
+        "fetch_value",
+        "select_value",
+        ("SELECT COUNT(*) FROM users",),
+        {"statement_config": None},
+        {"value_type": None, "statement_config": None},
+        42,
+    ),
+    (
+        "fetch_value_or_none",
+        "select_value_or_none",
+        ("SELECT MAX(id) FROM empty_table",),
+        {"statement_config": None},
+        {"value_type": None, "statement_config": None},
+        None,
+    ),
+    (
+        "fetch_to_arrow",
+        "select_to_arrow",
+        ("SELECT * FROM users",),
+        {
+            "statement_config": None,
+            "return_format": "table",
+            "native_only": False,
+            "batch_size": None,
+            "arrow_schema": None,
+        },
+        {
+            "statement_config": None,
+            "return_format": "table",
+            "native_only": False,
+            "batch_size": None,
+            "arrow_schema": None,
+        },
+        object(),
+    ),
+    (
+        "fetch_stream",
+        "select_stream",
+        ("SELECT * FROM users",),
+        {"schema_type": None, "statement_config": None, "chunk_size": 25, "native_only": False},
+        {"schema_type": None, "statement_config": None, "chunk_size": 25, "native_only": False},
+        object(),
+    ),
+    (
+        "fetch_with_total",
+        "select_with_total",
+        ("SELECT * FROM users LIMIT 2",),
+        {"schema_type": None, "statement_config": None},
+        {"schema_type": None, "statement_config": None, "count_with_window": False},
+        ([{"id": 1}, {"id": 2}], 100),
+    ),
+)
+
+
+@pytest.mark.parametrize("base", (SyncDriverAdapterBase, AsyncDriverAdapterBase), ids=("sync", "async"))
+@pytest.mark.parametrize(("alias_name", "target_name"), _ALIAS_PAIRS)
+def test_fetch_alias_matches_select_signature(base: type[Any], alias_name: str, target_name: str) -> None:
+    alias = getattr(base, alias_name)
+    target = getattr(base, target_name)
+
+    assert callable(alias)
+    assert inspect.signature(alias).parameters == inspect.signature(target).parameters
 
 
 @requires_interpreted
-def test_sync_fetch_delegates_to_select() -> None:
-    """Test that fetch() delegates to select() with identical arguments."""
-    # Create mock driver with mocked select method
-    mock_driver = Mock(spec=SyncDriverAdapterBase)
-    mock_driver.select = Mock(return_value=[{"id": 1}])
+@pytest.mark.parametrize(
+    ("alias_name", "target_name", "args", "call_kwargs", "expected_kwargs", "expected"), _DELEGATION_CASES
+)
+def test_sync_fetch_alias_delegates(
+    alias_name: str,
+    target_name: str,
+    args: tuple[Any, ...],
+    call_kwargs: dict[str, Any],
+    expected_kwargs: dict[str, Any],
+    expected: Any,
+) -> None:
+    driver = Mock(spec=SyncDriverAdapterBase)
+    target = Mock(return_value=expected)
+    setattr(driver, target_name, target)
 
-    # Call the real fetch method implementation
-    result = SyncDriverAdapterBase.fetch(
-        mock_driver, "SELECT * FROM users", {"id": 1}, schema_type=None, statement_config=None
-    )
+    result = getattr(SyncDriverAdapterBase, alias_name)(driver, *args, **call_kwargs)
 
-    # Verify select was called with same arguments
-    mock_driver.select.assert_called_once_with(
-        "SELECT * FROM users", {"id": 1}, schema_type=None, statement_config=None
-    )
-    assert result == [{"id": 1}]
-
-
-@requires_interpreted
-def test_sync_fetch_one_delegates_to_select_one() -> None:
-    """Test that fetch_one() delegates to select_one() with identical arguments."""
-    mock_driver = Mock(spec=SyncDriverAdapterBase)
-    mock_driver.select_one = Mock(return_value={"id": 1})
-
-    result = SyncDriverAdapterBase.fetch_one(
-        mock_driver, "SELECT * FROM users WHERE id = ?", {"id": 1}, schema_type=None, statement_config=None
-    )
-
-    mock_driver.select_one.assert_called_once_with(
-        "SELECT * FROM users WHERE id = ?", {"id": 1}, schema_type=None, statement_config=None
-    )
-    assert result == {"id": 1}
+    target.assert_called_once_with(*args, **expected_kwargs)
+    assert result is expected
 
 
 @requires_interpreted
-def test_sync_fetch_one_or_none_delegates_to_select_one_or_none() -> None:
-    """Test that fetch_one_or_none() delegates to select_one_or_none() with identical arguments."""
-    mock_driver = Mock(spec=SyncDriverAdapterBase)
-    mock_driver.select_one_or_none = Mock(return_value=None)
+@pytest.mark.parametrize(
+    ("alias_name", "target_name", "args", "call_kwargs", "expected_kwargs", "expected"),
+    tuple(case for case in _DELEGATION_CASES if case[0] != "fetch_stream"),
+)
+async def test_async_fetch_alias_delegates(
+    alias_name: str,
+    target_name: str,
+    args: tuple[Any, ...],
+    call_kwargs: dict[str, Any],
+    expected_kwargs: dict[str, Any],
+    expected: Any,
+) -> None:
+    driver = AsyncMock(spec=AsyncDriverAdapterBase)
+    target = AsyncMock(return_value=expected)
+    setattr(driver, target_name, target)
 
-    result = SyncDriverAdapterBase.fetch_one_or_none(
-        mock_driver, "SELECT * FROM users WHERE id = ?", {"id": 999}, schema_type=None, statement_config=None
-    )
+    result = await getattr(AsyncDriverAdapterBase, alias_name)(driver, *args, **call_kwargs)
 
-    mock_driver.select_one_or_none.assert_called_once_with(
-        "SELECT * FROM users WHERE id = ?", {"id": 999}, schema_type=None, statement_config=None
-    )
-    assert result is None
-
-
-@requires_interpreted
-def test_sync_fetch_value_delegates_to_select_value() -> None:
-    """Test that fetch_value() delegates to select_value() with identical arguments."""
-    mock_driver = Mock(spec=SyncDriverAdapterBase)
-    mock_driver.select_value = Mock(return_value=42)
-
-    result = SyncDriverAdapterBase.fetch_value(mock_driver, "SELECT COUNT(*) FROM users", statement_config=None)
-
-    mock_driver.select_value.assert_called_once_with(
-        "SELECT COUNT(*) FROM users", value_type=None, statement_config=None
-    )
-    assert result == 42
+    target.assert_awaited_once_with(*args, **expected_kwargs)
+    assert result is expected
 
 
 @requires_interpreted
-def test_sync_fetch_value_or_none_delegates_to_select_value_or_none() -> None:
-    """Test that fetch_value_or_none() delegates to select_value_or_none() with identical arguments."""
-    mock_driver = Mock(spec=SyncDriverAdapterBase)
-    mock_driver.select_value_or_none = Mock(return_value=None)
-
-    result = SyncDriverAdapterBase.fetch_value_or_none(
-        mock_driver, "SELECT MAX(id) FROM empty_table", statement_config=None
-    )
-
-    mock_driver.select_value_or_none.assert_called_once_with(
-        "SELECT MAX(id) FROM empty_table", value_type=None, statement_config=None
-    )
-    assert result is None
-
-
-@requires_interpreted
-def test_sync_fetch_to_arrow_delegates_to_select_to_arrow() -> None:
-    """Test that fetch_to_arrow() delegates to select_to_arrow() with identical arguments."""
-    mock_driver = Mock(spec=SyncDriverAdapterBase)
-    mock_arrow_result = Mock()
-    mock_driver.select_to_arrow = Mock(return_value=mock_arrow_result)
-
-    result = SyncDriverAdapterBase.fetch_to_arrow(
-        mock_driver,
-        "SELECT * FROM users",
-        statement_config=None,
-        return_format="table",
-        native_only=False,
-        batch_size=None,
-        arrow_schema=None,
-    )
-
-    mock_driver.select_to_arrow.assert_called_once_with(
-        "SELECT * FROM users",
-        statement_config=None,
-        return_format="table",
-        native_only=False,
-        batch_size=None,
-        arrow_schema=None,
-    )
-    assert result == mock_arrow_result
-
-
-@requires_interpreted
-def test_sync_fetch_stream_delegates_to_select_stream() -> None:
-    """Test that fetch_stream() delegates to select_stream() with identical arguments."""
-    mock_driver = Mock(spec=SyncDriverAdapterBase)
-    mock_stream = Mock()
-    mock_driver.select_stream = Mock(return_value=mock_stream)
-
-    result = SyncDriverAdapterBase.fetch_stream(
-        mock_driver, "SELECT * FROM users", schema_type=None, statement_config=None, chunk_size=25, native_only=False
-    )
-
-    mock_driver.select_stream.assert_called_once_with(
-        "SELECT * FROM users", schema_type=None, statement_config=None, chunk_size=25, native_only=False
-    )
-    assert result == mock_stream
-
-
-@requires_interpreted
-def test_sync_fetch_with_total_delegates_to_select_with_total() -> None:
-    """Test that fetch_with_total() delegates to select_with_total() with identical arguments."""
-    mock_driver = Mock(spec=SyncDriverAdapterBase)
-    mock_driver.select_with_total = Mock(return_value=([{"id": 1}, {"id": 2}], 100))
-
-    result = SyncDriverAdapterBase.fetch_with_total(
-        mock_driver, "SELECT * FROM users LIMIT 2", schema_type=None, statement_config=None
-    )
-
-    mock_driver.select_with_total.assert_called_once_with(
-        "SELECT * FROM users LIMIT 2", schema_type=None, statement_config=None, count_with_window=False
-    )
-    assert result == ([{"id": 1}, {"id": 2}], 100)
-
-
-@requires_interpreted
-async def test_async_fetch_delegates_to_select() -> None:
-    """Test that async fetch() delegates to async select() with identical arguments."""
-    mock_driver = AsyncMock(spec=AsyncDriverAdapterBase)
-    mock_driver.select = AsyncMock(return_value=[{"id": 1}])
-
-    result = await AsyncDriverAdapterBase.fetch(
-        mock_driver, "SELECT * FROM users", {"id": 1}, schema_type=None, statement_config=None
-    )
-
-    mock_driver.select.assert_called_once_with(
-        "SELECT * FROM users", {"id": 1}, schema_type=None, statement_config=None
-    )
-    assert result == [{"id": 1}]
-
-
-@requires_interpreted
-async def test_async_fetch_one_delegates_to_select_one() -> None:
-    """Test that async fetch_one() delegates to async select_one() with identical arguments."""
-    mock_driver = AsyncMock(spec=AsyncDriverAdapterBase)
-    mock_driver.select_one = AsyncMock(return_value={"id": 1})
-
-    result = await AsyncDriverAdapterBase.fetch_one(
-        mock_driver, "SELECT * FROM users WHERE id = ?", {"id": 1}, schema_type=None, statement_config=None
-    )
-
-    mock_driver.select_one.assert_called_once_with(
-        "SELECT * FROM users WHERE id = ?", {"id": 1}, schema_type=None, statement_config=None
-    )
-    assert result == {"id": 1}
-
-
-@requires_interpreted
-async def test_async_fetch_one_or_none_delegates_to_select_one_or_none() -> None:
-    """Test that async fetch_one_or_none() delegates to async select_one_or_none() with identical arguments."""
-    mock_driver = AsyncMock(spec=AsyncDriverAdapterBase)
-    mock_driver.select_one_or_none = AsyncMock(return_value=None)
-
-    result = await AsyncDriverAdapterBase.fetch_one_or_none(
-        mock_driver, "SELECT * FROM users WHERE id = ?", {"id": 999}, schema_type=None, statement_config=None
-    )
-
-    mock_driver.select_one_or_none.assert_called_once_with(
-        "SELECT * FROM users WHERE id = ?", {"id": 999}, schema_type=None, statement_config=None
-    )
-    assert result is None
-
-
-@requires_interpreted
-async def test_async_fetch_value_delegates_to_select_value() -> None:
-    """Test that async fetch_value() delegates to async select_value() with identical arguments."""
-    mock_driver = AsyncMock(spec=AsyncDriverAdapterBase)
-    mock_driver.select_value = AsyncMock(return_value=42)
-
-    result = await AsyncDriverAdapterBase.fetch_value(mock_driver, "SELECT COUNT(*) FROM users", statement_config=None)
-
-    mock_driver.select_value.assert_called_once_with(
-        "SELECT COUNT(*) FROM users", value_type=None, statement_config=None
-    )
-    assert result == 42
-
-
-@requires_interpreted
-async def test_async_fetch_value_or_none_delegates_to_select_value_or_none() -> None:
-    """Test that async fetch_value_or_none() delegates to async select_value_or_none() with identical arguments."""
-    mock_driver = AsyncMock(spec=AsyncDriverAdapterBase)
-    mock_driver.select_value_or_none = AsyncMock(return_value=None)
-
-    result = await AsyncDriverAdapterBase.fetch_value_or_none(
-        mock_driver, "SELECT MAX(id) FROM empty_table", statement_config=None
-    )
-
-    mock_driver.select_value_or_none.assert_called_once_with(
-        "SELECT MAX(id) FROM empty_table", value_type=None, statement_config=None
-    )
-    assert result is None
-
-
-@requires_interpreted
-async def test_async_fetch_to_arrow_delegates_to_select_to_arrow() -> None:
-    """Test that async fetch_to_arrow() delegates to async select_to_arrow() with identical arguments."""
-    mock_driver = AsyncMock(spec=AsyncDriverAdapterBase)
-    mock_arrow_result = Mock()
-    mock_driver.select_to_arrow = AsyncMock(return_value=mock_arrow_result)
-
-    result = await AsyncDriverAdapterBase.fetch_to_arrow(
-        mock_driver,
-        "SELECT * FROM users",
-        statement_config=None,
-        return_format="table",
-        native_only=False,
-        batch_size=None,
-        arrow_schema=None,
-    )
-
-    mock_driver.select_to_arrow.assert_called_once_with(
-        "SELECT * FROM users",
-        statement_config=None,
-        return_format="table",
-        native_only=False,
-        batch_size=None,
-        arrow_schema=None,
-    )
-    assert result == mock_arrow_result
-
-
-@requires_interpreted
-def test_async_fetch_stream_delegates_to_select_stream() -> None:
-    """Test that async fetch_stream() delegates to async select_stream() with identical arguments."""
-    mock_driver = Mock(spec=AsyncDriverAdapterBase)
-    mock_stream = Mock()
-    mock_driver.select_stream = Mock(return_value=mock_stream)
+def test_async_fetch_stream_delegates_without_awaiting() -> None:
+    driver = Mock(spec=AsyncDriverAdapterBase)
+    stream = object()
+    driver.select_stream = Mock(return_value=stream)
 
     result = AsyncDriverAdapterBase.fetch_stream(
-        mock_driver, "SELECT * FROM users", schema_type=None, statement_config=None, chunk_size=25, native_only=False
+        driver, "SELECT * FROM users", schema_type=None, statement_config=None, chunk_size=25, native_only=False
     )
 
-    mock_driver.select_stream.assert_called_once_with(
+    driver.select_stream.assert_called_once_with(
         "SELECT * FROM users", schema_type=None, statement_config=None, chunk_size=25, native_only=False
     )
-    assert result == mock_stream
+    assert result is stream
 
 
 @requires_interpreted
-async def test_async_fetch_with_total_delegates_to_select_with_total() -> None:
-    """Test that async fetch_with_total() delegates to async select_with_total() with identical arguments."""
-    mock_driver = AsyncMock(spec=AsyncDriverAdapterBase)
-    mock_driver.select_with_total = AsyncMock(return_value=([{"id": 1}, {"id": 2}], 100))
-
-    result = await AsyncDriverAdapterBase.fetch_with_total(
-        mock_driver, "SELECT * FROM users LIMIT 2", schema_type=None, statement_config=None
-    )
-
-    mock_driver.select_with_total.assert_called_once_with(
-        "SELECT * FROM users LIMIT 2", schema_type=None, statement_config=None, count_with_window=False
-    )
-    assert result == ([{"id": 1}, {"id": 2}], 100)
-
-
-# Test that fetch methods preserve schema_type argument handling
-
-
-@requires_interpreted
-def test_sync_fetch_with_schema_type_argument() -> None:
-    """Test that fetch() correctly passes schema_type to select()."""
-
+def test_sync_fetch_preserves_schema_type() -> None:
     class UserSchema:
-        """Sample schema class."""
+        pass
 
-        def __init__(self, **kwargs: Any) -> None:
-            self.id = kwargs.get("id")
-            self.name = kwargs.get("name")
+    driver = Mock(spec=SyncDriverAdapterBase)
+    expected = [UserSchema()]
+    driver.select = Mock(return_value=expected)
 
-    mock_driver = Mock(spec=SyncDriverAdapterBase)
-    expected_result = [UserSchema(id=1, name="Alice")]
-    mock_driver.select = Mock(return_value=expected_result)
+    result = SyncDriverAdapterBase.fetch(driver, "SELECT * FROM users", schema_type=UserSchema, statement_config=None)
 
-    result = SyncDriverAdapterBase.fetch(
-        mock_driver, "SELECT * FROM users", schema_type=UserSchema, statement_config=None
-    )
-
-    mock_driver.select.assert_called_once_with("SELECT * FROM users", schema_type=UserSchema, statement_config=None)
-    assert result == expected_result
+    driver.select.assert_called_once_with("SELECT * FROM users", schema_type=UserSchema, statement_config=None)
+    assert result is expected
 
 
 @requires_interpreted
-async def test_async_fetch_one_with_schema_type_argument() -> None:
-    """Test that async fetch_one() correctly passes schema_type to select_one()."""
-
+async def test_async_fetch_one_preserves_schema_type() -> None:
     class UserSchema:
-        """Sample schema class."""
+        pass
 
-        def __init__(self, **kwargs: Any) -> None:
-            self.id = kwargs.get("id")
-            self.name = kwargs.get("name")
-
-    mock_driver = AsyncMock(spec=AsyncDriverAdapterBase)
-    expected_result = UserSchema(id=1, name="Alice")
-    mock_driver.select_one = AsyncMock(return_value=expected_result)
+    driver = AsyncMock(spec=AsyncDriverAdapterBase)
+    expected = UserSchema()
+    driver.select_one = AsyncMock(return_value=expected)
 
     result = await AsyncDriverAdapterBase.fetch_one(
-        mock_driver, "SELECT * FROM users WHERE id = 1", schema_type=UserSchema, statement_config=None
+        driver, "SELECT * FROM users WHERE id = 1", schema_type=UserSchema, statement_config=None
     )
 
-    mock_driver.select_one.assert_called_once_with(
+    driver.select_one.assert_awaited_once_with(
         "SELECT * FROM users WHERE id = 1", schema_type=UserSchema, statement_config=None
     )
-    assert result == expected_result
+    assert result is expected

--- a/tests/unit/driver/test_query_cache.py
+++ b/tests/unit/driver/test_query_cache.py
@@ -20,7 +20,6 @@ from sqlspec.core import (
     get_cache,
 )
 from sqlspec.core.parameters._processor import ParameterProcessor
-from sqlspec.driver import _common as driver_common
 from sqlspec.driver._query_cache import CachedQuery, QueryCache
 from sqlspec.exceptions import SQLSpecError
 
@@ -53,27 +52,6 @@ def _make_cached(
         processed_state=processed_state,
         column_names=column_names,
     )
-
-
-def test_driver_common_dead_script_and_version_helpers_stay_removed() -> None:
-    """Retired private helper names should not reappear in the compiled driver module."""
-    for name in (
-        "EXEC_CURSOR_RESULT",
-        "EXEC_ROWCOUNT_OVERRIDE",
-        "EXEC_SPECIAL_DATA",
-        "ScriptExecutionResult",
-        "get_cached_version_for_driver",
-        "cache_version_for_driver",
-        "detect_version_with_queries",
-        "parse_version_string",
-    ):
-        assert not hasattr(driver_common, name)
-
-
-def test_private_statement_cache_helper_names_are_cleaned_up() -> None:
-    """Statement-cache helpers should use purpose-oriented private names."""
-    assert hasattr(driver_common.CommonDriverAttributesMixin, "_cached_execution")
-    assert not hasattr(driver_common.CommonDriverAttributesMixin, "_stmt_cache_lookup")
 
 
 def test_sync_execute_cache_hit_uses_fast_path(sqlite_sync_driver, monkeypatch) -> None:

--- a/tests/unit/exceptions/test_exceptions.py
+++ b/tests/unit/exceptions/test_exceptions.py
@@ -1,5 +1,3 @@
-import inspect
-
 import pytest
 
 from sqlspec.exceptions import (
@@ -202,11 +200,3 @@ def test_wrap_exceptions_wrap_exceptions_sqlspec_error_passes_through() -> None:
         with wrap_exceptions():
             raise original
     assert exc_info.value is original
-
-
-def test_wrap_exceptions_wrap_exceptions_does_not_guard_suppress_classinfo_shape() -> None:
-    """wrap_exceptions should delegate classinfo handling directly to isinstance."""
-    source = inspect.getsource(wrap_exceptions)
-    assert "isinstance(suppress, type)" not in source
-    assert "isinstance(suppress, tuple)" not in source
-    assert "isinstance(exc, suppress)" in source

--- a/tests/unit/extensions/test_adk/test_sql_template_hoist.py
+++ b/tests/unit/extensions/test_adk/test_sql_template_hoist.py
@@ -1,9 +1,6 @@
 # pyright: reportPrivateUsage=false
 """Regression tests for adapter ADK SQL template ownership."""
 
-import ast
-import importlib
-import inspect
 from unittest.mock import MagicMock
 
 import pytest
@@ -59,29 +56,6 @@ def _sync_session_ddl(store: object) -> dict[str, str]:
         "user_state": store._user_states_table_ddl(),  # type: ignore[attr-defined]
         "metadata": store._metadata_table_ddl(),  # type: ignore[attr-defined]
     }
-
-
-@pytest.mark.parametrize(
-    "module_name",
-    [
-        "sqlspec.adapters.psycopg.adk.store",
-        "sqlspec.adapters.cockroach_psycopg.adk.store",
-        "sqlspec.adapters.mysqlconnector.adk.store",
-        "sqlspec.adapters.oracledb.adk.store",
-    ],
-)
-def test_adk_ddl_methods_reference_module_templates(module_name: str) -> None:
-    module = importlib.import_module(module_name)
-    tree = ast.parse(inspect.getsource(module))
-
-    sql_owners = [
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and ("ddl" in node.name or "seed" in node.name)
-    ]
-    inline_templates = [node for owner in sql_owners for node in ast.walk(owner) if isinstance(node, ast.JoinedStr)]
-
-    assert not inline_templates
 
 
 @pytest.mark.anyio

--- a/tests/unit/extensions/test_adk/test_store_config.py
+++ b/tests/unit/extensions/test_adk/test_store_config.py
@@ -2,15 +2,12 @@
 """Tests for shared ADK store configuration behavior."""
 
 import importlib
-import inspect
 import logging
 from datetime import datetime
 from typing import Any
 
 import pytest
 
-import sqlspec.extensions.adk.artifact.store as artifact_store_module
-import sqlspec.extensions.adk.store as session_store_module
 from sqlspec.extensions.adk import EventRecord, SessionRecord
 from sqlspec.extensions.adk.artifact._types import ArtifactRecord
 from sqlspec.extensions.adk.artifact.store import BaseSyncADKArtifactStore
@@ -292,24 +289,6 @@ class _SyncMemoryStore(BaseSyncADKMemoryStore[Any]):
         return [f"DROP TABLE IF EXISTS {self._memory_table}"]
 
 
-def test_adk_store_private_sql_helpers_use_purpose_names() -> None:
-    assert hasattr(_SyncSessionStore, "_sessions_table_ddl")
-    assert hasattr(_SyncSessionStore, "_events_table_ddl")
-    assert not hasattr(_SyncSessionStore, "_metadata_seed_sql")
-    assert hasattr(_SyncSessionStore, "_drop_tables_sql")
-    assert not hasattr(_SyncSessionStore, "_get_create_sessions_table_sql")
-    assert not hasattr(_SyncSessionStore, "_get_create_events_table_sql")
-    assert not hasattr(_SyncSessionStore, "_get_seed_metadata_sql")
-    assert not hasattr(_SyncSessionStore, "_get_drop_tables_sql")
-
-
-def test_adk_memory_store_private_sql_helpers_use_purpose_names() -> None:
-    assert hasattr(_SyncMemoryStore, "_memory_table_ddl")
-    assert hasattr(_SyncMemoryStore, "_drop_memory_table_sql")
-    assert not hasattr(_SyncMemoryStore, "_get_create_memory_table_sql")
-    assert not hasattr(_SyncMemoryStore, "_get_drop_memory_table_sql")
-
-
 class _SyncArtifactStore(BaseSyncADKArtifactStore[Any]):
     def insert_artifact(self, record: ArtifactRecord) -> None:
         return None
@@ -345,25 +324,6 @@ def test_adk_base_stores_keep_original_config(store_cls: type[Any]) -> None:
     store = store_cls(config)
 
     assert store.config is config
-
-
-def test_adk_base_stores_do_not_keep_dead_private_helpers() -> None:
-    assert "_value_to_bytes" not in BaseAsyncADKStore.__dict__
-    assert "_value_to_bytes" not in BaseSyncADKStore.__dict__
-    assert "_adk_config" not in BaseSyncADKArtifactStore.__dict__
-
-
-def test_adk_table_helpers_have_one_private_owner() -> None:
-    for module in (session_store_module, memory_store_module, artifact_store_module):
-        source = inspect.getsource(module)
-        assert "def _ensure_table_name(" not in source
-        assert "VALID_TABLE_NAME_PATTERN" not in source
-        assert "MAX_TABLE_NAME_LENGTH" not in source
-
-    assert "def _unique_statements(" not in inspect.getsource(session_store_module)
-    assert "def _unique_statements(" not in inspect.getsource(memory_store_module)
-    assert "def _owner_id_column_name(" not in inspect.getsource(session_store_module)
-    assert "def _owner_id_column_name(" not in inspect.getsource(memory_store_module)
 
 
 def test_sync_session_store_manage_schema_false_skips_creation() -> None:

--- a/tests/unit/extensions/test_adk/test_store_instantiation.py
+++ b/tests/unit/extensions/test_adk/test_store_instantiation.py
@@ -9,7 +9,6 @@ The class list mirrors the shipped adapter ``adk`` exports and catches drift
 when a concrete store no longer satisfies the base contract.
 """
 
-import ast
 import importlib
 import inspect
 from typing import cast
@@ -167,43 +166,6 @@ def test_adk_store_registration_validator_resolves_sqlite_store_classes() -> Non
     config = SqliteConfig(connection_config={"database": ":memory:"}, extension_config={"adk": {}})
 
     _ensure_adk_store_registration(config)
-
-
-@pytest.mark.parametrize(
-    "class_path",
-    [
-        "sqlspec.adapters.psycopg.adk.PsycopgSyncADKStore",
-        "sqlspec.adapters.psycopg.adk.PsycopgSyncADKMemoryStore",
-        "sqlspec.adapters.cockroach_psycopg.adk.CockroachPsycopgSyncADKStore",
-        "sqlspec.adapters.cockroach_psycopg.adk.CockroachPsycopgSyncADKMemoryStore",
-        "sqlspec.adapters.mysqlconnector.adk.MysqlConnectorSyncADKStore",
-        "sqlspec.adapters.mysqlconnector.adk.MysqlConnectorSyncADKMemoryStore",
-        "sqlspec.adapters.oracledb.adk.OracleSyncADKStore",
-        "sqlspec.adapters.oracledb.adk.OracleSyncADKMemoryStore",
-        "sqlspec.adapters.sqlite.adk.SqliteADKStore",
-        "sqlspec.adapters.sqlite.adk.SqliteADKMemoryStore",
-    ],
-)
-def test_sync_store_public_methods_do_not_delegate_to_private_mirrors(class_path: str) -> None:
-    cls = _load_class(class_path)
-    tree = ast.parse(inspect.getsource(cls))
-
-    has_delegate = False
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.FunctionDef) or node.name.startswith("_"):
-            continue
-        for child in ast.walk(node):
-            if (
-                isinstance(child, ast.Call)
-                and isinstance(child.func, ast.Attribute)
-                and isinstance(child.func.value, ast.Name)
-                and child.func.value.id == "self"
-                and child.func.attr.startswith("_")
-                and child.func.attr[1:] == node.name
-            ):
-                has_delegate = True
-
-    assert not has_delegate
 
 
 def test_adk_store_registration_validator_resolves_duckdb_store_classes() -> None:

--- a/tests/unit/extensions/test_events/test_store_hooks.py
+++ b/tests/unit/extensions/test_events/test_store_hooks.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 from sqlspec.extensions.events import BaseEventQueueStore
-from sqlspec.extensions.events._queue import _BaseTableEventQueue
 
 if TYPE_CHECKING:
     from sqlspec.adapters.sqlite import SqliteConfig
@@ -22,30 +21,6 @@ if TYPE_CHECKING:
     BaseEventQueueStoreBase = BaseEventQueueStore[SqliteConfig]
 else:
     BaseEventQueueStoreBase = BaseEventQueueStore
-
-
-def test_private_sql_helpers_use_purpose_names() -> None:
-    assert hasattr(BaseEventQueueStore, "_table_ddl")
-    assert hasattr(BaseEventQueueStore, "_index_ddl")
-    assert not hasattr(BaseEventQueueStore, "_build_create_table_sql")
-    assert not hasattr(BaseEventQueueStore, "_build_index_sql")
-
-
-def test_table_queue_private_sql_helpers_use_purpose_names() -> None:
-    assert hasattr(_BaseTableEventQueue, "_insert_sql")
-    assert hasattr(_BaseTableEventQueue, "_select_sql")
-    assert hasattr(_BaseTableEventQueue, "_select_by_id_sql")
-    assert hasattr(_BaseTableEventQueue, "_claim_sql")
-    assert hasattr(_BaseTableEventQueue, "_ack_sql")
-    assert hasattr(_BaseTableEventQueue, "_nack_sql")
-    assert hasattr(_BaseTableEventQueue, "_cleanup_sql")
-    assert not hasattr(_BaseTableEventQueue, "_build_insert_sql")
-    assert not hasattr(_BaseTableEventQueue, "_build_select_sql")
-    assert not hasattr(_BaseTableEventQueue, "_build_select_by_id_sql")
-    assert not hasattr(_BaseTableEventQueue, "_build_claim_sql")
-    assert not hasattr(_BaseTableEventQueue, "_build_ack_sql")
-    assert not hasattr(_BaseTableEventQueue, "_build_nack_sql")
-    assert not hasattr(_BaseTableEventQueue, "_build_cleanup_sql")
 
 
 def test_base_store_string_type_default() -> None:

--- a/tests/unit/loader/test_sql_file_loader.py
+++ b/tests/unit/loader/test_sql_file_loader.py
@@ -15,7 +15,6 @@ from typing import Any
 
 import pytest
 
-import sqlspec.loader as loader_module
 from sqlspec.core import SQL
 from sqlspec.exceptions import SQLFileNotFoundError, SQLFileParseError, SQLStatementNotFoundError
 from sqlspec.loader import (
@@ -38,11 +37,6 @@ def test_named_statement_creation() -> None:
     assert stmt.sql == "SELECT 1"
     assert stmt.dialect == "postgres"
     assert stmt.start_line == 10
-
-
-def test_loader_dead_private_constants_stay_removed() -> None:
-    assert not hasattr(loader_module, "TRIM_SPECIAL_CHARS")
-    assert not hasattr(loader_module, "MIN_QUERY_PARTS")
 
 
 def test_named_statement_no_dialect() -> None:

--- a/tests/unit/migrations/test_migration_commands.py
+++ b/tests/unit/migrations/test_migration_commands.py
@@ -498,10 +498,3 @@ def test_commands_contract_base_revision_file_type_default_matches_concrete_comm
     assert base_param.default is None
     assert sync_param.default is None
     assert async_param.default is None
-
-
-def test_commands_contract_upgrade_documents_config_auto_sync_as_unoverridable() -> None:
-    sync_source = inspect.getsource(SyncMigrationCommands.upgrade)
-    async_source = inspect.getsource(AsyncMigrationCommands.upgrade)
-    assert "config auto_sync=False cannot be overridden by the call-site flag" in sync_source
-    assert "config auto_sync=False cannot be overridden by the call-site flag" in async_source

--- a/tests/unit/migrations/test_squash.py
+++ b/tests/unit/migrations/test_squash.py
@@ -7,23 +7,9 @@ Tests for:
 - Squashed file generation
 """
 
-import inspect
 from pathlib import Path
 
 import pytest
-
-
-def test_migration_backup_lifecycle_has_private_owner() -> None:
-    from sqlspec.migrations.fix import MigrationFixer
-    from sqlspec.migrations.squash import MigrationSquasher
-
-    assert "create_backup" in inspect.getsource(MigrationFixer.create_backup)
-    assert "restore_backup" in inspect.getsource(MigrationFixer.rollback)
-    assert "remove_backup" in inspect.getsource(MigrationFixer.cleanup)
-    assert "create_backup" in inspect.getsource(MigrationSquasher._create_backup)
-    assert "restore_backup" in inspect.getsource(MigrationSquasher._rollback_backup)
-    assert "Keep in sync" not in inspect.getsource(MigrationFixer)
-    assert "Keep in sync" not in inspect.getsource(MigrationSquasher)
 
 
 def test_squash_plan_squash_plan_instantiation(tmp_path: Path) -> None:

--- a/tests/unit/migrations/test_tracker_idempotency.py
+++ b/tests/unit/migrations/test_tracker_idempotency.py
@@ -12,15 +12,6 @@ from sqlspec.driver._sync import SyncDriverAdapterBase
 from sqlspec.migrations.tracker import AsyncMigrationTracker, SyncMigrationTracker
 
 
-def test_migration_tracker_private_sql_helpers_use_purpose_names() -> None:
-    assert hasattr(SyncMigrationTracker, "_tracking_table_ddl")
-    assert hasattr(SyncMigrationTracker, "_current_version_query")
-    assert hasattr(SyncMigrationTracker, "_record_migration_statement")
-    assert not hasattr(SyncMigrationTracker, "_get_create_table_sql")
-    assert not hasattr(SyncMigrationTracker, "_get_current_version_sql")
-    assert not hasattr(SyncMigrationTracker, "_get_record_migration_sql")
-
-
 def test_sync_update_version_record_success() -> None:
     """Test sync update succeeds when old version exists."""
     tracker = SyncMigrationTracker()

--- a/tests/unit/storage/test_storage_iterators.py
+++ b/tests/unit/storage/test_storage_iterators.py
@@ -4,12 +4,7 @@ import io
 
 import pytest
 
-import sqlspec.storage.backends.base as storage_base_module
 from sqlspec.storage.backends.base import AsyncObStoreStreamIterator, AsyncThreadedBytesIterator
-
-
-def test_storage_backends_base_dead_limiter_stays_removed() -> None:
-    assert not hasattr(storage_base_module, "storage_limiter")
 
 
 class FakeAsyncStream:

--- a/tests/unit/utils/test_fixtures.py
+++ b/tests/unit/utils/test_fixtures.py
@@ -7,7 +7,6 @@ JSON fixture file loading with compression support.
 
 import gzip
 import importlib
-import inspect
 import json
 import sys
 import zipfile
@@ -153,11 +152,6 @@ def test_async_fixture_wrappers_are_hoisted() -> None:
     assert isinstance(_async_read_compressed, _AsyncWrapper)
     assert isinstance(_async_serialize, _AsyncWrapper)
     assert isinstance(_async_compress, _AsyncWrapper)
-
-
-def test_async_fixture_functions_do_not_allocate_wrappers_inline() -> None:
-    assert "async_(" not in inspect.getsource(open_fixture_async)
-    assert "async_(" not in inspect.getsource(write_fixture_async)
 
 
 def test_serialize_dict() -> None:

--- a/tests/unit/utils/test_mypyc_inventory.py
+++ b/tests/unit/utils/test_mypyc_inventory.py
@@ -11,8 +11,6 @@ from types import ModuleType
 from uuid import UUID
 
 import sqlspec.utils.correlation as correlation_module
-import sqlspec.utils.schema as schema_module
-import sqlspec.utils.sync_tools as sync_tools_module
 from sqlspec.adapters.adbc.core import prepare_postgres_uuid_bindings
 from sqlspec.utils.correlation import CorrelationContext
 
@@ -309,14 +307,6 @@ def test_mypy_2_toolchain_policy_is_explicit_and_parallel_gate_is_default() -> N
     assert re.search("^dmypy:.*?## Run mypy daemon", makefile, flags=re.MULTILINE) is not None
     assert re.search("^mypy-parallel:.*?##", makefile, flags=re.MULTILINE) is not None
     assert re.search("^type-check:\\s+mypy pyright\\s+##", makefile, flags=re.MULTILINE) is not None
-
-
-def test_dead_code_removal_c13_return_value_helper_removed() -> None:
-    assert not hasattr(sync_tools_module, "_return_value")
-
-
-def test_dead_code_removal_c13_detect_schema_type_helper_removed() -> None:
-    assert not hasattr(schema_module, "_detect_schema_type")
 
 
 def test_correlation_context_function_is_public() -> None:

--- a/tests/unit/utils/test_type_guards.py
+++ b/tests/unit/utils/test_type_guards.py
@@ -7,7 +7,6 @@ Uses function-based pytest approach as per AGENTS.md requirements.
 import typing
 from collections.abc import Mapping
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, cast
 
 import msgspec
@@ -1108,21 +1107,9 @@ def test_supports_arrow_results_with_primitive_types() -> None:
     assert supports_arrow_results({"key": "value"}) is False
 
 
-def test_typing_module_typing_module_source_does_not_reference_private_typeddict() -> None:
-    """sqlspec.typing must not import or reference typing._TypedDict."""
-    assert "_TypedDict" not in Path("sqlspec/typing.py").read_text()
-
-
 def test_typing_module_supported_schema_model_includes_mapping() -> None:
     """SupportedSchemaModel should include Mapping[str, Any]."""
     from sqlspec.typing import SupportedSchemaModel
 
     args = typing.get_args(SupportedSchemaModel)
     assert any(getattr(arg, "__origin__", None) is Mapping for arg in args)
-
-
-def test_typing_module_typing_module_has_no_private_typeddict_name() -> None:
-    """sqlspec.typing should not expose the private _TypedDict name."""
-    import sqlspec.typing as typing_module
-
-    assert not hasattr(typing_module, "_TypedDict")


### PR DESCRIPTION
## Summary

- consolidate driver fetch alias coverage into sync/async behavior matrices
- replace duplicated MySQL-family insert-statement tests with one shared adapter contract
- remove unit tests that scan implementation source, preserve deleted private helper names, or assert exact internal delegation and ownership shapes
- retain observable behavior, public API, memory-layout, compiled-mode, and third-party signature contracts
