### PR TITLE
fix(litestar): resolve configs before app registration

### DIFF
--- a/docs/usage/frameworks/litestar/dependency_injection.rst
+++ b/docs/usage/frameworks/litestar/dependency_injection.rst
@@ -99,6 +99,59 @@ sync DuckDB for ETL operations:
        plugins=[SQLSpecPlugin(sqlspec=sqlspec)]  # Single plugin handles all configs
    )
 
+Config Lookup Outside App Construction
+--------------------------------------
+
+``SQLSpecPlugin.get_config()`` accepts two kinds of identifier, and they become
+available at different points in the application lifecycle:
+
+- **Registry identities** - a config instance, its concrete config type, or its
+  ``bind_key``. These exist as soon as the plugin is constructed, so composition
+  roots, CLI commands, and background workers can resolve a config without building
+  a Litestar application first.
+- **Litestar dependency identities** - ``session_key``, ``connection_key``, and
+  ``pool_key``. These name dependency providers generated during plugin
+  registration, so they resolve only after the plugin has been added to a
+  ``Litestar`` application.
+
+.. code-block:: python
+
+   from litestar import Litestar
+   from sqlspec import SQLSpec
+   from sqlspec.adapters.asyncpg import AsyncpgConfig
+   from sqlspec.extensions.litestar import SQLSpecPlugin
+
+   sqlspec = SQLSpec()
+   sqlspec.add_config(
+       AsyncpgConfig(
+           bind_key="primary",
+           connection_config={
+               "host": "localhost",
+               "port": 5432,
+               "database": "app",
+               "user": "app",
+               "password": "secret",
+           },
+       )
+   )
+
+   plugin = SQLSpecPlugin(sqlspec=sqlspec)
+
+   # Registry identity: resolves before the app exists
+   primary = plugin.get_config("primary")
+
+   app = Litestar(route_handlers=[], plugins=[plugin])
+
+   # Dependency identity: resolves only after registration
+   session_config = plugin.get_config("db_session")
+
+Give each database a distinct ``bind_key`` when several share the same config class.
+A config type resolves only when exactly one configuration uses it; a repeated type
+raises ``KeyError`` listing the candidate bind keys so you can pick the right one.
+A ``bind_key`` takes precedence over a dependency key of the same value in
+``get_config()``, while the request-scoped accessors always read strings as
+dependency keys.
+
 Advanced DuckDB Configuration
 -----------------------------
 

--- a/sqlspec/extensions/litestar/plugin.py
+++ b/sqlspec/extensions/litestar/plugin.py
@@ -454,6 +454,12 @@ class SQLSpecPlugin(InitPluginProtocol, CLIPlugin):
     ) -> "AsyncDatabaseConfig[Any, Any, Any] | NoPoolAsyncConfig[Any, Any]": ...
 
     @overload
+    def get_config(self, name: "SyncConfigT") -> "SyncConfigT": ...
+
+    @overload
+    def get_config(self, name: "AsyncConfigT") -> "AsyncConfigT": ...
+
+    @overload
     def get_config(self, name: str) -> "AnyDatabaseConfig": ...
 
     def get_config(
@@ -461,16 +467,24 @@ class SQLSpecPlugin(InitPluginProtocol, CLIPlugin):
     ) -> "DatabaseConfigProtocol[Any, Any, Any]":
         """Get a configuration instance by name.
 
+        Registry identifiers are available as soon as the plugin is constructed: a
+        config instance, its concrete config type when exactly one configuration has
+        that type, or a non-null ``bind_key``. A ``bind_key`` wins over a dependency
+        key of the same value. The generated Litestar dependency keys
+        (``session_key``, ``connection_key``, ``pool_key``) resolve only after the
+        plugin is registered with a Litestar application.
+
         Args:
             name: The configuration identifier.
 
         Raises:
-            KeyError: If no configuration is found for the given name.
+            KeyError: If no configuration is found for the given name, or if several
+                configurations share the requested concrete type.
 
         Returns:
             The configuration instance for the specified name.
         """
-        state = self._get_plugin_state(name)
+        state = self._registry_state(name) or self._dependency_state(name)
         return cast("DatabaseConfigProtocol[Any, Any, Any]", state.config)  # type: ignore[redundant-cast]
 
     def _ensure_connection_sync(self, plugin_state: PluginConfigState, state: "State", scope: "Scope") -> Any:
@@ -783,10 +797,54 @@ class SQLSpecPlugin(InitPluginProtocol, CLIPlugin):
         plugin_state = self._get_plugin_state(key)
         return await self._ensure_connection_async(plugin_state, state, scope)
 
+    def _registry_state(self, name: Any) -> "PluginConfigState | None":
+        """Resolve plugin state from registry identity, independent of Litestar registration.
+
+        Args:
+            name: A ``bind_key``, a config instance, or a concrete config type.
+
+        Raises:
+            KeyError: If several configurations share the requested concrete type.
+
+        Returns:
+            The matching plugin state, or ``None`` when the identifier is not a
+            registry identity.
+        """
+        if isinstance(name, str):
+            for state in self._plugin_configs:
+                if state.config.bind_key == name:
+                    return state
+            return None
+
+        if isinstance(name, type):
+            matches = [state for state in self._plugin_configs if type(state.config) is name]
+            if len(matches) > 1:
+                self._raise_ambiguous_config_type(name, matches)
+            return matches[0] if matches else None
+
+        for state in self._plugin_configs:
+            if state.config is name:
+                return state
+        return None
+
+    def _dependency_state(self, name: Any) -> PluginConfigState:
+        """Resolve plugin state from a Litestar dependency key, which exists only after registration.
+
+        Args:
+            name: A ``session_key``, ``connection_key``, or ``pool_key``.
+
+        Returns:
+            The matching plugin state.
+        """
+        for state in self._plugin_configs:
+            if state.annotation is None:
+                self._raise_plugin_not_registered()
+        return self._get_plugin_state(name)
+
     def _get_plugin_state(
         self, key: "str | DatabaseConfigProtocol[Any, Any, Any] | type[DatabaseConfigProtocol[Any, Any, Any]]"
     ) -> PluginConfigState:
-        """Get plugin state for a configuration by key."""
+        """Get plugin state for a configuration by Litestar dependency key, instance, or annotation."""
         if isinstance(key, str):
             for state in self._plugin_configs:
                 if key in {state.connection_key, state.pool_key, state.session_key}:
@@ -804,9 +862,11 @@ class SQLSpecPlugin(InitPluginProtocol, CLIPlugin):
 
     def _get_available_keys(self) -> "list[str]":
         """Get a list of all available configuration keys for error messages."""
-        keys = []
+        keys: list[str] = []
         for state in self._plugin_configs:
-            keys.extend([state.connection_key, state.pool_key, state.session_key])
+            for key in (state.config.bind_key, state.connection_key, state.pool_key, state.session_key):
+                if key is not None and key not in keys:
+                    keys.append(key)
         return keys
 
     def _ensure_dependency_keys(self) -> None:
@@ -845,6 +905,15 @@ class SQLSpecPlugin(InitPluginProtocol, CLIPlugin):
     def _raise_config_not_found(self, key: Any) -> NoReturn:
         """Raise error when configuration is not found."""
         msg = f"No database configuration found for name '{key}'. Available keys: {self._get_available_keys()}"
+        raise KeyError(msg)
+
+    def _raise_ambiguous_config_type(self, config_type: type, candidates: "list[PluginConfigState]") -> NoReturn:
+        """Raise error when several configurations share one concrete config type."""
+        bind_keys = [state.config.bind_key or "<unbound>" for state in candidates]
+        msg = (
+            f"Multiple database configurations use the type '{config_type.__name__}'. "
+            f"Look one up by its bind key instead. Candidate bind keys: {bind_keys}"
+        )
         raise KeyError(msg)
 
     def _raise_duplicate_connection_keys(self) -> None:

--- a/tests/unit/extensions/test_litestar/test_plugin_registration_guard.py
+++ b/tests/unit/extensions/test_litestar/test_plugin_registration_guard.py
@@ -1,36 +1,78 @@
-"""Tests for PluginConfigState access before on_app_init registration."""
+"""Tests for SQLSpecPlugin state access before on_app_init registration."""
+
+from typing import Any
 
 import pytest
 
 from sqlspec.adapters.aiosqlite.config import AiosqliteConfig
 from sqlspec.base import SQLSpec
 from sqlspec.exceptions import ImproperConfigurationError
-from sqlspec.extensions.litestar.plugin import DEFAULT_SESSION_KEY, SQLSpecPlugin
+from sqlspec.extensions.litestar.plugin import (
+    DEFAULT_CONNECTION_KEY,
+    DEFAULT_POOL_KEY,
+    DEFAULT_SESSION_KEY,
+    SQLSpecPlugin,
+)
+
+CUSTOM_KEYS = {"connection_key": "custom_connection", "pool_key": "custom_pool", "session_key": "custom_session"}
 
 
-def _build_unregistered_plugin() -> SQLSpecPlugin:
+def _build_unregistered_plugin(
+    bind_key: "str | None" = None, extension_config: "dict[str, Any] | None" = None
+) -> "tuple[SQLSpecPlugin, AiosqliteConfig]":
     """Build a plugin without running on_app_init."""
     sqlspec = SQLSpec()
-    sqlspec.add_config(AiosqliteConfig(connection_config={"database": ":memory:"}))
-    return SQLSpecPlugin(sqlspec=sqlspec)
+    config = sqlspec.add_config(
+        AiosqliteConfig(
+            connection_config={"database": ":memory:"}, bind_key=bind_key, extension_config=extension_config or {}
+        )
+    )
+    return SQLSpecPlugin(sqlspec=sqlspec), config
 
 
 def test_get_annotations_before_registration_raises_clear_error() -> None:
     """get_annotations() before on_app_init raises ImproperConfigurationError, not AttributeError."""
-    plugin = _build_unregistered_plugin()
+    plugin, _ = _build_unregistered_plugin()
     with pytest.raises(ImproperConfigurationError, match="on_app_init"):
         plugin.get_annotations()
 
 
 def test_get_annotation_before_registration_raises_clear_error() -> None:
     """get_annotation() before on_app_init raises ImproperConfigurationError, not AttributeError."""
-    plugin = _build_unregistered_plugin()
+    plugin, _ = _build_unregistered_plugin()
     with pytest.raises(ImproperConfigurationError, match="on_app_init"):
         plugin.get_annotation(DEFAULT_SESSION_KEY)
 
 
-def test_get_config_by_type_before_registration_raises_clear_error() -> None:
-    """get_config(config_type) before on_app_init raises ImproperConfigurationError, not AttributeError."""
-    plugin = _build_unregistered_plugin()
+def test_get_config_by_type_before_registration_returns_config() -> None:
+    """A concrete config type is a registry identity available at plugin construction."""
+    plugin, config = _build_unregistered_plugin()
+    assert plugin.get_config(AiosqliteConfig) is config
+
+
+def test_get_config_by_instance_before_registration_returns_config() -> None:
+    """A config instance resolves to itself at plugin construction."""
+    plugin, config = _build_unregistered_plugin()
+    assert plugin.get_config(config) is config
+
+
+def test_get_config_by_bind_key_before_registration_returns_config() -> None:
+    """A non-null bind_key resolves at plugin construction."""
+    plugin, config = _build_unregistered_plugin(bind_key="primary")
+    assert plugin.get_config("primary") is config
+
+
+@pytest.mark.parametrize("di_key", [DEFAULT_CONNECTION_KEY, DEFAULT_POOL_KEY, DEFAULT_SESSION_KEY])
+def test_get_config_by_default_di_key_before_registration_raises(di_key: str) -> None:
+    """Generated Litestar dependency keys stay registration-bound."""
+    plugin, _ = _build_unregistered_plugin()
     with pytest.raises(ImproperConfigurationError, match="on_app_init"):
-        plugin.get_config(AiosqliteConfig)
+        plugin.get_config(di_key)
+
+
+@pytest.mark.parametrize("di_key", list(CUSTOM_KEYS.values()))
+def test_get_config_by_custom_di_key_before_registration_raises(di_key: str) -> None:
+    """Custom Litestar dependency keys stay registration-bound."""
+    plugin, _ = _build_unregistered_plugin(bind_key="primary", extension_config={"litestar": CUSTOM_KEYS})
+    with pytest.raises(ImproperConfigurationError, match="on_app_init"):
+        plugin.get_config(di_key)

--- a/tests/unit/extensions/test_litestar/test_plugin_state_lookup.py
+++ b/tests/unit/extensions/test_litestar/test_plugin_state_lookup.py
@@ -1,10 +1,29 @@
 """Regression tests for SQLSpecPlugin key-lookup parity across state accessors."""
 
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
 from litestar.config.app import AppConfig
+from litestar.datastructures.state import State
 
 from sqlspec.adapters.aiosqlite.config import AiosqliteConfig
 from sqlspec.base import SQLSpec
+from sqlspec.extensions.litestar._utils import set_sqlspec_scope_state
 from sqlspec.extensions.litestar.plugin import DEFAULT_CONNECTION_KEY, DEFAULT_SESSION_KEY, SQLSpecPlugin
+
+if TYPE_CHECKING:
+    from litestar.types import HTTPScope
+
+REPLICA_KEYS: "dict[str, Any]" = {
+    "connection_key": "replica_connection",
+    "pool_key": "replica_pool",
+    "session_key": "replica_session",
+}
+ALIASED_KEYS: "dict[str, Any]" = {
+    "connection_key": "aliased_connection",
+    "pool_key": "aliased_pool",
+    "session_key": "aliased_session",
+}
 
 
 def _build_initialized_plugin() -> SQLSpecPlugin:
@@ -14,6 +33,18 @@ def _build_initialized_plugin() -> SQLSpecPlugin:
     plugin = SQLSpecPlugin(sqlspec=sqlspec)
     plugin.on_app_init(AppConfig())
     return plugin
+
+
+def _build_dual_plugin() -> "tuple[SQLSpecPlugin, AiosqliteConfig, AiosqliteConfig]":
+    """Build a plugin holding two configurations of the same concrete type."""
+    sqlspec = SQLSpec()
+    primary = sqlspec.add_config(AiosqliteConfig(connection_config={"database": ":memory:"}, bind_key="primary"))
+    replica = sqlspec.add_config(
+        AiosqliteConfig(
+            connection_config={"database": ":memory:"}, bind_key="replica", extension_config={"litestar": REPLICA_KEYS}
+        )
+    )
+    return SQLSpecPlugin(sqlspec=sqlspec), primary, replica
 
 
 def test_get_annotation_resolves_by_session_key() -> None:
@@ -30,3 +61,88 @@ def test_get_config_and_get_annotation_agree_on_session_key() -> None:
     config = plugin.get_config(DEFAULT_SESSION_KEY)
     assert plugin.get_config(DEFAULT_CONNECTION_KEY) is config
     assert plugin.get_annotation(DEFAULT_SESSION_KEY) is type(config)
+
+
+def test_post_registration_identifiers_agree() -> None:
+    """Bind key, unique config type, instance, and dependency keys resolve to one config."""
+    sqlspec = SQLSpec()
+    config = sqlspec.add_config(AiosqliteConfig(connection_config={"database": ":memory:"}, bind_key="primary"))
+    plugin = SQLSpecPlugin(sqlspec=sqlspec)
+    plugin.on_app_init(AppConfig())
+
+    assert plugin.get_config("primary") is config
+    assert plugin.get_config(AiosqliteConfig) is config
+    assert plugin.get_config(config) is config
+    assert plugin.get_config(DEFAULT_SESSION_KEY) is config
+    assert plugin.get_config(DEFAULT_CONNECTION_KEY) is config
+
+
+def test_distinct_bind_keys_resolve_before_registration() -> None:
+    """Two configs of the same type stay distinguishable by bind key at construction."""
+    plugin, primary, replica = _build_dual_plugin()
+    assert plugin.get_config("primary") is primary
+    assert plugin.get_config("replica") is replica
+
+
+def test_distinct_bind_keys_resolve_after_registration() -> None:
+    """Bind-key resolution is unchanged once on_app_init has run."""
+    plugin, primary, replica = _build_dual_plugin()
+    plugin.on_app_init(AppConfig())
+    assert plugin.get_config("primary") is primary
+    assert plugin.get_config("replica") is replica
+
+
+def test_repeated_config_type_is_ambiguous_before_registration() -> None:
+    """A repeated concrete type never falls back to first-match selection."""
+    plugin, _, _ = _build_dual_plugin()
+    with pytest.raises(KeyError) as exc_info:
+        plugin.get_config(AiosqliteConfig)
+    message = str(exc_info.value)
+    assert "primary" in message
+    assert "replica" in message
+
+
+def test_repeated_config_type_is_ambiguous_after_registration() -> None:
+    """Registration does not resolve the ambiguity of a repeated concrete type."""
+    plugin, _, _ = _build_dual_plugin()
+    plugin.on_app_init(AppConfig())
+    with pytest.raises(KeyError) as exc_info:
+        plugin.get_config(AiosqliteConfig)
+    message = str(exc_info.value)
+    assert "primary" in message
+    assert "replica" in message
+
+
+def test_unbound_config_type_ambiguity_lists_marker() -> None:
+    """Configs without a bind key are reported with an explicit marker."""
+    sqlspec = SQLSpec()
+    sqlspec.add_config(AiosqliteConfig(connection_config={"database": ":memory:"}))
+    sqlspec.add_config(
+        AiosqliteConfig(connection_config={"database": ":memory:"}, extension_config={"litestar": REPLICA_KEYS})
+    )
+    plugin = SQLSpecPlugin(sqlspec=sqlspec)
+    with pytest.raises(KeyError, match="<unbound>"):
+        plugin.get_config(AiosqliteConfig)
+
+
+def test_bind_key_wins_over_colliding_dependency_key() -> None:
+    """get_config() prefers a registry bind key while request accessors keep dependency-key meaning."""
+    sqlspec = SQLSpec()
+    aliased = sqlspec.add_config(
+        AiosqliteConfig(
+            connection_config={"database": ":memory:"},
+            bind_key=DEFAULT_SESSION_KEY,
+            extension_config={"litestar": ALIASED_KEYS},
+        )
+    )
+    default = sqlspec.add_config(AiosqliteConfig(connection_config={"database": ":memory:"}))
+    plugin = SQLSpecPlugin(sqlspec=sqlspec)
+    plugin.on_app_init(AppConfig())
+
+    assert plugin.get_config(DEFAULT_SESSION_KEY) is aliased
+    assert plugin.get_config(default) is default
+
+    scope = cast("HTTPScope", {"type": "http"})
+    connection = object()
+    set_sqlspec_scope_state(scope, DEFAULT_CONNECTION_KEY, connection)
+    assert plugin.provide_request_connection(DEFAULT_SESSION_KEY, State(), scope) is connection


### PR DESCRIPTION
`SQLSpecPlugin.get_config()` could not resolve a configuration until the plugin had been registered with a Litestar application, even though the plugin owns every configuration from the moment it is constructed. It also ignored each config's `bind_key` and recognised only generated Litestar dependency-injection keys.

- **Lookup works right after construction.** `get_config()` accepts a config instance, a config type, or a `bind_key` before `on_app_init()` ever runs.
- **`bind_key` is now a real identifier.** It is matched directly, and it takes precedence over a dependency key that happens to have the same string value.
- **Ambiguous types fail loudly.** Resolving by type works when exactly one configuration has that concrete type; multiple matches raise `KeyError` listing the candidate bind keys instead of silently returning the first match.
- **DI keys stay registration-bound.** `session_key`, `connection_key`, and `pool_key` identify generated Litestar wiring, so they still raise before registration, as do `get_annotation()` and `get_annotations()`. Request and connection providers are unchanged.

### How you use it

```python
plugin = SQLSpecPlugin(sqlspec=spec)

config = plugin.get_config("primary")      # by bind_key
config = plugin.get_config(AsyncpgConfig)  # by type, when unique
```

Both work before the plugin is passed to `Litestar(...)`, which makes it possible to build CLI commands, migration scripts, and standalone workers from the same plugin instance the app uses.

Closes #701
