### PR TITLE
fix(litestar): register plugin middleware at the outer boundary

### DIFF
--- a/sqlspec/extensions/litestar/plugin.py
+++ b/sqlspec/extensions/litestar/plugin.py
@@ -399,7 +399,11 @@ class SQLSpecPlugin(InitPluginProtocol, CLIPlugin):
         if self._enable_sqlcommenter_middleware:
             new_middlewares.append(DefineMiddleware(SQLCommenterMiddleware))
         if new_middlewares:
-            app_config.middleware = [*(app_config.middleware or []), *new_middlewares]
+            # Prepend so correlation context is established at the outer boundary of the
+            # pipeline. Appending makes these the innermost middleware, so a request
+            # rejected earlier (auth, CORS, rate limiting) never reaches them and its
+            # access log and error hooks have no correlation ID.
+            app_config.middleware = [*new_middlewares, *(app_config.middleware or [])]
 
         log_with_context(
             logger,

--- a/tests/integration/extensions/litestar/test_correlation_middleware.py
+++ b/tests/integration/extensions/litestar/test_correlation_middleware.py
@@ -1,6 +1,8 @@
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from litestar import Litestar, get
+from litestar.middleware import AbstractMiddleware, DefineMiddleware
+from litestar.response.base import ASGIResponse
 from litestar.testing import TestClient
 
 from sqlspec import SQLSpec
@@ -8,6 +10,9 @@ from sqlspec.adapters.sqlite import SqliteConfig
 from sqlspec.config import ExtensionConfigs
 from sqlspec.extensions.litestar import SQLSpecPlugin
 from sqlspec.utils.correlation import CorrelationContext
+
+if TYPE_CHECKING:
+    from litestar.types import Receive, Scope, Send
 
 
 def setup_function() -> None:
@@ -99,3 +104,28 @@ def test_correlation_middleware_auto_detection_can_be_disabled() -> None:
 
         response = client.get("/correlation", headers={"X-Custom-ID": "custom-value"})
         assert response.json()["correlation_id"] == "custom-value"
+
+
+def test_correlation_middleware_runs_before_user_middleware() -> None:
+    """A request rejected by user middleware still carries correlation context."""
+    observed: dict[str, str | None] = {}
+
+    class RejectingMiddleware(AbstractMiddleware):
+        async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+            observed["correlation_id"] = CorrelationContext.get()
+            await ASGIResponse(body=b'{"detail":"unauthorized"}', status_code=401)(scope, receive, send)
+
+    extension_config = cast("ExtensionConfigs", {"litestar": {"enable_correlation_middleware": True}})
+    spec = SQLSpec()
+    spec.add_config(SqliteConfig(connection_config={"database": ":memory:"}, extension_config=extension_config))
+    app = Litestar(
+        route_handlers=[correlation_handler],
+        plugins=[SQLSpecPlugin(sqlspec=spec)],
+        middleware=[DefineMiddleware(RejectingMiddleware)],
+    )
+
+    with TestClient(app) as client:
+        response = client.get("/correlation", headers={"X-Request-ID": "abc-123"})
+
+    assert response.status_code == 401
+    assert observed["correlation_id"] == "abc-123"


### PR DESCRIPTION
### Description

`SQLSpecPlugin.on_app_init` appended its middleware to `app_config.middleware`:

```python
app_config.middleware = [*(app_config.middleware or []), *new_middlewares]
```

Litestar runs `middleware` outermost first, so appending makes the plugin's entries the **innermost** in the pipeline. Any user middleware that rejects a request early (auth, CORS, rate limiting) short-circuits before the correlation middleware ever runs, and the access log and error hooks for exactly the requests you most want to trace have no correlation ID.

### Fix

Prepend instead, so the correlation context is established at the outer boundary:

```python
app_config.middleware = [*new_middlewares, *(app_config.middleware or [])]
```

### Verification

Reproduced with a small app: a user middleware that returns 401 before the handler, with `X-Request-ID: abc-123` on the request.

Before:

```
status: 401
correlation seen by outer rejecting middleware: None
```

After:

```
status: 401
correlation seen by outer rejecting middleware: 'abc-123'
```

### Tests

Added `test_correlation_middleware_runs_before_user_middleware` to the existing correlation middleware tests. It installs a middleware that rejects with 401, then asserts the correlation ID was populated at that point.

Confirmed it is a real regression test. With the fix reverted:

```
FAIL test_correlation_middleware_runs_before_user_middleware: AssertionError
6 passed, 1 failed
```

and with the fix restored all 7 pass. `ruff check` and `ruff format --check` pass on both touched files.

Closes #729
