### PR TITLE
chore: restore generic notify budget name and retarget release to v0.62.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,7 @@ important operational fixes.
 Recent Updates
 ==============
 
-v0.62.0 - ADK retention, migration prerequisites, and event payload budgets
+v0.62.0 - ADK session paging and retention, migrations, and event payloads
 ------------------------------------------------------------------------------
 
 **Added:**
@@ -30,6 +30,17 @@ v0.62.0 - ADK retention, migration prerequisites, and event payload budgets
   removed. Artifact stores gained an overridable
   ``delete_artifacts_older_than()`` hook that is non-abstract, so existing
   third-party subclasses continue to instantiate.
+* Google ADK session listings can be ordered and paged.
+  :meth:`SQLSpecSessionService.list_sessions() <sqlspec.extensions.adk.SQLSpecSessionService.list_sessions>`
+  and every adapter session store accept ``order_by`` (``"create_time"`` or
+  ``"update_time"``), ``descending``, ``limit``, and ``offset``. The bounds are
+  applied in SQL, so a page no longer reads the whole table into memory before
+  slicing it. ``limit=0`` returns an empty result without reaching the database,
+  and a positive ``offset`` requires a finite limit. The
+  :data:`~sqlspec.extensions.adk.SessionOrderBy` literal and the
+  :func:`~sqlspec.extensions.adk.normalize_session_list_options` validator are
+  exported so third-party stores can share the same allowlist and bounds
+  checking.
 * :meth:`SQLSpecPlugin.get_config() <sqlspec.extensions.litestar.SQLSpecPlugin.get_config>`
   resolves a configuration by instance, by concrete type, or by ``bind_key``
   immediately after plugin construction, which makes CLI commands, migration
@@ -38,6 +49,18 @@ v0.62.0 - ADK retention, migration prerequisites, and event payload budgets
 
 **Changed:**
 
+* Session listings order by the requested timestamp column and then by ``id``
+  in the same direction. The tie-break keeps paging deterministic when several
+  sessions share a timestamp, where equal timestamps previously came back in
+  whatever order the database chose. Unbounded listings still default to
+  ``update_time`` descending.
+* :func:`~sqlspec.extensions.adk.prune_sessions`,
+  :func:`~sqlspec.extensions.adk.prune_events`,
+  :func:`~sqlspec.extensions.adk.prune_memory`, and
+  :func:`~sqlspec.extensions.adk.prune_user_state` reject a non-positive
+  retention age. ``idle_days=0`` or ``older_than_days=0`` previously resolved to
+  a cutoff of "now" and deleted every row; all five prune helpers now raise
+  ``ValueError``, matching :func:`~sqlspec.extensions.adk.prune_artifacts`.
 * ``enable_sessions`` and ``enable_memory`` are now the only per-feature gates
   for ADK migrations, and they gate both the upgrade and downgrade directions
   consistently.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,13 +9,82 @@ important operational fixes.
 Recent Updates
 ==============
 
-v0.61.1 - Compiled async exception handling
+v0.62.0 - ADK retention, migration prerequisites, and event payload budgets
 ------------------------------------------------------------------------------
+
+**Added:**
+
+* Native PostgreSQL notification payloads can be measured before publishing.
+  :data:`~sqlspec.extensions.events.MAX_NOTIFY_BYTES`,
+  :func:`~sqlspec.extensions.events.measure_notify_payload`, and
+  :func:`~sqlspec.extensions.events.fits_notify_payload` are exported from
+  :mod:`sqlspec.extensions.events`, so producers can chunk a batch instead of
+  discovering an oversized envelope as an exception. Measurement covers the
+  complete encoded envelope in UTF-8 bytes and shares one serialization
+  function with the encoder.
+* Google ADK artifact versions can be pruned by age.
+  :func:`~sqlspec.extensions.adk.prune_artifacts` and
+  :func:`~sqlspec.extensions.adk.prune_artifacts_sync` delete SQL metadata
+  first, then remove the referenced content objects on a best-effort basis
+  through the configured storage registry, reporting the number of version rows
+  removed. Artifact stores gained an overridable
+  ``delete_artifacts_older_than()`` hook that is non-abstract, so existing
+  third-party subclasses continue to instantiate.
+* :meth:`SQLSpecPlugin.get_config() <sqlspec.extensions.litestar.SQLSpecPlugin.get_config>`
+  resolves a configuration by instance, by concrete type, or by ``bind_key``
+  immediately after plugin construction, which makes CLI commands, migration
+  scripts, and standalone workers able to share the application's plugin
+  instance.
+
+**Changed:**
+
+* ``enable_sessions`` and ``enable_memory`` are now the only per-feature gates
+  for ADK migrations, and they gate both the upgrade and downgrade directions
+  consistently.
+* The native notification payload ceiling is 7,999 encoded bytes rather than
+  8,000. PostgreSQL requires a payload shorter than 8,000 bytes, so an envelope
+  of exactly 8,000 bytes was previously accepted locally and then rejected by
+  the server. Oversize errors now report the measured size, the maximum, and
+  the helper to use.
+* Publication timestamps in native notification envelopes are serialized at
+  fixed microsecond width, so envelope size no longer varies with the clock
+  reading. Previously emitted variable-width timestamps still decode.
+
+**Removed:**
+
+* ``include_sessions_migration`` and ``include_memory_migration`` are removed
+  from the ADK configuration without an alias or deprecation shim. The first was
+  never read and the second duplicated ``enable_memory``; use ``enable_sessions``
+  and ``enable_memory`` instead. Passing the removed keys raises at
+  configuration construction.
+* The unused destructive ``0002_reset_adk_tables`` migration is deleted.
+  ``0001_create_adk_tables`` remains the single canonical ADK schema migration.
 
 **Fixed:**
 
+* Fresh PostgreSQL databases can run the packaged ADK schema migration with
+  memory enabled. The migration now emits ``CREATE EXTENSION IF NOT EXISTS
+  vector`` immediately before the first statement that declares a ``VECTOR``
+  column, scoped to PostgreSQL-family dialects. Previously the memory DDL
+  declared vector columns and indexes without installing the extension, failing
+  with ``type "vector" does not exist`` on any server where pgvector was not
+  already present. Startup paths such as ``create_tables()`` and
+  ``ensure_tables()`` never install extensions.
+* ``SQLSpecPlugin.get_config()`` no longer requires application registration to
+  resolve a configuration, and it honors each configuration's ``bind_key``.
+  Resolving by type raises ``KeyError`` listing candidate bind keys when several
+  configurations share a concrete type, rather than returning the first match.
+  Generated Litestar dependency keys remain registration-bound.
 * Compiled async drivers no longer re-raise an exception already being handled
   by the caller when a database operation inside that handler succeeds.
+
+**Upgrade notes:**
+
+* The pgvector migration change requires the database server to have the
+  pgvector files available and the migration role to be permitted to run
+  ``CREATE EXTENSION``. On managed services where that privilege is withheld, a
+  DBA or the provider must pre-provision the extension. The failure now surfaces
+  at ``CREATE EXTENSION`` rather than later as a missing type.
 
 v0.61.0 - Scoped memory recall and ADK modernization
 ------------------------------------------------------------------------------

--- a/docs/reference/extensions/events.rst
+++ b/docs/reference/extensions/events.rst
@@ -121,7 +121,7 @@ Notification payload budget
 ---------------------------
 
 PostgreSQL rejects a ``NOTIFY`` payload of 8,000 bytes or more, so SQLSpec
-publishes at most :data:`~sqlspec.extensions.events.POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES`
+publishes at most :data:`~sqlspec.extensions.events.MAX_NOTIFY_BYTES`
 (7,999) bytes. That budget covers the **complete encoded envelope** — the event
 ID, your payload mapping, your metadata mapping, and the publication timestamp —
 not just the payload you pass to ``publish()``. Sizes are counted in UTF-8
@@ -137,7 +137,7 @@ what is published:
 .. code-block:: python
 
    from sqlspec.extensions.events import (
-       POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES,
+       MAX_NOTIFY_BYTES,
        fits_notify_payload,
        measure_notify_payload,
    )
@@ -159,7 +159,7 @@ what is published:
 
    payload = {"records": [{"id": 1}]}
    if not fits_notify_payload(payload, event_id="ingest-42"):
-       overflow = measure_notify_payload(payload, event_id="ingest-42") - POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES
+       overflow = measure_notify_payload(payload, event_id="ingest-42") - MAX_NOTIFY_BYTES
        raise ValueError(f"event is {overflow} bytes over the notification budget")
 
 Publishing an oversized event raises
@@ -378,7 +378,7 @@ Protocols
 Payload Helpers
 ===============
 
-.. autodata:: sqlspec.extensions.events.POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES
+.. autodata:: sqlspec.extensions.events.MAX_NOTIFY_BYTES
 
 .. autofunction:: sqlspec.extensions.events.measure_notify_payload
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ maintainers = [{ name = "Litestar Developers", email = "hello@litestar.dev" }]
 name = "sqlspec"
 readme = "README.md"
 requires-python = ">=3.10, <4.0"
-version = "0.61.1"
+version = "0.62.0"
 
 [project.urls]
 Discord = "https://discord.gg/litestar"

--- a/sqlspec/extensions/events/__init__.py
+++ b/sqlspec/extensions/events/__init__.py
@@ -12,7 +12,7 @@ from sqlspec.extensions.events._channel import (
 from sqlspec.extensions.events._hints import EventRuntimeHints, get_runtime_hints, resolve_adapter_name
 from sqlspec.extensions.events._models import EventMessage
 from sqlspec.extensions.events._payload import (
-    POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES,
+    MAX_NOTIFY_BYTES,
     decode_notify_payload,
     encode_notify_payload,
     fits_notify_payload,
@@ -33,7 +33,7 @@ from sqlspec.extensions.events._store import (
 )
 
 __all__ = (
-    "POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES",
+    "MAX_NOTIFY_BYTES",
     "AsyncEventBackendProtocol",
     "AsyncEventChannel",
     "AsyncEventHandler",

--- a/sqlspec/extensions/events/_payload.py
+++ b/sqlspec/extensions/events/_payload.py
@@ -10,7 +10,7 @@ from sqlspec.utils.serializers import from_json, to_json
 from sqlspec.utils.uuids import uuid4
 
 __all__ = (
-    "POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES",
+    "MAX_NOTIFY_BYTES",
     "coerce_dict",
     "coerce_optional_dict",
     "decode_notify_payload",
@@ -20,7 +20,7 @@ __all__ = (
     "parse_event_timestamp",
 )
 
-POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES = 7999
+MAX_NOTIFY_BYTES = 7999
 
 
 def coerce_dict(value: Any) -> "dict[str, Any]":
@@ -60,10 +60,10 @@ def encode_notify_payload(event_id: str, payload: "dict[str, Any]", metadata: "d
     """
     encoded = _serialize_notify_envelope(event_id, payload, metadata, datetime.now(timezone.utc))
     encoded_bytes = len(encoded)
-    if encoded_bytes > POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES:
+    if encoded_bytes > MAX_NOTIFY_BYTES:
         msg = (
             f"PostgreSQL NOTIFY payload is {encoded_bytes} encoded bytes and exceeds the "
-            f"{POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES}-byte maximum. Use fits_notify_payload() or "
+            f"{MAX_NOTIFY_BYTES}-byte maximum. Use fits_notify_payload() or "
             "measure_notify_payload() to split the batch before publishing."
         )
         raise EventChannelError(msg)
@@ -86,7 +86,7 @@ def fits_notify_payload(
     payload: "dict[str, Any]", metadata: "dict[str, Any] | None" = None, *, event_id: "str | None" = None
 ) -> bool:
     """Return whether the native notification envelope fits the PostgreSQL budget."""
-    return measure_notify_payload(payload, metadata, event_id=event_id) <= POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES
+    return measure_notify_payload(payload, metadata, event_id=event_id) <= MAX_NOTIFY_BYTES
 
 
 def decode_notify_payload(channel: str, payload: str) -> "EventMessage":

--- a/tests/unit/extensions/test_events/test_backend_factories.py
+++ b/tests/unit/extensions/test_events/test_backend_factories.py
@@ -356,9 +356,9 @@ def test_oracle_backend_envelope_round_trip() -> None:
 
 def test_public_notify_payload_budget_exports() -> None:
     """The notification payload budget and preflight helpers are public."""
-    from sqlspec.extensions.events import POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES, fits_notify_payload, measure_notify_payload
+    from sqlspec.extensions.events import MAX_NOTIFY_BYTES, fits_notify_payload, measure_notify_payload
 
-    assert POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES == 7999
+    assert MAX_NOTIFY_BYTES == 7999
     assert callable(measure_notify_payload)
     assert callable(fits_notify_payload)
 
@@ -425,14 +425,14 @@ def test_measure_notify_payload_matches_encoding_for_explicit_event_ids(event_id
 def test_notify_payload_at_maximum_bytes_publishes() -> None:
     """An envelope of exactly the maximum size fits and encodes."""
     from sqlspec.extensions.events import (
-        POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES,
+        MAX_NOTIFY_BYTES,
         encode_notify_payload,
         fits_notify_payload,
         measure_notify_payload,
     )
 
     event_id = "evt_boundary"
-    payload = _payload_measuring_exactly(POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES, event_id)
+    payload = _payload_measuring_exactly(MAX_NOTIFY_BYTES, event_id)
 
     assert measure_notify_payload(payload, None, event_id=event_id) == 7999
     assert fits_notify_payload(payload, None, event_id=event_id) is True
@@ -443,14 +443,14 @@ def test_notify_payload_one_byte_over_maximum_is_rejected() -> None:
     """An envelope one byte past the maximum fails preflight and encoding."""
     from sqlspec.exceptions import EventChannelError
     from sqlspec.extensions.events import (
-        POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES,
+        MAX_NOTIFY_BYTES,
         encode_notify_payload,
         fits_notify_payload,
         measure_notify_payload,
     )
 
     event_id = "evt_boundary"
-    payload = _payload_measuring_exactly(POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES + 1, event_id)
+    payload = _payload_measuring_exactly(MAX_NOTIFY_BYTES + 1, event_id)
 
     assert measure_notify_payload(payload, None, event_id=event_id) == 8000
     assert fits_notify_payload(payload, None, event_id=event_id) is False

--- a/uv.lock
+++ b/uv.lock
@@ -6768,7 +6768,7 @@ wheels = [
 
 [[package]]
 name = "sqlspec"
-version = "0.61.1"
+version = "0.62.0"
 source = { editable = "." }
 dependencies = [
     { name = "mypy-extensions" },


### PR DESCRIPTION
Two follow-ups to the work merged since v0.61.0, plus the release notes for it.

**The notification payload budget constant is dialect-neutral again.** It was exported as `POSTGRES_NOTIFY_MAX_PAYLOAD_BYTES`, which contradicts the deliberately generic naming of the shared notify payload module — every sibling in it (`encode_notify_payload`, `decode_notify_payload`, `measure_notify_payload`, `fits_notify_payload`) is dialect-independent. Restored to `MAX_NOTIFY_BYTES`. The constant is unreleased, so no alias or deprecation path is needed.

**The pending release is now v0.62.0 rather than v0.61.1.** A patch entry no longer describes what has accumulated. The changelog entry covers everything since the last tagged release —

- **Added** — the public NOTIFY payload budget and preflight helpers, ADK artifact retention pruning, ordered and bounded ADK session listings, and pre-registration Litestar config lookup.
- **Changed** — the deterministic session ordering tie-break, retention helpers rejecting a non-positive age, ADK migration feature gating, the 7,999-byte notification ceiling, and fixed-width envelope timestamps.
- **Removed** — the duplicate `include_*_migration` ADK options and the unused `0002_reset_adk_tables` migration.
- **Fixed** — the pgvector migration prerequisite, `get_config()` resolution, and compiled async exception handling.

An upgrade note covers the `CREATE EXTENSION` privilege the pgvector change requires.

The session listing entries describe #720, which ships in the same release. They are written here so the whole release reads as one section and the two branches do not both edit it.

`pyproject.toml` and `uv.lock` are bumped to match.
