### PR TITLE
feat(events): expose a public NOTIFY payload budget

### DIFF
--- a/docs/reference/extensions/events.rst
+++ b/docs/reference/extensions/events.rst
@@ -117,6 +117,64 @@ the caller's polling cadence is respected.
 ``ack`` / ``nack`` semantics are unchanged. ``notify`` remains
 fire-and-forget; ``notify_queue`` acknowledges through the durable table queue.
 
+Notification payload budget
+---------------------------
+
+PostgreSQL rejects a ``NOTIFY`` payload of 8,000 bytes or more, so SQLSpec
+publishes at most :data:`~sqlspec.extensions.events.POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES`
+(7,999) bytes. That budget covers the **complete encoded envelope** — the event
+ID, your payload mapping, your metadata mapping, and the publication timestamp —
+not just the payload you pass to ``publish()``. Sizes are counted in UTF-8
+bytes, so accented characters, emoji, and CJK text each consume more than one
+byte per character.
+
+Use :func:`~sqlspec.extensions.events.fits_notify_payload` to check a
+prospective event and :func:`~sqlspec.extensions.events.measure_notify_payload`
+to size chunks. Pass your own ``event_id`` when you do not let the backend
+generate the canonical UUID-hex identifier, so the measurement matches exactly
+what is published:
+
+.. code-block:: python
+
+   from sqlspec.extensions.events import (
+       POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES,
+       fits_notify_payload,
+       measure_notify_payload,
+   )
+
+
+   def chunk_records(records, event_id, metadata=None):
+       """Split records into batches that fit one native notification."""
+       chunk = []
+       for record in records:
+           candidate = [*chunk, record]
+           if chunk and not fits_notify_payload({"records": candidate}, metadata, event_id=event_id):
+               yield chunk
+               chunk = [record]
+               continue
+           chunk = candidate
+       if chunk:
+           yield chunk
+
+
+   payload = {"records": [{"id": 1}]}
+   if not fits_notify_payload(payload, event_id="ingest-42"):
+       overflow = measure_notify_payload(payload, event_id="ingest-42") - POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES
+       raise ValueError(f"event is {overflow} bytes over the notification budget")
+
+Publishing an oversized event raises
+:class:`~sqlspec.exceptions.EventChannelError` before any database call, and the
+message reports both the measured and the maximum byte count.
+
+Large content does not belong in a notification. Write it to a durable table or
+object store and notify with a compact reference — a row ID, a batch ID, or an
+object key — that the consumer resolves after it wakes up. For ``notify_queue``,
+SQLSpec already does this: batch markers carry only ``marker_id`` and
+``batch_size``, and the durable queue rows remain the source of truth. A
+transient ``notify`` event is never durable regardless of its size, so a
+notification that fits the budget is still a best-effort wakeup and not a
+delivery guarantee.
+
 Batch publication and recovery
 ==============================
 
@@ -319,6 +377,12 @@ Protocols
 
 Payload Helpers
 ===============
+
+.. autodata:: sqlspec.extensions.events.POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES
+
+.. autofunction:: sqlspec.extensions.events.measure_notify_payload
+
+.. autofunction:: sqlspec.extensions.events.fits_notify_payload
 
 .. autofunction:: sqlspec.extensions.events.encode_notify_payload
 

--- a/sqlspec/extensions/events/__init__.py
+++ b/sqlspec/extensions/events/__init__.py
@@ -11,7 +11,14 @@ from sqlspec.extensions.events._channel import (
 )
 from sqlspec.extensions.events._hints import EventRuntimeHints, get_runtime_hints, resolve_adapter_name
 from sqlspec.extensions.events._models import EventMessage
-from sqlspec.extensions.events._payload import decode_notify_payload, encode_notify_payload, parse_event_timestamp
+from sqlspec.extensions.events._payload import (
+    POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES,
+    decode_notify_payload,
+    encode_notify_payload,
+    fits_notify_payload,
+    measure_notify_payload,
+    parse_event_timestamp,
+)
 from sqlspec.extensions.events._protocols import (
     AsyncEventBackendProtocol,
     AsyncEventHandler,
@@ -26,6 +33,7 @@ from sqlspec.extensions.events._store import (
 )
 
 __all__ = (
+    "POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES",
     "AsyncEventBackendProtocol",
     "AsyncEventChannel",
     "AsyncEventHandler",
@@ -42,8 +50,10 @@ __all__ = (
     "build_queue_backend",
     "decode_notify_payload",
     "encode_notify_payload",
+    "fits_notify_payload",
     "get_runtime_hints",
     "load_native_backend",
+    "measure_notify_payload",
     "normalize_event_channel_name",
     "normalize_queue_table_name",
     "parse_event_timestamp",

--- a/sqlspec/extensions/events/_payload.py
+++ b/sqlspec/extensions/events/_payload.py
@@ -10,14 +10,17 @@ from sqlspec.utils.serializers import from_json, to_json
 from sqlspec.utils.uuids import uuid4
 
 __all__ = (
+    "POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES",
     "coerce_dict",
     "coerce_optional_dict",
     "decode_notify_payload",
     "encode_notify_payload",
+    "fits_notify_payload",
+    "measure_notify_payload",
     "parse_event_timestamp",
 )
 
-MAX_NOTIFY_BYTES = 8000
+POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES = 7999
 
 
 def coerce_dict(value: Any) -> "dict[str, Any]":
@@ -30,25 +33,60 @@ def coerce_optional_dict(value: Any) -> "dict[str, Any] | None":
     return value if value is None or isinstance(value, dict) else {"value": value}
 
 
-def encode_notify_payload(event_id: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None") -> str:
-    """Encode event data as JSON for NOTIFY payload.
+def _serialize_notify_envelope(
+    event_id: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None", published_at: "datetime"
+) -> bytes:
+    """Serialize a native notification envelope to UTF-8 JSON bytes.
 
-    Raises:
-        EventChannelError: If the encoded payload exceeds PostgreSQL's 8KB limit.
+    The publication timestamp is normalized to UTC with microsecond precision so
+    the encoded envelope width is independent of the clock reading.
     """
-    encoded = to_json(
+    return to_json(
         {
             "event_id": event_id,
             "payload": payload,
             "metadata": metadata,
-            "published_at": datetime.now(timezone.utc).isoformat(),
+            "published_at": published_at.astimezone(timezone.utc).isoformat(timespec="microseconds"),
         },
         as_bytes=True,
     )
-    if len(encoded) > MAX_NOTIFY_BYTES:
-        msg = "PostgreSQL NOTIFY payload exceeds 8 KB limit"
+
+
+def encode_notify_payload(event_id: str, payload: "dict[str, Any]", metadata: "dict[str, Any] | None") -> str:
+    """Encode event data as JSON for NOTIFY payload.
+
+    Raises:
+        EventChannelError: If the encoded envelope exceeds the PostgreSQL notification budget.
+    """
+    encoded = _serialize_notify_envelope(event_id, payload, metadata, datetime.now(timezone.utc))
+    encoded_bytes = len(encoded)
+    if encoded_bytes > POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES:
+        msg = (
+            f"PostgreSQL NOTIFY payload is {encoded_bytes} encoded bytes and exceeds the "
+            f"{POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES}-byte maximum. Use fits_notify_payload() or "
+            "measure_notify_payload() to split the batch before publishing."
+        )
         raise EventChannelError(msg)
     return encoded.decode("utf-8")
+
+
+def measure_notify_payload(
+    payload: "dict[str, Any]", metadata: "dict[str, Any] | None" = None, *, event_id: "str | None" = None
+) -> int:
+    """Return the encoded UTF-8 byte size of the native notification envelope.
+
+    The measurement covers the complete envelope rather than only the payload
+    mapping. Omitting ``event_id`` measures the canonical backend UUID-hex shape.
+    """
+    resolved_event_id = uuid4().hex if event_id is None else event_id
+    return len(_serialize_notify_envelope(resolved_event_id, payload, metadata, datetime.now(timezone.utc)))
+
+
+def fits_notify_payload(
+    payload: "dict[str, Any]", metadata: "dict[str, Any] | None" = None, *, event_id: "str | None" = None
+) -> bool:
+    """Return whether the native notification envelope fits the PostgreSQL budget."""
+    return measure_notify_payload(payload, metadata, event_id=event_id) <= POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES
 
 
 def decode_notify_payload(channel: str, payload: str) -> "EventMessage":

--- a/tests/unit/extensions/test_events/test_backend_factories.py
+++ b/tests/unit/extensions/test_events/test_backend_factories.py
@@ -1,6 +1,8 @@
 # pyright: reportPrivateUsage=false
 """Unit tests for adapter-specific event backend factories."""
 
+from typing import Any
+
 import pytest
 
 
@@ -352,12 +354,155 @@ def test_oracle_backend_envelope_round_trip() -> None:
     assert message.metadata == {"source": "api"}
 
 
-def test_shared_payload_max_notify_bytes_constant() -> None:
-    """Shared payload module has MAX_NOTIFY_BYTES constant."""
+def test_public_notify_payload_budget_exports() -> None:
+    """The notification payload budget and preflight helpers are public."""
+    from sqlspec.extensions.events import POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES, fits_notify_payload, measure_notify_payload
+
+    assert POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES == 7999
+    assert callable(measure_notify_payload)
+    assert callable(fits_notify_payload)
+
+
+def _payload_measuring_exactly(size: int, event_id: str) -> "dict[str, Any]":
+    """Build an ASCII payload whose encoded envelope measures ``size`` bytes."""
+    from sqlspec.extensions.events import measure_notify_payload
+
+    overhead = measure_notify_payload({"chunk": ""}, None, event_id=event_id)
+    return {"chunk": "a" * (size - overhead)}
+
+
+def test_measure_notify_payload_matches_encoded_ascii_bytes() -> None:
+    """ASCII measurement equals the UTF-8 length of the encoded envelope."""
+    from sqlspec.extensions.events import encode_notify_payload, measure_notify_payload
+
+    payload = {"action": "test"}
+    metadata = {"user": "admin"}
+
+    encoded = encode_notify_payload("evt123", payload, metadata)
+
+    assert measure_notify_payload(payload, metadata, event_id="evt123") == len(encoded.encode("utf-8"))
+
+
+def test_measure_notify_payload_counts_multibyte_bytes() -> None:
+    """Multibyte measurement counts UTF-8 bytes rather than characters."""
+    from sqlspec.extensions.events import encode_notify_payload, measure_notify_payload
+
+    payload = {"message": "héllo → 世界"}
+    metadata = {"locale": "日本語"}
+
+    encoded = encode_notify_payload("evt_unicode", payload, metadata)
+
+    assert measure_notify_payload(payload, metadata, event_id="evt_unicode") == len(encoded.encode("utf-8"))
+    assert len(encoded.encode("utf-8")) > len(encoded)
+
+
+def test_measure_notify_payload_defaults_to_canonical_event_id_width() -> None:
+    """Omitting the event ID measures the canonical backend UUID-hex shape."""
+    from sqlspec.extensions.events import encode_notify_payload, measure_notify_payload
+    from sqlspec.utils.uuids import uuid4
+
+    payload = {"action": "refresh"}
+
+    measured = measure_notify_payload(payload)
+    encoded = encode_notify_payload(uuid4().hex, payload, None)
+
+    assert measured == len(encoded.encode("utf-8"))
+
+
+@pytest.mark.parametrize("event_id", ["e", "0123456789abcdef0123456789abcdef", "producer-shard-42-" + "x" * 64])
+def test_measure_notify_payload_matches_encoding_for_explicit_event_ids(event_id: str) -> None:
+    """Explicit event IDs of any width preflight exactly."""
+    from sqlspec.extensions.events import encode_notify_payload, measure_notify_payload
+
+    payload = {"action": "reindex", "shard": 42}
+    metadata = {"origin": "batch"}
+
+    encoded = encode_notify_payload(event_id, payload, metadata)
+
+    assert measure_notify_payload(payload, metadata, event_id=event_id) == len(encoded.encode("utf-8"))
+
+
+def test_notify_payload_at_maximum_bytes_publishes() -> None:
+    """An envelope of exactly the maximum size fits and encodes."""
+    from sqlspec.extensions.events import (
+        POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES,
+        encode_notify_payload,
+        fits_notify_payload,
+        measure_notify_payload,
+    )
+
+    event_id = "evt_boundary"
+    payload = _payload_measuring_exactly(POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES, event_id)
+
+    assert measure_notify_payload(payload, None, event_id=event_id) == 7999
+    assert fits_notify_payload(payload, None, event_id=event_id) is True
+    assert len(encode_notify_payload(event_id, payload, None).encode("utf-8")) == 7999
+
+
+def test_notify_payload_one_byte_over_maximum_is_rejected() -> None:
+    """An envelope one byte past the maximum fails preflight and encoding."""
+    from sqlspec.exceptions import EventChannelError
+    from sqlspec.extensions.events import (
+        POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES,
+        encode_notify_payload,
+        fits_notify_payload,
+        measure_notify_payload,
+    )
+
+    event_id = "evt_boundary"
+    payload = _payload_measuring_exactly(POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES + 1, event_id)
+
+    assert measure_notify_payload(payload, None, event_id=event_id) == 8000
+    assert fits_notify_payload(payload, None, event_id=event_id) is False
+
+    with pytest.raises(EventChannelError, match="8000"):
+        encode_notify_payload(event_id, payload, None)
+
+
+@pytest.mark.parametrize("microsecond", [0, 5, 123456])
+def test_serialized_envelope_timestamp_width_is_constant(microsecond: int) -> None:
+    """Envelope timestamps keep a constant width regardless of microsecond value."""
+    import json
+    from datetime import datetime, timezone
+
     from sqlspec.extensions.events import _payload
 
-    assert hasattr(_payload, "MAX_NOTIFY_BYTES")
-    assert _payload.MAX_NOTIFY_BYTES == 8000
+    published_at = datetime(2024, 1, 15, 10, 0, 0, microsecond, tzinfo=timezone.utc)
+    encoded = _payload._serialize_notify_envelope("evt_ts", {"action": "test"}, None, published_at)
+
+    assert json.loads(encoded)["published_at"] == f"2024-01-15T10:00:00.{microsecond:06d}+00:00"
+
+
+def test_encode_notify_payload_uses_fixed_width_microsecond_timestamp() -> None:
+    """New envelopes carry a fixed-width UTC microsecond timestamp."""
+    import json
+    import re
+
+    from sqlspec.extensions.events import encode_notify_payload
+
+    published_at = json.loads(encode_notify_payload("evt_ts", {"action": "test"}, None))["published_at"]
+
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}\+00:00", published_at)
+    assert len(published_at) == 32
+
+
+@pytest.mark.parametrize(
+    "legacy_timestamp", ["2024-01-15T10:00:00+00:00", "2024-01-15T10:00:00.123+00:00", "2024-01-15T10:00:00.123456"]
+)
+def test_decode_notify_payload_accepts_legacy_timestamp_widths(legacy_timestamp: str) -> None:
+    """Envelopes emitted with variable-width ISO timestamps still decode."""
+    import json
+
+    from sqlspec.extensions.events import decode_notify_payload
+
+    payload = json.dumps({"event_id": "evt_legacy", "payload": {"a": 1}, "published_at": legacy_timestamp})
+
+    message = decode_notify_payload("alerts", payload)
+
+    assert message.created_at.year == 2024
+    assert message.created_at.month == 1
+    assert message.created_at.day == 15
+    assert message.created_at.hour == 10
 
 
 def test_shared_encode_notify_payload() -> None:


### PR DESCRIPTION
Producers had no supported way to check whether an event would fit in a native PostgreSQL `NOTIFY` before publishing it — the size limit was private and the only feedback was an exception thrown after the fact. This adds a public preflight so a batch can be chunked in advance.

- **New public API** on `sqlspec.extensions.events`: `POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES`, `measure_notify_payload()`, and `fits_notify_payload()`.
- **Measurement is exact.** It counts the complete encoded envelope in UTF-8 bytes, not just the payload mapping, using the same serialization the asyncpg, psycopg, and psqlpy backends already use. The encoder and the preflight share one serialization function, so they cannot drift apart.
- **Fixes an off-by-one at the boundary.** PostgreSQL requires a payload shorter than 8,000 bytes, but the old check accepted exactly 8,000 and let the server reject it. The limit is now 7,999: 7,999 bytes fit, 8,000 do not.
- **Better failure message.** Oversized publishes now report the measured byte count, the maximum, and which helper to use.
- **Timestamps are fixed-width**, so envelope size no longer varies with the clock reading. Previously emitted variable-width timestamps still decode.

### How you use it

```python
from sqlspec.extensions.events import fits_notify_payload

batch = []
for record in records:
    candidate = [*batch, record]
    if not fits_notify_payload({"records": candidate}):
        await channel.notify("events", {"records": batch})
        batch = [record]
    else:
        batch = candidate
```

Pass `event_id=` when you supply your own identifiers; omitting it measures against the canonical backend UUID shape.

Closes #711
