### PR TITLE
fix(storage): keep resolved paths inside the backend root

### DIFF
--- a/sqlspec/exceptions.py
+++ b/sqlspec/exceptions.py
@@ -39,6 +39,7 @@ __all__ = (
     "StackExecutionError",
     "StorageCapabilityError",
     "StorageOperationFailedError",
+    "StoragePathTraversalError",
     "TransactionError",
     "TransactionRetryError",
     "UniqueViolationError",
@@ -296,6 +297,18 @@ class StorageCapabilityError(SQLSpecError):
 
 class FileNotFoundInStorageError(StorageOperationFailedError):
     """Raised when a file or object is not found in the storage backend."""
+
+
+class StoragePathTraversalError(StorageOperationFailedError):
+    """Raised when a storage path would resolve outside its backend root."""
+
+    def __init__(self, path: str, root: str | None = None) -> None:
+        detail = f"Storage path {path!r} resolves outside the backend root"
+        if root:
+            detail = f"{detail} {root!r}"
+        super().__init__(detail)
+        self.path = path
+        self.root = root
 
 
 class SQLFileNotFoundError(SQLSpecError):

--- a/sqlspec/storage/_paths.py
+++ b/sqlspec/storage/_paths.py
@@ -1,12 +1,16 @@
 """Pure storage path helpers safe for mypyc compilation."""
 
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Final
+
+from sqlspec.exceptions import StoragePathTraversalError
 
 __all__ = (
     "FILE_PROTOCOL",
     "FILE_SCHEME_PREFIX",
+    "ensure_path_within_root",
     "is_file_destination",
+    "reject_parent_traversal",
     "resolve_storage_path",
     "strip_windows_drive_prefix",
 )
@@ -14,6 +18,57 @@ __all__ = (
 
 FILE_PROTOCOL: Final[str] = "file"
 FILE_SCHEME_PREFIX: Final[str] = "file://"
+
+
+def reject_parent_traversal(path: "str | Path") -> None:
+    """Raise if any segment of ``path`` is a parent reference.
+
+    Both separators are considered, so a Windows-style key cannot smuggle a
+    parent reference past a POSIX-only split.
+
+    Args:
+        path: Caller-supplied storage path.
+
+    Raises:
+        StoragePathTraversalError: If a ``..`` segment is present.
+    """
+    path_str = str(path)
+    posix_parts = PurePosixPath(path_str).parts
+    windows_parts = PureWindowsPath(path_str).parts
+    if ".." in posix_parts or ".." in windows_parts:
+        raise StoragePathTraversalError(path_str)
+
+
+def ensure_path_within_root(path: "str | Path", root: "str | Path") -> str:
+    """Return ``path`` as a ``root``-relative POSIX path, refusing anything outside ``root``.
+
+    A relative path is joined to ``root``; an absolute path must already be inside
+    it. Parent references are rejected before any filesystem call, and the
+    resolved result is re-checked so a symlink cannot escape.
+
+    Args:
+        path: Caller-supplied storage path.
+        root: Directory the path must stay within.
+
+    Returns:
+        The path relative to ``root``, or ``""`` when it is ``root`` itself.
+
+    Raises:
+        StoragePathTraversalError: If the path escapes ``root``.
+    """
+    reject_parent_traversal(path)
+
+    root_obj = Path(str(root)).resolve()
+    path_obj = Path(str(path))
+    candidate = path_obj if path_obj.is_absolute() else root_obj / path_obj
+    resolved = candidate.resolve()
+
+    if resolved != root_obj and root_obj not in resolved.parents:
+        raise StoragePathTraversalError(str(path), str(root_obj))
+
+    if resolved == root_obj:
+        return ""
+    return resolved.relative_to(root_obj).as_posix()
 
 
 def strip_windows_drive_prefix(path: str) -> str:
@@ -52,7 +107,12 @@ def resolve_storage_path(
 
     Returns:
         Resolved path string suitable for the storage backend.
+
+    Raises:
+        StoragePathTraversalError: If the path contains a parent reference.
     """
+
+    reject_parent_traversal(path)
 
     path_str = str(path)
 

--- a/sqlspec/storage/backends/local.py
+++ b/sqlspec/storage/backends/local.py
@@ -15,7 +15,7 @@ from mypy_extensions import mypyc_attr
 
 from sqlspec.exceptions import FileNotFoundInStorageError
 from sqlspec.storage._arrow_stream import iter_parquet_row_groups, validate_parquet_stream_options
-from sqlspec.storage._paths import strip_windows_drive_prefix
+from sqlspec.storage._paths import ensure_path_within_root, strip_windows_drive_prefix
 from sqlspec.storage._utils import import_pyarrow_parquet
 from sqlspec.storage.backends.base import AsyncArrowBatchIterator, AsyncThreadedBytesIterator
 from sqlspec.storage.errors import execute_sync_storage_operation
@@ -88,16 +88,19 @@ class LocalStore:
         return str(self._resolve_path(path).resolve())
 
     def _resolve_path(self, path: "str | Path") -> Path:
-        """Resolve path relative to base_path.
+        """Resolve path relative to base_path, refusing anything outside it.
 
         Args:
             path: Path to resolve (absolute or relative).
 
         Returns:
-            Resolved Path object.
+            Resolved Path object inside ``base_path``.
+
+        Raises:
+            StoragePathTraversalError: If the path resolves outside ``base_path``.
         """
-        p = Path(path)
-        return p if p.is_absolute() else self.base_path / p
+        relative = ensure_path_within_root(path, self.base_path)
+        return self.base_path if not relative else self.base_path / relative
 
     def read_bytes_sync(self, path: "str | Path", **kwargs: Any) -> bytes:
         """Read bytes from file synchronously."""

--- a/sqlspec/storage/backends/obstore.py
+++ b/sqlspec/storage/backends/obstore.py
@@ -19,7 +19,12 @@ from typing_extensions import Self
 
 from sqlspec.exceptions import StorageOperationFailedError
 from sqlspec.storage._arrow_stream import iter_parquet_row_groups, validate_parquet_stream_options
-from sqlspec.storage._paths import is_file_destination, resolve_storage_path
+from sqlspec.storage._paths import (
+    ensure_path_within_root,
+    is_file_destination,
+    reject_parent_traversal,
+    resolve_storage_path,
+)
 from sqlspec.storage._utils import _log_storage_event, import_pyarrow, import_pyarrow_parquet
 from sqlspec.storage.backends.base import AsyncArrowBatchIterator, AsyncObStoreStreamIterator
 
@@ -229,18 +234,23 @@ class ObStoreBackend:
         return resolve_storage_path(path, self.base_path, self.protocol, strip_file_scheme=True)
 
     def _local_store_path(self, path: "str | Path") -> str:
-        """Resolve path for LocalStore which expects relative paths from its root."""
+        """Resolve path for LocalStore, which expects relative paths from its root.
 
-        path_obj = Path(str(path))
+        Args:
+            path: Caller-supplied storage path.
 
-        if path_obj.is_absolute() and self._local_store_root:
-            try:
-                rel = path_obj.relative_to(self._local_store_root)
-                return "" if str(rel) == "." else str(rel)
-            except ValueError:
-                return str(path).lstrip("/")
+        Returns:
+            The path relative to the store root.
 
-        return str(path)
+        Raises:
+            StoragePathTraversalError: If the path resolves outside the store root.
+        """
+
+        if not self._local_store_root:
+            reject_parent_traversal(path)
+            return str(path)
+
+        return ensure_path_within_root(path, self._local_store_root)
 
     def _read_bytes_resolved_sync(self, resolved_path: str) -> bytes:
         result = execute_sync_storage_operation(

--- a/tests/unit/storage/test_path_traversal.py
+++ b/tests/unit/storage/test_path_traversal.py
@@ -1,0 +1,97 @@
+"""Security tests for storage path containment.
+
+A caller-supplied object key must never resolve outside its backend's root.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from sqlspec.exceptions import StoragePathTraversalError
+from sqlspec.storage._paths import resolve_storage_path
+from sqlspec.storage.backends.local import LocalStore
+from sqlspec.typing import OBSTORE_INSTALLED
+
+ESCAPING_PATHS = ["../../etc/passwd", "../outside.txt", "nested/../../outside.txt", "..", "../"]
+
+
+@pytest.mark.parametrize("candidate", ESCAPING_PATHS)
+def test_local_store_rejects_escaping_relative_path(tmp_path: Path, candidate: str) -> None:
+    """A relative key containing ``..`` must not resolve outside the store root."""
+    store = LocalStore(str(tmp_path / "root"), base_path="workspaces")
+
+    with pytest.raises(StoragePathTraversalError):
+        store.resolve_uri(candidate)
+
+
+def test_local_store_rejects_absolute_path_outside_root(tmp_path: Path) -> None:
+    """An absolute key outside the root must be refused, not silently honoured."""
+    store = LocalStore(str(tmp_path / "root"))
+
+    with pytest.raises(StoragePathTraversalError):
+        store.resolve_uri("/etc/passwd")
+
+
+def test_local_store_allows_nested_path(tmp_path: Path) -> None:
+    """Legitimate nested keys keep working."""
+    store = LocalStore(str(tmp_path / "root"), base_path="workspaces")
+
+    resolved = store.resolve_uri(Path("a/b/data.parquet"))
+
+    assert resolved == str((tmp_path / "root" / "workspaces" / "a" / "b" / "data.parquet").resolve())
+
+
+def test_local_store_allows_absolute_path_inside_root(tmp_path: Path) -> None:
+    """An absolute key already inside the root is accepted."""
+    root = tmp_path / "root"
+    store = LocalStore(str(root))
+
+    resolved = store.resolve_uri(str(root / "data.parquet"))
+
+    assert resolved == str((root / "data.parquet").resolve())
+
+
+@pytest.mark.parametrize("candidate", ESCAPING_PATHS)
+def test_resolve_storage_path_rejects_escaping_relative_path(candidate: str) -> None:
+    """The shared resolver refuses traversal for local destinations."""
+    with pytest.raises(StoragePathTraversalError):
+        resolve_storage_path(candidate, base_path="workspaces")
+
+
+def test_resolve_storage_path_allows_nested_path() -> None:
+    """The shared resolver still joins ordinary relative keys."""
+    assert resolve_storage_path("a/b/data.parquet", base_path="workspaces") == "workspaces/a/b/data.parquet"
+
+
+def test_percent_encoded_dots_are_a_literal_name() -> None:
+    """``%2e%2e`` is a filename, not traversal, because nothing here decodes it."""
+    assert resolve_storage_path("%2e%2e/data.parquet", base_path="ws") == "ws/%2e%2e/data.parquet"
+
+
+def test_backslash_traversal_is_rejected() -> None:
+    """Windows-style separators must not smuggle a parent reference past the check."""
+    with pytest.raises(StoragePathTraversalError):
+        resolve_storage_path("..\\..\\outside.txt", base_path="ws")
+
+
+@pytest.mark.skipif(not OBSTORE_INSTALLED, reason="obstore missing")
+@pytest.mark.parametrize("candidate", ESCAPING_PATHS)
+def test_obstore_local_backend_rejects_escaping_path(tmp_path: Path, candidate: str) -> None:
+    """The obstore backend's local path must stay inside the store root."""
+    from sqlspec.storage.backends.obstore import ObStoreBackend
+
+    store = ObStoreBackend(f"file://{tmp_path / 'root'}")
+
+    with pytest.raises(StoragePathTraversalError):
+        store.resolve_uri(candidate)
+
+
+@pytest.mark.skipif(not OBSTORE_INSTALLED, reason="obstore missing")
+def test_obstore_local_backend_allows_nested_path(tmp_path: Path) -> None:
+    """Legitimate nested keys keep working on the obstore local backend."""
+    from sqlspec.storage.backends.obstore import ObStoreBackend
+
+    root = tmp_path / "root"
+    store = ObStoreBackend(f"file://{root}")
+
+    assert store.resolve_uri("a/b/data.parquet") == str((root / "a" / "b" / "data.parquet").resolve())


### PR DESCRIPTION
A caller-supplied object key containing parent references could resolve outside its storage backend's root. Both local backends joined the key to the root and then called `resolve()`, which collapses `..` *after* the join — so a store rooted at `/srv/data` returned `/etc/passwd` for a key of `../../../../etc/passwd`.

Stacked on #735; review that one first, or use the commit view here.

## Three affected paths

- **`LocalStore._resolve_path`** joined any relative key to `base_path` with no check, and returned any absolute key unchanged — so a path outside the root was honoured rather than refused.
- **`ObStoreBackend._local_store_path`** returned a relative key unchanged. Its fallback for an absolute key outside the root stripped the leading slash and rejoined it under the root, silently retargeting the write instead of failing.
- **`resolve_storage_path`** performed the same join for local destinations with no validation. This one also reaches the fsspec backend, so the guard covers all three backends.

## The fix

`ensure_path_within_root` and `reject_parent_traversal` in the shared path helpers:

- Parent references are refused **before** any filesystem call.
- The resolved result is re-checked against the root, so a symlink inside the root cannot escape either.
- An absolute key must already be inside the root.
- Percent-encoded sequences stay literal filenames, because nothing on this path decodes them.
- Windows-style separators are checked too, so a backslashed parent reference cannot pass a POSIX-only split. A legitimate POSIX filename containing a backslash is unaffected.

## Behaviour change to note

`resolve_storage_path` is exported from `sqlspec.storage`. A caller passing a key containing `..` now gets `StoragePathTraversalError` instead of a path outside the root. That is the point of the change, but it is a visible difference for anyone who was relying on the old silent behaviour.

`StoragePathTraversalError` subclasses `StorageOperationFailedError`, so existing handlers for storage failures already catch it.

## How you use it

Nothing to opt into — the guard is on by default. Legitimate nested keys are unaffected:

```python
store = LocalStore("/srv/data", base_path="workspaces")

store.resolve_uri("a/b/data.parquet")   # /srv/data/workspaces/a/b/data.parquet
store.resolve_uri("../../etc/passwd")   # StoragePathTraversalError
```