### PR TITLE
fix(migrations): initialize dialect before commands

### DIFF
--- a/sqlspec/config.py
+++ b/sqlspec/config.py
@@ -1524,8 +1524,8 @@ class DatabaseConfigProtocol(ABC, Generic[ConnectionT, PoolT, DriverT]):
         self.extension_config = extension_config or {}
         self.migration_config = migration_config or {}
         self._init_observability(observability_config)
-        self._initialize_migration_components()
         self.statement_config = statement_config or build_default_statement_config(default_dialect)
+        self._initialize_migration_components()
         self._storage_capabilities = None
         self.driver_features = seed_runtime_driver_features(driver_features, self.storage_capabilities())
         self._attach_lifecycle_hooks()

--- a/tests/unit/migrations/test_migration_commands.py
+++ b/tests/unit/migrations/test_migration_commands.py
@@ -48,6 +48,22 @@ def test_migration_commands_async_config_initialization(async_config: AiosqliteC
     assert hasattr(commands, "runner")
 
 
+def test_cached_sync_migration_commands_have_resolved_dialect(sync_config: SqliteConfig) -> None:
+    """Cached sync migration commands inherit the config's resolved dialect."""
+    commands = sync_config.get_migration_commands()
+
+    assert commands.runner.context is not None
+    assert commands.runner.context.dialect == "sqlite"
+
+
+def test_cached_async_migration_commands_have_resolved_dialect(async_config: AiosqliteConfig) -> None:
+    """Cached async migration commands inherit the config's resolved dialect."""
+    commands = async_config.get_migration_commands()
+
+    assert commands.runner.context is not None
+    assert commands.runner.context.dialect == "sqlite"
+
+
 def test_migration_commands_sync_init_delegation(tmp_path: Path, sync_config: SqliteConfig) -> None:
     """Test that sync config init is delegated directly to sync implementation."""
     with patch.object(SyncMigrationCommands, "init") as mock_init:


### PR DESCRIPTION
Migration commands were cached before the database statement configuration had resolved its dialect, leaving their migration context without dialect information.

Initialize the statement configuration first and cover both sync and async cached command paths.