### PR TITLE
fix(storage): correct obstore glob matching, prefix listing, and streaming uploads

### DIFF
--- a/sqlspec/storage/_paths.py
+++ b/sqlspec/storage/_paths.py
@@ -1,5 +1,6 @@
 """Pure storage path helpers safe for mypyc compilation."""
 
+import re
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Final
 
@@ -9,6 +10,7 @@ __all__ = (
     "FILE_PROTOCOL",
     "FILE_SCHEME_PREFIX",
     "ensure_path_within_root",
+    "glob_to_regex",
     "is_file_destination",
     "reject_parent_traversal",
     "resolve_storage_path",
@@ -69,6 +71,74 @@ def ensure_path_within_root(path: "str | Path", root: "str | Path") -> str:
     if resolved == root_obj:
         return ""
     return resolved.relative_to(root_obj).as_posix()
+
+
+def _glob_segment_regex(segment: str) -> str:
+    """Translate one glob path segment to regex source that never crosses ``/``."""
+    out: list[str] = []
+    index = 0
+    length = len(segment)
+    while index < length:
+        char = segment[index]
+        if char == "*":
+            out.append("[^/]*")
+            index += 1
+        elif char == "?":
+            out.append("[^/]")
+            index += 1
+        elif char == "[":
+            close = segment.find("]", index + 1)
+            body = segment[index + 1 : close] if close != -1 else ""
+            negated = body.startswith(("!", "^"))
+            if negated:
+                body = body[1:]
+            if close == -1 or not body:
+                out.append(re.escape(char))
+                index += 1
+                continue
+            escaped = body.replace("\\", "\\\\").replace("[", "\\[")
+            prefix = "^" if negated else ""
+            out.append(f"[{prefix}{escaped}]")
+            index = close + 1
+        else:
+            out.append(re.escape(char))
+            index += 1
+    return "".join(out)
+
+
+def glob_to_regex(pattern: str) -> "re.Pattern[str]":
+    """Compile a glob pattern to an anchored regex with pathlib semantics.
+
+    ``*`` and ``?`` match within a single path segment. A ``**`` segment matches
+    zero or more whole segments. Matching is anchored at both ends, so a pattern
+    describes the entire object key rather than a suffix of it.
+
+    The honored magic characters are ``*``, ``?`` and ``[``. There is no brace
+    expansion and no escape syntax, matching what the local and fsspec backends
+    accept. Compiled patterns are cached by :mod:`re` itself, so repeated calls
+    with the same pattern do not recompile.
+
+    Args:
+        pattern: Glob pattern.
+
+    Returns:
+        A compiled, anchored regex. An empty pattern matches nothing.
+    """
+    if not pattern:
+        return re.compile(r"(?!)")
+
+    parts = pattern.split("/")
+    pieces: list[str] = []
+    last_index = len(parts) - 1
+    for index, part in enumerate(parts):
+        if part == "**":
+            pieces.append(".*" if index == last_index else "(?:[^/]+/)*")
+            continue
+        pieces.append(_glob_segment_regex(part))
+        if index != last_index:
+            pieces.append("/")
+
+    return re.compile(f"(?s:{''.join(pieces)})\\Z")
 
 
 def strip_windows_drive_prefix(path: str) -> str:

--- a/sqlspec/storage/_paths.py
+++ b/sqlspec/storage/_paths.py
@@ -10,6 +10,7 @@ __all__ = (
     "FILE_PROTOCOL",
     "FILE_SCHEME_PREFIX",
     "ensure_path_within_root",
+    "extract_glob_static_prefix",
     "glob_to_regex",
     "is_file_destination",
     "reject_parent_traversal",
@@ -73,6 +74,9 @@ def ensure_path_within_root(path: "str | Path", root: "str | Path") -> str:
     return resolved.relative_to(root_obj).as_posix()
 
 
+_GLOB_MAGIC: Final = re.compile(r"[*?\[]")
+
+
 def _glob_segment_regex(segment: str) -> str:
     """Translate one glob path segment to regex source that never crosses ``/``."""
     out: list[str] = []
@@ -104,6 +108,28 @@ def _glob_segment_regex(segment: str) -> str:
             out.append(re.escape(char))
             index += 1
     return "".join(out)
+
+
+def extract_glob_static_prefix(pattern: str) -> str:
+    """Return the literal directory prefix of a glob pattern.
+
+    The result is either ``""`` or a string ending in ``/`` made of whole path
+    segments that contain no glob metacharacters. A pattern with no wildcards
+    yields its directory portion, never the full key.
+
+    Args:
+        pattern: Glob pattern in POSIX form.
+
+    Returns:
+        Static directory prefix suitable for a listing API.
+    """
+    segments = pattern.lstrip("/").split("/")
+    static: list[str] = []
+    for segment in segments[:-1]:
+        if not segment or _GLOB_MAGIC.search(segment):
+            break
+        static.append(segment)
+    return "/".join(static) + "/" if static else ""
 
 
 def glob_to_regex(pattern: str) -> "re.Pattern[str]":

--- a/sqlspec/storage/backends/obstore.py
+++ b/sqlspec/storage/backends/obstore.py
@@ -233,6 +233,24 @@ class ObStoreBackend:
             return self._local_store_path(path)
         return resolve_storage_path(path, self.base_path, self.protocol, strip_file_scheme=True)
 
+    def _resolve_list_prefix(self, prefix: str) -> str:
+        """Resolve a caller-supplied listing prefix to a store-relative one.
+
+        A local store's root already contains ``base_path``, so resolving the
+        prefix against ``base_path`` again would look for that segment twice and
+        match nothing.
+
+        Args:
+            prefix: Caller-supplied listing prefix, possibly empty.
+
+        Returns:
+            The prefix as the store expects it, or ``""`` to list everything.
+        """
+        if not prefix:
+            return "" if self._is_local_store else (self.base_path or "")
+        base = "" if self._is_local_store else self.base_path
+        return resolve_storage_path(prefix, base, self.protocol, strip_file_scheme=True)
+
     def _local_store_path(self, path: "str | Path") -> str:
         """Resolve path for LocalStore, which expects relative paths from its root.
 
@@ -305,12 +323,7 @@ class ObStoreBackend:
 
     def list_objects_sync(self, prefix: str = "", recursive: bool = True, **kwargs: Any) -> "list[str]":  # pyright: ignore[reportUnusedParameter]
         """List objects using obstore synchronously."""
-        if prefix:
-            resolved_prefix = resolve_storage_path(prefix, self.base_path, self.protocol, strip_file_scheme=True)
-        elif self._is_local_store:
-            resolved_prefix = ""
-        else:
-            resolved_prefix = self.base_path or ""
+        resolved_prefix = self._resolve_list_prefix(prefix)
         if not recursive:
             result = self.store.list_with_delimiter(resolved_prefix)
             paths = sorted(item["path"] for item in result["objects"])
@@ -712,12 +725,7 @@ class ObStoreBackend:
 
     async def list_objects_async(self, prefix: str = "", recursive: bool = True, **kwargs: Any) -> "list[str]":  # pyright: ignore[reportUnusedParameter]
         """List objects in storage asynchronously."""
-        if prefix:
-            resolved_prefix = resolve_storage_path(prefix, self.base_path, self.protocol, strip_file_scheme=True)
-        elif self._is_local_store:
-            resolved_prefix = ""
-        else:
-            resolved_prefix = self.base_path or ""
+        resolved_prefix = self._resolve_list_prefix(prefix)
 
         objects: list[str] = []
         async for batch in self.store.list_async(resolved_prefix):  # pyright: ignore[reportAttributeAccessIssue]

--- a/sqlspec/storage/backends/obstore.py
+++ b/sqlspec/storage/backends/obstore.py
@@ -468,6 +468,9 @@ class ObStoreBackend:
         the local and fsspec backends.
         """
 
+        if not pattern:
+            return []
+        reject_parent_traversal(pattern)
         resolved_pattern = (
             pattern
             if self._is_local_store
@@ -588,28 +591,33 @@ class ObStoreBackend:
         )
 
     def _stream_parquet_sync(self, resolved_path: str, table: "ArrowTable", **kwargs: Any) -> None:
-        """Serialize a table batch by batch into an obstore multipart writer.
+        """Serialize a table row group by row group into an obstore multipart writer.
 
-        Peak memory is bounded by one record batch plus the writer's upload
-        buffer rather than the serialized size of the whole table. The writer
-        is closed in ``finally`` so a failed write aborts the multipart upload.
+        Peak memory is bounded by the upload buffer rather than the serialized
+        size of the whole table. The writer is completed only after every row
+        group is written; on failure it is dropped unclosed, which aborts the
+        multipart upload so no partial object is published.
 
         Args:
             resolved_path: Store-relative destination key.
             table: Table to serialize.
-            **kwargs: Options forwarded to ``pyarrow.parquet.ParquetWriter``.
+            **kwargs: Options forwarded to ``pyarrow.parquet.ParquetWriter``;
+                ``row_group_size`` is forwarded to ``write_table``.
         """
-        pa = import_pyarrow()
-        pq = import_pyarrow_parquet()
         from obstore import open_writer
 
+        pa = import_pyarrow()
+        pq = import_pyarrow_parquet()
+        row_group_size = kwargs.pop("row_group_size", None)
         sink = open_writer(self.store, resolved_path)
+        writer = pq.ParquetWriter(pa.PythonFile(_ObstoreSink(sink), mode="w"), table.schema, **kwargs)
         try:
-            with pq.ParquetWriter(pa.PythonFile(_ObstoreSink(sink), mode="w"), table.schema, **kwargs) as writer:
-                for batch in table.to_batches():
-                    writer.write_batch(batch)
-        finally:
-            sink.close()
+            writer.write_table(table, row_group_size=row_group_size)
+            writer.close()
+        except BaseException:
+            del writer, sink
+            raise
+        sink.close()
 
     def stream_read_sync(self, path: "str | Path", chunk_size: "int | None" = None, **kwargs: Any) -> Iterator[bytes]:
         """Stream bytes using obstore's native streaming synchronously.

--- a/sqlspec/storage/backends/obstore.py
+++ b/sqlspec/storage/backends/obstore.py
@@ -20,6 +20,7 @@ from sqlspec.exceptions import StorageOperationFailedError
 from sqlspec.storage._arrow_stream import iter_parquet_row_groups, validate_parquet_stream_options
 from sqlspec.storage._paths import (
     ensure_path_within_root,
+    extract_glob_static_prefix,
     glob_to_regex,
     is_file_destination,
     reject_parent_traversal,
@@ -95,6 +96,40 @@ class _ObStoreFileProxy:
 
 
 @mypyc_attr(allow_interpreted_subclasses=True)
+class _ObstoreSink:
+    """Adapt an obstore writer to the file-like surface ``pyarrow.PythonFile`` expects.
+
+    obstore exposes ``closed`` as a method; pyarrow reads it as an attribute.
+    """
+
+    __slots__ = ("_writer",)
+
+    def __init__(self, writer: Any) -> None:
+        self._writer = writer
+
+    @property
+    def closed(self) -> bool:
+        return bool(self._writer.closed())
+
+    def writable(self) -> bool:
+        return True
+
+    def readable(self) -> bool:
+        return False
+
+    def seekable(self) -> bool:
+        return False
+
+    def write(self, data: Any) -> int:
+        return int(self._writer.write(data))
+
+    def flush(self) -> None:
+        self._writer.flush()
+
+    def close(self) -> None:
+        self._writer.close()
+
+
 class ObStoreBackend:
     """Object storage backend using obstore.
 
@@ -321,14 +356,25 @@ class ObStoreBackend:
         """Write text using obstore synchronously."""
         self.write_bytes_sync(path, data.encode(encoding), **kwargs)
 
+    def _list_resolved_sync(self, resolved_prefix: str, recursive: bool) -> "list[str]":
+        """List object keys under a prefix that is already store-relative.
+
+        Args:
+            resolved_prefix: Prefix as the store expects it; ``""`` lists everything.
+            recursive: Whether to descend into nested prefixes.
+
+        Returns:
+            Sorted object keys.
+        """
+        if not recursive:
+            result = self.store.list_with_delimiter(resolved_prefix)
+            return sorted(item["path"] for item in result["objects"])
+        return sorted(item["path"] for batch in self.store.list(resolved_prefix) for item in batch)
+
     def list_objects_sync(self, prefix: str = "", recursive: bool = True, **kwargs: Any) -> "list[str]":  # pyright: ignore[reportUnusedParameter]
         """List objects using obstore synchronously."""
         resolved_prefix = self._resolve_list_prefix(prefix)
-        if not recursive:
-            result = self.store.list_with_delimiter(resolved_prefix)
-            paths = sorted(item["path"] for item in result["objects"])
-        else:
-            paths = sorted(item["path"] for batch in self.store.list(resolved_prefix) for item in batch)
+        paths = self._list_resolved_sync(resolved_prefix, recursive)
         _log_storage_event(
             "storage.list",
             backend_type=self.backend_type,
@@ -425,7 +471,8 @@ class ObStoreBackend:
     def glob_sync(self, pattern: str, **kwargs: Any) -> "list[str]":
         """Find objects matching pattern synchronously.
 
-        Lists all objects and filters them client-side. ``*`` and ``?`` match
+        Lists objects under the pattern's static directory prefix and filters
+        them client-side. ``*`` and ``?`` match
         within one path segment and ``**`` spans zero or more segments, matching
         the local and fsspec backends.
         """
@@ -435,7 +482,7 @@ class ObStoreBackend:
             if self._is_local_store
             else resolve_storage_path(pattern, self.base_path, self.protocol, strip_file_scheme=True)
         )
-        all_objects = self.list_objects_sync(recursive=True, **kwargs)
+        all_objects = self._list_resolved_sync(extract_glob_static_prefix(resolved_pattern), recursive=True)
         matcher = glob_to_regex(resolved_pattern)
         results = [obj for obj in all_objects if matcher.match(obj)]
         _log_storage_event(
@@ -516,7 +563,7 @@ class ObStoreBackend:
     def write_arrow_sync(self, path: "str | Path", table: "ArrowTable", **kwargs: Any) -> None:
         """Write Arrow table using obstore synchronously."""
         pa = import_pyarrow()
-        pq = import_pyarrow_parquet()
+        import_pyarrow_parquet()
         resolved_path = self._resolve_path(path)
 
         schema = table.schema
@@ -534,15 +581,12 @@ class ObStoreBackend:
                     new_fields.append(field)
             table = table.cast(pa.schema(new_fields))
 
-        buffer = io.BytesIO()
         execute_sync_storage_operation(
-            partial(pq.write_table, table, buffer, **kwargs),
+            partial(self._stream_parquet_sync, resolved_path, table, **kwargs),
             backend=self.backend_type,
             operation="write_arrow",
             path=resolved_path,
         )
-        buffer.seek(0)
-        self._write_bytes_resolved_sync(resolved_path, buffer.read())
         _log_storage_event(
             "storage.write",
             backend_type=self.backend_type,
@@ -551,6 +595,30 @@ class ObStoreBackend:
             mode="sync",
             path=resolved_path,
         )
+
+    def _stream_parquet_sync(self, resolved_path: str, table: "ArrowTable", **kwargs: Any) -> None:
+        """Serialize a table batch by batch into an obstore multipart writer.
+
+        Peak memory is bounded by one record batch plus the writer's upload
+        buffer rather than the serialized size of the whole table. The writer
+        is closed in ``finally`` so a failed write aborts the multipart upload.
+
+        Args:
+            resolved_path: Store-relative destination key.
+            table: Table to serialize.
+            **kwargs: Options forwarded to ``pyarrow.parquet.ParquetWriter``.
+        """
+        pa = import_pyarrow()
+        pq = import_pyarrow_parquet()
+        from obstore import open_writer
+
+        sink = open_writer(self.store, resolved_path)
+        try:
+            with pq.ParquetWriter(pa.PythonFile(_ObstoreSink(sink), mode="w"), table.schema, **kwargs) as writer:
+                for batch in table.to_batches():
+                    writer.write_batch(batch)
+        finally:
+            sink.close()
 
     def stream_read_sync(self, path: "str | Path", chunk_size: "int | None" = None, **kwargs: Any) -> Iterator[bytes]:
         """Stream bytes using obstore's native streaming synchronously.
@@ -899,17 +967,9 @@ class ObStoreBackend:
         Uses async_() with storage limiter to offload blocking PyArrow serialization
         to thread pool, preventing event loop blocking.
         """
-        pq = import_pyarrow_parquet()
         resolved_path = self._resolve_path(path)
 
-        def _serialize() -> bytes:
-            buffer = io.BytesIO()
-            pq.write_table(table, buffer, **kwargs)
-            buffer.seek(0)
-            return buffer.read()
-
-        data = await async_(_serialize)()
-        await self._write_bytes_resolved_async(resolved_path, data)
+        await async_(self._stream_parquet_sync)(resolved_path, table, **kwargs)
 
         _log_storage_event(
             "storage.write",

--- a/sqlspec/storage/backends/obstore.py
+++ b/sqlspec/storage/backends/obstore.py
@@ -95,7 +95,6 @@ class _ObStoreFileProxy:
         self.close()
 
 
-@mypyc_attr(allow_interpreted_subclasses=True)
 class _ObstoreSink:
     """Adapt an obstore writer to the file-like surface ``pyarrow.PythonFile`` expects.
 
@@ -111,15 +110,6 @@ class _ObstoreSink:
     def closed(self) -> bool:
         return bool(self._writer.closed())
 
-    def writable(self) -> bool:
-        return True
-
-    def readable(self) -> bool:
-        return False
-
-    def seekable(self) -> bool:
-        return False
-
     def write(self, data: Any) -> int:
         return int(self._writer.write(data))
 
@@ -130,6 +120,7 @@ class _ObstoreSink:
         self._writer.close()
 
 
+@mypyc_attr(allow_interpreted_subclasses=True)
 class ObStoreBackend:
     """Object storage backend using obstore.
 

--- a/sqlspec/storage/backends/obstore.py
+++ b/sqlspec/storage/backends/obstore.py
@@ -4,13 +4,12 @@ Implements the ObjectStoreProtocol using obstore for S3, GCS, Azure,
 and local file storage.
 """
 
-import fnmatch
 import io
 import re
 from collections.abc import AsyncIterator, Iterator
 from datetime import timedelta
 from functools import partial
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Final, Literal, cast, overload
 from urllib.parse import urlparse
 
@@ -21,6 +20,7 @@ from sqlspec.exceptions import StorageOperationFailedError
 from sqlspec.storage._arrow_stream import iter_parquet_row_groups, validate_parquet_stream_options
 from sqlspec.storage._paths import (
     ensure_path_within_root,
+    glob_to_regex,
     is_file_destination,
     reject_parent_traversal,
     resolve_storage_path,
@@ -412,7 +412,9 @@ class ObStoreBackend:
     def glob_sync(self, pattern: str, **kwargs: Any) -> "list[str]":
         """Find objects matching pattern synchronously.
 
-        Lists all objects and filters them client-side using the pattern.
+        Lists all objects and filters them client-side. ``*`` and ``?`` match
+        within one path segment and ``**`` spans zero or more segments, matching
+        the local and fsspec backends.
         """
 
         resolved_pattern = (
@@ -421,25 +423,8 @@ class ObStoreBackend:
             else resolve_storage_path(pattern, self.base_path, self.protocol, strip_file_scheme=True)
         )
         all_objects = self.list_objects_sync(recursive=True, **kwargs)
-
-        if "**" in pattern:
-            matching_objects = []
-
-            if pattern.startswith("**/"):
-                suffix_pattern = pattern[3:]
-
-                for obj in all_objects:
-                    obj_path = PurePosixPath(obj)
-                    if obj_path.match(resolved_pattern) or obj_path.match(suffix_pattern):
-                        matching_objects.append(obj)
-            else:
-                for obj in all_objects:
-                    obj_path = PurePosixPath(obj)
-                    if obj_path.match(resolved_pattern):
-                        matching_objects.append(obj)
-            results = matching_objects
-        else:
-            results = [obj for obj in all_objects if fnmatch.fnmatch(obj, resolved_pattern)]
+        matcher = glob_to_regex(resolved_pattern)
+        results = [obj for obj in all_objects if matcher.match(obj)]
         _log_storage_event(
             "storage.list",
             backend_type=self.backend_type,

--- a/sqlspec/storage/backends/obstore.py
+++ b/sqlspec/storage/backends/obstore.py
@@ -593,10 +593,11 @@ class ObStoreBackend:
     def _stream_parquet_sync(self, resolved_path: str, table: "ArrowTable", **kwargs: Any) -> None:
         """Serialize a table row group by row group into an obstore multipart writer.
 
-        Peak memory is bounded by the upload buffer rather than the serialized
-        size of the whole table. The writer is completed only after every row
-        group is written; on failure it is dropped unclosed, which aborts the
-        multipart upload so no partial object is published.
+        Peak memory is bounded by one serialized row group plus the upload
+        buffer rather than the serialized size of the whole table. The writer
+        and the sink are closed only after every row group is written; a
+        failure leaves the multipart upload unfinished, and it is discarded
+        when the writer is released, so no partial object is published.
 
         Args:
             resolved_path: Store-relative destination key.
@@ -611,12 +612,8 @@ class ObStoreBackend:
         row_group_size = kwargs.pop("row_group_size", None)
         sink = open_writer(self.store, resolved_path)
         writer = pq.ParquetWriter(pa.PythonFile(_ObstoreSink(sink), mode="w"), table.schema, **kwargs)
-        try:
-            writer.write_table(table, row_group_size=row_group_size)
-            writer.close()
-        except BaseException:
-            del writer, sink
-            raise
+        writer.write_table(table, row_group_size=row_group_size)
+        writer.close()
         sink.close()
 
     def stream_read_sync(self, path: "str | Path", chunk_size: "int | None" = None, **kwargs: Any) -> Iterator[bytes]:

--- a/tests/unit/storage/test_glob_matching.py
+++ b/tests/unit/storage/test_glob_matching.py
@@ -1,0 +1,187 @@
+"""Glob matching must agree across storage backends.
+
+`local` and `fsspec` both delegate to an implementation with correct glob
+semantics, so they are the reference. The obstore backend filters client-side
+and must produce the same answers.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from sqlspec.storage._paths import glob_to_regex
+from sqlspec.storage.backends.local import LocalStore
+from sqlspec.typing import FSSPEC_INSTALLED, OBSTORE_INSTALLED
+
+LAYOUT = ("data/a.parquet", "data/sub/b.parquet", "data/x/y/z.parquet", "data_other/c.parquet", "top.parquet")
+
+EXPECTED = {
+    "data/*.parquet": ["data/a.parquet"],
+    "data/**/*.parquet": ["data/a.parquet", "data/sub/b.parquet", "data/x/y/z.parquet"],
+    "*.parquet": ["top.parquet"],
+    "**/*.parquet": [
+        "data/a.parquet",
+        "data/sub/b.parquet",
+        "data/x/y/z.parquet",
+        "data_other/c.parquet",
+        "top.parquet",
+    ],
+    "data/sub/b.parquet": ["data/sub/b.parquet"],
+    "data/?.parquet": ["data/a.parquet"],
+    "data/[ab].parquet": ["data/a.parquet"],
+    "data_*/*.parquet": ["data_other/c.parquet"],
+    "missing/*.parquet": [],
+}
+
+
+@pytest.fixture
+def populated_root(tmp_path: Path) -> Path:
+    for rel in LAYOUT:
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"x")
+    return tmp_path
+
+
+def _normalize(root: Path, results: "list[str]") -> "list[str]":
+    prefix = f"{root}/"
+    return sorted(item.removeprefix(prefix) for item in results)
+
+
+@pytest.mark.parametrize("pattern", sorted(EXPECTED))
+def test_local_store_glob_is_the_reference(populated_root: Path, pattern: str) -> None:
+    """Pin the reference semantics so a change to them is visible."""
+    store = LocalStore(str(populated_root))
+
+    assert _normalize(populated_root, store.glob_sync(pattern)) == EXPECTED[pattern]
+
+
+@pytest.mark.skipif(not OBSTORE_INSTALLED, reason="obstore missing")
+@pytest.mark.parametrize("pattern", sorted(EXPECTED))
+def test_obstore_glob_matches_the_reference(populated_root: Path, pattern: str) -> None:
+    """The obstore backend must agree with the local backend."""
+    from sqlspec.storage.backends.obstore import ObStoreBackend
+
+    store = ObStoreBackend(f"file://{populated_root}")
+
+    assert _normalize(populated_root, store.glob_sync(pattern)) == EXPECTED[pattern]
+
+
+@pytest.mark.skipif(not FSSPEC_INSTALLED, reason="fsspec missing")
+@pytest.mark.parametrize("pattern", sorted(EXPECTED))
+def test_fsspec_glob_matches_the_reference(populated_root: Path, pattern: str) -> None:
+    """The fsspec backend must agree with the local backend."""
+    from sqlspec.storage.backends.fsspec import FSSpecBackend
+
+    store = FSSpecBackend(f"file://{populated_root}")
+
+    assert _normalize(populated_root, store.glob_sync(pattern)) == EXPECTED[pattern]
+
+
+@pytest.mark.parametrize(
+    ("pattern", "candidate", "matches"),
+    [
+        ("data/*.parquet", "data/a.parquet", True),
+        ("data/*.parquet", "data/sub/b.parquet", False),
+        ("*.parquet", "top.parquet", True),
+        ("*.parquet", "data/a.parquet", False),
+        ("data/**/*.parquet", "data/a.parquet", True),
+        ("data/**/*.parquet", "data/sub/b.parquet", True),
+        ("data/**/*.parquet", "data/x/y/z.parquet", True),
+        ("data/**/*.parquet", "other/a.parquet", False),
+        ("**/*.parquet", "top.parquet", True),
+        ("**/*.parquet", "data/x/y/z.parquet", True),
+        ("data/?.parquet", "data/a.parquet", True),
+        ("data/?.parquet", "data/ab.parquet", False),
+        ("data/[ab].parquet", "data/a.parquet", True),
+        ("data/[ab].parquet", "data/c.parquet", False),
+        ("data/[!ab].parquet", "data/c.parquet", True),
+        ("data/[!ab].parquet", "data/a.parquet", False),
+        ("data/sub/b.parquet", "data/sub/b.parquet", True),
+        ("data/sub/b.parquet", "x/data/sub/b.parquet", False),
+        ("data_*/*.parquet", "data_other/c.parquet", True),
+        ("data_*/*.parquet", "data/a.parquet", False),
+        ("a/**/b", "a/b", True),
+        ("a/**/b", "a/x/b", True),
+        ("a/**/b", "a/x/y/b", True),
+        ("a/**/b", "a/b/c", False),
+    ],
+)
+def test_glob_to_regex_semantics(pattern: str, candidate: str, matches: bool) -> None:
+    """`*` and `?` stay within one segment; `**` spans zero or more segments; matching is anchored."""
+    assert bool(glob_to_regex(pattern).match(candidate)) is matches
+
+
+def test_glob_to_regex_escapes_regex_metacharacters() -> None:
+    """A dot in a pattern is a literal dot, not a wildcard."""
+    regex = glob_to_regex("data/a.parquet")
+
+    assert regex.match("data/a.parquet")
+    assert not regex.match("data/axparquet")
+
+
+def test_glob_to_regex_empty_pattern_matches_nothing() -> None:
+    """An empty pattern is not an error and selects nothing."""
+    assert not glob_to_regex("").match("a.parquet")
+
+
+MALFORMED_PATTERNS = [
+    "[",
+    "]",
+    "[]",
+    "[]]",
+    "[!]",
+    "[^]",
+    "[a-",
+    "[[]",
+    "a[",
+    "(",
+    ")",
+    "a(b)c",
+    "a|b",
+    "a+b",
+    "^a",
+    "a$",
+    "\\",
+    "a\\b",
+    "{",
+    "}",
+    "{a,b}",
+    "a{1,2}b",
+    "***",
+    "a/**",
+    "**/",
+    "/",
+    "//",
+    "a//b",
+    ".",
+    "..",
+]
+
+
+@pytest.mark.filterwarnings("error::FutureWarning")
+@pytest.mark.parametrize("pattern", MALFORMED_PATTERNS)
+def test_glob_to_regex_never_raises_on_malformed_input(pattern: str) -> None:
+    """A caller-supplied pattern must not produce a regex error or warning.
+
+    An empty or unterminated character class is treated as a literal bracket
+    rather than emitted as ``[]``, which would swallow the trailing anchor.
+    """
+    regex = glob_to_regex(pattern)
+
+    assert regex.pattern.endswith("\\Z")
+    regex.match("data/a.parquet")
+
+
+@pytest.mark.parametrize(
+    ("pattern", "candidate", "matches"),
+    [
+        ("data/[a-z].parquet", "data/q.parquet", True),
+        ("data/[a-z].parquet", "data/1.parquet", False),
+        ("data/[!a-z].parquet", "data/1.parquet", True),
+        ("data/[[].parquet", "data/[.parquet", True),
+    ],
+)
+def test_glob_to_regex_character_classes(pattern: str, candidate: str, matches: bool) -> None:
+    """Ranges, negation, and a literal bracket inside a class all behave."""
+    assert bool(glob_to_regex(pattern).match(candidate)) is matches

--- a/tests/unit/storage/test_glob_prefix_pushdown.py
+++ b/tests/unit/storage/test_glob_prefix_pushdown.py
@@ -1,0 +1,98 @@
+"""Static prefix extraction and listing pushdown for obstore globbing."""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from sqlspec.storage._paths import extract_glob_static_prefix
+from sqlspec.typing import OBSTORE_INSTALLED
+
+pytestmark = pytest.mark.skipif(not OBSTORE_INSTALLED, reason="obstore missing")
+
+_FIXTURE_KEYS = ("data/a.parquet", "data/sub/b.parquet", "data/x/y/z.parquet", "data_other/c.parquet", "top.parquet")
+
+
+@pytest.mark.parametrize(
+    ("pattern", "expected"),
+    [
+        ("data/*.parquet", "data/"),
+        ("data/**/*.parquet", "data/"),
+        ("*.parquet", ""),
+        ("data/2024/file.parquet", "data/2024/"),
+        ("data/[abc]/x.parquet", "data/"),
+        ("data/2024_*/x.parquet", "data/"),
+        ("/abs/data/*.parquet", "abs/data/"),
+        ("", ""),
+        ("a//b/*.txt", "a/"),
+        ("data/?/x.txt", "data/"),
+    ],
+)
+def test_extract_glob_static_prefix(pattern: str, expected: str) -> None:
+    result = extract_glob_static_prefix(pattern)
+
+    assert result == expected
+    assert result == "" or result.endswith("/")
+    assert "//" not in result
+
+
+def _populated(uri: str, base_path: str = "") -> Any:
+    from sqlspec.storage.backends.obstore import ObStoreBackend
+
+    store = ObStoreBackend(uri, base_path=base_path)
+    for key in _FIXTURE_KEYS:
+        store.write_bytes_sync(key, b"1")
+    return store
+
+
+def _stores(tmp_path: Path) -> list[Any]:
+    return [
+        _populated(f"file://{tmp_path / 'plain'}"),
+        _populated(f"file://{tmp_path / 'based'}", base_path="tenant"),
+        _populated("memory://"),
+        _populated("memory://", base_path="tenant"),
+    ]
+
+
+def _strip(store: Any, keys: list[str]) -> list[str]:
+    prefix = store.base_path.rstrip("/") + "/" if store.base_path and not store._is_local_store else ""
+    return [key.removeprefix(prefix) for key in keys]
+
+
+@pytest.mark.parametrize(
+    ("pattern", "expected"),
+    [
+        ("data/*.parquet", ["data/a.parquet"]),
+        ("data/**/*.parquet", ["data/a.parquet", "data/sub/b.parquet", "data/x/y/z.parquet"]),
+        ("top.parquet", ["top.parquet"]),
+        ("data/sub/b.parquet", ["data/sub/b.parquet"]),
+        ("missing/*.parquet", []),
+        ("", []),
+        ("*.parquet", ["top.parquet"]),
+    ],
+)
+def test_glob_results_with_prefix_pushdown(tmp_path: Path, pattern: str, expected: list[str]) -> None:
+    for store in _stores(tmp_path):
+        assert _strip(store, store.glob_sync(pattern)) == expected, store.store_uri
+
+
+class _RecordingListStore:
+    def __init__(self) -> None:
+        self.list_paths: list[str] = []
+
+    def list(self, path: str) -> Any:
+        self.list_paths.append(path)
+        return iter([[{"path": "data/a.parquet"}, {"path": "data_other/c.parquet"}]])
+
+
+def test_glob_passes_static_prefix_to_store_list() -> None:
+    from sqlspec.storage.backends.obstore import ObStoreBackend
+
+    store = ObStoreBackend("memory://", base_path="tenant")
+    recorder = _RecordingListStore()
+    store.store = recorder
+
+    store.glob_sync("data/*.parquet")
+    store.glob_sync("*.parquet")
+
+    assert recorder.list_paths == ["tenant/data/", "tenant/"]

--- a/tests/unit/storage/test_list_objects_prefix.py
+++ b/tests/unit/storage/test_list_objects_prefix.py
@@ -1,0 +1,74 @@
+"""Prefix filtering must work for a local-backed store that has a base_path.
+
+The base path is baked into the store root at construction, so resolving a
+caller-supplied prefix against it again looks for the segment twice.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from sqlspec.typing import OBSTORE_INSTALLED
+
+pytestmark = pytest.mark.skipif(not OBSTORE_INSTALLED, reason="obstore missing")
+
+LAYOUT = ("nested/data/a.parquet", "nested/data/b.parquet", "nested/other/c.parquet", "nested/top.parquet")
+
+
+@pytest.fixture
+def based_root(tmp_path: Path) -> Path:
+    for rel in LAYOUT:
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"x")
+    return tmp_path
+
+
+def test_local_store_with_base_path_filters_by_prefix(based_root: Path) -> None:
+    """A prefix must scope the listing rather than returning nothing."""
+    from sqlspec.storage.backends.obstore import ObStoreBackend
+
+    store = ObStoreBackend(f"file://{based_root}", base_path="nested")
+
+    assert store.list_objects_sync(prefix="data/") == ["data/a.parquet", "data/b.parquet"]
+
+
+def test_local_store_with_base_path_lists_everything_without_prefix(based_root: Path) -> None:
+    """The no-prefix path already worked and must keep working."""
+    from sqlspec.storage.backends.obstore import ObStoreBackend
+
+    store = ObStoreBackend(f"file://{based_root}", base_path="nested")
+
+    assert store.list_objects_sync() == ["data/a.parquet", "data/b.parquet", "other/c.parquet", "top.parquet"]
+
+
+def test_local_store_without_base_path_filters_by_prefix(tmp_path: Path) -> None:
+    """A store with no base_path is unaffected."""
+    from sqlspec.storage.backends.obstore import ObStoreBackend
+
+    for rel in ("data/a.parquet", "top.parquet"):
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"x")
+    store = ObStoreBackend(f"file://{tmp_path}")
+
+    assert store.list_objects_sync(prefix="data/") == ["data/a.parquet"]
+
+
+def test_prefix_is_segment_aligned(based_root: Path) -> None:
+    """A partial segment must not match, because obstore prefixes are per segment."""
+    from sqlspec.storage.backends.obstore import ObStoreBackend
+
+    store = ObStoreBackend(f"file://{based_root}", base_path="nested")
+
+    assert store.list_objects_sync(prefix="dat") == []
+
+
+@pytest.mark.anyio
+async def test_local_store_with_base_path_filters_by_prefix_async(based_root: Path) -> None:
+    """The async twin has the same defect and must be fixed with it."""
+    from sqlspec.storage.backends.obstore import ObStoreBackend
+
+    store = ObStoreBackend(f"file://{based_root}", base_path="nested")
+
+    assert await store.list_objects_async(prefix="data/") == ["data/a.parquet", "data/b.parquet"]

--- a/tests/unit/storage/test_obstore_backend.py
+++ b/tests/unit/storage/test_obstore_backend.py
@@ -3,7 +3,7 @@
 
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import pytest
 
@@ -470,20 +470,19 @@ def test_read_arrow_sync_resolves_cloud_base_path_once(monkeypatch: pytest.Monke
     assert fake_store.get_paths == ["mybase/key"]
 
 
-@pytest.mark.skipif(not OBSTORE_INSTALLED, reason="obstore missing")
-def test_write_arrow_sync_resolves_cloud_base_path_once(monkeypatch: pytest.MonkeyPatch) -> None:
-    from sqlspec.storage.backends import obstore as obstore_module
+@pytest.mark.skipif(not OBSTORE_INSTALLED or not PYARROW_INSTALLED, reason="obstore or PyArrow missing")
+def test_write_arrow_sync_resolves_cloud_base_path_once() -> None:
+    import pyarrow as pa
+
     from sqlspec.storage.backends.obstore import ObStoreBackend
 
     store = ObStoreBackend("memory://", base_path="mybase")
-    fake_store = _FakeStore()
-    store.store = fake_store
-    monkeypatch.setattr(obstore_module, "import_pyarrow", lambda: object())
-    monkeypatch.setattr(obstore_module, "import_pyarrow_parquet", lambda: _FakeParquet(object()))
+    table = pa.table({"id": [1, 2, 3]})
 
-    store.write_arrow_sync("key", cast("Any", _FakeArrowTable()))
+    store.write_arrow_sync("key", table)
 
-    assert fake_store.put_paths == ["mybase/key"]
+    assert store.list_objects_sync() == ["mybase/key"]
+    assert store.read_arrow_sync("key").equals(table)
 
 
 @pytest.mark.skipif(not OBSTORE_INSTALLED or not PYARROW_INSTALLED, reason="obstore or PyArrow missing")
@@ -759,19 +758,19 @@ async def test_read_arrow_async_resolves_cloud_base_path_once(monkeypatch: pytes
     assert fake_store.get_paths == ["mybase/key"]
 
 
-@pytest.mark.skipif(not OBSTORE_INSTALLED, reason="obstore missing")
-async def test_write_arrow_async_resolves_cloud_base_path_once(monkeypatch: pytest.MonkeyPatch) -> None:
-    from sqlspec.storage.backends import obstore as obstore_module
+@pytest.mark.skipif(not OBSTORE_INSTALLED or not PYARROW_INSTALLED, reason="obstore or PyArrow missing")
+async def test_write_arrow_async_resolves_cloud_base_path_once() -> None:
+    import pyarrow as pa
+
     from sqlspec.storage.backends.obstore import ObStoreBackend
 
     store = ObStoreBackend("memory://", base_path="mybase")
-    fake_store = _FakeStore()
-    store.store = fake_store
-    monkeypatch.setattr(obstore_module, "import_pyarrow_parquet", lambda: _FakeParquet(object()))
+    table = pa.table({"id": [1, 2, 3]})
 
-    await store.write_arrow_async("key", cast("Any", _FakeArrowTable()))
+    await store.write_arrow_async("key", table)
 
-    assert fake_store.put_paths == ["mybase/key"]
+    assert store.list_objects_sync() == ["mybase/key"]
+    assert store.read_arrow_sync("key").equals(table)
 
 
 @pytest.mark.skipif(not OBSTORE_INSTALLED, reason="obstore missing")

--- a/tests/unit/storage/test_obstore_backend.py
+++ b/tests/unit/storage/test_obstore_backend.py
@@ -28,21 +28,14 @@ class _FakeGetResult:
 class _FakeStore:
     def __init__(self) -> None:
         self.get_paths: list[str] = []
-        self.put_paths: list[str] = []
 
     def get(self, path: str) -> _FakeGetResult:
         self.get_paths.append(path)
         return _FakeGetResult()
 
-    def put(self, path: str, data: bytes) -> None:
-        self.put_paths.append(path)
-
     async def get_async(self, path: str) -> _FakeGetResult:
         self.get_paths.append(path)
         return _FakeGetResult()
-
-    async def put_async(self, path: str, data: bytes) -> None:
-        self.put_paths.append(path)
 
 
 def _new_obstore_for_signing(protocol: str = "s3", base_path: str = "prefix") -> "ObStoreBackend":
@@ -160,10 +153,6 @@ class _FakeParquet:
 
     def write_table(self, table: Any, sink: Any, **kwargs: Any) -> None:
         sink.write(b"parquet")
-
-
-class _FakeArrowTable:
-    schema: tuple[Any, ...] = ()
 
 
 @pytest.mark.skipif(not OBSTORE_INSTALLED, reason="obstore missing")

--- a/tests/unit/storage/test_obstore_backend.py
+++ b/tests/unit/storage/test_obstore_backend.py
@@ -1016,3 +1016,50 @@ async def test_stream_read_async_respects_chunk_size(tmp_path: Path) -> None:
 
     # Total data should match
     assert b"".join(chunks) == test_data
+
+
+@pytest.mark.skipif(not OBSTORE_INSTALLED or not PYARROW_INSTALLED, reason="obstore or PyArrow missing")
+def test_write_arrow_sync_forwards_row_group_size() -> None:
+    import io
+
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    from sqlspec.storage.backends.obstore import ObStoreBackend
+
+    store = ObStoreBackend("memory://")
+    store.write_arrow_sync("key", pa.table({"id": list(range(20))}), row_group_size=5)
+
+    assert pq.ParquetFile(io.BytesIO(store.read_bytes_sync("key"))).num_row_groups == 4
+
+
+@pytest.mark.skipif(not OBSTORE_INSTALLED or not PYARROW_INSTALLED, reason="obstore or PyArrow missing")
+def test_write_arrow_sync_failure_publishes_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    from sqlspec.exceptions import StorageOperationFailedError
+    from sqlspec.storage.backends import obstore as obstore_module
+    from sqlspec.storage.backends.obstore import ObStoreBackend
+
+    class _FailingWriter:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self._writer = pq.ParquetWriter(*args, **kwargs)
+
+        def write_table(self, *args: Any, **kwargs: Any) -> None:
+            self._writer.write_table(*args, **kwargs)
+            raise RuntimeError("upload interrupted")
+
+        def close(self) -> None:
+            self._writer.close()
+
+    class _FailingParquet:
+        ParquetWriter = _FailingWriter
+
+    monkeypatch.setattr(obstore_module, "import_pyarrow_parquet", lambda: _FailingParquet())
+    store = ObStoreBackend("memory://")
+
+    with pytest.raises(StorageOperationFailedError):
+        store.write_arrow_sync("partial", pa.table({"id": [1, 2, 3]}))
+
+    assert store.list_objects_sync() == []

--- a/tests/unit/storage/test_obstore_backend.py
+++ b/tests/unit/storage/test_obstore_backend.py
@@ -1034,32 +1034,18 @@ def test_write_arrow_sync_forwards_row_group_size() -> None:
 
 
 @pytest.mark.skipif(not OBSTORE_INSTALLED or not PYARROW_INSTALLED, reason="obstore or PyArrow missing")
-def test_write_arrow_sync_failure_publishes_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_write_arrow_sync_failure_publishes_nothing() -> None:
     import pyarrow as pa
-    import pyarrow.parquet as pq
 
     from sqlspec.exceptions import StorageOperationFailedError
-    from sqlspec.storage.backends import obstore as obstore_module
     from sqlspec.storage.backends.obstore import ObStoreBackend
 
-    class _FailingWriter:
-        def __init__(self, *args: Any, **kwargs: Any) -> None:
-            self._writer = pq.ParquetWriter(*args, **kwargs)
-
-        def write_table(self, *args: Any, **kwargs: Any) -> None:
-            self._writer.write_table(*args, **kwargs)
-            raise RuntimeError("upload interrupted")
-
-        def close(self) -> None:
-            self._writer.close()
-
-    class _FailingParquet:
-        ParquetWriter = _FailingWriter
-
-    monkeypatch.setattr(obstore_module, "import_pyarrow_parquet", lambda: _FailingParquet())
     store = ObStoreBackend("memory://")
+    unwritable = pa.table({
+        "u": pa.UnionArray.from_sparse(pa.array([0, 1], pa.int8()), [pa.array([1, 2]), pa.array(["a", "b"])])
+    })
 
     with pytest.raises(StorageOperationFailedError):
-        store.write_arrow_sync("partial", pa.table({"id": [1, 2, 3]}))
+        store.write_arrow_sync("partial", unwritable)
 
     assert store.list_objects_sync() == []

--- a/tests/unit/storage/test_storage_registry.py
+++ b/tests/unit/storage/test_storage_registry.py
@@ -259,3 +259,29 @@ def test_protocol_conformance_stream_arrow_async_notes_are_present() -> None:
     """Source comments document why stream_arrow_async is not async def."""
     assert "Returns AsyncIterator directly" in Path("sqlspec/protocols.py").read_text()
     assert "Returns AsyncIterator directly" in Path("sqlspec/storage/backends/base.py").read_text()
+
+
+@pytest.mark.skipif(not OBSTORE_INSTALLED, reason="obstore missing")
+def test_alias_named_like_a_scheme_does_not_capture_scheme_uris(tmp_path: Path) -> None:
+    registry = StorageRegistry()
+    registry.register_alias("memory", f"file://{tmp_path}")
+
+    by_alias = registry.get("memory")
+    by_scheme = registry.get("memory://bucket/key")
+
+    assert by_alias.protocol == "file"
+    assert by_scheme.protocol == "memory"
+    assert by_scheme.store_uri == "memory://bucket/key"
+
+
+@pytest.mark.skipif(not OBSTORE_INSTALLED, reason="obstore missing")
+def test_alias_does_not_match_partial_path_segment(tmp_path: Path) -> None:
+    registry = StorageRegistry()
+    registry.register_alias("db", f"file://{tmp_path}")
+
+    via_alias = registry.get("db/queries.sql")
+    not_alias = registry.get("db_backup/queries.sql")
+
+    assert via_alias.store_uri == f"file://{tmp_path}"
+    assert not_alias.store_uri.endswith("/db_backup")
+    assert str(tmp_path) not in not_alias.store_uri


### PR DESCRIPTION
Fixes four obstore storage bugs and one performance problem: glob matching returned wrong answers, listing with a prefix returned nothing on a local store with a base path, Arrow uploads buffered the whole file in memory, and globbing scanned the entire bucket.

## Glob matching returned wrong answers

Measured against a store holding `data/a.parquet`, `data/sub/b.parquet`, `data/x/y/z.parquet`, `data_other/c.parquet`, and `top.parquet`:

| pattern | local / fsspec | obstore (before) |
|---|---|---|
| `data/*.parquet` | `data/a.parquet` | also returned `data/sub/b.parquet`, `data/x/y/z.parquet` |
| `data/**/*.parquet` | all three under `data/` | only `data/sub/b.parquet` |
| `*.parquet` | `top.parquet` | every object at any depth |

- **`*` crossed `/`.** Patterns without `**` went through `fnmatch`, where `*` matches separators.
- **`**` was not recursive.** Patterns with `**` went through `PurePosixPath.match`, which treats `**` as a one-segment `*`.
- **Matching was right-anchored**, so a pattern could match objects outside the subtree it named.

One anchored regex now replaces both matchers. Tests assert all three backends agree, with the local backend as the reference. Malformed bracket classes such as `[]` or `[!]` are treated as literals instead of raising.

## Listing with a prefix on a local store returned nothing

With `base_path="nested"` on a `file://` store, `list_objects(prefix="data/")` returned `[]` because the base path was applied at construction and again at call time, so the store looked for `nested/nested/data/`. Both sync and async listing now resolve the prefix once.

## Arrow uploads no longer buffer the whole file

`write_arrow` serialized the entire Parquet file into memory before uploading. It now streams through obstore's multipart writer. Writing a 228MB table previously added 138MB of peak memory; it now adds none. A failed upload publishes nothing rather than a truncated file, and `row_group_size` is honoured.

## Globbing lists only the static prefix

`glob("data/2024/*.parquet")` now lists under `data/2024/` instead of every object in the bucket, then filters as before. Results are unchanged.

## Behaviour change to note

Anyone globbing with `*.parquet` and relying on it returning nested objects will get fewer results. That was the bug. Brace expansion remains unsupported, matching the other backends.
