### PR TITLE
feat(adk): add ordering and pagination to session listings

### DIFF
--- a/docs/extensions/adk/quickstart.rst
+++ b/docs/extensions/adk/quickstart.rst
@@ -55,6 +55,46 @@ Events are persisted automatically when you use the session service with an
 ADK runner. Each call to ``append_event()`` atomically stores the event and
 updates the session's durable state via ``append_event_and_update_state()``.
 
+Listing Sessions
+----------------
+
+``SQLSpecSessionService.list_sessions()`` accepts optional ordering and paging
+arguments in addition to Google ADK's ``app_name`` and ``user_id``. They are a
+SQLSpec extension to ADK's narrower base signature, and the ordering and page
+bounds are applied in SQL rather than by trimming a fully materialized result.
+
+.. code-block:: python
+
+   # Most recently updated sessions for one user, 20 at a time
+   page = await session_service.list_sessions(
+       app_name="my_agent",
+       user_id="user_123",
+       limit=20,
+       offset=0,
+   )
+
+   # Oldest conversations first
+   oldest = await session_service.list_sessions(
+       app_name="my_agent",
+       user_id="user_123",
+       order_by="create_time",
+       descending=False,
+       limit=20,
+   )
+
+The contract is deliberately narrow:
+
+- The default is unchanged: ``update_time`` descending, with no page bounds.
+- ``order_by`` accepts only ``create_time`` or ``update_time``. No other value
+  and no raw SQL expression reaches a query.
+- ``id`` is applied as a secondary sort key in the same direction, so pages stay
+  deterministic when two sessions share a timestamp.
+- ``limit`` and ``offset`` accept non-negative integers. ``limit=0`` returns an
+  empty response without touching the database, and a positive ``offset``
+  requires a finite ``limit``.
+- The response is Google ADK's ``ListSessionsResponse``. It carries no total
+  count and no cursor token, so paginate by advancing ``offset`` yourself.
+
 Scoped State
 ------------
 

--- a/sqlspec/adapters/adbc/adk/store.py
+++ b/sqlspec/adapters/adbc/adk/store.py
@@ -619,7 +619,7 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         return cursor.execute(self._format_sql(sql), params)
 
     def _session_list_query(
-        self, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+        self, app_name: str, user_id: "str | None", column: str, direction: str, limit: "int | None", offset: int
     ) -> "tuple[str, tuple[Any, ...]]":
         """Return the bounded session-list query in the current dialect's page grammar."""
         params: list[Any] = [app_name]
@@ -641,7 +641,7 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         SELECT id, app_name, user_id, state, create_time, update_time
         FROM {self._session_table}
         WHERE {where_clause}
-        ORDER BY {order_clause}{page_clause}
+        ORDER BY {column} {direction}, id {direction}{page_clause}
         """
         return sql, tuple(params)
 
@@ -836,11 +836,11 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         Returns:
             List of session records.
         """
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
-        sql, params = self._session_list_query(app_name, user_id, order_clause, page_limit, page_offset)
+        sql, params = self._session_list_query(app_name, user_id, column, direction, page_limit, page_offset)
 
         try:
             with self._config.provide_connection() as conn:

--- a/sqlspec/adapters/adbc/adk/store.py
+++ b/sqlspec/adapters/adbc/adk/store.py
@@ -5,7 +5,7 @@ import re
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Final, Literal
 
-from sqlspec.extensions.adk import BaseSyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import BaseSyncADKStore, StoredEvent, StoredSession, normalize_session_list_options
 from sqlspec.extensions.adk.memory.store import BaseSyncADKMemoryStore
 from sqlspec.utils.logging import get_logger
 from sqlspec.utils.serializers import from_json, to_json
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from sqlspec.adapters.adbc.config import AdbcConfig
-    from sqlspec.extensions.adk import StoredMemory
+    from sqlspec.extensions.adk import SessionOrderBy, StoredMemory
 
 __all__ = ("AdbcADKMemoryStore", "AdbcADKStore")
 
@@ -96,9 +96,20 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         """Update session state."""
         self._update_session_state(app_name, user_id, session_id, state)
 
-    def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
+    def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List sessions for an app."""
-        return self._list_sessions(app_name, user_id)
+        return self._list_sessions(
+            app_name, user_id, order_by=order_by, descending=descending, limit=limit, offset=offset
+        )
 
     def delete_session(self, app_name: str, user_id: str, session_id: str) -> None:
         """Delete session and associated events."""
@@ -607,6 +618,33 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
         """Execute parameterized SQL using the current ADBC dialect's placeholder style."""
         return cursor.execute(self._format_sql(sql), params)
 
+    def _session_list_query(
+        self, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+    ) -> "tuple[str, tuple[Any, ...]]":
+        """Return the bounded session-list query in the current dialect's page grammar."""
+        params: list[Any] = [app_name]
+        where_clause = "app_name = ?"
+        if user_id is not None:
+            params.append(user_id)
+            where_clause = f"{where_clause} AND user_id = ?"
+
+        page_clause = ""
+        if limit is not None:
+            if self._dialect == DIALECT_GENERIC:
+                params.extend((offset, limit))
+                page_clause = "\n            OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
+            else:
+                params.extend((limit, offset))
+                page_clause = "\n            LIMIT ? OFFSET ?"
+
+        sql = f"""
+        SELECT id, app_name, user_id, state, create_time, update_time
+        FROM {self._session_table}
+        WHERE {where_clause}
+        ORDER BY {order_clause}{page_clause}
+        """
+        return sql, tuple(params)
+
     def _json_placeholder(self) -> str:
         """Return a JSON parameter placeholder for the current dialect."""
         if self._dialect == DIALECT_POSTGRESQL:
@@ -775,32 +813,34 @@ class AdbcADKStore(BaseSyncADKStore["AdbcConfig"]):
             finally:
                 cursor.close()
 
-    def _list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
+    def _list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List sessions for an app, optionally filtered by user.
 
         Args:
             app_name: Application name.
             user_id: User identifier. If None, lists all sessions for the app.
+            order_by: Timestamp column to sort on.
+            descending: Sort direction for the timestamp column and the id tie-break.
+            limit: Maximum number of sessions to return.
+            offset: Number of leading rows to skip.
 
         Returns:
-            List of session records ordered by update_time DESC.
+            List of session records.
         """
-        if user_id is None:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = ?
-            ORDER BY update_time DESC
-            """
-            params: tuple[str, ...] = (app_name,)
-        else:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = ? AND user_id = ?
-            ORDER BY update_time DESC
-            """
-            params = (app_name, user_id)
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
+
+        sql, params = self._session_list_query(app_name, user_id, order_clause, page_limit, page_offset)
 
         try:
             with self._config.provide_connection() as conn:

--- a/sqlspec/adapters/aiomysql/adk/store.py
+++ b/sqlspec/adapters/aiomysql/adk/store.py
@@ -175,11 +175,13 @@ class AiomysqlADKStore(BaseAsyncADKStore["AiomysqlConfig"]):
         offset: "int | None" = None,
     ) -> "list[StoredSession]":
         """List sessions for an app, optionally filtered by user."""
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
-        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
+        sql, params = _session_list_query(
+            self._session_table, app_name, user_id, column, direction, page_limit, page_offset
+        )
 
         try:
             async with (
@@ -954,7 +956,13 @@ def _build_mysql_scope_where(
 
 
 def _session_list_query(
-    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+    session_table: str,
+    app_name: str,
+    user_id: "str | None",
+    column: str,
+    direction: str,
+    limit: "int | None",
+    offset: int,
 ) -> "tuple[str, tuple[Any, ...]]":
     """Return the bounded session-list query and its bound values."""
     params: list[Any] = [app_name]
@@ -972,6 +980,6 @@ def _session_list_query(
     SELECT id, app_name, user_id, state, create_time, update_time
     FROM {session_table}
     WHERE {where_clause}
-    ORDER BY {order_clause}{page_clause}
+    ORDER BY {column} {direction}, id {direction}{page_clause}
     """
     return sql, tuple(params)

--- a/sqlspec/adapters/aiomysql/adk/store.py
+++ b/sqlspec/adapters/aiomysql/adk/store.py
@@ -9,7 +9,7 @@ from typing_extensions import NotRequired
 
 from sqlspec.adapters.aiomysql._typing import AiomysqlCursor, AiomysqlRawCursor
 from sqlspec.config import ADKConfig
-from sqlspec.extensions.adk import BaseAsyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import BaseAsyncADKStore, StoredEvent, StoredSession, normalize_session_list_options
 from sqlspec.extensions.adk.memory.store import BaseAsyncADKMemoryStore
 from sqlspec.utils.serializers import from_json, to_json
 
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from datetime import datetime, timedelta
 
     from sqlspec.adapters.aiomysql.config import AiomysqlConfig
-    from sqlspec.extensions.adk import StoredMemory
+    from sqlspec.extensions.adk import SessionOrderBy, StoredMemory
 
 
 __all__ = ("AiomysqlADKConfig", "AiomysqlADKMemoryStore", "AiomysqlADKStore")
@@ -164,24 +164,22 @@ class AiomysqlADKStore(BaseAsyncADKStore["AiomysqlConfig"]):
             await cursor.execute(sql, (to_json(state), app_name, user_id, session_id))
             await conn.commit()
 
-    async def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
+    async def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List sessions for an app, optionally filtered by user."""
-        if user_id is None:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = %s
-            ORDER BY update_time DESC
-            """
-            params: tuple[Any, ...] = (app_name,)
-        else:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = %s AND user_id = %s
-            ORDER BY update_time DESC
-            """
-            params = (app_name, user_id)
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
+
+        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
 
         try:
             async with (
@@ -953,3 +951,27 @@ def _build_mysql_scope_where(
     if scope_filter == "user":
         return "app_name = %s AND scope = 'user' AND user_id = %s", (app_name, user_id)
     return "app_name = %s AND scope = 'app'", (app_name,)
+
+
+def _session_list_query(
+    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+) -> "tuple[str, tuple[Any, ...]]":
+    """Return the bounded session-list query and its bound values."""
+    params: list[Any] = [app_name]
+    where_clause = "app_name = %s"
+    if user_id is not None:
+        params.append(user_id)
+        where_clause = f"{where_clause} AND user_id = %s"
+
+    page_clause = ""
+    if limit is not None:
+        params.extend((limit, offset))
+        page_clause = "\n            LIMIT %s OFFSET %s"
+
+    sql = f"""
+    SELECT id, app_name, user_id, state, create_time, update_time
+    FROM {session_table}
+    WHERE {where_clause}
+    ORDER BY {order_clause}{page_clause}
+    """
+    return sql, tuple(params)

--- a/sqlspec/adapters/aiosqlite/adk/store.py
+++ b/sqlspec/adapters/aiosqlite/adk/store.py
@@ -231,11 +231,13 @@ class AiosqliteADKStore(BaseAsyncADKStore["AiosqliteConfig"]):
         Returns:
             List of session records.
         """
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
-        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
+        sql, params = _session_list_query(
+            self._session_table, app_name, user_id, column, direction, page_limit, page_offset
+        )
 
         try:
             async with self._config.provide_connection() as conn:
@@ -1115,7 +1117,13 @@ def _build_sqlite_scope_clause(
 
 
 def _session_list_query(
-    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+    session_table: str,
+    app_name: str,
+    user_id: "str | None",
+    column: str,
+    direction: str,
+    limit: "int | None",
+    offset: int,
 ) -> "tuple[str, tuple[Any, ...]]":
     """Return the bounded session-list query and its bound values."""
     params: list[Any] = [app_name]
@@ -1133,6 +1141,6 @@ def _session_list_query(
     SELECT id, app_name, user_id, state, create_time, update_time
     FROM {session_table}
     WHERE {where_clause}
-    ORDER BY {order_clause}{page_clause}
+    ORDER BY {column} {direction}, id {direction}{page_clause}
     """
     return sql, tuple(params)

--- a/sqlspec/adapters/aiosqlite/adk/store.py
+++ b/sqlspec/adapters/aiosqlite/adk/store.py
@@ -11,7 +11,7 @@ from typing_extensions import NotRequired
 from sqlspec.adapters.aiosqlite.config import _render_pragmas
 from sqlspec.config import ADKConfig
 from sqlspec.exceptions import ImproperConfigurationError
-from sqlspec.extensions.adk import BaseAsyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import BaseAsyncADKStore, StoredEvent, StoredSession, normalize_session_list_options
 from sqlspec.extensions.adk.memory.store import BaseAsyncADKMemoryStore
 from sqlspec.utils.serializers import from_json, to_json
 
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from sqlspec.adapters.aiosqlite.config import AiosqliteConfig
-    from sqlspec.extensions.adk import StoredMemory
+    from sqlspec.extensions.adk import SessionOrderBy, StoredMemory
 
 __all__ = ("AiosqliteADKConfig", "AiosqliteADKMemoryStore", "AiosqliteADKStore")
 
@@ -208,32 +208,34 @@ class AiosqliteADKStore(BaseAsyncADKStore["AiosqliteConfig"]):
             await conn.execute(sql, (state_json, now_julian, app_name, user_id, session_id))
             await conn.commit()
 
-    async def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
+    async def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List sessions for an app, optionally filtered by user.
 
         Args:
             app_name: Application name.
             user_id: User identifier. If None, lists all sessions for the app.
+            order_by: Timestamp column to sort on.
+            descending: Sort direction for the timestamp column and the id tie-break.
+            limit: Maximum number of sessions to return.
+            offset: Number of leading rows to skip.
 
         Returns:
-            List of session records ordered by update_time DESC.
+            List of session records.
         """
-        if user_id is None:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = ?
-            ORDER BY update_time DESC
-            """
-            params: tuple[str, ...] = (app_name,)
-        else:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = ? AND user_id = ?
-            ORDER BY update_time DESC
-            """
-            params = (app_name, user_id)
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
+
+        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
 
         try:
             async with self._config.provide_connection() as conn:
@@ -1110,3 +1112,27 @@ def _build_sqlite_scope_clause(
     if scope_filter == "user":
         return f"{prefix}app_name = ? AND {prefix}scope = 'user' AND {prefix}user_id = ?", (app_name, user_id)
     return f"{prefix}app_name = ? AND {prefix}scope = 'app'", (app_name,)
+
+
+def _session_list_query(
+    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+) -> "tuple[str, tuple[Any, ...]]":
+    """Return the bounded session-list query and its bound values."""
+    params: list[Any] = [app_name]
+    where_clause = "app_name = ?"
+    if user_id is not None:
+        params.append(user_id)
+        where_clause = f"{where_clause} AND user_id = ?"
+
+    page_clause = ""
+    if limit is not None:
+        params.extend((limit, offset))
+        page_clause = "\n            LIMIT ? OFFSET ?"
+
+    sql = f"""
+    SELECT id, app_name, user_id, state, create_time, update_time
+    FROM {session_table}
+    WHERE {where_clause}
+    ORDER BY {order_clause}{page_clause}
+    """
+    return sql, tuple(params)

--- a/sqlspec/adapters/arrow_odbc/adk/store.py
+++ b/sqlspec/adapters/arrow_odbc/adk/store.py
@@ -7,7 +7,7 @@ from typing_extensions import NotRequired
 
 from sqlspec.config import ADKConfig
 from sqlspec.exceptions import SQLSpecError
-from sqlspec.extensions.adk import BaseSyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import BaseSyncADKStore, StoredEvent, StoredSession, normalize_session_list_options
 from sqlspec.extensions.adk.memory import BaseSyncADKMemoryStore, StoredMemory
 from sqlspec.utils.serializers import from_json, to_json
 
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from datetime import timedelta
 
     from sqlspec.adapters.arrow_odbc.config import ArrowOdbcConfig
+    from sqlspec.extensions.adk import SessionOrderBy
 else:
     ArrowOdbcConfig = Any
 
@@ -130,24 +131,22 @@ class ArrowOdbcADKStore(BaseSyncADKStore["ArrowOdbcConfig"]):
             commit=True,
         )
 
-    def list_sessions(self, app_name: str, user_id: "str | None" = None) -> "list[StoredSession]":
+    def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List ADK sessions for an application, optionally scoped to a user."""
-        if user_id is None:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {_table_ref(self._session_table)}
-            WHERE app_name = ?
-            ORDER BY update_time DESC
-            """
-            params: tuple[Any, ...] = (app_name,)
-        else:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {_table_ref(self._session_table)}
-            WHERE app_name = ? AND user_id = ?
-            ORDER BY update_time DESC
-            """
-            params = (app_name, user_id)
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
+
+        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
         try:
             rows = self._execute_fetchall(sql, params)
         except SQLSpecError as exc:
@@ -912,3 +911,27 @@ def _build_arrow_odbc_scope_where(
     if scope_filter == "user":
         return "app_name = ? AND scope = 'user' AND user_id = ?", (app_name, user_id)
     return "app_name = ? AND scope = 'app'", (app_name,)
+
+
+def _session_list_query(
+    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+) -> "tuple[str, tuple[Any, ...]]":
+    """Return the bounded session-list query and its bound values."""
+    params: list[Any] = [app_name]
+    where_clause = "app_name = ?"
+    if user_id is not None:
+        params.append(user_id)
+        where_clause = f"{where_clause} AND user_id = ?"
+
+    page_clause = ""
+    if limit is not None:
+        params.extend((offset, limit))
+        page_clause = "\n            OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
+
+    sql = f"""
+    SELECT id, app_name, user_id, state, create_time, update_time
+    FROM {_table_ref(session_table)}
+    WHERE {where_clause}
+    ORDER BY {order_clause}{page_clause}
+    """
+    return sql, tuple(params)

--- a/sqlspec/adapters/arrow_odbc/adk/store.py
+++ b/sqlspec/adapters/arrow_odbc/adk/store.py
@@ -142,11 +142,13 @@ class ArrowOdbcADKStore(BaseSyncADKStore["ArrowOdbcConfig"]):
         offset: "int | None" = None,
     ) -> "list[StoredSession]":
         """List ADK sessions for an application, optionally scoped to a user."""
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
-        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
+        sql, params = _session_list_query(
+            self._session_table, app_name, user_id, column, direction, page_limit, page_offset
+        )
         try:
             rows = self._execute_fetchall(sql, params)
         except SQLSpecError as exc:
@@ -914,7 +916,13 @@ def _build_arrow_odbc_scope_where(
 
 
 def _session_list_query(
-    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+    session_table: str,
+    app_name: str,
+    user_id: "str | None",
+    column: str,
+    direction: str,
+    limit: "int | None",
+    offset: int,
 ) -> "tuple[str, tuple[Any, ...]]":
     """Return the bounded session-list query and its bound values."""
     params: list[Any] = [app_name]
@@ -932,6 +940,6 @@ def _session_list_query(
     SELECT id, app_name, user_id, state, create_time, update_time
     FROM {_table_ref(session_table)}
     WHERE {where_clause}
-    ORDER BY {order_clause}{page_clause}
+    ORDER BY {column} {direction}, id {direction}{page_clause}
     """
     return sql, tuple(params)

--- a/sqlspec/adapters/asyncmy/adk/store.py
+++ b/sqlspec/adapters/asyncmy/adk/store.py
@@ -8,7 +8,7 @@ import asyncmy
 from typing_extensions import NotRequired
 
 from sqlspec.config import ADKConfig
-from sqlspec.extensions.adk import BaseAsyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import BaseAsyncADKStore, StoredEvent, StoredSession, normalize_session_list_options
 from sqlspec.extensions.adk.memory.store import BaseAsyncADKMemoryStore
 from sqlspec.utils.serializers import from_json, to_json
 
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from datetime import datetime, timedelta
 
     from sqlspec.adapters.asyncmy.config import AsyncmyConfig
-    from sqlspec.extensions.adk import StoredMemory
+    from sqlspec.extensions.adk import SessionOrderBy, StoredMemory
 
 
 __all__ = ("AsyncmyADKConfig", "AsyncmyADKMemoryStore", "AsyncmyADKStore")
@@ -147,24 +147,22 @@ class AsyncmyADKStore(BaseAsyncADKStore["AsyncmyConfig"]):
             await cursor.execute(sql, (to_json(state), app_name, user_id, session_id))
             await conn.commit()
 
-    async def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
+    async def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List sessions for an app, optionally filtered by user."""
-        if user_id is None:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = %s
-            ORDER BY update_time DESC
-            """
-            params: tuple[Any, ...] = (app_name,)
-        else:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = %s AND user_id = %s
-            ORDER BY update_time DESC
-            """
-            params = (app_name, user_id)
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
+
+        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
 
         try:
             async with self._config.provide_connection() as conn, conn.cursor() as cursor:
@@ -890,3 +888,27 @@ def _build_mysql_scope_where(
     if scope_filter == "user":
         return "app_name = %s AND scope = 'user' AND user_id = %s", (app_name, user_id)
     return "app_name = %s AND scope = 'app'", (app_name,)
+
+
+def _session_list_query(
+    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+) -> "tuple[str, tuple[Any, ...]]":
+    """Return the bounded session-list query and its bound values."""
+    params: list[Any] = [app_name]
+    where_clause = "app_name = %s"
+    if user_id is not None:
+        params.append(user_id)
+        where_clause = f"{where_clause} AND user_id = %s"
+
+    page_clause = ""
+    if limit is not None:
+        params.extend((limit, offset))
+        page_clause = "\n            LIMIT %s OFFSET %s"
+
+    sql = f"""
+    SELECT id, app_name, user_id, state, create_time, update_time
+    FROM {session_table}
+    WHERE {where_clause}
+    ORDER BY {order_clause}{page_clause}
+    """
+    return sql, tuple(params)

--- a/sqlspec/adapters/asyncmy/adk/store.py
+++ b/sqlspec/adapters/asyncmy/adk/store.py
@@ -158,11 +158,13 @@ class AsyncmyADKStore(BaseAsyncADKStore["AsyncmyConfig"]):
         offset: "int | None" = None,
     ) -> "list[StoredSession]":
         """List sessions for an app, optionally filtered by user."""
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
-        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
+        sql, params = _session_list_query(
+            self._session_table, app_name, user_id, column, direction, page_limit, page_offset
+        )
 
         try:
             async with self._config.provide_connection() as conn, conn.cursor() as cursor:
@@ -891,7 +893,13 @@ def _build_mysql_scope_where(
 
 
 def _session_list_query(
-    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+    session_table: str,
+    app_name: str,
+    user_id: "str | None",
+    column: str,
+    direction: str,
+    limit: "int | None",
+    offset: int,
 ) -> "tuple[str, tuple[Any, ...]]":
     """Return the bounded session-list query and its bound values."""
     params: list[Any] = [app_name]
@@ -909,6 +917,6 @@ def _session_list_query(
     SELECT id, app_name, user_id, state, create_time, update_time
     FROM {session_table}
     WHERE {where_clause}
-    ORDER BY {order_clause}{page_clause}
+    ORDER BY {column} {direction}, id {direction}{page_clause}
     """
     return sql, tuple(params)

--- a/sqlspec/adapters/asyncpg/adk/store.py
+++ b/sqlspec/adapters/asyncpg/adk/store.py
@@ -169,7 +169,7 @@ class AsyncpgADKStore(BaseAsyncADKStore[AsyncConfigT]):
         limit: "int | None" = None,
         offset: "int | None" = None,
     ) -> "list[StoredSession]":
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
@@ -190,7 +190,7 @@ class AsyncpgADKStore(BaseAsyncADKStore[AsyncConfigT]):
         SELECT id, app_name, user_id, state, create_time, update_time
         FROM {self._session_table}
         WHERE {where_clause}
-        ORDER BY {order_clause}{page_clause}
+        ORDER BY {column} {direction}, id {direction}{page_clause}
         """
 
         try:

--- a/sqlspec/adapters/asyncpg/adk/store.py
+++ b/sqlspec/adapters/asyncpg/adk/store.py
@@ -6,7 +6,7 @@ import asyncpg
 from typing_extensions import NotRequired
 
 from sqlspec.config import ADKConfig, AsyncConfigT
-from sqlspec.extensions.adk import BaseAsyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import BaseAsyncADKStore, StoredEvent, StoredSession, normalize_session_list_options
 from sqlspec.extensions.adk.memory.store import BaseAsyncADKMemoryStore
 
 if TYPE_CHECKING:
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from datetime import datetime, timedelta
 
     from sqlspec.adapters.asyncpg.config import AsyncpgConfig
-    from sqlspec.extensions.adk import StoredMemory
+    from sqlspec.extensions.adk import SessionOrderBy, StoredMemory
 
 
 __all__ = ("AsyncpgADKConfig", "AsyncpgADKMemoryStore", "AsyncpgADKStore")
@@ -159,23 +159,39 @@ class AsyncpgADKStore(BaseAsyncADKStore[AsyncConfigT]):
         async with self._config.provide_connection() as conn:
             await conn.execute(sql, app_name, user_id, session_id)
 
-    async def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
-        if user_id is None:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = $1
-            ORDER BY update_time DESC
-            """
-            params = [app_name]
-        else:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = $1 AND user_id = $2
-            ORDER BY update_time DESC
-            """
-            params = [app_name, user_id]
+    async def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
+
+        params: list[Any] = [app_name]
+        where_clause = "app_name = $1"
+        if user_id is not None:
+            params.append(user_id)
+            where_clause = f"{where_clause} AND user_id = ${len(params)}"
+
+        page_clause = ""
+        if page_limit is not None:
+            params.append(page_limit)
+            limit_placeholder = f"${len(params)}"
+            params.append(page_offset)
+            page_clause = f"\n            LIMIT {limit_placeholder} OFFSET ${len(params)}"
+
+        sql = f"""
+        SELECT id, app_name, user_id, state, create_time, update_time
+        FROM {self._session_table}
+        WHERE {where_clause}
+        ORDER BY {order_clause}{page_clause}
+        """
 
         try:
             async with self._config.provide_connection() as conn:

--- a/sqlspec/adapters/bigquery/adk/store.py
+++ b/sqlspec/adapters/bigquery/adk/store.py
@@ -340,7 +340,7 @@ class BigQueryADKStore(BaseSyncADKStore[BigQueryConfig]):
         limit: "int | None" = None,
         offset: "int | None" = None,
     ) -> "list[StoredSession]":
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
@@ -358,7 +358,7 @@ class BigQueryADKStore(BaseSyncADKStore[BigQueryConfig]):
         if user_id is not None:
             sql += " AND user_id = @user_id"
             params.append(self._query_param("user_id", user_id))
-        sql += f" ORDER BY {order_clause}"
+        sql += f" ORDER BY {column} {direction}, id {direction}"
         if page_limit is not None:
             sql += " LIMIT @limit OFFSET @offset"
             params.append(self._query_param("limit", page_limit, bq_type="INT64"))

--- a/sqlspec/adapters/bigquery/adk/store.py
+++ b/sqlspec/adapters/bigquery/adk/store.py
@@ -17,13 +17,15 @@ from typing_extensions import NotRequired, TypedDict
 
 from sqlspec.adapters.bigquery.config import BigQueryConfig
 from sqlspec.config import ADKConfig
-from sqlspec.extensions.adk import BaseSyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import BaseSyncADKStore, StoredEvent, StoredSession, normalize_session_list_options
 from sqlspec.extensions.adk._config_utils import _adk_config_from_extension
 from sqlspec.utils.serializers import from_json, to_json
 from sqlspec.utils.uuids import uuid4
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
+    from sqlspec.extensions.adk import SessionOrderBy
 
 __all__ = ("BigQueryADKConfig", "BigQueryADKRetentionConfig", "BigQueryADKStore")
 
@@ -109,9 +111,20 @@ class BigQueryADKStore(BaseSyncADKStore[BigQueryConfig]):
         """Replace the durable session state snapshot."""
         self._update_session_state(app_name, user_id, session_id, state)
 
-    def list_sessions(self, app_name: str, user_id: "str | None" = None) -> "list[StoredSession]":
+    def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List sessions for an app, optionally filtered by user."""
-        return self._list_sessions(app_name, user_id)
+        return self._list_sessions(
+            app_name, user_id, order_by=order_by, descending=descending, limit=limit, offset=offset
+        )
 
     def delete_session(self, app_name: str, user_id: str, session_id: str) -> None:
         """Delete a session and its replicated events."""
@@ -317,7 +330,20 @@ class BigQueryADKStore(BaseSyncADKStore[BigQueryConfig]):
             ],
         )
 
-    def _list_sessions(self, app_name: str, user_id: "str | None" = None) -> "list[StoredSession]":
+    def _list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
+
         window_start = datetime.now(timezone.utc) - timedelta(days=self._lookup_window_days)
         sql = f"""
         SELECT id, app_name, user_id, state, create_time, update_time
@@ -332,7 +358,11 @@ class BigQueryADKStore(BaseSyncADKStore[BigQueryConfig]):
         if user_id is not None:
             sql += " AND user_id = @user_id"
             params.append(self._query_param("user_id", user_id))
-        sql += " ORDER BY update_time DESC"
+        sql += f" ORDER BY {order_clause}"
+        if page_limit is not None:
+            sql += " LIMIT @limit OFFSET @offset"
+            params.append(self._query_param("limit", page_limit, bq_type="INT64"))
+            params.append(self._query_param("offset", page_offset, bq_type="INT64"))
         rows = self._run_query(sql, params)
         return [_session_record_from_row(row) for row in rows]
 

--- a/sqlspec/adapters/cockroach_asyncpg/adk/store.py
+++ b/sqlspec/adapters/cockroach_asyncpg/adk/store.py
@@ -6,7 +6,7 @@ import asyncpg
 from typing_extensions import NotRequired
 
 from sqlspec.config import ADKConfig
-from sqlspec.extensions.adk import BaseAsyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import BaseAsyncADKStore, StoredEvent, StoredSession, normalize_session_list_options
 from sqlspec.extensions.adk.memory.store import BaseAsyncADKMemoryStore
 from sqlspec.utils.logging import get_logger
 
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from datetime import datetime, timedelta
 
     from sqlspec.adapters.cockroach_asyncpg.config import CockroachAsyncpgConfig
-    from sqlspec.extensions.adk import StoredMemory
+    from sqlspec.extensions.adk import SessionOrderBy, StoredMemory
 
 
 __all__ = ("CockroachAsyncpgADKConfig", "CockroachAsyncpgADKMemoryStore", "CockroachAsyncpgADKStore")
@@ -155,23 +155,40 @@ class CockroachAsyncpgADKStore(BaseAsyncADKStore["CockroachAsyncpgConfig"]):
         async with self._config.provide_connection() as conn:
             await conn.execute(sql, state, app_name, user_id, session_id)
 
-    async def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
-        if user_id is None:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = $1
-            ORDER BY update_time DESC
-            """
-            params: tuple[Any, ...] = (app_name,)
-        else:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = $1 AND user_id = $2
-            ORDER BY update_time DESC
-            """
-            params = (app_name, user_id)
+    async def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
+
+        values: list[Any] = [app_name]
+        where_clause = "app_name = $1"
+        if user_id is not None:
+            values.append(user_id)
+            where_clause = f"{where_clause} AND user_id = ${len(values)}"
+
+        page_clause = ""
+        if page_limit is not None:
+            values.append(page_limit)
+            limit_placeholder = f"${len(values)}"
+            values.append(page_offset)
+            page_clause = f"\n            LIMIT {limit_placeholder} OFFSET ${len(values)}"
+
+        sql = f"""
+        SELECT id, app_name, user_id, state, create_time, update_time
+        FROM {self._session_table}
+        WHERE {where_clause}
+        ORDER BY {order_clause}{page_clause}
+        """
+        params: tuple[Any, ...] = tuple(values)
 
         try:
             async with self._config.provide_connection() as conn:

--- a/sqlspec/adapters/cockroach_asyncpg/adk/store.py
+++ b/sqlspec/adapters/cockroach_asyncpg/adk/store.py
@@ -165,7 +165,7 @@ class CockroachAsyncpgADKStore(BaseAsyncADKStore["CockroachAsyncpgConfig"]):
         limit: "int | None" = None,
         offset: "int | None" = None,
     ) -> "list[StoredSession]":
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
@@ -186,7 +186,7 @@ class CockroachAsyncpgADKStore(BaseAsyncADKStore["CockroachAsyncpgConfig"]):
         SELECT id, app_name, user_id, state, create_time, update_time
         FROM {self._session_table}
         WHERE {where_clause}
-        ORDER BY {order_clause}{page_clause}
+        ORDER BY {column} {direction}, id {direction}{page_clause}
         """
         params: tuple[Any, ...] = tuple(values)
 

--- a/sqlspec/adapters/cockroach_psycopg/adk/store.py
+++ b/sqlspec/adapters/cockroach_psycopg/adk/store.py
@@ -305,11 +305,13 @@ class CockroachPsycopgAsyncADKStore(BaseAsyncADKStore["CockroachPsycopgAsyncConf
         limit: "int | None" = None,
         offset: "int | None" = None,
     ) -> "list[StoredSession]":
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
-        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
+        sql, params = _session_list_query(
+            self._session_table, app_name, user_id, column, direction, page_limit, page_offset
+        )
 
         try:
             async with self._config.provide_connection() as conn, conn.cursor(row_factory=dict_row) as cur:
@@ -782,11 +784,13 @@ class CockroachPsycopgSyncADKStore(BaseSyncADKStore["CockroachPsycopgSyncConfig"
         offset: "int | None" = None,
     ) -> "list[StoredSession]":
         """List sessions for an app."""
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
-        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
+        sql, params = _session_list_query(
+            self._session_table, app_name, user_id, column, direction, page_limit, page_offset
+        )
 
         try:
             with self._config.provide_connection() as conn, conn.cursor(row_factory=dict_row) as cur:
@@ -1623,7 +1627,13 @@ def _build_cockroach_scope_where(
 
 
 def _session_list_query(
-    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+    session_table: str,
+    app_name: str,
+    user_id: "str | None",
+    column: str,
+    direction: str,
+    limit: "int | None",
+    offset: int,
 ) -> "tuple[str, tuple[Any, ...]]":
     """Return the bounded session-list query and its bound values."""
     params: list[Any] = [app_name]
@@ -1641,6 +1651,6 @@ def _session_list_query(
     SELECT id, app_name, user_id, state, create_time, update_time
     FROM {session_table}
     WHERE {where_clause}
-    ORDER BY {order_clause}{page_clause}
+    ORDER BY {column} {direction}, id {direction}{page_clause}
     """
     return sql, tuple(params)

--- a/sqlspec/adapters/cockroach_psycopg/adk/store.py
+++ b/sqlspec/adapters/cockroach_psycopg/adk/store.py
@@ -9,7 +9,13 @@ from psycopg.types.json import Jsonb
 from typing_extensions import NotRequired
 
 from sqlspec.config import ADKConfig
-from sqlspec.extensions.adk import BaseAsyncADKStore, BaseSyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import (
+    BaseAsyncADKStore,
+    BaseSyncADKStore,
+    StoredEvent,
+    StoredSession,
+    normalize_session_list_options,
+)
 from sqlspec.extensions.adk.memory.store import BaseAsyncADKMemoryStore, BaseSyncADKMemoryStore
 from sqlspec.utils.logging import get_logger
 
@@ -18,7 +24,7 @@ if TYPE_CHECKING:
     from datetime import datetime, timedelta
 
     from sqlspec.adapters.cockroach_psycopg.config import CockroachPsycopgAsyncConfig, CockroachPsycopgSyncConfig
-    from sqlspec.extensions.adk import StoredMemory
+    from sqlspec.extensions.adk import SessionOrderBy, StoredMemory
 
 
 __all__ = (
@@ -289,23 +295,21 @@ class CockroachPsycopgAsyncADKStore(BaseAsyncADKStore["CockroachPsycopgAsyncConf
             await cur.execute(sql.encode(), (Jsonb(state), app_name, user_id, session_id))
             await conn.commit()
 
-    async def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
-        if user_id is None:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = %s
-            ORDER BY update_time DESC
-            """
-            params: tuple[str, ...] = (app_name,)
-        else:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = %s AND user_id = %s
-            ORDER BY update_time DESC
-            """
-            params = (app_name, user_id)
+    async def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
+
+        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
 
         try:
             async with self._config.provide_connection() as conn, conn.cursor(row_factory=dict_row) as cur:
@@ -767,24 +771,22 @@ class CockroachPsycopgSyncADKStore(BaseSyncADKStore["CockroachPsycopgSyncConfig"
             cur.execute(sql.encode(), (Jsonb(state), app_name, user_id, session_id))
             conn.commit()
 
-    def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
+    def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List sessions for an app."""
-        if user_id is None:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = %s
-            ORDER BY update_time DESC
-            """
-            params: tuple[str, ...] = (app_name,)
-        else:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = %s AND user_id = %s
-            ORDER BY update_time DESC
-            """
-            params = (app_name, user_id)
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
+
+        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
 
         try:
             with self._config.provide_connection() as conn, conn.cursor(row_factory=dict_row) as cur:
@@ -1618,3 +1620,27 @@ def _build_cockroach_scope_where(
     if scope_filter == "user":
         return "app_name = %s AND scope = 'user' AND user_id = %s", (app_name, user_id)
     return "app_name = %s AND scope = 'app'", (app_name,)
+
+
+def _session_list_query(
+    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+) -> "tuple[str, tuple[Any, ...]]":
+    """Return the bounded session-list query and its bound values."""
+    params: list[Any] = [app_name]
+    where_clause = "app_name = %s"
+    if user_id is not None:
+        params.append(user_id)
+        where_clause = f"{where_clause} AND user_id = %s"
+
+    page_clause = ""
+    if limit is not None:
+        params.extend((limit, offset))
+        page_clause = "\n            LIMIT %s OFFSET %s"
+
+    sql = f"""
+    SELECT id, app_name, user_id, state, create_time, update_time
+    FROM {session_table}
+    WHERE {where_clause}
+    ORDER BY {order_clause}{page_clause}
+    """
+    return sql, tuple(params)

--- a/sqlspec/adapters/duckdb/adk/store.py
+++ b/sqlspec/adapters/duckdb/adk/store.py
@@ -586,11 +586,13 @@ class DuckdbADKStore(BaseSyncADKStore["DuckDBConfig"]):
         offset: "int | None" = None,
     ) -> "list[StoredSession]":
         """Synchronous implementation of list_sessions."""
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
-        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
+        sql, params = _session_list_query(
+            self._session_table, app_name, user_id, column, direction, page_limit, page_offset
+        )
 
         try:
             with self._config.provide_connection() as conn:
@@ -1326,7 +1328,13 @@ def _build_duckdb_scope_where(
 
 
 def _session_list_query(
-    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+    session_table: str,
+    app_name: str,
+    user_id: "str | None",
+    column: str,
+    direction: str,
+    limit: "int | None",
+    offset: int,
 ) -> "tuple[str, tuple[Any, ...]]":
     """Return the bounded session-list query and its bound values."""
     params: list[Any] = [app_name]
@@ -1344,6 +1352,6 @@ def _session_list_query(
     SELECT id, app_name, user_id, state, create_time, update_time
     FROM {session_table}
     WHERE {where_clause}
-    ORDER BY {order_clause}{page_clause}
+    ORDER BY {column} {direction}, id {direction}{page_clause}
     """
     return sql, tuple(params)

--- a/sqlspec/adapters/duckdb/adk/store.py
+++ b/sqlspec/adapters/duckdb/adk/store.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any, Final, Literal, cast
 from typing_extensions import NotRequired, TypedDict
 
 from sqlspec.config import ADKConfig
-from sqlspec.extensions.adk import BaseSyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import BaseSyncADKStore, StoredEvent, StoredSession, normalize_session_list_options
 from sqlspec.extensions.adk.memory.store import BaseSyncADKMemoryStore
 from sqlspec.utils.logging import get_logger
 from sqlspec.utils.serializers import from_json, to_json
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from sqlspec.adapters.duckdb.config import DuckDBConfig
-    from sqlspec.extensions.adk import StoredMemory
+    from sqlspec.extensions.adk import SessionOrderBy, StoredMemory
 
 
 __all__ = ("DuckdbADKConfig", "DuckdbADKFTSOptions", "DuckdbADKMemoryStore", "DuckdbADKStore")
@@ -161,17 +161,32 @@ class DuckdbADKStore(BaseSyncADKStore["DuckDBConfig"]):
         """
         self._update_session_state(app_name, user_id, session_id, state)
 
-    def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
+    def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List sessions for an app, optionally filtered by user.
 
         Args:
             app_name: Application name.
             user_id: User identifier. If None, lists all sessions for the app.
+            order_by: Timestamp column to sort on.
+            descending: Sort direction for the timestamp column and the id tie-break.
+            limit: Maximum number of sessions to return.
+            offset: Number of leading rows to skip.
 
         Returns:
-            List of session records ordered by update_time DESC.
+            List of session records.
         """
-        return self._list_sessions(app_name, user_id)
+        return self._list_sessions(
+            app_name, user_id, order_by=order_by, descending=descending, limit=limit, offset=offset
+        )
 
     def delete_session(self, app_name: str, user_id: str, session_id: str) -> None:
         """Delete session and all associated events.
@@ -560,24 +575,22 @@ class DuckdbADKStore(BaseSyncADKStore["DuckDBConfig"]):
             conn.execute(delete_session_sql, (app_name, user_id, session_id))
             conn.commit()
 
-    def _list_sessions(self, app_name: str, user_id: "str | None" = None) -> "list[StoredSession]":
+    def _list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """Synchronous implementation of list_sessions."""
-        if user_id is None:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = ?
-            ORDER BY update_time DESC
-            """
-            params: tuple[str, ...] = (app_name,)
-        else:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = ? AND user_id = ?
-            ORDER BY update_time DESC
-            """
-            params = (app_name, user_id)
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
+
+        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
 
         try:
             with self._config.provide_connection() as conn:
@@ -1310,3 +1323,27 @@ def _build_duckdb_scope_where(
     if scope_filter == "user":
         return f"{pfx}app_name = ? AND {pfx}scope = 'user' AND {pfx}user_id = ?", (app_name, user_id)
     return f"{pfx}app_name = ? AND {pfx}scope = 'app'", (app_name,)
+
+
+def _session_list_query(
+    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+) -> "tuple[str, tuple[Any, ...]]":
+    """Return the bounded session-list query and its bound values."""
+    params: list[Any] = [app_name]
+    where_clause = "app_name = ?"
+    if user_id is not None:
+        params.append(user_id)
+        where_clause = f"{where_clause} AND user_id = ?"
+
+    page_clause = ""
+    if limit is not None:
+        params.extend((limit, offset))
+        page_clause = "\n            LIMIT ? OFFSET ?"
+
+    sql = f"""
+    SELECT id, app_name, user_id, state, create_time, update_time
+    FROM {session_table}
+    WHERE {where_clause}
+    ORDER BY {order_clause}{page_clause}
+    """
+    return sql, tuple(params)

--- a/sqlspec/adapters/mssql_python/adk/store.py
+++ b/sqlspec/adapters/mssql_python/adk/store.py
@@ -147,11 +147,13 @@ class MssqlPythonADKStore(BaseSyncADKStore["MssqlPythonConfig"]):
         offset: "int | None" = None,
     ) -> "list[StoredSession]":
         """List ADK sessions for an application, optionally scoped to a user."""
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
-        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
+        sql, params = _session_list_query(
+            self._session_table, app_name, user_id, column, direction, page_limit, page_offset
+        )
         try:
             rows = self._execute_fetchall(sql, params)
         except MSSQL_ERROR as exc:
@@ -700,7 +702,13 @@ def _raise_session_not_found(session_id: str) -> None:
 
 
 def _session_list_query(
-    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+    session_table: str,
+    app_name: str,
+    user_id: "str | None",
+    column: str,
+    direction: str,
+    limit: "int | None",
+    offset: int,
 ) -> "tuple[str, tuple[Any, ...]]":
     """Return the bounded session-list query and its bound values."""
     params: list[Any] = [app_name]
@@ -718,6 +726,6 @@ def _session_list_query(
     SELECT id, app_name, user_id, state, create_time, update_time
     FROM {_table_ref(session_table)}
     WHERE {where_clause}
-    ORDER BY {order_clause}{page_clause}
+    ORDER BY {column} {direction}, id {direction}{page_clause}
     """
     return sql, tuple(params)

--- a/sqlspec/adapters/mssql_python/adk/store.py
+++ b/sqlspec/adapters/mssql_python/adk/store.py
@@ -9,7 +9,7 @@ from typing_extensions import NotRequired
 from sqlspec.adapters.mssql_python._typing import MSSQL_PYTHON_MODULE, MssqlPythonCursor
 from sqlspec.adapters.mssql_python.data_dictionary import MssqlVersionInfo
 from sqlspec.config import ADKConfig
-from sqlspec.extensions.adk import BaseSyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import BaseSyncADKStore, StoredEvent, StoredSession, normalize_session_list_options
 from sqlspec.utils.serializers import from_json, to_json
 
 if TYPE_CHECKING:
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
     from sqlspec.adapters.mssql_python.config import MssqlPythonConfig
     from sqlspec.adapters.mssql_python.driver import MssqlPythonDriver
+    from sqlspec.extensions.adk import SessionOrderBy
 
 __all__ = ("MssqlPythonADKConfig", "MssqlPythonADKStore")
 
@@ -135,24 +136,22 @@ class MssqlPythonADKStore(BaseSyncADKStore["MssqlPythonConfig"]):
             commit=True,
         )
 
-    def list_sessions(self, app_name: str, user_id: "str | None" = None) -> "list[StoredSession]":
+    def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List ADK sessions for an application, optionally scoped to a user."""
-        if user_id is None:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {_table_ref(self._session_table)}
-            WHERE app_name = ?
-            ORDER BY update_time DESC
-            """
-            params: tuple[Any, ...] = (app_name,)
-        else:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {_table_ref(self._session_table)}
-            WHERE app_name = ? AND user_id = ?
-            ORDER BY update_time DESC
-            """
-            params = (app_name, user_id)
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
+
+        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
         try:
             rows = self._execute_fetchall(sql, params)
         except MSSQL_ERROR as exc:
@@ -698,3 +697,27 @@ def _escape_sql_literal(value: str) -> str:
 def _raise_session_not_found(session_id: str) -> None:
     msg = f"Session {session_id} not found during append_event_and_update_state."
     raise ValueError(msg)
+
+
+def _session_list_query(
+    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+) -> "tuple[str, tuple[Any, ...]]":
+    """Return the bounded session-list query and its bound values."""
+    params: list[Any] = [app_name]
+    where_clause = "app_name = ?"
+    if user_id is not None:
+        params.append(user_id)
+        where_clause = f"{where_clause} AND user_id = ?"
+
+    page_clause = ""
+    if limit is not None:
+        params.extend((offset, limit))
+        page_clause = "\n            OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
+
+    sql = f"""
+    SELECT id, app_name, user_id, state, create_time, update_time
+    FROM {_table_ref(session_table)}
+    WHERE {where_clause}
+    ORDER BY {order_clause}{page_clause}
+    """
+    return sql, tuple(params)

--- a/sqlspec/adapters/mysqlconnector/adk/store.py
+++ b/sqlspec/adapters/mysqlconnector/adk/store.py
@@ -7,7 +7,13 @@ from typing import TYPE_CHECKING, Any, Final, Literal, cast
 from typing_extensions import NotRequired
 
 from sqlspec.config import ADKConfig
-from sqlspec.extensions.adk import BaseAsyncADKStore, BaseSyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import (
+    BaseAsyncADKStore,
+    BaseSyncADKStore,
+    StoredEvent,
+    StoredSession,
+    normalize_session_list_options,
+)
 from sqlspec.extensions.adk.memory.store import BaseAsyncADKMemoryStore, BaseSyncADKMemoryStore
 from sqlspec.protocols import HasErrnoProtocol
 from sqlspec.utils.serializers import from_json, to_json
@@ -17,7 +23,7 @@ if TYPE_CHECKING:
     from datetime import datetime, timedelta
 
     from sqlspec.adapters.mysqlconnector.config import MysqlConnectorAsyncConfig, MysqlConnectorSyncConfig
-    from sqlspec.extensions.adk import StoredMemory
+    from sqlspec.extensions.adk import SessionOrderBy, StoredMemory
 
 
 __all__ = (
@@ -261,25 +267,23 @@ class MysqlConnectorAsyncADKStore(BaseAsyncADKStore["MysqlConnectorAsyncConfig"]
                 await cursor.close()
             await conn.commit()
 
-    async def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
-        import mysql.connector
+    async def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
 
-        if user_id is None:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = %s
-            ORDER BY update_time DESC
-            """
-            params: tuple[Any, ...] = (app_name,)
-        else:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = %s AND user_id = %s
-            ORDER BY update_time DESC
-            """
-            params = (app_name, user_id)
+        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
+
+        import mysql.connector
 
         try:
             async with self._config.provide_connection() as conn:
@@ -617,26 +621,24 @@ class MysqlConnectorSyncADKStore(BaseSyncADKStore["MysqlConnectorSyncConfig"]):
                 cursor.close()
             conn.commit()
 
-    def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
+    def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List sessions for an app."""
-        import mysql.connector
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
 
-        if user_id is None:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = %s
-            ORDER BY update_time DESC
-            """
-            params: tuple[Any, ...] = (app_name,)
-        else:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = %s AND user_id = %s
-            ORDER BY update_time DESC
-            """
-            params = (app_name, user_id)
+        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
+
+        import mysql.connector
 
         try:
             with self._config.provide_connection() as conn:
@@ -1602,3 +1604,27 @@ def _build_mysql_scope_where(
     if scope_filter == "user":
         return "app_name = %s AND scope = 'user' AND user_id = %s", (app_name, user_id)
     return "app_name = %s AND scope = 'app'", (app_name,)
+
+
+def _session_list_query(
+    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+) -> "tuple[str, tuple[Any, ...]]":
+    """Return the bounded session-list query and its bound values."""
+    params: list[Any] = [app_name]
+    where_clause = "app_name = %s"
+    if user_id is not None:
+        params.append(user_id)
+        where_clause = f"{where_clause} AND user_id = %s"
+
+    page_clause = ""
+    if limit is not None:
+        params.extend((limit, offset))
+        page_clause = "\n            LIMIT %s OFFSET %s"
+
+    sql = f"""
+    SELECT id, app_name, user_id, state, create_time, update_time
+    FROM {session_table}
+    WHERE {where_clause}
+    ORDER BY {order_clause}{page_clause}
+    """
+    return sql, tuple(params)

--- a/sqlspec/adapters/mysqlconnector/adk/store.py
+++ b/sqlspec/adapters/mysqlconnector/adk/store.py
@@ -277,11 +277,13 @@ class MysqlConnectorAsyncADKStore(BaseAsyncADKStore["MysqlConnectorAsyncConfig"]
         limit: "int | None" = None,
         offset: "int | None" = None,
     ) -> "list[StoredSession]":
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
-        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
+        sql, params = _session_list_query(
+            self._session_table, app_name, user_id, column, direction, page_limit, page_offset
+        )
 
         import mysql.connector
 
@@ -632,11 +634,13 @@ class MysqlConnectorSyncADKStore(BaseSyncADKStore["MysqlConnectorSyncConfig"]):
         offset: "int | None" = None,
     ) -> "list[StoredSession]":
         """List sessions for an app."""
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
-        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
+        sql, params = _session_list_query(
+            self._session_table, app_name, user_id, column, direction, page_limit, page_offset
+        )
 
         import mysql.connector
 
@@ -1607,7 +1611,13 @@ def _build_mysql_scope_where(
 
 
 def _session_list_query(
-    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+    session_table: str,
+    app_name: str,
+    user_id: "str | None",
+    column: str,
+    direction: str,
+    limit: "int | None",
+    offset: int,
 ) -> "tuple[str, tuple[Any, ...]]":
     """Return the bounded session-list query and its bound values."""
     params: list[Any] = [app_name]
@@ -1625,6 +1635,6 @@ def _session_list_query(
     SELECT id, app_name, user_id, state, create_time, update_time
     FROM {session_table}
     WHERE {where_clause}
-    ORDER BY {order_clause}{page_clause}
+    ORDER BY {column} {direction}, id {direction}{page_clause}
     """
     return sql, tuple(params)

--- a/sqlspec/adapters/oracledb/adk/store.py
+++ b/sqlspec/adapters/oracledb/adk/store.py
@@ -534,11 +534,13 @@ class OracleAsyncADKStore(BaseAsyncADKStore["OracleAsyncConfig"]):
             Uses composite index on (app_name, user_id) when user_id is provided.
             State is deserialized using version-appropriate format.
         """
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
-        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
+        sql, params = _session_list_query(
+            self._session_table, app_name, user_id, column, direction, page_limit, page_offset
+        )
 
         try:
             async with self._config.provide_connection() as conn:
@@ -1538,11 +1540,13 @@ class OracleSyncADKStore(BaseSyncADKStore["OracleSyncConfig"]):
             Uses composite index on (app_name, user_id) when user_id is provided.
             State is deserialized using version-appropriate format.
         """
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
-        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
+        sql, params = _session_list_query(
+            self._session_table, app_name, user_id, column, direction, page_limit, page_offset
+        )
 
         try:
             with self._config.provide_connection() as conn:
@@ -3109,7 +3113,13 @@ def _build_oracle_scope_where(
 
 
 def _session_list_query(
-    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+    session_table: str,
+    app_name: str,
+    user_id: "str | None",
+    column: str,
+    direction: str,
+    limit: "int | None",
+    offset: int,
 ) -> "tuple[str, dict[str, Any]]":
     """Return the bounded session-list query and its named binds."""
     params: dict[str, Any] = {"app_name": app_name}
@@ -3128,6 +3138,6 @@ def _session_list_query(
     SELECT id, app_name, user_id, state, create_time, update_time
     FROM {session_table}
     WHERE {where_clause}
-    ORDER BY {order_clause}{page_clause}
+    ORDER BY {column} {direction}, id {direction}{page_clause}
     """
     return sql, params

--- a/sqlspec/adapters/oracledb/adk/store.py
+++ b/sqlspec/adapters/oracledb/adk/store.py
@@ -15,7 +15,13 @@ from sqlspec.adapters.oracledb.data_dictionary import (
     storage_type_from_version,
 )
 from sqlspec.config import ADKConfig
-from sqlspec.extensions.adk import BaseAsyncADKStore, BaseSyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import (
+    BaseAsyncADKStore,
+    BaseSyncADKStore,
+    StoredEvent,
+    StoredSession,
+    normalize_session_list_options,
+)
 from sqlspec.extensions.adk.memory.store import BaseAsyncADKMemoryStore, BaseSyncADKMemoryStore
 from sqlspec.utils.logging import get_logger
 from sqlspec.utils.serializers import from_json, to_json
@@ -26,7 +32,7 @@ if TYPE_CHECKING:
     from datetime import datetime, timedelta
 
     from sqlspec.adapters.oracledb.config import OracleAsyncConfig, OracleSyncConfig
-    from sqlspec.extensions.adk import StoredMemory
+    from sqlspec.extensions.adk import SessionOrderBy, StoredMemory
 
 __all__ = (
     "JSONStorageType",
@@ -501,37 +507,38 @@ class OracleAsyncADKStore(BaseAsyncADKStore["OracleAsyncConfig"]):
             await cursor.execute(sql, {"state": state_data, "app_name": app_name, "user_id": user_id, "id": session_id})
             await conn.commit()
 
-    async def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
+    async def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List sessions for an app, optionally filtered by user.
 
         Args:
             app_name: Application name.
             user_id: User identifier. If None, lists all sessions for the app.
+            order_by: Timestamp column to sort on.
+            descending: Sort direction for the timestamp column and the id tie-break.
+            limit: Maximum number of sessions to return.
+            offset: Number of leading rows to skip.
 
         Returns:
-            List of session records ordered by update_time DESC.
+            List of session records.
 
         Notes:
             Uses composite index on (app_name, user_id) when user_id is provided.
             State is deserialized using version-appropriate format.
         """
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
 
-        if user_id is None:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = :app_name
-            ORDER BY update_time DESC
-            """
-            params = {"app_name": app_name}
-        else:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = :app_name AND user_id = :user_id
-            ORDER BY update_time DESC
-            """
-            params = {"app_name": app_name, "user_id": user_id}
+        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
 
         try:
             async with self._config.provide_connection() as conn:
@@ -1504,38 +1511,38 @@ class OracleSyncADKStore(BaseSyncADKStore["OracleSyncConfig"]):
             cursor.execute(sql, {"state": state_data, "app_name": app_name, "user_id": user_id, "id": session_id})
             conn.commit()
 
-    def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
-        """List sessions for an app."""
+    def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List sessions for an app, optionally filtered by user.
 
         Args:
             app_name: Application name.
             user_id: User identifier. If None, lists all sessions for the app.
+            order_by: Timestamp column to sort on.
+            descending: Sort direction for the timestamp column and the id tie-break.
+            limit: Maximum number of sessions to return.
+            offset: Number of leading rows to skip.
 
         Returns:
-            List of session records ordered by update_time DESC.
+            List of session records.
 
         Notes:
             Uses composite index on (app_name, user_id) when user_id is provided.
             State is deserialized using version-appropriate format.
         """
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
 
-        if user_id is None:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = :app_name
-            ORDER BY update_time DESC
-            """
-            params = {"app_name": app_name}
-        else:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = :app_name AND user_id = :user_id
-            ORDER BY update_time DESC
-            """
-            params = {"app_name": app_name, "user_id": user_id}
+        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
 
         try:
             with self._config.provide_connection() as conn:
@@ -3099,3 +3106,28 @@ def _build_oracle_scope_where(
             "user_id": user_id,
         }
     return "app_name = :app_name AND scope = 'app'", {"app_name": app_name}
+
+
+def _session_list_query(
+    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+) -> "tuple[str, dict[str, Any]]":
+    """Return the bounded session-list query and its named binds."""
+    params: dict[str, Any] = {"app_name": app_name}
+    where_clause = "app_name = :app_name"
+    if user_id is not None:
+        params["user_id"] = user_id
+        where_clause = f"{where_clause} AND user_id = :user_id"
+
+    page_clause = ""
+    if limit is not None:
+        params["page_limit"] = limit
+        params["page_offset"] = offset
+        page_clause = "\n            OFFSET :page_offset ROWS FETCH NEXT :page_limit ROWS ONLY"
+
+    sql = f"""
+    SELECT id, app_name, user_id, state, create_time, update_time
+    FROM {session_table}
+    WHERE {where_clause}
+    ORDER BY {order_clause}{page_clause}
+    """
+    return sql, params

--- a/sqlspec/adapters/psqlpy/adk/store.py
+++ b/sqlspec/adapters/psqlpy/adk/store.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Final, Literal, NoReturn, cast
 from typing_extensions import NotRequired
 
 from sqlspec.config import ADKConfig
-from sqlspec.extensions.adk import BaseAsyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import BaseAsyncADKStore, StoredEvent, StoredSession, normalize_session_list_options
 from sqlspec.extensions.adk.memory.store import BaseAsyncADKMemoryStore
 from sqlspec.utils.logging import get_logger
 from sqlspec.utils.type_guards import has_query_result_metadata
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from datetime import datetime, timedelta
 
     from sqlspec.adapters.psqlpy.config import PsqlpyConfig
-    from sqlspec.extensions.adk import StoredMemory
+    from sqlspec.extensions.adk import SessionOrderBy, StoredMemory
 
 
 __all__ = ("PsqlpyADKConfig", "PsqlpyADKMemoryStore", "PsqlpyADKStore")
@@ -160,23 +160,39 @@ class PsqlpyADKStore(BaseAsyncADKStore["PsqlpyConfig"]):
         async with self._config.provide_connection() as conn:  # pyright: ignore[reportAttributeAccessIssue]
             await conn.execute(sql, [state, app_name, user_id, session_id])
 
-    async def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
-        if user_id is None:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = $1
-            ORDER BY update_time DESC
-            """
-            params = [app_name]
-        else:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = $1 AND user_id = $2
-            ORDER BY update_time DESC
-            """
-            params = [app_name, user_id]
+    async def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
+
+        params: list[Any] = [app_name]
+        where_clause = "app_name = $1"
+        if user_id is not None:
+            params.append(user_id)
+            where_clause = f"{where_clause} AND user_id = ${len(params)}"
+
+        page_clause = ""
+        if page_limit is not None:
+            params.append(page_limit)
+            limit_placeholder = f"${len(params)}"
+            params.append(page_offset)
+            page_clause = f"\n            LIMIT {limit_placeholder} OFFSET ${len(params)}"
+
+        sql = f"""
+        SELECT id, app_name, user_id, state, create_time, update_time
+        FROM {self._session_table}
+        WHERE {where_clause}
+        ORDER BY {order_clause}{page_clause}
+        """
 
         try:
             async with self._config.provide_connection() as conn:  # pyright: ignore[reportAttributeAccessIssue]

--- a/sqlspec/adapters/psqlpy/adk/store.py
+++ b/sqlspec/adapters/psqlpy/adk/store.py
@@ -170,7 +170,7 @@ class PsqlpyADKStore(BaseAsyncADKStore["PsqlpyConfig"]):
         limit: "int | None" = None,
         offset: "int | None" = None,
     ) -> "list[StoredSession]":
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
@@ -191,7 +191,7 @@ class PsqlpyADKStore(BaseAsyncADKStore["PsqlpyConfig"]):
         SELECT id, app_name, user_id, state, create_time, update_time
         FROM {self._session_table}
         WHERE {where_clause}
-        ORDER BY {order_clause}{page_clause}
+        ORDER BY {column} {direction}, id {direction}{page_clause}
         """
 
         try:

--- a/sqlspec/adapters/psycopg/adk/store.py
+++ b/sqlspec/adapters/psycopg/adk/store.py
@@ -1,6 +1,6 @@
 """Psycopg ADK store for Google Agent Development Kit session/event storage."""
 
-from typing import TYPE_CHECKING, Any, Final, Literal, NoReturn, cast
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, cast
 
 from psycopg import errors
 from psycopg import sql as pg_sql
@@ -37,13 +37,6 @@ __all__ = (
 
 logger = get_logger("sqlspec.adapters.psycopg.adk.store")
 
-
-SESSION_ORDER_CLAUSES: Final = {
-    "create_time ASC, id ASC": pg_sql.SQL("create_time ASC, id ASC"),
-    "create_time DESC, id DESC": pg_sql.SQL("create_time DESC, id DESC"),
-    "update_time ASC, id ASC": pg_sql.SQL("update_time ASC, id ASC"),
-    "update_time DESC, id DESC": pg_sql.SQL("update_time DESC, id DESC"),
-}
 
 _ADK_SESSIONS_TABLE_DDL_TEMPLATE = ",\n            {0}"
 
@@ -304,12 +297,12 @@ class PsycopgAsyncADKStore(BaseAsyncADKStore["PsycopgAsyncConfig"]):
         limit: "int | None" = None,
         offset: "int | None" = None,
     ) -> "list[StoredSession]":
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
         query, params = _session_list_query(
-            self._session_table, app_name, user_id, order_clause, page_limit, page_offset
+            self._session_table, app_name, user_id, column, direction, page_limit, page_offset
         )
 
         try:
@@ -811,12 +804,12 @@ class PsycopgSyncADKStore(BaseSyncADKStore["PsycopgSyncConfig"]):
         offset: "int | None" = None,
     ) -> "list[StoredSession]":
         """List sessions for an app."""
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
         query, params = _session_list_query(
-            self._session_table, app_name, user_id, order_clause, page_limit, page_offset
+            self._session_table, app_name, user_id, column, direction, page_limit, page_offset
         )
 
         try:
@@ -1931,7 +1924,13 @@ def _build_psycopg_scope_where(
 
 
 def _session_list_query(
-    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+    session_table: str,
+    app_name: str,
+    user_id: "str | None",
+    column: str,
+    direction: str,
+    limit: "int | None",
+    offset: int,
 ) -> "tuple[pg_sql.Composed, tuple[Any, ...]]":
     """Return the bounded session-list query and its bound values."""
     params: list[Any] = [app_name]
@@ -1945,15 +1944,19 @@ def _session_list_query(
         params.extend((limit, offset))
         page_clause = pg_sql.SQL(" LIMIT %s OFFSET %s")
 
+    column_sql = pg_sql.SQL("create_time") if column == "create_time" else pg_sql.SQL("update_time")
+    direction_sql = pg_sql.SQL("DESC") if direction == "DESC" else pg_sql.SQL("ASC")
+
     query = pg_sql.SQL("""
     SELECT id, app_name, user_id, state, create_time, update_time
     FROM {table}
     WHERE app_name = %s{user_filter}
-    ORDER BY {order}{page}
+    ORDER BY {column} {direction}, id {direction}{page}
     """).format(
         table=pg_sql.Identifier(session_table),
         user_filter=user_filter,
-        order=SESSION_ORDER_CLAUSES[order_clause],
+        column=column_sql,
+        direction=direction_sql,
         page=page_clause,
     )
     return query, tuple(params)

--- a/sqlspec/adapters/psycopg/adk/store.py
+++ b/sqlspec/adapters/psycopg/adk/store.py
@@ -1,6 +1,6 @@
 """Psycopg ADK store for Google Agent Development Kit session/event storage."""
 
-from typing import TYPE_CHECKING, Any, Literal, NoReturn, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, NoReturn, cast
 
 from psycopg import errors
 from psycopg import sql as pg_sql
@@ -9,7 +9,13 @@ from psycopg.types.json import Jsonb
 from typing_extensions import NotRequired
 
 from sqlspec.config import ADKConfig
-from sqlspec.extensions.adk import BaseAsyncADKStore, BaseSyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import (
+    BaseAsyncADKStore,
+    BaseSyncADKStore,
+    StoredEvent,
+    StoredSession,
+    normalize_session_list_options,
+)
 from sqlspec.extensions.adk.memory.store import BaseAsyncADKMemoryStore, BaseSyncADKMemoryStore
 from sqlspec.utils.logging import get_logger
 
@@ -18,7 +24,7 @@ if TYPE_CHECKING:
     from datetime import datetime, timedelta
 
     from sqlspec.adapters.psycopg.config import PsycopgAsyncConfig, PsycopgSyncConfig
-    from sqlspec.extensions.adk import StoredMemory
+    from sqlspec.extensions.adk import SessionOrderBy, StoredMemory
 
 
 __all__ = (
@@ -31,6 +37,13 @@ __all__ = (
 
 logger = get_logger("sqlspec.adapters.psycopg.adk.store")
 
+
+SESSION_ORDER_CLAUSES: Final = {
+    "create_time ASC, id ASC": pg_sql.SQL("create_time ASC, id ASC"),
+    "create_time DESC, id DESC": pg_sql.SQL("create_time DESC, id DESC"),
+    "update_time ASC, id ASC": pg_sql.SQL("update_time ASC, id ASC"),
+    "update_time DESC, id DESC": pg_sql.SQL("update_time DESC, id DESC"),
+}
 
 _ADK_SESSIONS_TABLE_DDL_TEMPLATE = ",\n            {0}"
 
@@ -281,23 +294,23 @@ class PsycopgAsyncADKStore(BaseAsyncADKStore["PsycopgAsyncConfig"]):
         async with self._config.provide_connection() as conn, conn.cursor(row_factory=dict_row) as cur:
             await cur.execute(query, (Jsonb(state), app_name, user_id, session_id))
 
-    async def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
-        if user_id is None:
-            query = pg_sql.SQL("""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {table}
-            WHERE app_name = %s
-            ORDER BY update_time DESC
-            """).format(table=pg_sql.Identifier(self._session_table))
-            params: tuple[str, ...] = (app_name,)
-        else:
-            query = pg_sql.SQL("""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {table}
-            WHERE app_name = %s AND user_id = %s
-            ORDER BY update_time DESC
-            """).format(table=pg_sql.Identifier(self._session_table))
-            params = (app_name, user_id)
+    async def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
+
+        query, params = _session_list_query(
+            self._session_table, app_name, user_id, order_clause, page_limit, page_offset
+        )
 
         try:
             async with self._config.provide_connection() as conn, conn.cursor(row_factory=dict_row) as cur:
@@ -787,24 +800,24 @@ class PsycopgSyncADKStore(BaseSyncADKStore["PsycopgSyncConfig"]):
         with self._config.provide_connection() as conn, conn.cursor(row_factory=dict_row) as cur:
             cur.execute(query, (Jsonb(state), app_name, user_id, session_id))
 
-    def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
+    def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List sessions for an app."""
-        if user_id is None:
-            query = pg_sql.SQL("""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {table}
-            WHERE app_name = %s
-            ORDER BY update_time DESC
-            """).format(table=pg_sql.Identifier(self._session_table))
-            params: tuple[str, ...] = (app_name,)
-        else:
-            query = pg_sql.SQL("""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {table}
-            WHERE app_name = %s AND user_id = %s
-            ORDER BY update_time DESC
-            """).format(table=pg_sql.Identifier(self._session_table))
-            params = (app_name, user_id)
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
+
+        query, params = _session_list_query(
+            self._session_table, app_name, user_id, order_clause, page_limit, page_offset
+        )
 
         try:
             with self._config.provide_connection() as conn, conn.cursor(row_factory=dict_row) as cur:
@@ -1915,3 +1928,32 @@ def _build_psycopg_scope_where(
         return where, (app_name, user_id)
     where = pg_sql.SQL("app_name = %s AND scope = 'app'")
     return where, (app_name,)
+
+
+def _session_list_query(
+    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+) -> "tuple[pg_sql.Composed, tuple[Any, ...]]":
+    """Return the bounded session-list query and its bound values."""
+    params: list[Any] = [app_name]
+    user_filter = pg_sql.SQL("")
+    if user_id is not None:
+        params.append(user_id)
+        user_filter = pg_sql.SQL(" AND user_id = %s")
+
+    page_clause = pg_sql.SQL("")
+    if limit is not None:
+        params.extend((limit, offset))
+        page_clause = pg_sql.SQL(" LIMIT %s OFFSET %s")
+
+    query = pg_sql.SQL("""
+    SELECT id, app_name, user_id, state, create_time, update_time
+    FROM {table}
+    WHERE app_name = %s{user_filter}
+    ORDER BY {order}{page}
+    """).format(
+        table=pg_sql.Identifier(session_table),
+        user_filter=user_filter,
+        order=SESSION_ORDER_CLAUSES[order_clause],
+        page=page_clause,
+    )
+    return query, tuple(params)

--- a/sqlspec/adapters/pymssql/adk/store.py
+++ b/sqlspec/adapters/pymssql/adk/store.py
@@ -150,11 +150,13 @@ class PymssqlADKStore(BaseSyncADKStore["PymssqlConfig"]):
         offset: "int | None" = None,
     ) -> "list[StoredSession]":
         """List ADK sessions for an application, optionally scoped to a user."""
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
-        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
+        sql, params = _session_list_query(
+            self._session_table, app_name, user_id, column, direction, page_limit, page_offset
+        )
         try:
             rows = self._execute_fetchall(sql, params)
         except MSSQL_ERROR as exc:
@@ -905,7 +907,13 @@ def _build_mssql_scope_where(
 
 
 def _session_list_query(
-    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+    session_table: str,
+    app_name: str,
+    user_id: "str | None",
+    column: str,
+    direction: str,
+    limit: "int | None",
+    offset: int,
 ) -> "tuple[str, tuple[Any, ...]]":
     """Return the bounded session-list query and its bound values."""
     params: list[Any] = [app_name]
@@ -923,6 +931,6 @@ def _session_list_query(
     SELECT id, app_name, user_id, state, create_time, update_time
     FROM {_table_ref(session_table)}
     WHERE {where_clause}
-    ORDER BY {order_clause}{page_clause}
+    ORDER BY {column} {direction}, id {direction}{page_clause}
     """
     return sql, tuple(params)

--- a/sqlspec/adapters/pymssql/adk/store.py
+++ b/sqlspec/adapters/pymssql/adk/store.py
@@ -9,7 +9,7 @@ from typing_extensions import NotRequired
 from sqlspec.adapters.pymssql._typing import PYMSSQL_MODULE, PymssqlCursor
 from sqlspec.adapters.pymssql.data_dictionary import MssqlVersionInfo
 from sqlspec.config import ADKConfig
-from sqlspec.extensions.adk import BaseSyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import BaseSyncADKStore, StoredEvent, StoredSession, normalize_session_list_options
 from sqlspec.extensions.adk.memory.store import BaseSyncADKMemoryStore
 from sqlspec.utils.serializers import from_json, to_json
 
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
     from sqlspec.adapters.pymssql.config import PymssqlConfig
     from sqlspec.adapters.pymssql.driver import PymssqlDriver
+    from sqlspec.extensions.adk import SessionOrderBy
     from sqlspec.extensions.adk.memory._types import StoredMemory
 
 __all__ = ("PymssqlADKConfig", "PymssqlADKMemoryStore", "PymssqlADKStore")
@@ -138,24 +139,22 @@ class PymssqlADKStore(BaseSyncADKStore["PymssqlConfig"]):
             commit=True,
         )
 
-    def list_sessions(self, app_name: str, user_id: "str | None" = None) -> "list[StoredSession]":
+    def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List ADK sessions for an application, optionally scoped to a user."""
-        if user_id is None:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {_table_ref(self._session_table)}
-            WHERE app_name = %s
-            ORDER BY update_time DESC
-            """
-            params: tuple[Any, ...] = (app_name,)
-        else:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {_table_ref(self._session_table)}
-            WHERE app_name = %s AND user_id = %s
-            ORDER BY update_time DESC
-            """
-            params = (app_name, user_id)
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
+
+        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
         try:
             rows = self._execute_fetchall(sql, params)
         except MSSQL_ERROR as exc:
@@ -903,3 +902,27 @@ def _build_mssql_scope_where(
     if scope_filter == "user":
         return "app_name = %s AND scope = 'user' AND user_id = %s", (app_name, user_id)
     return "app_name = %s AND scope = 'app'", (app_name,)
+
+
+def _session_list_query(
+    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+) -> "tuple[str, tuple[Any, ...]]":
+    """Return the bounded session-list query and its bound values."""
+    params: list[Any] = [app_name]
+    where_clause = "app_name = %s"
+    if user_id is not None:
+        params.append(user_id)
+        where_clause = f"{where_clause} AND user_id = %s"
+
+    page_clause = ""
+    if limit is not None:
+        params.extend((offset, limit))
+        page_clause = "\n            OFFSET %s ROWS FETCH NEXT %s ROWS ONLY"
+
+    sql = f"""
+    SELECT id, app_name, user_id, state, create_time, update_time
+    FROM {_table_ref(session_table)}
+    WHERE {where_clause}
+    ORDER BY {order_clause}{page_clause}
+    """
+    return sql, tuple(params)

--- a/sqlspec/adapters/pymysql/adk/store.py
+++ b/sqlspec/adapters/pymysql/adk/store.py
@@ -8,7 +8,7 @@ import pymysql
 from typing_extensions import NotRequired
 
 from sqlspec.config import ADKConfig
-from sqlspec.extensions.adk import BaseSyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import BaseSyncADKStore, StoredEvent, StoredSession, normalize_session_list_options
 from sqlspec.extensions.adk.memory.store import BaseSyncADKMemoryStore
 from sqlspec.utils.serializers import from_json, to_json
 
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from datetime import datetime, timedelta
 
     from sqlspec.adapters.pymysql.config import PyMysqlConfig
-    from sqlspec.extensions.adk import StoredMemory
+    from sqlspec.extensions.adk import SessionOrderBy, StoredMemory
 
 
 __all__ = ("PyMysqlADKConfig", "PyMysqlADKMemoryStore", "PyMysqlADKStore")
@@ -85,9 +85,20 @@ class PyMysqlADKStore(BaseSyncADKStore["PyMysqlConfig"]):
         """Update session state."""
         _update_session_state(self, app_name, user_id, session_id, state)
 
-    def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
+    def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List sessions for an app."""
-        return _list_sessions(self, app_name, user_id)
+        return _list_sessions(
+            self, app_name, user_id, order_by=order_by, descending=descending, limit=limit, offset=offset
+        )
 
     def delete_session(self, app_name: str, user_id: str, session_id: str) -> None:
         """Delete session and associated events."""
@@ -552,23 +563,21 @@ def _update_session_state(
         conn.commit()
 
 
-def _list_sessions(store: PyMysqlADKStore, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
-    if user_id is None:
-        sql = f"""
-        SELECT id, app_name, user_id, state, create_time, update_time
-        FROM {store._session_table}
-        WHERE app_name = %s
-        ORDER BY update_time DESC
-        """
-        params: tuple[Any, ...] = (app_name,)
-    else:
-        sql = f"""
-        SELECT id, app_name, user_id, state, create_time, update_time
-        FROM {store._session_table}
-        WHERE app_name = %s AND user_id = %s
-        ORDER BY update_time DESC
-        """
-        params = (app_name, user_id)
+def _list_sessions(
+    store: PyMysqlADKStore,
+    app_name: str,
+    user_id: "str | None" = None,
+    *,
+    order_by: "SessionOrderBy" = "update_time",
+    descending: bool = True,
+    limit: "int | None" = None,
+    offset: "int | None" = None,
+) -> "list[StoredSession]":
+    order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+    if page_limit == 0:
+        return []
+
+    sql, params = _session_list_query(store._session_table, app_name, user_id, order_clause, page_limit, page_offset)
 
     try:
         with store._config.provide_connection() as conn:
@@ -1025,3 +1034,27 @@ def _build_mysql_scope_where(
     if scope_filter == "user":
         return "app_name = %s AND scope = 'user' AND user_id = %s", (app_name, user_id)
     return "app_name = %s AND scope = 'app'", (app_name,)
+
+
+def _session_list_query(
+    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+) -> "tuple[str, tuple[Any, ...]]":
+    """Return the bounded session-list query and its bound values."""
+    params: list[Any] = [app_name]
+    where_clause = "app_name = %s"
+    if user_id is not None:
+        params.append(user_id)
+        where_clause = f"{where_clause} AND user_id = %s"
+
+    page_clause = ""
+    if limit is not None:
+        params.extend((limit, offset))
+        page_clause = "\n            LIMIT %s OFFSET %s"
+
+    sql = f"""
+    SELECT id, app_name, user_id, state, create_time, update_time
+    FROM {session_table}
+    WHERE {where_clause}
+    ORDER BY {order_clause}{page_clause}
+    """
+    return sql, tuple(params)

--- a/sqlspec/adapters/pymysql/adk/store.py
+++ b/sqlspec/adapters/pymysql/adk/store.py
@@ -573,11 +573,13 @@ def _list_sessions(
     limit: "int | None" = None,
     offset: "int | None" = None,
 ) -> "list[StoredSession]":
-    order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+    column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
     if page_limit == 0:
         return []
 
-    sql, params = _session_list_query(store._session_table, app_name, user_id, order_clause, page_limit, page_offset)
+    sql, params = _session_list_query(
+        store._session_table, app_name, user_id, column, direction, page_limit, page_offset
+    )
 
     try:
         with store._config.provide_connection() as conn:
@@ -1037,7 +1039,13 @@ def _build_mysql_scope_where(
 
 
 def _session_list_query(
-    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+    session_table: str,
+    app_name: str,
+    user_id: "str | None",
+    column: str,
+    direction: str,
+    limit: "int | None",
+    offset: int,
 ) -> "tuple[str, tuple[Any, ...]]":
     """Return the bounded session-list query and its bound values."""
     params: list[Any] = [app_name]
@@ -1055,6 +1063,6 @@ def _session_list_query(
     SELECT id, app_name, user_id, state, create_time, update_time
     FROM {session_table}
     WHERE {where_clause}
-    ORDER BY {order_clause}{page_clause}
+    ORDER BY {column} {direction}, id {direction}{page_clause}
     """
     return sql, tuple(params)

--- a/sqlspec/adapters/spanner/adk/store.py
+++ b/sqlspec/adapters/spanner/adk/store.py
@@ -395,7 +395,7 @@ class SpannerSyncADKStore(BaseSyncADKStore[SpannerSyncConfig]):
         limit: "int | None" = None,
         offset: "int | None" = None,
     ) -> "list[StoredSession]":
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
@@ -412,7 +412,7 @@ class SpannerSyncADKStore(BaseSyncADKStore[SpannerSyncConfig]):
             types["user_id"] = SPANNER_PARAM_TYPES.STRING
         if self._shard_count > 1:
             sql = f"{sql} AND shard_id = MOD(FARM_FINGERPRINT(id), {self._shard_count})"
-        sql = f"{sql} ORDER BY {order_clause}"
+        sql = f"{sql} ORDER BY {column} {direction}, id {direction}"
         if page_limit is not None:
             sql = f"{sql} LIMIT @limit OFFSET @offset"
             params["limit"] = page_limit

--- a/sqlspec/adapters/spanner/adk/store.py
+++ b/sqlspec/adapters/spanner/adk/store.py
@@ -11,7 +11,7 @@ from typing_extensions import NotRequired, TypedDict
 from sqlspec.adapters.spanner.config import SpannerSyncConfig
 from sqlspec.config import ADKConfig
 from sqlspec.exceptions import OperationalError
-from sqlspec.extensions.adk import BaseSyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import BaseSyncADKStore, StoredEvent, StoredSession, normalize_session_list_options
 from sqlspec.extensions.adk.memory.store import BaseSyncADKMemoryStore
 from sqlspec.protocols import SpannerParamTypesProtocol
 from sqlspec.utils.serializers import from_json, to_json
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from google.cloud.spanner_v1.database import Database
     from google.cloud.spanner_v1.transaction import Transaction
 
-    from sqlspec.extensions.adk import StoredMemory
+    from sqlspec.extensions.adk import SessionOrderBy, StoredMemory
 
 __all__ = ("SpannerADKConfig", "SpannerADKRetentionConfig", "SpannerSyncADKMemoryStore", "SpannerSyncADKStore")
 
@@ -112,10 +112,21 @@ class SpannerSyncADKStore(BaseSyncADKStore[SpannerSyncConfig]):
         """Update session state."""
         self._update_session_state(app_name, user_id, session_id, state)
 
-    def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
+    def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List sessions for an app."""
         try:
-            return self._list_sessions(app_name, user_id)
+            return self._list_sessions(
+                app_name, user_id, order_by=order_by, descending=descending, limit=limit, offset=offset
+            )
         except NotFound as exc:
             if _is_spanner_table_missing(exc, self._session_table):
                 return []
@@ -374,7 +385,20 @@ class SpannerSyncADKStore(BaseSyncADKStore[SpannerSyncConfig]):
             )
         ])
 
-    def _list_sessions(self, app_name: str, user_id: "str | None" = None) -> "list[StoredSession]":
+    def _list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
+
         sql = f"""
             SELECT id, app_name, user_id, state, create_time, update_time{", " + self._owner_id_column_name if self._owner_id_column_name else ""}
             FROM {self._session_table}
@@ -388,7 +412,13 @@ class SpannerSyncADKStore(BaseSyncADKStore[SpannerSyncConfig]):
             types["user_id"] = SPANNER_PARAM_TYPES.STRING
         if self._shard_count > 1:
             sql = f"{sql} AND shard_id = MOD(FARM_FINGERPRINT(id), {self._shard_count})"
-        sql = f"{sql} ORDER BY update_time DESC"
+        sql = f"{sql} ORDER BY {order_clause}"
+        if page_limit is not None:
+            sql = f"{sql} LIMIT @limit OFFSET @offset"
+            params["limit"] = page_limit
+            params["offset"] = page_offset
+            types["limit"] = SPANNER_PARAM_TYPES.INT64
+            types["offset"] = SPANNER_PARAM_TYPES.INT64
 
         rows = self._run_read(sql, params, types)
         records: list[StoredSession] = []

--- a/sqlspec/adapters/sqlite/adk/store.py
+++ b/sqlspec/adapters/sqlite/adk/store.py
@@ -11,7 +11,7 @@ from typing_extensions import NotRequired
 from sqlspec.adapters.sqlite.config import _render_pragmas
 from sqlspec.config import ADKConfig
 from sqlspec.exceptions import ImproperConfigurationError
-from sqlspec.extensions.adk import BaseSyncADKStore, StoredEvent, StoredSession
+from sqlspec.extensions.adk import BaseSyncADKStore, StoredEvent, StoredSession, normalize_session_list_options
 from sqlspec.extensions.adk.memory.store import BaseSyncADKMemoryStore
 from sqlspec.utils.logging import get_logger
 from sqlspec.utils.serializers import from_json, to_json
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from sqlspec.adapters.sqlite.config import SqliteConfig
-    from sqlspec.extensions.adk import StoredMemory
+    from sqlspec.extensions.adk import SessionOrderBy, StoredMemory
 
 __all__ = ("SqliteADKConfig", "SqliteADKMemoryStore", "SqliteADKStore")
 
@@ -225,33 +225,34 @@ class SqliteADKStore(BaseSyncADKStore["SqliteConfig"]):
             conn.execute(sql, (state_json, now_julian, app_name, user_id, session_id))
             conn.commit()
 
-    def list_sessions(self, app_name: str, user_id: str | None = None) -> "list[StoredSession]":
+    def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List sessions for an app, optionally filtered by user.
 
         Args:
             app_name: Application name.
             user_id: User identifier. If None, lists all sessions for the app.
+            order_by: Timestamp column to sort on.
+            descending: Sort direction for the timestamp column and the id tie-break.
+            limit: Maximum number of sessions to return.
+            offset: Number of leading rows to skip.
 
         Returns:
-            List of session records ordered by update_time DESC.
+            List of session records.
         """
-        """Synchronous implementation of list_sessions."""
-        if user_id is None:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = ?
-            ORDER BY update_time DESC
-            """
-            params: tuple[str, ...] = (app_name,)
-        else:
-            sql = f"""
-            SELECT id, app_name, user_id, state, create_time, update_time
-            FROM {self._session_table}
-            WHERE app_name = ? AND user_id = ?
-            ORDER BY update_time DESC
-            """
-            params = (app_name, user_id)
+        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            return []
+
+        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
 
         try:
             with self._config.provide_connection() as conn:
@@ -1191,3 +1192,27 @@ def _build_sqlite_scope_clause(
     if scope_filter == "user":
         return f"{prefix}app_name = ? AND {prefix}scope = 'user' AND {prefix}user_id = ?", (app_name, user_id)
     return f"{prefix}app_name = ? AND {prefix}scope = 'app'", (app_name,)
+
+
+def _session_list_query(
+    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+) -> "tuple[str, tuple[Any, ...]]":
+    """Return the bounded session-list query and its bound values."""
+    params: list[Any] = [app_name]
+    where_clause = "app_name = ?"
+    if user_id is not None:
+        params.append(user_id)
+        where_clause = f"{where_clause} AND user_id = ?"
+
+    page_clause = ""
+    if limit is not None:
+        params.extend((limit, offset))
+        page_clause = "\n            LIMIT ? OFFSET ?"
+
+    sql = f"""
+    SELECT id, app_name, user_id, state, create_time, update_time
+    FROM {session_table}
+    WHERE {where_clause}
+    ORDER BY {order_clause}{page_clause}
+    """
+    return sql, tuple(params)

--- a/sqlspec/adapters/sqlite/adk/store.py
+++ b/sqlspec/adapters/sqlite/adk/store.py
@@ -248,11 +248,13 @@ class SqliteADKStore(BaseSyncADKStore["SqliteConfig"]):
         Returns:
             List of session records.
         """
-        order_clause, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        column, direction, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             return []
 
-        sql, params = _session_list_query(self._session_table, app_name, user_id, order_clause, page_limit, page_offset)
+        sql, params = _session_list_query(
+            self._session_table, app_name, user_id, column, direction, page_limit, page_offset
+        )
 
         try:
             with self._config.provide_connection() as conn:
@@ -1195,7 +1197,13 @@ def _build_sqlite_scope_clause(
 
 
 def _session_list_query(
-    session_table: str, app_name: str, user_id: "str | None", order_clause: str, limit: "int | None", offset: int
+    session_table: str,
+    app_name: str,
+    user_id: "str | None",
+    column: str,
+    direction: str,
+    limit: "int | None",
+    offset: int,
 ) -> "tuple[str, tuple[Any, ...]]":
     """Return the bounded session-list query and its bound values."""
     params: list[Any] = [app_name]
@@ -1213,6 +1221,6 @@ def _session_list_query(
     SELECT id, app_name, user_id, state, create_time, update_time
     FROM {session_table}
     WHERE {where_clause}
-    ORDER BY {order_clause}{page_clause}
+    ORDER BY {column} {direction}, id {direction}{page_clause}
     """
     return sql, tuple(params)

--- a/sqlspec/extensions/adk/__init__.py
+++ b/sqlspec/extensions/adk/__init__.py
@@ -15,6 +15,8 @@ Public API exports:
     - BaseSyncADKMemoryStore: Base class for sync memory store implementations
     - BaseAsyncADKArtifactStore: Base class for async artifact metadata stores
     - BaseSyncADKArtifactStore: Base class for sync artifact metadata stores
+    - SessionOrderBy: Literal of the timestamp columns a session listing may order by
+    - normalize_session_list_options: Shared validator for session list ordering and paging
     - StoredSession: TypedDict for session database records
     - StoredEvent: TypedDict for event database records
     - StoredMemory: TypedDict for memory database records
@@ -22,7 +24,7 @@ Public API exports:
 """
 
 from sqlspec.config import ADKConfig
-from sqlspec.extensions.adk._types import StoredEvent, StoredSession
+from sqlspec.extensions.adk._types import SessionOrderBy, StoredEvent, StoredSession
 from sqlspec.extensions.adk.artifact import (
     BaseAsyncADKArtifactStore,
     BaseSyncADKArtifactStore,
@@ -50,7 +52,7 @@ from sqlspec.extensions.adk.memory import (
     StoredMemory,
 )
 from sqlspec.extensions.adk.service import SQLSpecSessionService
-from sqlspec.extensions.adk.store import BaseAsyncADKStore, BaseSyncADKStore
+from sqlspec.extensions.adk.store import BaseAsyncADKStore, BaseSyncADKStore, normalize_session_list_options
 
 __all__ = (
     "ADKConfig",
@@ -65,10 +67,12 @@ __all__ = (
     "SQLSpecMemoryService",
     "SQLSpecSessionService",
     "SQLSpecSyncMemoryService",
+    "SessionOrderBy",
     "StoredArtifact",
     "StoredEvent",
     "StoredMemory",
     "StoredSession",
+    "normalize_session_list_options",
     "prune_artifacts",
     "prune_artifacts_sync",
     "prune_events",

--- a/sqlspec/extensions/adk/_types.py
+++ b/sqlspec/extensions/adk/_types.py
@@ -5,9 +5,12 @@ They are separate from the Pydantic models to keep mypyc compilation working.
 """
 
 from datetime import datetime
-from typing import Any, TypedDict
+from typing import Any, Literal, TypedDict
 
-__all__ = ("StoredEvent", "StoredSession")
+__all__ = ("SessionOrderBy", "StoredEvent", "StoredSession")
+
+SessionOrderBy = Literal["create_time", "update_time"]
+"""Timestamp column a session listing may be ordered by."""
 
 
 class StoredSession(TypedDict):

--- a/sqlspec/extensions/adk/maintenance.py
+++ b/sqlspec/extensions/adk/maintenance.py
@@ -86,22 +86,23 @@ def _resolve_artifact_service(target: Any) -> Any:
     raise TypeError(msg)
 
 
-def _ensure_positive_days(older_than_days: Any) -> int:
+def _ensure_positive_days(value: Any, parameter: str) -> int:
     """Validate a retention age expressed in whole days.
 
     Args:
-        older_than_days: Candidate age value.
+        value: Candidate age value.
+        parameter: Name of the keyword argument being validated.
 
     Returns:
         The validated age in days.
 
     Raises:
-        ValueError: If the value is not a positive built-in integer.
+        ValueError: If the value is not a positive integer.
     """
-    if type(older_than_days) is not int or older_than_days <= 0:
-        msg = f"older_than_days must be a positive integer, got {older_than_days!r}"
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        msg = f"{parameter} must be a positive integer, got {value!r}"
         raise ValueError(msg)
-    return older_than_days
+    return value
 
 
 async def _call_store_method(store: Any, method_name: str, *args: Any, **kwargs: Any) -> int:
@@ -125,11 +126,15 @@ async def prune_sessions(target: Any, *, idle_days: int = 30, app_name: str | No
 
     Returns:
         PruneReport containing deleted row count and timing.
+
+    Raises:
+        ValueError: If ``idle_days`` is not a positive integer.
     """
+    retention_days = _ensure_positive_days(idle_days, "idle_days")
     start = time.perf_counter()
     store = _resolve_session_store(target)
     table_name = getattr(store, "session_table", "adk_session")
-    cutoff = datetime.now(timezone.utc) - timedelta(days=idle_days)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
     deleted = await _call_store_method(store, "delete_idle_sessions", cutoff, app_name=app_name)
     elapsed_ms = (time.perf_counter() - start) * 1000.0
     return PruneReport(deleted_count=deleted, elapsed_ms=elapsed_ms, table=str(table_name))
@@ -145,11 +150,15 @@ async def prune_events(target: Any, *, older_than_days: int = 90, app_name: str 
 
     Returns:
         PruneReport containing deleted row count and timing.
+
+    Raises:
+        ValueError: If ``older_than_days`` is not a positive integer.
     """
+    retention_days = _ensure_positive_days(older_than_days, "older_than_days")
     start = time.perf_counter()
     store = _resolve_session_store(target)
     table_name = getattr(store, "events_table", "adk_event")
-    cutoff = datetime.now(timezone.utc) - timedelta(days=older_than_days)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
     deleted = await _call_store_method(store, "delete_expired_events", cutoff, app_name=app_name)
     elapsed_ms = (time.perf_counter() - start) * 1000.0
     return PruneReport(deleted_count=deleted, elapsed_ms=elapsed_ms, table=str(table_name))
@@ -172,13 +181,17 @@ async def prune_memory(
 
     Returns:
         PruneReport containing deleted row count and timing.
+
+    Raises:
+        ValueError: If ``older_than_days`` is not a positive integer.
     """
+    retention_days = _ensure_positive_days(older_than_days, "older_than_days")
     start = time.perf_counter()
     store = _resolve_memory_store(target)
     table_name = getattr(store, "memory_table", "adk_memory")
     scope_param = None if scope == "all" else scope
     deleted = await _call_store_method(
-        store, "delete_entries_older_than", older_than_days, app_name=app_name, scope=scope_param
+        store, "delete_entries_older_than", retention_days, app_name=app_name, scope=scope_param
     )
     elapsed_ms = (time.perf_counter() - start) * 1000.0
     return PruneReport(deleted_count=deleted, elapsed_ms=elapsed_ms, table=str(table_name))
@@ -194,11 +207,15 @@ async def prune_user_state(target: Any, *, idle_days: int = 180, app_name: str |
 
     Returns:
         PruneReport containing deleted row count and timing.
+
+    Raises:
+        ValueError: If ``idle_days`` is not a positive integer.
     """
+    retention_days = _ensure_positive_days(idle_days, "idle_days")
     start = time.perf_counter()
     store = _resolve_session_store(target)
     table_name = getattr(store, "user_state_table", "adk_user_state")
-    cutoff = datetime.now(timezone.utc) - timedelta(days=idle_days)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
     deleted = await _call_store_method(store, "delete_idle_user_states", cutoff, app_name=app_name)
     elapsed_ms = (time.perf_counter() - start) * 1000.0
     return PruneReport(deleted_count=deleted, elapsed_ms=elapsed_ms, table=str(table_name))
@@ -221,8 +238,11 @@ async def prune_artifacts(target: Any, *, older_than_days: int = 90, app_name: s
 
     Returns:
         PruneReport containing deleted version-row count and timing.
+
+    Raises:
+        ValueError: If ``older_than_days`` is not a positive integer.
     """
-    retention_days = _ensure_positive_days(older_than_days)
+    retention_days = _ensure_positive_days(older_than_days, "older_than_days")
     start = time.perf_counter()
     service = _resolve_artifact_service(target)
     table_name = getattr(service.store, "artifact_table", "adk_artifact")

--- a/sqlspec/extensions/adk/service.py
+++ b/sqlspec/extensions/adk/service.py
@@ -15,6 +15,7 @@ from sqlspec.extensions.adk.converters import (
     record_to_session,
     split_scoped_state,
 )
+from sqlspec.extensions.adk.store import normalize_session_list_options
 from sqlspec.utils.logging import get_logger, log_with_context
 from sqlspec.utils.sync_tools import async_
 from sqlspec.utils.uuids import uuid4
@@ -25,6 +26,7 @@ if TYPE_CHECKING:
     from google.adk.events.event import Event
     from google.adk.sessions import Session
 
+    from sqlspec.extensions.adk._types import SessionOrderBy
     from sqlspec.extensions.adk.store import BaseAsyncADKStore, BaseSyncADKStore
 
     ADKStore = BaseAsyncADKStore | BaseSyncADKStore
@@ -179,17 +181,53 @@ class SQLSpecSessionService(BaseSessionService):
             return {}
         return {key.removeprefix("user:") if key.startswith("user:") else key: value for key, value in state.items()}
 
-    async def list_sessions(self, *, app_name: str, user_id: str | None = None) -> "ListSessionsResponse":
-        """List all sessions for an app, optionally filtered by user.
+    async def list_sessions(
+        self,
+        *,
+        app_name: str,
+        user_id: "str | None" = None,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "ListSessionsResponse":
+        """List sessions for an app, optionally filtered by user.
+
+        Ordering and bounded pagination are a SQLSpec extension to Google ADK's
+        narrower base signature; the response model itself is unchanged and
+        carries neither a total count nor a cursor token.
 
         Args:
             app_name: Name of the application.
             user_id: ID of the user. If None, all sessions for the app are listed.
+            order_by: Timestamp column to sort on. Only ``create_time`` and
+                ``update_time`` are accepted.
+            descending: Sort direction applied to the timestamp column and the
+                ``id`` tie-break that keeps pages deterministic.
+            limit: Maximum number of sessions to return. ``0`` returns an empty
+                response without reaching the store.
+            offset: Number of leading rows to skip. Requires a finite limit
+                when positive.
 
         Returns:
             Response containing list of sessions (without events).
         """
-        records = await self._call_store("list_sessions", app_name, user_id=user_id)
+        _, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        if page_limit == 0:
+            log_with_context(
+                logger, logging.DEBUG, "adk.session.list", app_name=app_name, has_user_id=user_id is not None, count=0
+            )
+            return ListSessionsResponse(sessions=[])
+
+        records = await self._call_store(
+            "list_sessions",
+            app_name,
+            user_id=user_id,
+            order_by=order_by,
+            descending=descending,
+            limit=page_limit,
+            offset=page_offset,
+        )
 
         sessions = [record_to_session(record, events=[]) for record in records]
         log_with_context(

--- a/sqlspec/extensions/adk/service.py
+++ b/sqlspec/extensions/adk/service.py
@@ -212,7 +212,7 @@ class SQLSpecSessionService(BaseSessionService):
         Returns:
             Response containing list of sessions (without events).
         """
-        _, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
+        _, _, page_limit, page_offset = normalize_session_list_options(order_by, descending, limit, offset)
         if page_limit == 0:
             log_with_context(
                 logger, logging.DEBUG, "adk.session.list", app_name=app_name, has_user_id=user_id is not None, count=0

--- a/sqlspec/extensions/adk/store.py
+++ b/sqlspec/extensions/adk/store.py
@@ -925,8 +925,8 @@ def normalize_session_list_options(
     descending: bool = True,
     limit: "int | None" = None,
     offset: "int | None" = None,
-) -> "tuple[str, int | None, int]":
-    """Validate session listing options and render their deterministic order clause.
+) -> "tuple[SessionOrderBy, str, int | None, int]":
+    """Validate session listing options and resolve their ordering parts.
 
     Args:
         order_by: Timestamp column to sort on. Only ``create_time`` and
@@ -938,8 +938,9 @@ def normalize_session_list_options(
         offset: Number of leading rows to skip. ``None`` is equivalent to zero.
 
     Returns:
-        The ``ORDER BY`` clause body, the validated limit, and the normalized
-        offset.
+        The allowlisted order column, the ``ASC``/``DESC`` direction keyword,
+        the validated limit, and the normalized offset. Callers render the
+        ``ORDER BY`` body in whichever form their driver accepts.
 
     Raises:
         ValueError: If the order column is outside the allowlist, a page bound
@@ -961,8 +962,7 @@ def normalize_session_list_options(
         msg = "offset requires a limit; unbounded offset is not supported"
         raise ValueError(msg)
 
-    direction = "DESC" if descending else "ASC"
-    return f"{order_by} {direction}, id {direction}", limit, normalized_offset
+    return order_by, "DESC" if descending else "ASC", limit, normalized_offset
 
 
 def _run_lifecycle_sync(config: Any, statements: "list[str]") -> None:

--- a/sqlspec/extensions/adk/store.py
+++ b/sqlspec/extensions/adk/store.py
@@ -17,13 +17,15 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from sqlspec.config import DatabaseConfigProtocol
-    from sqlspec.extensions.adk._types import StoredEvent, StoredSession
+    from sqlspec.extensions.adk._types import SessionOrderBy, StoredEvent, StoredSession
 
-__all__ = ("BaseAsyncADKStore", "BaseSyncADKStore")
+__all__ = ("BaseAsyncADKStore", "BaseSyncADKStore", "normalize_session_list_options")
 
 ConfigT = TypeVar("ConfigT", bound="DatabaseConfigProtocol[Any, Any, Any]")
 
 logger = get_logger("sqlspec.extensions.adk.store")
+
+SESSION_ORDER_COLUMNS: Final = ("create_time", "update_time")
 
 ADK_RESET_TABLE_PROFILES: Final = (
     ("adk_session", "adk_event", "adk_app_state", "adk_user_state", "adk_internal_metadata"),
@@ -304,12 +306,28 @@ class BaseAsyncADKStore(_ADKStoreCommon[ConfigT], ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def list_sessions(self, app_name: str, user_id: "str | None" = None) -> "list[StoredSession]":
+    async def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
         """List all sessions for an app, optionally filtered by user.
 
         Args:
             app_name: Name of the application.
             user_id: ID of the user. If None, returns all sessions for the app.
+            order_by: Timestamp column to sort on.
+            descending: Sort direction applied to the timestamp column and the
+                ``id`` tie-break.
+            limit: Maximum number of sessions to return. ``0`` returns an empty
+                list without database work.
+            offset: Number of leading rows to skip. Requires a finite limit
+                when positive.
 
         Returns:
             List of session records.
@@ -702,8 +720,32 @@ class BaseSyncADKStore(_ADKStoreCommon[ConfigT], ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def list_sessions(self, app_name: str, user_id: "str | None" = None) -> "list[StoredSession]":
-        """List all sessions for an app, optionally filtered by user."""
+    def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: "SessionOrderBy" = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> "list[StoredSession]":
+        """List all sessions for an app, optionally filtered by user.
+
+        Args:
+            app_name: Name of the application.
+            user_id: ID of the user. If None, returns all sessions for the app.
+            order_by: Timestamp column to sort on.
+            descending: Sort direction applied to the timestamp column and the
+                ``id`` tie-break.
+            limit: Maximum number of sessions to return. ``0`` returns an empty
+                list without database work.
+            offset: Number of leading rows to skip. Requires a finite limit
+                when positive.
+
+        Returns:
+            List of session records.
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -876,6 +918,51 @@ class BaseSyncADKStore(_ADKStoreCommon[ConfigT], ABC):
     def _drop_tables_sql(self) -> "list[str]":
         """Get the DROP TABLE SQL statements for this database dialect."""
         raise NotImplementedError
+
+
+def normalize_session_list_options(
+    order_by: "SessionOrderBy" = "update_time",
+    descending: bool = True,
+    limit: "int | None" = None,
+    offset: "int | None" = None,
+) -> "tuple[str, int | None, int]":
+    """Validate session listing options and render their deterministic order clause.
+
+    Args:
+        order_by: Timestamp column to sort on. Only ``create_time`` and
+            ``update_time`` are accepted.
+        descending: Sort direction applied to both the timestamp column and the
+            ``id`` tie-break.
+        limit: Maximum number of sessions to return, or ``None`` for an
+            unbounded listing.
+        offset: Number of leading rows to skip. ``None`` is equivalent to zero.
+
+    Returns:
+        The ``ORDER BY`` clause body, the validated limit, and the normalized
+        offset.
+
+    Raises:
+        ValueError: If the order column is outside the allowlist, a page bound
+            is a boolean or a negative integer, or a positive offset is
+            combined with an unbounded limit.
+    """
+    if order_by not in SESSION_ORDER_COLUMNS:
+        msg = f"order_by must be one of {SESSION_ORDER_COLUMNS}, got {order_by!r}"
+        raise ValueError(msg)
+    if limit is not None and (isinstance(limit, bool) or not isinstance(limit, int) or limit < 0):
+        msg = f"limit must be a non-negative integer or None, got {limit!r}"
+        raise ValueError(msg)
+    if offset is not None and (isinstance(offset, bool) or not isinstance(offset, int) or offset < 0):
+        msg = f"offset must be a non-negative integer or None, got {offset!r}"
+        raise ValueError(msg)
+
+    normalized_offset = 0 if offset is None else offset
+    if normalized_offset > 0 and limit is None:
+        msg = "offset requires a limit; unbounded offset is not supported"
+        raise ValueError(msg)
+
+    direction = "DESC" if descending else "ASC"
+    return f"{order_by} {direction}, id {direction}", limit, normalized_offset
 
 
 def _run_lifecycle_sync(config: Any, statements: "list[str]") -> None:

--- a/sqlspec/extensions/litestar/plugin.py
+++ b/sqlspec/extensions/litestar/plugin.py
@@ -836,9 +836,8 @@ class SQLSpecPlugin(InitPluginProtocol, CLIPlugin):
         Returns:
             The matching plugin state.
         """
-        for state in self._plugin_configs:
-            if state.annotation is None:
-                self._raise_plugin_not_registered()
+        if any(state.annotation is None for state in self._plugin_configs):
+            self._raise_plugin_not_registered()
         return self._get_plugin_state(name)
 
     def _get_plugin_state(

--- a/tests/integration/adapters/_shared/adk_behaviors.py
+++ b/tests/integration/adapters/_shared/adk_behaviors.py
@@ -221,3 +221,118 @@ async def assert_adk_reads_empty_when_tables_missing_contract(make_store: Any) -
         assert await _resolve(store.get_user_state("app", "user")) is None
     finally:
         await _aclose(config)
+
+
+_LIST_ORDER_SESSION_IDS = ("s-c", "s-a", "s-d", "s-b")
+"""Creation order deliberately differs from id order so both sort keys are observable."""
+
+
+async def _seed_list_order_sessions(store: Any) -> None:
+    """Create the ordering fixture: four sessions for user-a and one each for the other scopes."""
+    await _resolve(store.create_tables())
+    for session_id in _LIST_ORDER_SESSION_IDS:
+        await _resolve(store.create_session(session_id, "app", "user-a", {}))
+    await _resolve(store.create_session("s-other-user", "app", "user-b", {}))
+    await _resolve(store.create_session("s-other-app", "other", "user-a", {}))
+
+
+async def _session_ids(store: Any, **options: Any) -> "list[str]":
+    rows = await _resolve(store.list_sessions("app", "user-a", **options))
+    return [row["id"] for row in rows]
+
+
+async def assert_adk_list_sessions_default_order_contract(make_store: Any) -> None:
+    """The default listing stays recent-first and unbounded."""
+    config, store = make_store()
+    try:
+        await _seed_list_order_sessions(store)
+
+        rows = await _resolve(store.list_sessions("app", "user-a"))
+        update_times = [row["update_time"] for row in rows]
+
+        assert {row["id"] for row in rows} == set(_LIST_ORDER_SESSION_IDS)
+        assert update_times == sorted(update_times, reverse=True)
+        assert [row["id"] for row in rows] == await _session_ids(store, order_by="update_time", descending=True)
+    finally:
+        await _aclose(config)
+
+
+async def assert_adk_list_sessions_ordering_contract(make_store: Any) -> None:
+    """Both order columns sort in both directions and stay a stable total order."""
+    config, store = make_store()
+    try:
+        await _seed_list_order_sessions(store)
+
+        for order_by in ("create_time", "update_time"):
+            ascending = await _session_ids(store, order_by=order_by, descending=False)
+            descending = await _session_ids(store, order_by=order_by, descending=True)
+
+            assert sorted(ascending) == sorted(_LIST_ORDER_SESSION_IDS)
+            assert descending == list(reversed(ascending))
+            assert ascending == await _session_ids(store, order_by=order_by, descending=False)
+    finally:
+        await _aclose(config)
+
+
+async def assert_adk_list_sessions_paging_contract(make_store: Any) -> None:
+    """Finite pages partition the ordered listing without overlaps or gaps."""
+    config, store = make_store()
+    try:
+        await _seed_list_order_sessions(store)
+
+        for order_by in ("create_time", "update_time"):
+            for descending in (True, False):
+                options = {"order_by": order_by, "descending": descending}
+                everything = await _session_ids(store, **options)
+                first = await _session_ids(store, limit=2, offset=0, **options)
+                second = await _session_ids(store, limit=2, offset=2, **options)
+
+                assert first + second == everything
+                assert not set(first) & set(second)
+                assert await _session_ids(store, limit=2, offset=len(everything), **options) == []
+                assert await _session_ids(store, limit=10, offset=1, **options) == everything[1:]
+    finally:
+        await _aclose(config)
+
+
+async def assert_adk_list_sessions_filtering_precedes_paging_contract(make_store: Any) -> None:
+    """User and app filtering narrow the result set before the page is taken."""
+    config, store = make_store()
+    try:
+        await _seed_list_order_sessions(store)
+
+        app_page = await _resolve(store.list_sessions("app", limit=10, offset=0))
+        user_page = await _resolve(store.list_sessions("app", "user-b", limit=10, offset=0))
+
+        assert {row["id"] for row in app_page} == {*_LIST_ORDER_SESSION_IDS, "s-other-user"}
+        assert [row["id"] for row in user_page] == ["s-other-user"]
+        assert await _resolve(store.list_sessions("app", "user-b", limit=1, offset=1)) == []
+    finally:
+        await _aclose(config)
+
+
+async def assert_adk_list_sessions_option_validation_contract(make_store: Any) -> None:
+    """A zero limit answers empty and invalid options raise before any query runs."""
+    config, store = make_store()
+    try:
+        await _seed_list_order_sessions(store)
+
+        assert await _resolve(store.list_sessions("app", "user-a", limit=0)) == []
+        assert await _resolve(store.list_sessions("app", "user-a", limit=0, offset=2)) == []
+
+        for options in (
+            {"order_by": "id"},
+            {"order_by": "state"},
+            {"limit": -1},
+            {"offset": -1, "limit": 5},
+            {"limit": True},
+            {"offset": False, "limit": 5},
+            {"offset": 1},
+        ):
+            try:
+                await _resolve(store.list_sessions("app", "user-a", **options))
+            except ValueError:
+                continue
+            raise AssertionError(f"list_sessions accepted invalid options: {options}")
+    finally:
+        await _aclose(config)

--- a/tests/integration/adapters/_shared/suite_adk_store_contract.py
+++ b/tests/integration/adapters/_shared/suite_adk_store_contract.py
@@ -11,6 +11,11 @@ from tests.integration.adapters._shared.adk_behaviors import (
     assert_adk_get_events_filtering_contract,
     assert_adk_get_nonexistent_session_contract,
     assert_adk_list_sessions_contract,
+    assert_adk_list_sessions_default_order_contract,
+    assert_adk_list_sessions_filtering_precedes_paging_contract,
+    assert_adk_list_sessions_option_validation_contract,
+    assert_adk_list_sessions_ordering_contract,
+    assert_adk_list_sessions_paging_contract,
     assert_adk_reads_empty_when_tables_missing_contract,
     assert_adk_session_round_trip_contract,
     assert_adk_update_session_state_contract,
@@ -40,6 +45,31 @@ async def test_adk_update_session_state_contract(adk_store_case: AdkStoreCaseCon
 async def test_adk_list_sessions_contract(adk_store_case: AdkStoreCaseContext) -> None:
     """list_sessions filters by app and optional user."""
     await assert_adk_list_sessions_contract(adk_store_case.make_store)
+
+
+async def test_adk_list_sessions_default_order_contract(adk_store_case: AdkStoreCaseContext) -> None:
+    """The default listing stays recent-first and unbounded."""
+    await assert_adk_list_sessions_default_order_contract(adk_store_case.make_store)
+
+
+async def test_adk_list_sessions_ordering_contract(adk_store_case: AdkStoreCaseContext) -> None:
+    """Both order columns sort in both directions and stay a stable total order."""
+    await assert_adk_list_sessions_ordering_contract(adk_store_case.make_store)
+
+
+async def test_adk_list_sessions_paging_contract(adk_store_case: AdkStoreCaseContext) -> None:
+    """Finite pages partition the ordered listing without overlaps or gaps."""
+    await assert_adk_list_sessions_paging_contract(adk_store_case.make_store)
+
+
+async def test_adk_list_sessions_filtering_precedes_paging_contract(adk_store_case: AdkStoreCaseContext) -> None:
+    """User and app filtering narrow the result set before the page is taken."""
+    await assert_adk_list_sessions_filtering_precedes_paging_contract(adk_store_case.make_store)
+
+
+async def test_adk_list_sessions_option_validation_contract(adk_store_case: AdkStoreCaseContext) -> None:
+    """A zero limit answers empty and invalid options raise before any query runs."""
+    await assert_adk_list_sessions_option_validation_contract(adk_store_case.make_store)
 
 
 async def test_adk_delete_session_cascade_contract(adk_store_case: AdkStoreCaseContext) -> None:

--- a/tests/unit/adapters/test_adbc/test_adk_dialect_support.py
+++ b/tests/unit/adapters/test_adbc/test_adk_dialect_support.py
@@ -200,3 +200,75 @@ def test_owner_id_column_snowflake() -> None:
 
     ddl = store._sessions_ddl_snowflake()  # pyright: ignore[reportPrivateUsage]
     assert "account_id VARCHAR NOT NULL" in ddl
+
+
+def _store_for(driver_name: str) -> AdbcADKStore:
+    return AdbcADKStore(AdbcConfig(connection_config={"driver_name": driver_name, "uri": ":memory:"}))
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+@pytest.mark.parametrize("driver_name", ["postgresql", "sqlite", "duckdb", "snowflake"])
+def test_limit_offset_dialects_bind_a_row_limited_page(driver_name: str) -> None:
+    """PostgreSQL, SQLite, DuckDB, and Snowflake page with bound LIMIT/OFFSET."""
+    store = _store_for(driver_name)
+
+    sql, params = store._session_list_query("app", "u1", "create_time ASC, id ASC", 10, 20)  # pyright: ignore[reportPrivateUsage]
+
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM adk_session WHERE app_name = ? AND user_id = ? "
+        "ORDER BY create_time ASC, id ASC LIMIT ? OFFSET ?"
+    )
+    assert params == ("app", "u1", 10, 20)
+
+
+def test_generic_dialect_pages_with_standard_offset_fetch() -> None:
+    """The generic branch uses SQL:2008 row-limiting with the offset bound first."""
+    store = _store_for("unknown_driver")
+
+    sql, params = store._session_list_query("app", None, "update_time DESC, id DESC", 10, 0)  # pyright: ignore[reportPrivateUsage]
+
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM adk_session WHERE app_name = ? "
+        "ORDER BY update_time DESC, id DESC OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
+    )
+    assert params == ("app", 0, 10)
+
+
+@pytest.mark.parametrize("driver_name", ["postgresql", "sqlite", "duckdb", "snowflake", "unknown_driver"])
+def test_every_dialect_omits_pagination_for_an_unbounded_listing(driver_name: str) -> None:
+    """Without a limit no dialect emits a row-limiting clause."""
+    store = _store_for(driver_name)
+
+    sql, params = store._session_list_query("app", None, "update_time DESC, id DESC", None, 0)  # pyright: ignore[reportPrivateUsage]
+
+    assert _normalized(sql).endswith("WHERE app_name = ? ORDER BY update_time DESC, id DESC")
+    assert params == ("app",)
+
+
+def test_list_sessions_zero_limit_returns_empty_without_a_query() -> None:
+    """A zero limit short-circuits before any database work."""
+    store = _store_for("sqlite")
+
+    assert store.list_sessions("app", limit=0) == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+def test_list_sessions_rejects_invalid_options_before_connecting(options: "dict[str, object]") -> None:
+    """Invalid ordering or paging fails before a connection is acquired."""
+    store = _store_for("sqlite")
+
+    with pytest.raises(ValueError):
+        store.list_sessions("app", **options)  # type: ignore[arg-type]

--- a/tests/unit/adapters/test_adbc/test_adk_dialect_support.py
+++ b/tests/unit/adapters/test_adbc/test_adk_dialect_support.py
@@ -215,7 +215,7 @@ def test_limit_offset_dialects_bind_a_row_limited_page(driver_name: str) -> None
     """PostgreSQL, SQLite, DuckDB, and Snowflake page with bound LIMIT/OFFSET."""
     store = _store_for(driver_name)
 
-    sql, params = store._session_list_query("app", "u1", "create_time ASC, id ASC", 10, 20)  # pyright: ignore[reportPrivateUsage]
+    sql, params = store._session_list_query("app", "u1", "create_time", "ASC", 10, 20)  # pyright: ignore[reportPrivateUsage]
 
     assert _normalized(sql) == (
         "SELECT id, app_name, user_id, state, create_time, update_time "
@@ -229,7 +229,7 @@ def test_generic_dialect_pages_with_standard_offset_fetch() -> None:
     """The generic branch uses SQL:2008 row-limiting with the offset bound first."""
     store = _store_for("unknown_driver")
 
-    sql, params = store._session_list_query("app", None, "update_time DESC, id DESC", 10, 0)  # pyright: ignore[reportPrivateUsage]
+    sql, params = store._session_list_query("app", None, "update_time", "DESC", 10, 0)  # pyright: ignore[reportPrivateUsage]
 
     assert _normalized(sql) == (
         "SELECT id, app_name, user_id, state, create_time, update_time "
@@ -244,7 +244,7 @@ def test_every_dialect_omits_pagination_for_an_unbounded_listing(driver_name: st
     """Without a limit no dialect emits a row-limiting clause."""
     store = _store_for(driver_name)
 
-    sql, params = store._session_list_query("app", None, "update_time DESC, id DESC", None, 0)  # pyright: ignore[reportPrivateUsage]
+    sql, params = store._session_list_query("app", None, "update_time", "DESC", None, 0)  # pyright: ignore[reportPrivateUsage]
 
     assert _normalized(sql).endswith("WHERE app_name = ? ORDER BY update_time DESC, id DESC")
     assert params == ("app",)

--- a/tests/unit/adapters/test_aiomysql/test_adk_store.py
+++ b/tests/unit/adapters/test_aiomysql/test_adk_store.py
@@ -5,7 +5,8 @@ import asyncio
 from typing import Any, cast, get_args, get_origin
 from unittest.mock import MagicMock
 
-from typing_extensions import NotRequired
+import pytest
+from typing_extensions import NotRequired, Self
 
 from sqlspec.adapters.aiomysql.adk import AiomysqlADKConfig, AiomysqlADKMemoryStore, AiomysqlADKStore
 from sqlspec.config import ADKConfig
@@ -101,3 +102,113 @@ def test_aiomysql_table_missing_uses_errno_attribute() -> None:
     from sqlspec.adapters.aiomysql.adk.store import _is_mysql_table_missing
 
     assert _is_mysql_table_missing(_MysqlMissingTableError()) is True
+
+
+class _RecordingCursor:
+    """Records the SQL and bound parameters a session listing issues."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def record(self, sql: str, params: "Any" = None) -> None:
+        self.calls.append((sql, tuple(params or ())))
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+class _AsyncCursor(_RecordingCursor):
+    async def execute(self, sql: str, params: "Any" = None) -> None:
+        self.record(sql, params)
+
+    async def fetchall(self) -> "list[Any]":
+        return []
+
+    async def close(self) -> None:
+        return None
+
+
+class _AsyncConnection:
+    def __init__(self, cursor: _AsyncCursor) -> None:
+        self._cursor = cursor
+
+    async def cursor(self, cursor_class: "Any" = None) -> _AsyncCursor:
+        return self._cursor
+
+    async def __aenter__(self) -> "Self":
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+
+def _session_store_with_cursor() -> "tuple[AiomysqlADKStore, _AsyncCursor]":
+    cursor = _AsyncCursor()
+    config = _mock_config()
+    config.provide_connection = lambda *_a, **_k: _AsyncConnection(cursor)
+    return AiomysqlADKStore(config), cursor
+
+
+async def test_aiomysql_list_sessions_binds_order_and_page() -> None:
+    """Explicit ordering renders inline while page bounds bind as pyformat parameters."""
+    store, cursor = _session_store_with_cursor()
+
+    await store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM adk_session WHERE app_name = %s AND user_id = %s "
+        "ORDER BY create_time ASC, id ASC LIMIT %s OFFSET %s"
+    )
+    assert params == ("app", "u1", 10, 20)
+
+
+async def test_aiomysql_list_sessions_defaults_to_recent_first_without_a_page() -> None:
+    """The default listing keeps recent-first ordering and binds no page values."""
+    store, cursor = _session_store_with_cursor()
+
+    await store.list_sessions("app")
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql).endswith("WHERE app_name = %s ORDER BY update_time DESC, id DESC")
+    assert params == ("app",)
+
+
+async def test_aiomysql_list_sessions_orders_page_after_scope_parameters() -> None:
+    """Page values bind after the scope parameters that are actually present."""
+    store, cursor = _session_store_with_cursor()
+
+    await store.list_sessions("app", limit=5)
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql).endswith("ORDER BY update_time DESC, id DESC LIMIT %s OFFSET %s")
+    assert params == ("app", 5, 0)
+
+
+async def test_aiomysql_list_sessions_zero_limit_never_queries() -> None:
+    """A zero limit short-circuits before any database work."""
+    store, cursor = _session_store_with_cursor()
+
+    assert await store.list_sessions("app", limit=0) == []
+    assert cursor.calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+async def test_aiomysql_list_sessions_rejects_invalid_options(options: "dict[str, Any]") -> None:
+    """Invalid ordering or paging fails before a connection is acquired."""
+    store, cursor = _session_store_with_cursor()
+
+    with pytest.raises(ValueError):
+        await store.list_sessions("app", **options)
+
+    assert cursor.calls == []

--- a/tests/unit/adapters/test_aiosqlite/test_adk_config.py
+++ b/tests/unit/adapters/test_aiosqlite/test_adk_config.py
@@ -1,8 +1,10 @@
 """Aiosqlite ADK adapter-local configuration tests."""
 
-from typing import get_type_hints
+from typing import Any, get_type_hints
+from unittest.mock import MagicMock
 
 import pytest
+from typing_extensions import Self
 
 from sqlspec.adapters.aiosqlite.adk import AiosqliteADKConfig, AiosqliteADKMemoryStore, AiosqliteADKStore
 from sqlspec.adapters.aiosqlite.config import AiosqliteConfig
@@ -86,3 +88,105 @@ async def test_aiosqlite_adk_fts5_options_render_only_when_fts_enabled() -> None
     sql = await configured_store._memory_table_ddl()
     assert "tokenize = 'porter unicode61'" in sql
     assert "detail = column" in sql
+
+
+class _SessionListCursor:
+    def __init__(self) -> None:
+        self.rows: list[Any] = []
+
+    async def fetchall(self) -> "list[Any]":
+        return self.rows
+
+
+class _SessionListConnection:
+    """Record the session-list query and its bound parameters."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def execute(self, sql: str, params: "tuple[Any, ...] | None" = None) -> _SessionListCursor:
+        if params is not None:
+            self.calls.append((sql, params))
+        return _SessionListCursor()
+
+    async def __aenter__(self) -> "Self":
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+def _session_store_with_connection() -> "tuple[AiosqliteADKStore, _SessionListConnection]":
+    conn = _SessionListConnection()
+    config = MagicMock()
+    config.extension_config = {"adk": {}}
+    config.provide_connection = lambda *_a, **_k: conn
+    return AiosqliteADKStore(config), conn
+
+
+async def test_aiosqlite_list_sessions_binds_order_and_page() -> None:
+    """Explicit ordering renders inline while page bounds bind as qmark parameters."""
+    store, conn = _session_store_with_connection()
+
+    await store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params = conn.calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM adk_session WHERE app_name = ? AND user_id = ? "
+        "ORDER BY create_time ASC, id ASC LIMIT ? OFFSET ?"
+    )
+    assert params == ("app", "u1", 10, 20)
+
+
+async def test_aiosqlite_list_sessions_defaults_to_recent_first_without_a_page() -> None:
+    """The default listing keeps recent-first ordering and binds no page values."""
+    store, conn = _session_store_with_connection()
+
+    await store.list_sessions("app")
+
+    sql, params = conn.calls[0]
+    assert _normalized(sql).endswith("WHERE app_name = ? ORDER BY update_time DESC, id DESC")
+    assert params == ("app",)
+
+
+async def test_aiosqlite_list_sessions_orders_page_after_scope_parameters() -> None:
+    """Page values bind after the scope parameters that are actually present."""
+    store, conn = _session_store_with_connection()
+
+    await store.list_sessions("app", limit=5)
+
+    sql, params = conn.calls[0]
+    assert _normalized(sql).endswith("ORDER BY update_time DESC, id DESC LIMIT ? OFFSET ?")
+    assert params == ("app", 5, 0)
+
+
+async def test_aiosqlite_list_sessions_zero_limit_never_opens_a_connection() -> None:
+    """A zero limit short-circuits before any database work."""
+    store, conn = _session_store_with_connection()
+
+    assert await store.list_sessions("app", limit=0) == []
+    assert conn.calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+async def test_aiosqlite_list_sessions_rejects_invalid_options_before_connecting(options: "dict[str, Any]") -> None:
+    """Invalid ordering or paging fails before a connection is acquired."""
+    store, conn = _session_store_with_connection()
+
+    with pytest.raises(ValueError):
+        await store.list_sessions("app", **options)
+
+    assert conn.calls == []

--- a/tests/unit/adapters/test_arrow_odbc/test_adk_store.py
+++ b/tests/unit/adapters/test_arrow_odbc/test_adk_store.py
@@ -4,6 +4,8 @@
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 from sqlspec.adapters.arrow_odbc.adk import ArrowOdbcADKStore
 
 
@@ -87,3 +89,87 @@ def test_existence_checks_bounded_query_count() -> None:
 
     assert driver.data_dictionary.get_tables.call_count == 1
     assert driver.data_dictionary.get_indexes.call_count == 1
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+def _session_store_with_capture(
+    monkeypatch: "pytest.MonkeyPatch",
+) -> "tuple[ArrowOdbcADKStore, list[tuple[str, tuple[Any, ...]]]]":
+    calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def capture(_store: ArrowOdbcADKStore, sql: str, params: "tuple[Any, ...]" = ()) -> "list[Any]":
+        calls.append((sql, tuple(params)))
+        return []
+
+    monkeypatch.setattr(ArrowOdbcADKStore, "_execute_fetchall", capture)
+    return ArrowOdbcADKStore(_mock_config()), calls
+
+
+def test_arrow_odbc_list_sessions_binds_order_and_page(monkeypatch: "pytest.MonkeyPatch") -> None:
+    """SQL Server row limiting binds the offset before the row count."""
+    store, calls = _session_store_with_capture(monkeypatch)
+
+    store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params = calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM [dbo].[adk_session] WHERE app_name = ? AND user_id = ? "
+        "ORDER BY create_time ASC, id ASC "
+        "OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
+    )
+    assert params == ("app", "u1", 20, 10)
+
+
+def test_arrow_odbc_list_sessions_defaults_to_recent_first_without_a_page(monkeypatch: "pytest.MonkeyPatch") -> None:
+    """The default listing keeps recent-first ordering and emits no row limiting."""
+    store, calls = _session_store_with_capture(monkeypatch)
+
+    store.list_sessions("app")
+
+    sql, params = calls[0]
+    assert _normalized(sql).endswith("WHERE app_name = ? ORDER BY update_time DESC, id DESC")
+    assert params == ("app",)
+
+
+def test_arrow_odbc_list_sessions_pages_an_unfiltered_listing(monkeypatch: "pytest.MonkeyPatch") -> None:
+    """Row limiting composes with an app-only listing."""
+    store, calls = _session_store_with_capture(monkeypatch)
+
+    store.list_sessions("app", limit=5)
+
+    sql, params = calls[0]
+    assert _normalized(sql).endswith("ORDER BY update_time DESC, id DESC OFFSET ? ROWS FETCH NEXT ? ROWS ONLY")
+    assert params == ("app", 0, 5)
+
+
+def test_arrow_odbc_list_sessions_zero_limit_never_queries(monkeypatch: "pytest.MonkeyPatch") -> None:
+    """A zero limit short-circuits before any database work."""
+    store, calls = _session_store_with_capture(monkeypatch)
+
+    assert store.list_sessions("app", limit=0) == []
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+def test_arrow_odbc_list_sessions_rejects_invalid_options(
+    monkeypatch: "pytest.MonkeyPatch", options: "dict[str, Any]"
+) -> None:
+    """Invalid ordering or paging fails before a connection is acquired."""
+    store, calls = _session_store_with_capture(monkeypatch)
+
+    with pytest.raises(ValueError):
+        store.list_sessions("app", **options)
+
+    assert calls == []

--- a/tests/unit/adapters/test_asyncmy/test_adk_store.py
+++ b/tests/unit/adapters/test_asyncmy/test_adk_store.py
@@ -5,7 +5,8 @@ import asyncio
 from typing import Any, cast, get_args, get_origin
 from unittest.mock import MagicMock
 
-from typing_extensions import NotRequired
+import pytest
+from typing_extensions import NotRequired, Self
 
 from sqlspec.adapters.asyncmy.adk import AsyncmyADKConfig, AsyncmyADKMemoryStore, AsyncmyADKStore
 from sqlspec.config import ADKConfig
@@ -101,3 +102,116 @@ def test_asyncmy_adk_tables_apply_adapter_local_mysql_profile() -> None:
     assert "COMMENT='adk-app-state'" in app_state_sql
     assert "COMMENT='adk-user-state'" in user_state_sql
     assert "COMMENT='adk-memory'" in memory_sql
+
+
+class _RecordingCursor:
+    """Records the SQL and bound parameters a session listing issues."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def record(self, sql: str, params: "Any" = None) -> None:
+        self.calls.append((sql, tuple(params or ())))
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+class _AsyncCursor(_RecordingCursor):
+    async def execute(self, sql: str, params: "Any" = None) -> None:
+        self.record(sql, params)
+
+    async def fetchall(self) -> "list[Any]":
+        return []
+
+    async def __aenter__(self) -> "Self":
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+
+class _AsyncConnection:
+    def __init__(self, cursor: _AsyncCursor) -> None:
+        self._cursor = cursor
+
+    def cursor(self) -> _AsyncCursor:
+        return self._cursor
+
+    async def __aenter__(self) -> "Self":
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+
+def _session_store_with_cursor() -> "tuple[AsyncmyADKStore, _AsyncCursor]":
+    cursor = _AsyncCursor()
+    config = _mock_config()
+    config.provide_connection = lambda *_a, **_k: _AsyncConnection(cursor)
+    return AsyncmyADKStore(config), cursor
+
+
+async def test_asyncmy_list_sessions_binds_order_and_page() -> None:
+    """Explicit ordering renders inline while page bounds bind as pyformat parameters."""
+    store, cursor = _session_store_with_cursor()
+
+    await store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM adk_session WHERE app_name = %s AND user_id = %s "
+        "ORDER BY create_time ASC, id ASC LIMIT %s OFFSET %s"
+    )
+    assert params == ("app", "u1", 10, 20)
+
+
+async def test_asyncmy_list_sessions_defaults_to_recent_first_without_a_page() -> None:
+    """The default listing keeps recent-first ordering and binds no page values."""
+    store, cursor = _session_store_with_cursor()
+
+    await store.list_sessions("app")
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql).endswith("WHERE app_name = %s ORDER BY update_time DESC, id DESC")
+    assert params == ("app",)
+
+
+async def test_asyncmy_list_sessions_orders_page_after_scope_parameters() -> None:
+    """Page values bind after the scope parameters that are actually present."""
+    store, cursor = _session_store_with_cursor()
+
+    await store.list_sessions("app", limit=5)
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql).endswith("ORDER BY update_time DESC, id DESC LIMIT %s OFFSET %s")
+    assert params == ("app", 5, 0)
+
+
+async def test_asyncmy_list_sessions_zero_limit_never_queries() -> None:
+    """A zero limit short-circuits before any database work."""
+    store, cursor = _session_store_with_cursor()
+
+    assert await store.list_sessions("app", limit=0) == []
+    assert cursor.calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+async def test_asyncmy_list_sessions_rejects_invalid_options(options: "dict[str, Any]") -> None:
+    """Invalid ordering or paging fails before a connection is acquired."""
+    store, cursor = _session_store_with_cursor()
+
+    with pytest.raises(ValueError):
+        await store.list_sessions("app", **options)
+
+    assert cursor.calls == []

--- a/tests/unit/adapters/test_asyncpg/test_adk_store.py
+++ b/tests/unit/adapters/test_asyncpg/test_adk_store.py
@@ -4,6 +4,7 @@
 from typing import Any, cast, get_args, get_origin
 from unittest.mock import MagicMock
 
+import pytest
 from typing_extensions import NotRequired, Self
 
 from sqlspec.adapters.asyncpg.adk import AsyncpgADKConfig, AsyncpgADKMemoryStore, AsyncpgADKStore
@@ -188,3 +189,81 @@ async def test_asyncpg_memory_search_embedding_only_orders_by_distance() -> None
     assert "ORDER BY embedding <=>" in sql
     assert "rrf_score" not in sql
     assert [0.5, 0.6] in params
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+def _session_store_with_connection() -> "tuple[AsyncpgADKStore, _RecordingConnection]":
+    conn = _RecordingConnection()
+    config = _mock_config()
+    config.provide_connection = lambda *_a, **_k: conn
+    return AsyncpgADKStore(config), conn
+
+
+async def test_asyncpg_list_sessions_binds_order_and_page() -> None:
+    """Explicit ordering renders inline while page bounds bind as numbered parameters."""
+    store, conn = _session_store_with_connection()
+
+    await store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params = conn.calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM adk_session WHERE app_name = $1 AND user_id = $2 "
+        "ORDER BY create_time ASC, id ASC LIMIT $3 OFFSET $4"
+    )
+    assert params == ("app", "u1", 10, 20)
+
+
+async def test_asyncpg_list_sessions_defaults_to_recent_first_without_a_page() -> None:
+    """The default listing keeps recent-first ordering and binds no page values."""
+    store, conn = _session_store_with_connection()
+
+    await store.list_sessions("app")
+
+    sql, params = conn.calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM adk_session WHERE app_name = $1 ORDER BY update_time DESC, id DESC"
+    )
+    assert params == ("app",)
+
+
+async def test_asyncpg_list_sessions_numbers_page_placeholders_without_a_user_filter() -> None:
+    """Page placeholders follow the scope parameters that are actually present."""
+    store, conn = _session_store_with_connection()
+
+    await store.list_sessions("app", limit=5)
+
+    sql, params = conn.calls[0]
+    assert _normalized(sql).endswith("ORDER BY update_time DESC, id DESC LIMIT $2 OFFSET $3")
+    assert params == ("app", 5, 0)
+
+
+async def test_asyncpg_list_sessions_zero_limit_never_opens_a_connection() -> None:
+    """A zero limit short-circuits before any database work."""
+    store, conn = _session_store_with_connection()
+
+    assert await store.list_sessions("app", limit=0) == []
+    assert conn.calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+async def test_asyncpg_list_sessions_rejects_invalid_options_before_connecting(options: "dict[str, Any]") -> None:
+    """Invalid ordering or paging fails before a connection is acquired."""
+    store, conn = _session_store_with_connection()
+
+    with pytest.raises(ValueError):
+        await store.list_sessions("app", **options)
+
+    assert conn.calls == []

--- a/tests/unit/adapters/test_bigquery/test_adk_store.py
+++ b/tests/unit/adapters/test_bigquery/test_adk_store.py
@@ -213,3 +213,84 @@ def test_bigquery_adk_create_session_includes_owner_column_when_configured(monke
     assert any(
         getattr(param, "name", "") == "owner_id" and getattr(param, "value", None) == "tenant-1" for param in params
     )
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+def _capture_session_list(monkeypatch: Any, store: BigQueryADKStore) -> "list[tuple[str, list[Any]]]":
+    calls: list[tuple[str, list[Any]]] = []
+
+    def capture(_store: BigQueryADKStore, sql: str, parameters: Any = None) -> "list[dict[str, Any]]":
+        calls.append((sql, list(parameters or [])))
+        return []
+
+    monkeypatch.setattr(BigQueryADKStore, "_run_query", capture)
+    return calls
+
+
+def test_bigquery_list_sessions_binds_order_and_page(monkeypatch: Any) -> None:
+    """Explicit ordering renders inline while page bounds bind as named INT64 parameters."""
+    store = _make_store()
+    calls = _capture_session_list(monkeypatch, store)
+
+    store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, parameters = calls[0]
+    assert _normalized(sql).endswith("ORDER BY create_time ASC, id ASC LIMIT @limit OFFSET @offset")
+    assert [(p.name, p.type_, p.value) for p in parameters[-2:]] == [("limit", "INT64", 10), ("offset", "INT64", 20)]
+
+
+def test_bigquery_list_sessions_defaults_to_recent_first_without_a_page(monkeypatch: Any) -> None:
+    """The default listing keeps recent-first ordering and binds no page values."""
+    store = _make_store()
+    calls = _capture_session_list(monkeypatch, store)
+
+    store.list_sessions("app")
+
+    sql, parameters = calls[0]
+    assert _normalized(sql).endswith("ORDER BY update_time DESC, id DESC")
+    assert [p.name for p in parameters] == ["app_name", "window_start"]
+
+
+def test_bigquery_list_sessions_composes_user_filter_with_a_page(monkeypatch: Any) -> None:
+    """User filtering precedes the bound page values."""
+    store = _make_store()
+    calls = _capture_session_list(monkeypatch, store)
+
+    store.list_sessions("app", "u1", limit=5)
+
+    sql, parameters = calls[0]
+    assert "AND user_id = @user_id" in sql
+    assert [p.name for p in parameters] == ["app_name", "window_start", "user_id", "limit", "offset"]
+    assert [p.value for p in parameters[-2:]] == [5, 0]
+
+
+def test_bigquery_list_sessions_zero_limit_never_queries(monkeypatch: Any) -> None:
+    """A zero limit short-circuits before any query is issued."""
+    store = _make_store()
+    calls = _capture_session_list(monkeypatch, store)
+
+    assert store.list_sessions("app", limit=0) == []
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+def test_bigquery_list_sessions_rejects_invalid_options(monkeypatch: Any, options: "dict[str, Any]") -> None:
+    """Invalid ordering or paging fails before a query is issued."""
+    store = _make_store()
+    calls = _capture_session_list(monkeypatch, store)
+
+    with pytest.raises(ValueError):
+        store.list_sessions("app", **options)
+
+    assert calls == []

--- a/tests/unit/adapters/test_cockroach_asyncpg/test_adk_store.py
+++ b/tests/unit/adapters/test_cockroach_asyncpg/test_adk_store.py
@@ -5,7 +5,7 @@ from typing import Any, cast, get_args, get_origin
 from unittest.mock import MagicMock
 
 import pytest
-from typing_extensions import NotRequired
+from typing_extensions import NotRequired, Self
 
 from sqlspec.adapters.cockroach_asyncpg.adk import (
     CockroachAsyncpgADKConfig,
@@ -104,3 +104,97 @@ async def test_cockroach_asyncpg_memory_table_applies_trigram_index_and_locality
     assert "LOCALITY GLOBAL" in sql
     assert "idx_adk_memory_content_trgm" in sql
     assert "ON adk_memory USING GIN (content_text gin_trgm_ops)" in sql
+
+
+class _RecordingConnection:
+    """Captures the SQL and bound parameters a session listing issues."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def fetch(self, sql: str, *params: Any) -> "list[Any]":
+        self.calls.append((sql, params))
+        return []
+
+    async def __aenter__(self) -> "Self":
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+def _session_store_with_connection() -> "tuple[CockroachAsyncpgADKStore, _RecordingConnection]":
+    conn = _RecordingConnection()
+    config = _mock_config()
+    config.provide_connection = lambda *_a, **_k: conn
+    return CockroachAsyncpgADKStore(config), conn
+
+
+async def test_cockroach_asyncpg_list_sessions_binds_order_and_page() -> None:
+    """Explicit ordering renders inline while page bounds bind as numbered parameters."""
+    store, conn = _session_store_with_connection()
+
+    await store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params = conn.calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM adk_session WHERE app_name = $1 AND user_id = $2 "
+        "ORDER BY create_time ASC, id ASC LIMIT $3 OFFSET $4"
+    )
+    assert params == ("app", "u1", 10, 20)
+
+
+async def test_cockroach_asyncpg_list_sessions_defaults_to_recent_first_without_a_page() -> None:
+    """The default listing keeps recent-first ordering and binds no page values."""
+    store, conn = _session_store_with_connection()
+
+    await store.list_sessions("app")
+
+    sql, params = conn.calls[0]
+    assert _normalized(sql).endswith("WHERE app_name = $1 ORDER BY update_time DESC, id DESC")
+    assert params == ("app",)
+
+
+async def test_cockroach_asyncpg_list_sessions_numbers_page_placeholders_without_a_user_filter() -> None:
+    """Page placeholders follow the scope parameters that are actually present."""
+    store, conn = _session_store_with_connection()
+
+    await store.list_sessions("app", limit=5)
+
+    sql, params = conn.calls[0]
+    assert _normalized(sql).endswith("ORDER BY update_time DESC, id DESC LIMIT $2 OFFSET $3")
+    assert params == ("app", 5, 0)
+
+
+async def test_cockroach_asyncpg_list_sessions_zero_limit_never_opens_a_connection() -> None:
+    """A zero limit short-circuits before any database work."""
+    store, conn = _session_store_with_connection()
+
+    assert await store.list_sessions("app", limit=0) == []
+    assert conn.calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+async def test_cockroach_asyncpg_list_sessions_rejects_invalid_options_before_connecting(
+    options: "dict[str, Any]",
+) -> None:
+    """Invalid ordering or paging fails before a connection is acquired."""
+    store, conn = _session_store_with_connection()
+
+    with pytest.raises(ValueError):
+        await store.list_sessions("app", **options)
+
+    assert conn.calls == []

--- a/tests/unit/adapters/test_cockroach_psycopg/test_adk_store.py
+++ b/tests/unit/adapters/test_cockroach_psycopg/test_adk_store.py
@@ -5,7 +5,7 @@ from typing import Any, cast, get_args, get_origin
 from unittest.mock import MagicMock
 
 import pytest
-from typing_extensions import NotRequired
+from typing_extensions import NotRequired, Self
 
 from sqlspec.adapters.cockroach_psycopg.adk import (
     CockroachPsycopgADKConfig,
@@ -162,3 +162,161 @@ def test_cockroach_psycopg_sync_memory_table_applies_trigram_index_and_locality(
     assert "LOCALITY GLOBAL" in sql
     assert "idx_adk_memory_content_trgm" in sql
     assert "ON adk_memory USING GIN (content_text gin_trgm_ops)" in sql
+
+
+class _RecordingCursor:
+    """Captures the SQL and bound parameters a session listing issues."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def execute(self, sql: Any, params: Any = None) -> None:
+        self.calls.append((sql.decode() if isinstance(sql, bytes) else str(sql), tuple(params or ())))
+
+    def fetchall(self) -> "list[Any]":
+        return []
+
+    def __enter__(self) -> "Self":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        return None
+
+
+class _RecordingAsyncCursor(_RecordingCursor):
+    async def execute(self, sql: Any, params: Any = None) -> None:  # type: ignore[override]
+        _RecordingCursor.execute(self, sql, params)
+
+    async def fetchall(self) -> "list[Any]":  # type: ignore[override]
+        return []
+
+    async def __aenter__(self) -> "Self":
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+
+class _RecordingConnection:
+    def __init__(self, cursor: _RecordingCursor) -> None:
+        self._cursor = cursor
+
+    def cursor(self, **_: Any) -> Any:
+        return self._cursor
+
+    def __enter__(self) -> "Self":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        return None
+
+    async def __aenter__(self) -> "Self":
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+def _async_session_store() -> "tuple[CockroachPsycopgAsyncADKStore, _RecordingCursor]":
+    cursor = _RecordingAsyncCursor()
+    config = _mock_config()
+    config.provide_connection = lambda *_a, **_k: _RecordingConnection(cursor)
+    return CockroachPsycopgAsyncADKStore(config), cursor
+
+
+def _sync_session_store() -> "tuple[CockroachPsycopgSyncADKStore, _RecordingCursor]":
+    cursor = _RecordingCursor()
+    config = _mock_config()
+    config.provide_connection = lambda *_a, **_k: _RecordingConnection(cursor)
+    return CockroachPsycopgSyncADKStore(config), cursor
+
+
+async def test_cockroach_psycopg_async_list_sessions_binds_order_and_page() -> None:
+    """Explicit ordering renders inline while page bounds bind as pyformat parameters."""
+    store, cursor = _async_session_store()
+
+    await store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM adk_session WHERE app_name = %s AND user_id = %s "
+        "ORDER BY create_time ASC, id ASC LIMIT %s OFFSET %s"
+    )
+    assert params == ("app", "u1", 10, 20)
+
+
+def test_cockroach_psycopg_sync_list_sessions_binds_order_and_page() -> None:
+    """The sync path produces the same bounded query as the async path."""
+    store, cursor = _sync_session_store()
+
+    store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM adk_session WHERE app_name = %s AND user_id = %s "
+        "ORDER BY create_time ASC, id ASC LIMIT %s OFFSET %s"
+    )
+    assert params == ("app", "u1", 10, 20)
+
+
+async def test_cockroach_psycopg_async_list_sessions_defaults_to_recent_first() -> None:
+    """The default listing keeps recent-first ordering and binds no page values."""
+    store, cursor = _async_session_store()
+
+    await store.list_sessions("app")
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql).endswith("WHERE app_name = %s ORDER BY update_time DESC, id DESC")
+    assert params == ("app",)
+
+
+def test_cockroach_psycopg_sync_list_sessions_orders_page_after_scope_parameters() -> None:
+    """Page placeholders follow the scope parameters that are actually present."""
+    store, cursor = _sync_session_store()
+
+    store.list_sessions("app", limit=5)
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql).endswith("ORDER BY update_time DESC, id DESC LIMIT %s OFFSET %s")
+    assert params == ("app", 5, 0)
+
+
+async def test_cockroach_psycopg_async_list_sessions_zero_limit_never_queries() -> None:
+    """A zero limit short-circuits before any database work."""
+    store, cursor = _async_session_store()
+
+    assert await store.list_sessions("app", limit=0) == []
+    assert cursor.calls == []
+
+
+def test_cockroach_psycopg_sync_list_sessions_zero_limit_never_queries() -> None:
+    """A zero limit short-circuits before any database work on the sync path."""
+    store, cursor = _sync_session_store()
+
+    assert store.list_sessions("app", limit=0) == []
+    assert cursor.calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+def test_cockroach_psycopg_sync_list_sessions_rejects_invalid_options(options: "dict[str, Any]") -> None:
+    """Invalid ordering or paging fails before a connection is acquired."""
+    store, cursor = _sync_session_store()
+
+    with pytest.raises(ValueError):
+        store.list_sessions("app", **options)
+
+    assert cursor.calls == []

--- a/tests/unit/adapters/test_duckdb/test_adk_store.py
+++ b/tests/unit/adapters/test_duckdb/test_adk_store.py
@@ -5,7 +5,8 @@ from textwrap import dedent
 from typing import Any, cast, get_args, get_origin
 from unittest.mock import MagicMock
 
-from typing_extensions import NotRequired
+import pytest
+from typing_extensions import NotRequired, Self
 
 import sqlspec.adapters.duckdb.adk as duckdb_adk
 from sqlspec.adapters.duckdb.adk import DuckdbADKMemoryStore, DuckdbADKStore
@@ -147,3 +148,100 @@ def test_duckdb_adk_memory_fts_pragmas_apply_adapter_local_options() -> None:
         "PRAGMA create_fts_index('adk_memory', 'id', 'content_text', "
         "overwrite=1, stemmer='none', stopwords='none', ignore='[^a-z]+', strip_accents=0, lower=0)"
     )
+
+
+class _SessionListCursor:
+    def fetchall(self) -> "list[Any]":
+        return []
+
+
+class _SessionListConnection:
+    """Record the session-list query and its bound parameters."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def execute(self, sql: str, params: "tuple[Any, ...] | None" = None) -> _SessionListCursor:
+        self.calls.append((sql, tuple(params or ())))
+        return _SessionListCursor()
+
+    def __enter__(self) -> "Self":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        return None
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+def _session_store_with_connection() -> "tuple[DuckdbADKStore, _SessionListConnection]":
+    conn = _SessionListConnection()
+    config = _mock_config()
+    config.provide_connection = lambda *_a, **_k: conn
+    return DuckdbADKStore(config), conn
+
+
+def test_duckdb_list_sessions_binds_order_and_page() -> None:
+    """Explicit ordering renders inline while page bounds bind as qmark parameters."""
+    store, conn = _session_store_with_connection()
+
+    store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params = conn.calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM adk_session WHERE app_name = ? AND user_id = ? "
+        "ORDER BY create_time ASC, id ASC LIMIT ? OFFSET ?"
+    )
+    assert params == ("app", "u1", 10, 20)
+
+
+def test_duckdb_list_sessions_defaults_to_recent_first_without_a_page() -> None:
+    """The default listing keeps recent-first ordering and binds no page values."""
+    store, conn = _session_store_with_connection()
+
+    store.list_sessions("app")
+
+    sql, params = conn.calls[0]
+    assert _normalized(sql).endswith("WHERE app_name = ? ORDER BY update_time DESC, id DESC")
+    assert params == ("app",)
+
+
+def test_duckdb_list_sessions_orders_page_after_scope_parameters() -> None:
+    """Page values bind after the scope parameters that are actually present."""
+    store, conn = _session_store_with_connection()
+
+    store.list_sessions("app", limit=5)
+
+    sql, params = conn.calls[0]
+    assert _normalized(sql).endswith("ORDER BY update_time DESC, id DESC LIMIT ? OFFSET ?")
+    assert params == ("app", 5, 0)
+
+
+def test_duckdb_list_sessions_zero_limit_never_opens_a_connection() -> None:
+    """A zero limit short-circuits before any database work."""
+    store, conn = _session_store_with_connection()
+
+    assert store.list_sessions("app", limit=0) == []
+    assert conn.calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+def test_duckdb_list_sessions_rejects_invalid_options_before_connecting(options: "dict[str, Any]") -> None:
+    """Invalid ordering or paging fails before a connection is acquired."""
+    store, conn = _session_store_with_connection()
+
+    with pytest.raises(ValueError):
+        store.list_sessions("app", **options)
+
+    assert conn.calls == []

--- a/tests/unit/adapters/test_mssql_python/test_adk_store.py
+++ b/tests/unit/adapters/test_mssql_python/test_adk_store.py
@@ -4,6 +4,7 @@
 from typing import Any, cast, get_args, get_origin
 from unittest.mock import MagicMock
 
+import pytest
 from typing_extensions import NotRequired
 
 from sqlspec.adapters.mssql_python.adk import MssqlPythonADKConfig, MssqlPythonADKStore
@@ -101,3 +102,87 @@ def test_sync_store_uses_tsql_upsert_and_top_limit() -> None:
     assert "SELECT TOP (?)" in events_sql
     assert params[0] == 5
     assert "LIMIT" not in events_sql
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+def _session_store_with_capture(
+    monkeypatch: "pytest.MonkeyPatch",
+) -> "tuple[MssqlPythonADKStore, list[tuple[str, tuple[Any, ...]]]]":
+    calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def capture(_store: MssqlPythonADKStore, sql: str, params: "tuple[Any, ...]" = ()) -> "list[Any]":
+        calls.append((sql, tuple(params)))
+        return []
+
+    monkeypatch.setattr(MssqlPythonADKStore, "_execute_fetchall", capture)
+    return MssqlPythonADKStore(_mock_config()), calls
+
+
+def test_mssql_python_list_sessions_binds_order_and_page(monkeypatch: "pytest.MonkeyPatch") -> None:
+    """SQL Server row limiting binds the offset before the row count."""
+    store, calls = _session_store_with_capture(monkeypatch)
+
+    store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params = calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM [dbo].[adk_session] WHERE app_name = ? AND user_id = ? "
+        "ORDER BY create_time ASC, id ASC "
+        "OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
+    )
+    assert params == ("app", "u1", 20, 10)
+
+
+def test_mssql_python_list_sessions_defaults_to_recent_first_without_a_page(monkeypatch: "pytest.MonkeyPatch") -> None:
+    """The default listing keeps recent-first ordering and emits no row limiting."""
+    store, calls = _session_store_with_capture(monkeypatch)
+
+    store.list_sessions("app")
+
+    sql, params = calls[0]
+    assert _normalized(sql).endswith("WHERE app_name = ? ORDER BY update_time DESC, id DESC")
+    assert params == ("app",)
+
+
+def test_mssql_python_list_sessions_pages_an_unfiltered_listing(monkeypatch: "pytest.MonkeyPatch") -> None:
+    """Row limiting composes with an app-only listing."""
+    store, calls = _session_store_with_capture(monkeypatch)
+
+    store.list_sessions("app", limit=5)
+
+    sql, params = calls[0]
+    assert _normalized(sql).endswith("ORDER BY update_time DESC, id DESC OFFSET ? ROWS FETCH NEXT ? ROWS ONLY")
+    assert params == ("app", 0, 5)
+
+
+def test_mssql_python_list_sessions_zero_limit_never_queries(monkeypatch: "pytest.MonkeyPatch") -> None:
+    """A zero limit short-circuits before any database work."""
+    store, calls = _session_store_with_capture(monkeypatch)
+
+    assert store.list_sessions("app", limit=0) == []
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+def test_mssql_python_list_sessions_rejects_invalid_options(
+    monkeypatch: "pytest.MonkeyPatch", options: "dict[str, Any]"
+) -> None:
+    """Invalid ordering or paging fails before a connection is acquired."""
+    store, calls = _session_store_with_capture(monkeypatch)
+
+    with pytest.raises(ValueError):
+        store.list_sessions("app", **options)
+
+    assert calls == []

--- a/tests/unit/adapters/test_mysqlconnector/test_adk_store.py
+++ b/tests/unit/adapters/test_mysqlconnector/test_adk_store.py
@@ -5,7 +5,8 @@ import asyncio
 from typing import Any, cast, get_args, get_origin
 from unittest.mock import MagicMock
 
-from typing_extensions import NotRequired
+import pytest
+from typing_extensions import NotRequired, Self
 
 from sqlspec.adapters.mysqlconnector.adk import (
     MysqlConnectorADKConfig,
@@ -116,3 +117,209 @@ def test_mysqlconnector_sync_adk_tables_apply_same_mysql_profile() -> None:
     )
     assert "INDEX idx_adk_event_session (session_id, timestamp ASC, invocation_id)" in events_sql
     assert "COMMENT='adk-memory'" in memory_sql
+
+
+class _RecordingCursor:
+    """Records the SQL and bound parameters a session listing issues."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def record(self, sql: str, params: "Any" = None) -> None:
+        self.calls.append((sql, tuple(params or ())))
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+class _AsyncCursor(_RecordingCursor):
+    async def execute(self, sql: str, params: "Any" = None) -> None:
+        self.record(sql, params)
+
+    async def fetchall(self) -> "list[Any]":
+        return []
+
+    async def close(self) -> None:
+        return None
+
+
+class _SyncCursor(_RecordingCursor):
+    def execute(self, sql: str, params: "Any" = None) -> None:
+        self.record(sql, params)
+
+    def fetchall(self) -> "list[Any]":
+        return []
+
+    def close(self) -> None:
+        return None
+
+
+class _AsyncConnection:
+    def __init__(self, cursor: _AsyncCursor) -> None:
+        self._cursor = cursor
+
+    async def cursor(self) -> _AsyncCursor:
+        return self._cursor
+
+    async def __aenter__(self) -> "Self":
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+
+class _SyncConnection:
+    def __init__(self, cursor: _SyncCursor) -> None:
+        self._cursor = cursor
+
+    def cursor(self) -> _SyncCursor:
+        return self._cursor
+
+    def __enter__(self) -> "Self":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        return None
+
+
+def _session_store_with_cursor() -> "tuple[MysqlConnectorAsyncADKStore, _AsyncCursor]":
+    cursor = _AsyncCursor()
+    config = _mock_config()
+    config.provide_connection = lambda *_a, **_k: _AsyncConnection(cursor)
+    return MysqlConnectorAsyncADKStore(config), cursor
+
+
+def _sync_session_store_with_cursor() -> "tuple[MysqlConnectorSyncADKStore, _SyncCursor]":
+    cursor = _SyncCursor()
+    config = _mock_config()
+    config.provide_connection = lambda *_a, **_k: _SyncConnection(cursor)
+    return MysqlConnectorSyncADKStore(config), cursor
+
+
+async def test_mysqlconnector_async_list_sessions_binds_order_and_page() -> None:
+    """Explicit ordering renders inline while page bounds bind as pyformat parameters."""
+    store, cursor = _session_store_with_cursor()
+
+    await store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM adk_session WHERE app_name = %s AND user_id = %s "
+        "ORDER BY create_time ASC, id ASC LIMIT %s OFFSET %s"
+    )
+    assert params == ("app", "u1", 10, 20)
+
+
+async def test_mysqlconnector_async_list_sessions_defaults_to_recent_first_without_a_page() -> None:
+    """The default listing keeps recent-first ordering and binds no page values."""
+    store, cursor = _session_store_with_cursor()
+
+    await store.list_sessions("app")
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql).endswith("WHERE app_name = %s ORDER BY update_time DESC, id DESC")
+    assert params == ("app",)
+
+
+async def test_mysqlconnector_async_list_sessions_orders_page_after_scope_parameters() -> None:
+    """Page values bind after the scope parameters that are actually present."""
+    store, cursor = _session_store_with_cursor()
+
+    await store.list_sessions("app", limit=5)
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql).endswith("ORDER BY update_time DESC, id DESC LIMIT %s OFFSET %s")
+    assert params == ("app", 5, 0)
+
+
+async def test_mysqlconnector_async_list_sessions_zero_limit_never_queries() -> None:
+    """A zero limit short-circuits before any database work."""
+    store, cursor = _session_store_with_cursor()
+
+    assert await store.list_sessions("app", limit=0) == []
+    assert cursor.calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+async def test_mysqlconnector_async_list_sessions_rejects_invalid_options(options: "dict[str, Any]") -> None:
+    """Invalid ordering or paging fails before a connection is acquired."""
+    store, cursor = _session_store_with_cursor()
+
+    with pytest.raises(ValueError):
+        await store.list_sessions("app", **options)
+
+    assert cursor.calls == []
+
+
+def test_mysqlconnector_sync_list_sessions_binds_order_and_page() -> None:
+    """Explicit ordering renders inline while page bounds bind as pyformat parameters."""
+    store, cursor = _sync_session_store_with_cursor()
+
+    store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM adk_session WHERE app_name = %s AND user_id = %s "
+        "ORDER BY create_time ASC, id ASC LIMIT %s OFFSET %s"
+    )
+    assert params == ("app", "u1", 10, 20)
+
+
+def test_mysqlconnector_sync_list_sessions_defaults_to_recent_first_without_a_page() -> None:
+    """The default listing keeps recent-first ordering and binds no page values."""
+    store, cursor = _sync_session_store_with_cursor()
+
+    store.list_sessions("app")
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql).endswith("WHERE app_name = %s ORDER BY update_time DESC, id DESC")
+    assert params == ("app",)
+
+
+def test_mysqlconnector_sync_list_sessions_orders_page_after_scope_parameters() -> None:
+    """Page values bind after the scope parameters that are actually present."""
+    store, cursor = _sync_session_store_with_cursor()
+
+    store.list_sessions("app", limit=5)
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql).endswith("ORDER BY update_time DESC, id DESC LIMIT %s OFFSET %s")
+    assert params == ("app", 5, 0)
+
+
+def test_mysqlconnector_sync_list_sessions_zero_limit_never_queries() -> None:
+    """A zero limit short-circuits before any database work."""
+    store, cursor = _sync_session_store_with_cursor()
+
+    assert store.list_sessions("app", limit=0) == []
+    assert cursor.calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+def test_mysqlconnector_sync_list_sessions_rejects_invalid_options(options: "dict[str, Any]") -> None:
+    """Invalid ordering or paging fails before a connection is acquired."""
+    store, cursor = _sync_session_store_with_cursor()
+
+    with pytest.raises(ValueError):
+        store.list_sessions("app", **options)
+
+    assert cursor.calls == []

--- a/tests/unit/adapters/test_oracledb/test_oracle_adk_store.py
+++ b/tests/unit/adapters/test_oracledb/test_oracle_adk_store.py
@@ -6,7 +6,8 @@ from decimal import Decimal
 from typing import Any, cast, get_args, get_origin
 from unittest.mock import MagicMock
 
-from typing_extensions import NotRequired
+import pytest
+from typing_extensions import NotRequired, Self
 
 from sqlspec.adapters.oracledb.adk import (
     JSONStorageType,
@@ -341,3 +342,155 @@ def test_oracle_adk_create_tables_creates_absent_tables() -> None:
     executed = " ".join(str(call.args[0]) for call in driver.execute_script.call_args_list)
     assert "CREATE TABLE" in executed.upper()
     assert "SQLCODE != -955" not in executed
+
+
+class _RecordingCursor:
+    """Records the SQL and named binds a session listing issues."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def execute(self, sql: str, params: "dict[str, Any] | None" = None) -> None:
+        self.calls.append((sql, dict(params or {})))
+
+    def fetchall(self) -> "list[Any]":
+        return []
+
+
+class _AsyncRecordingCursor(_RecordingCursor):
+    async def execute(self, sql: str, params: "dict[str, Any] | None" = None) -> None:  # type: ignore[override]
+        _RecordingCursor.execute(self, sql, params)
+
+    async def fetchall(self) -> "list[Any]":  # type: ignore[override]
+        return []
+
+
+class _RecordingConnection:
+    def __init__(self, cursor: _RecordingCursor) -> None:
+        self._cursor = cursor
+
+    def cursor(self) -> _RecordingCursor:
+        return self._cursor
+
+    def __enter__(self) -> "Self":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        return None
+
+    async def __aenter__(self) -> "Self":
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+def _async_session_store() -> "tuple[OracleAsyncADKStore, _RecordingCursor]":
+    cursor = _AsyncRecordingCursor()
+    config = _config_for_storage(JSONStorageType.BLOB_JSON)
+    config.extension_config = {"adk": {}}
+    config.provide_connection = lambda *_a, **_k: _RecordingConnection(cursor)
+    return OracleAsyncADKStore(config), cursor
+
+
+def _sync_session_store() -> "tuple[OracleSyncADKStore, _RecordingCursor]":
+    cursor = _RecordingCursor()
+    config = _config_for_storage(JSONStorageType.BLOB_JSON)
+    config.extension_config = {"adk": {}}
+    config.provide_connection = lambda *_a, **_k: _RecordingConnection(cursor)
+    return OracleSyncADKStore(config), cursor
+
+
+async def test_oracle_async_list_sessions_binds_order_and_page() -> None:
+    """Oracle row limiting binds the page values as named parameters."""
+    store, cursor = _async_session_store()
+
+    await store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM adk_session WHERE app_name = :app_name AND user_id = :user_id "
+        "ORDER BY create_time ASC, id ASC "
+        "OFFSET :page_offset ROWS FETCH NEXT :page_limit ROWS ONLY"
+    )
+    assert params == {"app_name": "app", "user_id": "u1", "page_limit": 10, "page_offset": 20}
+
+
+def test_oracle_sync_list_sessions_binds_order_and_page() -> None:
+    """The sync cursor path produces the same bounded query as the async path."""
+    store, cursor = _sync_session_store()
+
+    store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM adk_session WHERE app_name = :app_name AND user_id = :user_id "
+        "ORDER BY create_time ASC, id ASC "
+        "OFFSET :page_offset ROWS FETCH NEXT :page_limit ROWS ONLY"
+    )
+    assert params == {"app_name": "app", "user_id": "u1", "page_limit": 10, "page_offset": 20}
+
+
+async def test_oracle_async_list_sessions_defaults_to_recent_first_without_a_page() -> None:
+    """The default listing keeps recent-first ordering and binds no page values."""
+    store, cursor = _async_session_store()
+
+    await store.list_sessions("app")
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql).endswith("WHERE app_name = :app_name ORDER BY update_time DESC, id DESC")
+    assert params == {"app_name": "app"}
+
+
+def test_oracle_sync_list_sessions_pages_an_unfiltered_listing() -> None:
+    """Row limiting composes with an app-only listing."""
+    store, cursor = _sync_session_store()
+
+    store.list_sessions("app", limit=5)
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql).endswith(
+        "ORDER BY update_time DESC, id DESC OFFSET :page_offset ROWS FETCH NEXT :page_limit ROWS ONLY"
+    )
+    assert params == {"app_name": "app", "page_limit": 5, "page_offset": 0}
+
+
+async def test_oracle_async_list_sessions_zero_limit_never_queries() -> None:
+    """A zero limit short-circuits before any database work."""
+    store, cursor = _async_session_store()
+
+    assert await store.list_sessions("app", limit=0) == []
+    assert cursor.calls == []
+
+
+def test_oracle_sync_list_sessions_zero_limit_never_queries() -> None:
+    """A zero limit short-circuits before any database work on the sync path."""
+    store, cursor = _sync_session_store()
+
+    assert store.list_sessions("app", limit=0) == []
+    assert cursor.calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+def test_oracle_sync_list_sessions_rejects_invalid_options(options: "dict[str, Any]") -> None:
+    """Invalid ordering or paging fails before a connection is acquired."""
+    store, cursor = _sync_session_store()
+
+    with pytest.raises(ValueError):
+        store.list_sessions("app", **options)
+
+    assert cursor.calls == []

--- a/tests/unit/adapters/test_psqlpy/test_adk_store.py
+++ b/tests/unit/adapters/test_psqlpy/test_adk_store.py
@@ -4,7 +4,8 @@
 from typing import Any, cast, get_args, get_origin
 from unittest.mock import MagicMock
 
-from typing_extensions import NotRequired
+import pytest
+from typing_extensions import NotRequired, Self
 
 from sqlspec.adapters.psqlpy.adk import PsqlpyADKConfig, PsqlpyADKStore
 from sqlspec.config import ADKConfig
@@ -58,3 +59,95 @@ async def test_psqlpy_adk_events_table_applies_adapter_local_extension_config() 
     assert "idx_adk_event_author_gc" in sql
     assert "idx_adk_event_node_path_gc" in sql
     assert "INCLUDE (invocation_id)" in sql
+
+
+class _RecordingConnection:
+    """Captures the SQL and bound parameters a session listing issues."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    async def fetch(self, sql: str, params: "list[Any]") -> None:
+        self.calls.append((sql, tuple(params)))
+        return
+
+    async def __aenter__(self) -> "Self":
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+def _session_store_with_connection() -> "tuple[PsqlpyADKStore, _RecordingConnection]":
+    conn = _RecordingConnection()
+    config = _mock_config()
+    config.provide_connection = lambda *_a, **_k: conn
+    return PsqlpyADKStore(config), conn
+
+
+async def test_psqlpy_list_sessions_binds_order_and_page() -> None:
+    """Explicit ordering renders inline while page bounds bind as numbered parameters."""
+    store, conn = _session_store_with_connection()
+
+    await store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params = conn.calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM adk_session WHERE app_name = $1 AND user_id = $2 "
+        "ORDER BY create_time ASC, id ASC LIMIT $3 OFFSET $4"
+    )
+    assert params == ("app", "u1", 10, 20)
+
+
+async def test_psqlpy_list_sessions_defaults_to_recent_first_without_a_page() -> None:
+    """The default listing keeps recent-first ordering and binds no page values."""
+    store, conn = _session_store_with_connection()
+
+    await store.list_sessions("app")
+
+    sql, params = conn.calls[0]
+    assert _normalized(sql).endswith("WHERE app_name = $1 ORDER BY update_time DESC, id DESC")
+    assert params == ("app",)
+
+
+async def test_psqlpy_list_sessions_numbers_page_placeholders_without_a_user_filter() -> None:
+    """Page placeholders follow the scope parameters that are actually present."""
+    store, conn = _session_store_with_connection()
+
+    await store.list_sessions("app", limit=5)
+
+    sql, params = conn.calls[0]
+    assert _normalized(sql).endswith("ORDER BY update_time DESC, id DESC LIMIT $2 OFFSET $3")
+    assert params == ("app", 5, 0)
+
+
+async def test_psqlpy_list_sessions_zero_limit_never_opens_a_connection() -> None:
+    """A zero limit short-circuits before any database work."""
+    store, conn = _session_store_with_connection()
+
+    assert await store.list_sessions("app", limit=0) == []
+    assert conn.calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+async def test_psqlpy_list_sessions_rejects_invalid_options_before_connecting(options: "dict[str, Any]") -> None:
+    """Invalid ordering or paging fails before a connection is acquired."""
+    store, conn = _session_store_with_connection()
+
+    with pytest.raises(ValueError):
+        await store.list_sessions("app", **options)
+
+    assert conn.calls == []

--- a/tests/unit/adapters/test_psycopg/test_adk_store.py
+++ b/tests/unit/adapters/test_psycopg/test_adk_store.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Any, cast, get_args, get_origin
 from unittest.mock import MagicMock
 
+import pytest
 from psycopg.types.json import Jsonb
 from typing_extensions import NotRequired, Self
 
@@ -262,3 +263,122 @@ def test_sync_append_event_and_update_state_writes_scoped_state_in_one_unit() ->
     assert user_state_params[:2] == ("app", "user")
     assert getattr(user_state_params[2], "obj", None) == {"user:theme": "dark"}
     assert connection.commit_called
+
+
+class _AsyncDummyCursor(_DummyCursor):
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        return None
+
+    async def execute(self, query: Any, params: Any = None) -> None:  # type: ignore[override]
+        _DummyCursor.execute(self, query, params)
+
+    async def fetchall(self) -> "list[dict[str, Any]]":  # type: ignore[override]
+        return self._rows
+
+
+class _AsyncDummyConnection(_DummyConnection):
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        return None
+
+
+def _rendered(query: Any) -> str:
+    return " ".join(query.as_string(None).split())
+
+
+def _async_session_store() -> "tuple[PsycopgAsyncADKStore, _AsyncDummyCursor]":
+    cursor = _AsyncDummyCursor()
+    config = _mock_config()
+    config.provide_connection = lambda *_a, **_k: _AsyncDummyConnection(cursor)
+    return PsycopgAsyncADKStore(config), cursor
+
+
+def _sync_session_store() -> "tuple[PsycopgSyncADKStore, _DummyCursor]":
+    cursor = _DummyCursor()
+    config = _mock_config()
+    config.provide_connection = lambda *_a, **_k: _DummyConnection(cursor)
+    return PsycopgSyncADKStore(config), cursor
+
+
+async def test_psycopg_async_list_sessions_binds_order_and_page() -> None:
+    """Explicit ordering renders inline while page bounds bind as pyformat parameters."""
+    store, cursor = _async_session_store()
+
+    await store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    query, params = cursor.execute_calls[0]
+    assert _rendered(query) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        'FROM "adk_session" WHERE app_name = %s AND user_id = %s '
+        "ORDER BY create_time ASC, id ASC LIMIT %s OFFSET %s"
+    )
+    assert params == ("app", "u1", 10, 20)
+
+
+def test_psycopg_sync_list_sessions_binds_order_and_page() -> None:
+    """The sync path produces the same bounded query as the async path."""
+    store, cursor = _sync_session_store()
+
+    store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    query, params = cursor.execute_calls[0]
+    assert _rendered(query) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        'FROM "adk_session" WHERE app_name = %s AND user_id = %s '
+        "ORDER BY create_time ASC, id ASC LIMIT %s OFFSET %s"
+    )
+    assert params == ("app", "u1", 10, 20)
+
+
+async def test_psycopg_async_list_sessions_defaults_to_recent_first() -> None:
+    """The default listing keeps recent-first ordering and binds no page values."""
+    store, cursor = _async_session_store()
+
+    await store.list_sessions("app")
+
+    query, params = cursor.execute_calls[0]
+    assert _rendered(query).endswith("WHERE app_name = %s ORDER BY update_time DESC, id DESC")
+    assert params == ("app",)
+
+
+def test_psycopg_sync_list_sessions_orders_page_after_scope_parameters() -> None:
+    """Page placeholders follow the scope parameters that are actually present."""
+    store, cursor = _sync_session_store()
+
+    store.list_sessions("app", limit=5)
+
+    query, params = cursor.execute_calls[0]
+    assert _rendered(query).endswith("ORDER BY update_time DESC, id DESC LIMIT %s OFFSET %s")
+    assert params == ("app", 5, 0)
+
+
+def test_psycopg_sync_list_sessions_zero_limit_never_queries() -> None:
+    """A zero limit short-circuits before any database work."""
+    store, cursor = _sync_session_store()
+
+    assert store.list_sessions("app", limit=0) == []
+    assert cursor.execute_calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+def test_psycopg_sync_list_sessions_rejects_invalid_options(options: "dict[str, Any]") -> None:
+    """Invalid ordering or paging fails before a connection is acquired."""
+    store, cursor = _sync_session_store()
+
+    with pytest.raises(ValueError):
+        store.list_sessions("app", **options)
+
+    assert cursor.execute_calls == []

--- a/tests/unit/adapters/test_pymssql/test_adk_store.py
+++ b/tests/unit/adapters/test_pymssql/test_adk_store.py
@@ -1,0 +1,99 @@
+# pyright: reportPrivateUsage=false
+"""Unit tests for pymssql ADK store session listing."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from sqlspec.adapters.pymssql.adk import PymssqlADKStore
+
+
+def _mock_config(adk_config: "dict[str, object] | None" = None) -> MagicMock:
+    config = MagicMock()
+    config.extension_config = {"adk": adk_config or {}}
+    return config
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+def _session_store_with_capture(
+    monkeypatch: "pytest.MonkeyPatch",
+) -> "tuple[PymssqlADKStore, list[tuple[str, tuple[Any, ...]]]]":
+    calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def capture(_store: PymssqlADKStore, sql: str, params: "tuple[Any, ...]" = ()) -> "list[Any]":
+        calls.append((sql, tuple(params)))
+        return []
+
+    monkeypatch.setattr(PymssqlADKStore, "_execute_fetchall", capture)
+    return PymssqlADKStore(_mock_config()), calls
+
+
+def test_pymssql_list_sessions_binds_order_and_page(monkeypatch: "pytest.MonkeyPatch") -> None:
+    """SQL Server row limiting binds the offset before the row count."""
+    store, calls = _session_store_with_capture(monkeypatch)
+
+    store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params = calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM [dbo].[adk_session] WHERE app_name = %s AND user_id = %s "
+        "ORDER BY create_time ASC, id ASC "
+        "OFFSET %s ROWS FETCH NEXT %s ROWS ONLY"
+    )
+    assert params == ("app", "u1", 20, 10)
+
+
+def test_pymssql_list_sessions_defaults_to_recent_first_without_a_page(monkeypatch: "pytest.MonkeyPatch") -> None:
+    """The default listing keeps recent-first ordering and emits no row limiting."""
+    store, calls = _session_store_with_capture(monkeypatch)
+
+    store.list_sessions("app")
+
+    sql, params = calls[0]
+    assert _normalized(sql).endswith("WHERE app_name = %s ORDER BY update_time DESC, id DESC")
+    assert params == ("app",)
+
+
+def test_pymssql_list_sessions_pages_an_unfiltered_listing(monkeypatch: "pytest.MonkeyPatch") -> None:
+    """Row limiting composes with an app-only listing."""
+    store, calls = _session_store_with_capture(monkeypatch)
+
+    store.list_sessions("app", limit=5)
+
+    sql, params = calls[0]
+    assert _normalized(sql).endswith("ORDER BY update_time DESC, id DESC OFFSET %s ROWS FETCH NEXT %s ROWS ONLY")
+    assert params == ("app", 0, 5)
+
+
+def test_pymssql_list_sessions_zero_limit_never_queries(monkeypatch: "pytest.MonkeyPatch") -> None:
+    """A zero limit short-circuits before any database work."""
+    store, calls = _session_store_with_capture(monkeypatch)
+
+    assert store.list_sessions("app", limit=0) == []
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+def test_pymssql_list_sessions_rejects_invalid_options(
+    monkeypatch: "pytest.MonkeyPatch", options: "dict[str, Any]"
+) -> None:
+    """Invalid ordering or paging fails before a connection is acquired."""
+    store, calls = _session_store_with_capture(monkeypatch)
+
+    with pytest.raises(ValueError):
+        store.list_sessions("app", **options)
+
+    assert calls == []

--- a/tests/unit/adapters/test_pymysql/test_adk_store.py
+++ b/tests/unit/adapters/test_pymysql/test_adk_store.py
@@ -4,7 +4,8 @@
 from typing import Any, cast, get_args, get_origin
 from unittest.mock import MagicMock
 
-from typing_extensions import NotRequired
+import pytest
+from typing_extensions import NotRequired, Self
 
 from sqlspec.adapters.pymysql.adk import PyMysqlADKConfig, PyMysqlADKMemoryStore, PyMysqlADKStore
 from sqlspec.config import ADKConfig
@@ -100,3 +101,113 @@ def test_pymysql_adk_tables_apply_adapter_local_mysql_profile() -> None:
     assert "COMMENT='adk-app-state'" in app_state_sql
     assert "COMMENT='adk-user-state'" in user_state_sql
     assert "COMMENT='adk-memory'" in memory_sql
+
+
+class _RecordingCursor:
+    """Records the SQL and bound parameters a session listing issues."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def record(self, sql: str, params: "Any" = None) -> None:
+        self.calls.append((sql, tuple(params or ())))
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+class _SyncCursor(_RecordingCursor):
+    def execute(self, sql: str, params: "Any" = None) -> None:
+        self.record(sql, params)
+
+    def fetchall(self) -> "list[Any]":
+        return []
+
+    def close(self) -> None:
+        return None
+
+
+class _SyncConnection:
+    def __init__(self, cursor: _SyncCursor) -> None:
+        self._cursor = cursor
+
+    def cursor(self) -> _SyncCursor:
+        return self._cursor
+
+    def __enter__(self) -> "Self":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        return None
+
+
+def _sync_session_store_with_cursor() -> "tuple[PyMysqlADKStore, _SyncCursor]":
+    cursor = _SyncCursor()
+    config = _mock_config()
+    config.provide_connection = lambda *_a, **_k: _SyncConnection(cursor)
+    return PyMysqlADKStore(config), cursor
+
+
+def test_pymysql_list_sessions_binds_order_and_page() -> None:
+    """Explicit ordering renders inline while page bounds bind as pyformat parameters."""
+    store, cursor = _sync_session_store_with_cursor()
+
+    store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM adk_session WHERE app_name = %s AND user_id = %s "
+        "ORDER BY create_time ASC, id ASC LIMIT %s OFFSET %s"
+    )
+    assert params == ("app", "u1", 10, 20)
+
+
+def test_pymysql_list_sessions_defaults_to_recent_first_without_a_page() -> None:
+    """The default listing keeps recent-first ordering and binds no page values."""
+    store, cursor = _sync_session_store_with_cursor()
+
+    store.list_sessions("app")
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql).endswith("WHERE app_name = %s ORDER BY update_time DESC, id DESC")
+    assert params == ("app",)
+
+
+def test_pymysql_list_sessions_orders_page_after_scope_parameters() -> None:
+    """Page values bind after the scope parameters that are actually present."""
+    store, cursor = _sync_session_store_with_cursor()
+
+    store.list_sessions("app", limit=5)
+
+    sql, params = cursor.calls[0]
+    assert _normalized(sql).endswith("ORDER BY update_time DESC, id DESC LIMIT %s OFFSET %s")
+    assert params == ("app", 5, 0)
+
+
+def test_pymysql_list_sessions_zero_limit_never_queries() -> None:
+    """A zero limit short-circuits before any database work."""
+    store, cursor = _sync_session_store_with_cursor()
+
+    assert store.list_sessions("app", limit=0) == []
+    assert cursor.calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+def test_pymysql_list_sessions_rejects_invalid_options(options: "dict[str, Any]") -> None:
+    """Invalid ordering or paging fails before a connection is acquired."""
+    store, cursor = _sync_session_store_with_cursor()
+
+    with pytest.raises(ValueError):
+        store.list_sessions("app", **options)
+
+    assert cursor.calls == []

--- a/tests/unit/adapters/test_spanner/test_adk_store.py
+++ b/tests/unit/adapters/test_spanner/test_adk_store.py
@@ -6,7 +6,9 @@ from types import SimpleNamespace
 from typing import Any, cast, get_args, get_origin
 from unittest.mock import MagicMock, patch
 
+import pytest
 from google.api_core.exceptions import NotFound
+from google.cloud.spanner_v1 import param_types
 from typing_extensions import NotRequired
 
 from sqlspec.adapters.spanner.adk import (
@@ -278,3 +280,86 @@ def test_get_events_returns_empty_when_spanner_events_table_missing() -> None:
         result = store.get_events("app", "user", "session")
 
     assert result == []
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+def _capture_session_list(store: SpannerSyncADKStore) -> "list[tuple[str, dict[str, Any], dict[str, Any]]]":
+    calls: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+
+    def capture(sql: str, params: "dict[str, Any] | None" = None, types: "dict[str, Any] | None" = None) -> "list[Any]":
+        calls.append((sql, dict(params or {}), dict(types or {})))
+        return []
+
+    store._run_read = capture  # type: ignore[method-assign]
+    return calls
+
+
+def test_spanner_list_sessions_binds_order_and_page() -> None:
+    """Explicit ordering renders inline while page bounds bind as typed named parameters."""
+    store = SpannerSyncADKStore(_mock_config())
+    calls = _capture_session_list(store)
+
+    store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params, types = calls[0]
+    assert _normalized(sql).endswith("ORDER BY create_time ASC, id ASC LIMIT @limit OFFSET @offset")
+    assert params["limit"] == 10
+    assert params["offset"] == 20
+    assert types["limit"] is param_types.INT64
+    assert types["offset"] is param_types.INT64
+
+
+def test_spanner_list_sessions_defaults_to_recent_first_without_a_page() -> None:
+    """The default listing keeps recent-first ordering and binds no page values."""
+    store = SpannerSyncADKStore(_mock_config())
+    calls = _capture_session_list(store)
+
+    store.list_sessions("app")
+
+    sql, params, _ = calls[0]
+    assert _normalized(sql).endswith("ORDER BY update_time DESC, id DESC")
+    assert set(params) == {"app_name"}
+
+
+def test_spanner_list_sessions_composes_user_filter_with_a_page() -> None:
+    """User filtering composes with the bound page values."""
+    store = SpannerSyncADKStore(_mock_config())
+    calls = _capture_session_list(store)
+
+    store.list_sessions("app", "u1", limit=5)
+
+    sql, params, _ = calls[0]
+    assert "AND user_id = @user_id" in sql
+    assert params == {"app_name": "app", "user_id": "u1", "limit": 5, "offset": 0}
+
+
+def test_spanner_list_sessions_zero_limit_never_reads() -> None:
+    """A zero limit short-circuits before any read is issued."""
+    store = SpannerSyncADKStore(_mock_config())
+    calls = _capture_session_list(store)
+
+    assert store.list_sessions("app", limit=0) == []
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+def test_spanner_list_sessions_rejects_invalid_options(options: "dict[str, Any]") -> None:
+    """Invalid ordering or paging fails before a read is issued."""
+    store = SpannerSyncADKStore(_mock_config())
+    calls = _capture_session_list(store)
+
+    with pytest.raises(ValueError):
+        store.list_sessions("app", **options)
+
+    assert calls == []

--- a/tests/unit/adapters/test_sqlite/test_adk_config.py
+++ b/tests/unit/adapters/test_sqlite/test_adk_config.py
@@ -1,8 +1,10 @@
 """SQLite ADK adapter-local configuration tests."""
 
-from typing import get_type_hints
+from typing import Any, get_type_hints
+from unittest.mock import MagicMock
 
 import pytest
+from typing_extensions import Self
 
 from sqlspec.adapters.sqlite.adk import SqliteADKConfig, SqliteADKMemoryStore, SqliteADKStore
 from sqlspec.adapters.sqlite.config import SqliteConfig
@@ -86,3 +88,105 @@ def test_sqlite_adk_fts5_options_render_only_when_fts_enabled() -> None:
     sql = configured_store._memory_table_ddl()
     assert "tokenize = 'porter unicode61'" in sql
     assert "detail = column" in sql
+
+
+class _SessionListCursor:
+    def __init__(self) -> None:
+        self.rows: list[Any] = []
+
+    def fetchall(self) -> "list[Any]":
+        return self.rows
+
+
+class _SessionListConnection:
+    """Record the session-list query and its bound parameters."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def execute(self, sql: str, params: "tuple[Any, ...] | None" = None) -> _SessionListCursor:
+        if params is not None:
+            self.calls.append((sql, params))
+        return _SessionListCursor()
+
+    def __enter__(self) -> "Self":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        return None
+
+
+def _normalized(sql: str) -> str:
+    return " ".join(sql.split())
+
+
+def _session_store_with_connection() -> "tuple[SqliteADKStore, _SessionListConnection]":
+    conn = _SessionListConnection()
+    config = MagicMock()
+    config.extension_config = {"adk": {}}
+    config.provide_connection = lambda *_a, **_k: conn
+    return SqliteADKStore(config), conn
+
+
+def test_sqlite_list_sessions_binds_order_and_page() -> None:
+    """Explicit ordering renders inline while page bounds bind as qmark parameters."""
+    store, conn = _session_store_with_connection()
+
+    store.list_sessions("app", "u1", order_by="create_time", descending=False, limit=10, offset=20)
+
+    sql, params = conn.calls[0]
+    assert _normalized(sql) == (
+        "SELECT id, app_name, user_id, state, create_time, update_time "
+        "FROM adk_session WHERE app_name = ? AND user_id = ? "
+        "ORDER BY create_time ASC, id ASC LIMIT ? OFFSET ?"
+    )
+    assert params == ("app", "u1", 10, 20)
+
+
+def test_sqlite_list_sessions_defaults_to_recent_first_without_a_page() -> None:
+    """The default listing keeps recent-first ordering and binds no page values."""
+    store, conn = _session_store_with_connection()
+
+    store.list_sessions("app")
+
+    sql, params = conn.calls[0]
+    assert _normalized(sql).endswith("WHERE app_name = ? ORDER BY update_time DESC, id DESC")
+    assert params == ("app",)
+
+
+def test_sqlite_list_sessions_orders_page_after_scope_parameters() -> None:
+    """Page values bind after the scope parameters that are actually present."""
+    store, conn = _session_store_with_connection()
+
+    store.list_sessions("app", limit=5)
+
+    sql, params = conn.calls[0]
+    assert _normalized(sql).endswith("ORDER BY update_time DESC, id DESC LIMIT ? OFFSET ?")
+    assert params == ("app", 5, 0)
+
+
+def test_sqlite_list_sessions_zero_limit_never_opens_a_connection() -> None:
+    """A zero limit short-circuits before any database work."""
+    store, conn = _session_store_with_connection()
+
+    assert store.list_sessions("app", limit=0) == []
+    assert conn.calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "id"}, id="unknown-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": 5}, id="unbounded-offset"),
+    ],
+)
+def test_sqlite_list_sessions_rejects_invalid_options_before_connecting(options: "dict[str, Any]") -> None:
+    """Invalid ordering or paging fails before a connection is acquired."""
+    store, conn = _session_store_with_connection()
+
+    with pytest.raises(ValueError):
+        store.list_sessions("app", **options)
+
+    assert conn.calls == []

--- a/tests/unit/extensions/test_adk/test_maintenance.py
+++ b/tests/unit/extensions/test_adk/test_maintenance.py
@@ -241,6 +241,34 @@ def test_prune_artifacts_rejects_invalid_age_before_target_resolution() -> None:
         prune_artifacts_sync("invalid_target_string", older_than_days=0)
 
 
+@pytest.mark.parametrize(
+    "age", [pytest.param(False, id="false"), pytest.param(0, id="zero"), pytest.param(-1, id="negative")]
+)
+@pytest.mark.parametrize(
+    ("prune", "parameter", "store_factory", "deleter"),
+    [
+        pytest.param(prune_sessions_sync, "idle_days", MockSyncSessionStore, "delete_idle_sessions", id="sessions"),
+        pytest.param(prune_events_sync, "older_than_days", MockSyncSessionStore, "delete_expired_events", id="events"),
+        pytest.param(
+            prune_memory_sync, "older_than_days", MockSyncMemoryStore, "delete_entries_older_than", id="memory"
+        ),
+        pytest.param(
+            prune_user_state_sync, "idle_days", MockSyncSessionStore, "delete_idle_user_states", id="user_state"
+        ),
+    ],
+)
+def test_prune_helpers_reject_non_positive_ages(
+    prune: Any, parameter: str, store_factory: Any, deleter: str, age: Any
+) -> None:
+    """Every retention helper refuses a non-positive age instead of deleting everything."""
+    store = store_factory()
+
+    with pytest.raises(ValueError, match=f"{parameter} must be a positive integer"):
+        prune(store, **{parameter: age})
+
+    getattr(store, deleter).assert_not_called()
+
+
 def test_artifact_prune_helpers_are_publicly_exported() -> None:
     import sqlspec.extensions.adk as adk
 

--- a/tests/unit/extensions/test_adk/test_service.py
+++ b/tests/unit/extensions/test_adk/test_service.py
@@ -10,6 +10,7 @@ The store is mocked — no database required.
 """
 
 import importlib.util
+import inspect
 from datetime import datetime, timezone
 from typing import Any
 
@@ -25,6 +26,7 @@ from google.adk.sessions.session import Session
 
 from sqlspec.extensions.adk._types import StoredEvent, StoredSession
 from sqlspec.extensions.adk.service import SQLSpecSessionService
+from sqlspec.extensions.adk.store import BaseAsyncADKStore, BaseSyncADKStore
 
 # ---------------------------------------------------------------------------
 # Mock store
@@ -44,6 +46,7 @@ class MockStore:
         self.append_event_and_update_state_called = False
         self.get_session_calls = 0
         self.get_events_calls: list[dict[str, Any]] = []
+        self.list_sessions_calls: list[dict[str, Any]] = []
         self.upsert_app_state_calls: list[dict[str, Any]] = []
         self.upsert_user_state_calls: list[dict[str, Any]] = []
 
@@ -150,8 +153,25 @@ class MockStore:
         })
         return []
 
-    async def list_sessions(self, *, app_name: str, user_id: "str | None" = None) -> list:
-        return []
+    async def list_sessions(
+        self,
+        app_name: str,
+        user_id: "str | None" = None,
+        *,
+        order_by: str = "update_time",
+        descending: bool = True,
+        limit: "int | None" = None,
+        offset: "int | None" = None,
+    ) -> list:
+        self.list_sessions_calls.append({
+            "app_name": app_name,
+            "user_id": user_id,
+            "order_by": order_by,
+            "descending": descending,
+            "limit": limit,
+            "offset": offset,
+        })
+        return [self._session_record]
 
     async def delete_session(self, app_name: str, user_id: str, session_id: str) -> None:
         pass
@@ -696,3 +716,88 @@ async def test_create_session_sets_storage_update_marker() -> None:
     session = await service.create_session(app_name="app", user_id="u1")
 
     assert session._storage_update_marker is not None
+
+
+# ---------------------------------------------------------------------------
+# list_sessions — ordering and bounded pagination
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_list_sessions_forwards_explicit_order_and_page() -> None:
+    """Explicit ordering and page bounds reach the store unchanged."""
+    store = MockStore()
+    service = SQLSpecSessionService(store)  # type: ignore[arg-type]
+
+    await service.list_sessions(
+        app_name="app", user_id="u1", order_by="create_time", descending=False, limit=25, offset=50
+    )
+
+    assert store.list_sessions_calls == [
+        {"app_name": "app", "user_id": "u1", "order_by": "create_time", "descending": False, "limit": 25, "offset": 50}
+    ]
+
+
+@pytest.mark.anyio
+async def test_list_sessions_forwards_recent_first_defaults() -> None:
+    """Omitting the options keeps the historical recent-first listing."""
+    store = MockStore()
+    service = SQLSpecSessionService(store)  # type: ignore[arg-type]
+
+    await service.list_sessions(app_name="app")
+
+    assert store.list_sessions_calls == [
+        {"app_name": "app", "user_id": None, "order_by": "update_time", "descending": True, "limit": None, "offset": 0}
+    ]
+
+
+@pytest.mark.anyio
+async def test_list_sessions_zero_limit_skips_the_store() -> None:
+    """A zero limit answers with an empty response without any store call."""
+    store = MockStore()
+    service = SQLSpecSessionService(store)  # type: ignore[arg-type]
+
+    response = await service.list_sessions(app_name="app", limit=0)
+
+    assert response.sessions == []
+    assert store.list_sessions_calls == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        pytest.param({"order_by": "state"}, id="unknown-order-column"),
+        pytest.param({"order_by": "update_time; DROP TABLE adk_session"}, id="injected-order-column"),
+        pytest.param({"limit": -1}, id="negative-limit"),
+        pytest.param({"offset": -1, "limit": 5}, id="negative-offset"),
+        pytest.param({"limit": True}, id="boolean-limit"),
+        pytest.param({"offset": False, "limit": 5}, id="boolean-offset"),
+        pytest.param({"offset": 10}, id="unbounded-offset"),
+    ],
+)
+@pytest.mark.anyio
+async def test_list_sessions_rejects_invalid_options_before_store_io(options: "dict[str, Any]") -> None:
+    """Invalid ordering or paging fails before the store is reached."""
+    store = MockStore()
+    service = SQLSpecSessionService(store)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError):
+        await service.list_sessions(app_name="app", **options)
+
+    assert store.list_sessions_calls == []
+
+
+def test_service_and_store_contracts_share_session_list_options() -> None:
+    """The concrete service exposes the same list options as both store bases."""
+
+    def options(func: Any) -> "dict[str, Any]":
+        return {
+            name: (parameter.kind, parameter.default)
+            for name, parameter in inspect.signature(func).parameters.items()
+            if name in {"order_by", "descending", "limit", "offset"}
+        }
+
+    service_options = options(SQLSpecSessionService.list_sessions)
+
+    assert service_options == options(BaseAsyncADKStore.list_sessions)
+    assert service_options == options(BaseSyncADKStore.list_sessions)

--- a/tests/unit/extensions/test_adk/test_store_config.py
+++ b/tests/unit/extensions/test_adk/test_store_config.py
@@ -1,6 +1,7 @@
 # pyright: reportPrivateUsage=false
 """Tests for shared ADK store configuration behavior."""
 
+import inspect
 import logging
 from collections.abc import Sequence
 from datetime import datetime
@@ -8,13 +9,13 @@ from typing import Any, Literal
 
 import pytest
 
-from sqlspec.extensions.adk import StoredEvent, StoredSession
+from sqlspec.extensions.adk import SessionOrderBy, StoredEvent, StoredSession
 from sqlspec.extensions.adk.artifact._types import StoredArtifact
 from sqlspec.extensions.adk.artifact.store import BaseSyncADKArtifactStore
 from sqlspec.extensions.adk.memory import StoredMemory
 from sqlspec.extensions.adk.memory import store as memory_store_module
 from sqlspec.extensions.adk.memory.store import BaseSyncADKMemoryStore
-from sqlspec.extensions.adk.store import BaseAsyncADKStore, BaseSyncADKStore
+from sqlspec.extensions.adk.store import BaseAsyncADKStore, BaseSyncADKStore, normalize_session_list_options
 
 
 class _Config:
@@ -51,7 +52,16 @@ class _AsyncSessionStore(BaseAsyncADKStore[Any]):
     async def update_session_state(self, app_name: str, user_id: str, session_id: str, state: dict[str, Any]) -> None:
         return None
 
-    async def list_sessions(self, app_name: str, user_id: str | None = None) -> list[StoredSession]:
+    async def list_sessions(
+        self,
+        app_name: str,
+        user_id: str | None = None,
+        *,
+        order_by: SessionOrderBy = "update_time",
+        descending: bool = True,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[StoredSession]:
         return []
 
     async def delete_session(self, app_name: str, user_id: str, session_id: str) -> None:
@@ -172,7 +182,16 @@ class _SyncSessionStore(BaseSyncADKStore[Any]):
     def update_session_state(self, app_name: str, user_id: str, session_id: str, state: dict[str, Any]) -> None:
         return None
 
-    def list_sessions(self, app_name: str, user_id: str | None = None) -> list[StoredSession]:
+    def list_sessions(
+        self,
+        app_name: str,
+        user_id: str | None = None,
+        *,
+        order_by: SessionOrderBy = "update_time",
+        descending: bool = True,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[StoredSession]:
         return []
 
     def delete_session(self, app_name: str, user_id: str, session_id: str) -> None:
@@ -422,3 +441,73 @@ def test_sync_memory_store_reset_drop_tables_uses_drop_sql() -> None:
         "DROP TABLE IF EXISTS adk_memory",
         "DROP TABLE IF EXISTS adk_memory_entries",
     ]
+
+
+def _session_list_options(func: Any) -> "dict[str, Any]":
+    signature = inspect.signature(func)
+    return {
+        name: (parameter.kind, parameter.default)
+        for name, parameter in signature.parameters.items()
+        if name in {"order_by", "descending", "limit", "offset"}
+    }
+
+
+def test_base_stores_declare_identical_session_list_options() -> None:
+    """Sync and async base contracts expose the same keyword-only list options."""
+    expected = {
+        "order_by": (inspect.Parameter.KEYWORD_ONLY, "update_time"),
+        "descending": (inspect.Parameter.KEYWORD_ONLY, True),
+        "limit": (inspect.Parameter.KEYWORD_ONLY, None),
+        "offset": (inspect.Parameter.KEYWORD_ONLY, None),
+    }
+
+    assert _session_list_options(BaseAsyncADKStore.list_sessions) == expected
+    assert _session_list_options(BaseSyncADKStore.list_sessions) == expected
+
+
+def test_session_list_options_default_to_recent_first() -> None:
+    """The default contract keeps the historical recent-first ordering."""
+    assert normalize_session_list_options() == ("update_time DESC, id DESC", None, 0)
+
+
+@pytest.mark.parametrize(
+    ("order_by", "descending", "expected_clause"),
+    [
+        ("update_time", True, "update_time DESC, id DESC"),
+        ("update_time", False, "update_time ASC, id ASC"),
+        ("create_time", True, "create_time DESC, id DESC"),
+        ("create_time", False, "create_time ASC, id ASC"),
+    ],
+)
+def test_session_order_clause_ties_break_on_id_in_the_same_direction(
+    order_by: SessionOrderBy, descending: bool, expected_clause: str
+) -> None:
+    """The id tie-break always follows the timestamp column's direction."""
+    clause, _, _ = normalize_session_list_options(order_by, descending)
+
+    assert clause == expected_clause
+
+
+def test_session_list_options_normalize_absent_offset_to_zero() -> None:
+    """A missing offset is equivalent to starting at the first row."""
+    assert normalize_session_list_options("update_time", True, 10, None) == ("update_time DESC, id DESC", 10, 0)
+
+
+@pytest.mark.parametrize(
+    ("order_by", "limit", "offset"),
+    [
+        ("state", None, None),
+        ("id", None, None),
+        ("update_time", -1, None),
+        ("update_time", 5, -1),
+        ("update_time", True, None),
+        ("update_time", 5, True),
+        ("update_time", None, 10),
+        ("update_time", "5", None),
+        ("update_time", 5, "10"),
+    ],
+)
+def test_session_list_options_reject_invalid_input(order_by: Any, limit: Any, offset: Any) -> None:
+    """Unsupported order columns and page bounds raise before any query is built."""
+    with pytest.raises(ValueError):
+        normalize_session_list_options(order_by, True, limit, offset)

--- a/tests/unit/extensions/test_adk/test_store_config.py
+++ b/tests/unit/extensions/test_adk/test_store_config.py
@@ -467,30 +467,30 @@ def test_base_stores_declare_identical_session_list_options() -> None:
 
 def test_session_list_options_default_to_recent_first() -> None:
     """The default contract keeps the historical recent-first ordering."""
-    assert normalize_session_list_options() == ("update_time DESC, id DESC", None, 0)
+    assert normalize_session_list_options() == ("update_time", "DESC", None, 0)
 
 
 @pytest.mark.parametrize(
-    ("order_by", "descending", "expected_clause"),
+    ("order_by", "descending", "expected_direction"),
     [
-        ("update_time", True, "update_time DESC, id DESC"),
-        ("update_time", False, "update_time ASC, id ASC"),
-        ("create_time", True, "create_time DESC, id DESC"),
-        ("create_time", False, "create_time ASC, id ASC"),
+        ("update_time", True, "DESC"),
+        ("update_time", False, "ASC"),
+        ("create_time", True, "DESC"),
+        ("create_time", False, "ASC"),
     ],
 )
-def test_session_order_clause_ties_break_on_id_in_the_same_direction(
-    order_by: SessionOrderBy, descending: bool, expected_clause: str
+def test_session_order_parts_resolve_column_and_direction(
+    order_by: SessionOrderBy, descending: bool, expected_direction: str
 ) -> None:
-    """The id tie-break always follows the timestamp column's direction."""
-    clause, _, _ = normalize_session_list_options(order_by, descending)
+    """Adapters receive the allowlisted column and direction as separate parts."""
+    column, direction, _, _ = normalize_session_list_options(order_by, descending)
 
-    assert clause == expected_clause
+    assert (column, direction) == (order_by, expected_direction)
 
 
 def test_session_list_options_normalize_absent_offset_to_zero() -> None:
     """A missing offset is equivalent to starting at the first row."""
-    assert normalize_session_list_options("update_time", True, 10, None) == ("update_time DESC, id DESC", 10, 0)
+    assert normalize_session_list_options("update_time", True, 10, None) == ("update_time", "DESC", 10, 0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`list_sessions()` returned every session for an app or user with no way to order or page the result. Stores already sorted by `update_time DESC` internally, so the real gap was caller-selectable ordering plus SQL-side limit and offset. Paging now happens in the database rather than by fetching everything and slicing in Python.

- **New keyword options** on `SQLSpecSessionService.list_sessions()` and on every sync and async store: `order_by`, `descending`, `limit`, and `offset`.
- **Ordering is a closed allowlist.** Only `create_time` and `update_time` are accepted; no caller-supplied identifier or direction is ever interpolated into SQL.
- **Pages are stable.** `id` is applied as a same-direction secondary sort, so rows with identical timestamps cannot shuffle between pages.
- **Defaults are unchanged.** Calling `list_sessions()` with no new arguments behaves exactly as before.
- **Bounds are validated.** `limit` and `offset` reject booleans and negative values, `limit=0` returns empty without touching the database, and a positive `offset` requires a limit.
- **Every first-party store is covered** — PostgreSQL, CockroachDB, SQLite, DuckDB, ADBC, BigQuery, Spanner, the MySQL family, Oracle, and SQL Server — each using its own dialect's paging grammar.

### How you use it

```python
page = await service.list_sessions(
    app_name="agent_app",
    user_id="user-1",
    order_by="create_time",
    descending=False,
    limit=20,
    offset=40,
)
```

### Also in this change

**Retention helpers reject a non-positive age.** `prune_sessions()`, `prune_events()`, `prune_memory()`, and `prune_user_state()` accepted zero and negative day counts, where a zero silently meant "delete everything". All four now raise `ValueError`, matching `prune_artifacts()`.

Closes #712
