### PR TITLE
fix: preserve transactions and prevent duplicate cached execution

### DIFF
--- a/sqlspec/adapters/pymssql/driver.py
+++ b/sqlspec/adapters/pymssql/driver.py
@@ -117,7 +117,7 @@ class PymssqlStreamSource:
 class PymssqlDriver(SyncDriverAdapterBase):
     """SQL Server database driver using pymssql."""
 
-    __slots__ = ("_column_name_cache", "_data_dictionary")
+    __slots__ = ("_column_name_cache", "_data_dictionary", "_transaction_active")
     dialect = "tsql"
 
     def __init__(
@@ -134,6 +134,7 @@ class PymssqlDriver(SyncDriverAdapterBase):
         super().__init__(connection=connection, statement_config=statement_config, driver_features=driver_features)
         self._data_dictionary: PymssqlSyncDataDictionary | None = None
         self._column_name_cache: dict[int, tuple[Any, list[str]]] = {}
+        self._transaction_active = False
 
     def dispatch_execute(self, cursor: "PymssqlRawCursor", statement: "SQL") -> "ExecutionResult":
         sql, prepared_parameters = self._compiled_sql(statement, self.statement_config)
@@ -180,6 +181,7 @@ class PymssqlDriver(SyncDriverAdapterBase):
         try:
             with PymssqlCursor(self.connection) as cursor:
                 cursor.execute("BEGIN TRANSACTION")
+            self._transaction_active = True
         except _pymssql_error_type() as exc:
             msg = f"Failed to begin SQL Server transaction: {exc}"
             raise SQLSpecError(msg) from exc
@@ -187,6 +189,7 @@ class PymssqlDriver(SyncDriverAdapterBase):
     def commit(self) -> None:
         try:
             self.connection.commit()
+            self._transaction_active = False
         except _pymssql_error_type() as exc:
             msg = f"Failed to commit SQL Server transaction: {exc}"
             raise SQLSpecError(msg) from exc
@@ -194,6 +197,7 @@ class PymssqlDriver(SyncDriverAdapterBase):
     def rollback(self) -> None:
         try:
             self.connection.rollback()
+            self._transaction_active = False
         except _pymssql_error_type() as exc:
             msg = f"Failed to rollback SQL Server transaction: {exc}"
             raise SQLSpecError(msg) from exc
@@ -234,7 +238,8 @@ class PymssqlDriver(SyncDriverAdapterBase):
         return resolve_rowcount(cursor)
 
     def _connection_in_transaction(self) -> bool:
-        return False
+        """Return whether a transaction opened by this driver remains active."""
+        return self._transaction_active
 
 
 class _UnavailablePymssqlError(Exception):

--- a/sqlspec/driver/_async.py
+++ b/sqlspec/driver/_async.py
@@ -35,6 +35,7 @@ from sqlspec.storage import AsyncStoragePipeline, StorageBridgeJob, StorageDesti
 from sqlspec.utils.arrow_helpers import convert_dict_to_arrow_with_schema
 from sqlspec.utils.logging import get_logger, log_with_context
 from sqlspec.utils.schema import ValueT, to_value_type
+from sqlspec.utils.type_guards import resolve_row_format
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Mapping, Sequence
@@ -1740,40 +1741,31 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin):
                 )
                 if can_use_cursor_fast_path:
                     assert execute is not None
-                    try:
-                        execute_result = execute(cached.compiled_sql, params)
-                        if isawaitable(execute_result):
-                            await execute_result
-                            if cached.operation_profile.returns_rows:
-                                assert fetchall is not None
-                                fetched_data = fetchall()
-                                if isawaitable(fetched_data):
-                                    fetched_data = await fetched_data
-                                data, column_names, row_count = self.collect_rows(cursor, fetched_data)
-                                execution_result = self.create_execution_result(
-                                    cursor,
-                                    selected_data=data,
-                                    column_names=column_names,
-                                    data_row_count=row_count,
-                                    is_select_result=True,
-                                    row_format="tuple",
-                                )
-                                direct_statement = self._cached_statement(
-                                    sql,
-                                    params,
-                                    cached,
-                                    params,
-                                    params_are_simple=True,
-                                    compiled_sql=cached.compiled_sql,
-                                )
-                                result = self.build_statement_result(direct_statement, execution_result)
-                            else:
-                                affected_rows = self.resolve_rowcount(cursor)
-                                result = DMLResult(cached.operation_type, affected_rows)
-                    except (AttributeError, NotImplementedError):
-                        pass
-
-                if result is None:
+                    execute_result = execute(cached.compiled_sql, params)
+                    if isawaitable(execute_result):
+                        await execute_result
+                    if cached.operation_profile.returns_rows:
+                        assert fetchall is not None
+                        fetched_data = fetchall()
+                        if isawaitable(fetched_data):
+                            fetched_data = await fetched_data
+                        data, column_names, row_count = self.collect_rows(cursor, fetched_data)
+                        execution_result = self.create_execution_result(
+                            cursor,
+                            selected_data=data,
+                            column_names=column_names,
+                            data_row_count=row_count,
+                            is_select_result=True,
+                            row_format=resolve_row_format(data),
+                        )
+                        direct_statement = self._cached_statement(
+                            sql, params, cached, params, params_are_simple=True, compiled_sql=cached.compiled_sql
+                        )
+                        result = self.build_statement_result(direct_statement, execution_result)
+                    else:
+                        affected_rows = self.resolve_rowcount(cursor)
+                        result = DMLResult(cached.operation_type, affected_rows)
+                else:
                     direct_statement = self._cached_statement(
                         sql, params, cached, params, params_are_simple=True, compiled_sql=cached.compiled_sql
                     )

--- a/sqlspec/driver/_sync.py
+++ b/sqlspec/driver/_sync.py
@@ -33,6 +33,7 @@ from sqlspec.storage import StorageBridgeJob, StorageDestination, StorageFormat,
 from sqlspec.utils.arrow_helpers import convert_dict_to_arrow_with_schema
 from sqlspec.utils.logging import get_logger, log_with_context
 from sqlspec.utils.schema import ValueT, to_value_type
+from sqlspec.utils.type_guards import resolve_row_format
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -445,33 +446,35 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin):
         result: SQLResult | None = None
         try:
             with exc_handler, self.with_cursor(self.connection) as cursor:
-                if hasattr(cursor, "execute"):
-                    try:
-                        cursor.execute(cached.compiled_sql, params)
-                        if cached.operation_profile.returns_rows:
-                            fetched_data = cursor.fetchall()
-                            data, column_names, row_count = self.collect_rows(cursor, fetched_data)
-                            execution_result = self.create_execution_result(
-                                cursor,
-                                selected_data=data,
-                                column_names=column_names,
-                                data_row_count=row_count,
-                                is_select_result=True,
-                                row_format="tuple",
-                            )
-                            direct_statement = self._cached_statement(
-                                sql, params, cached, params, params_are_simple=True, compiled_sql=cached.compiled_sql
-                            )
-                            result = self.build_statement_result(direct_statement, execution_result)
-                        else:
-                            affected_rows = self.resolve_rowcount(cursor)
-                            result = DMLResult(cached.operation_type, affected_rows)
-                    except (AttributeError, NotImplementedError):
-                        # Cursor is not DB-API compatible for direct execution.
-                        # Fall back to adapter dispatch path.
-                        pass
-
-                if result is None:
+                execute = getattr(cursor, "execute", None)
+                fetchall = getattr(cursor, "fetchall", None)
+                can_use_cursor_fast_path = execute is not None and (
+                    (cached.operation_profile.returns_rows and fetchall is not None)
+                    or (not cached.operation_profile.returns_rows and hasattr(cursor, "rowcount"))
+                )
+                if can_use_cursor_fast_path:
+                    assert execute is not None
+                    execute(cached.compiled_sql, params)
+                    if cached.operation_profile.returns_rows:
+                        assert fetchall is not None
+                        fetched_data = fetchall()
+                        data, column_names, row_count = self.collect_rows(cursor, fetched_data)
+                        execution_result = self.create_execution_result(
+                            cursor,
+                            selected_data=data,
+                            column_names=column_names,
+                            data_row_count=row_count,
+                            is_select_result=True,
+                            row_format=resolve_row_format(data),
+                        )
+                        direct_statement = self._cached_statement(
+                            sql, params, cached, params, params_are_simple=True, compiled_sql=cached.compiled_sql
+                        )
+                        result = self.build_statement_result(direct_statement, execution_result)
+                    else:
+                        affected_rows = self.resolve_rowcount(cursor)
+                        result = DMLResult(cached.operation_type, affected_rows)
+                else:
                     direct_statement = self._cached_statement(
                         sql, params, cached, params, params_are_simple=True, compiled_sql=cached.compiled_sql
                     )

--- a/sqlspec/driver/_sync.py
+++ b/sqlspec/driver/_sync.py
@@ -448,14 +448,14 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin):
             with exc_handler, self.with_cursor(self.connection) as cursor:
                 execute = getattr(cursor, "execute", None)
                 fetchall = getattr(cursor, "fetchall", None)
+                returns_rows = cached.operation_profile.returns_rows
                 can_use_cursor_fast_path = execute is not None and (
-                    (cached.operation_profile.returns_rows and fetchall is not None)
-                    or (not cached.operation_profile.returns_rows and hasattr(cursor, "rowcount"))
+                    (returns_rows and fetchall is not None) or (not returns_rows and hasattr(cursor, "rowcount"))
                 )
                 if can_use_cursor_fast_path:
                     assert execute is not None
                     execute(cached.compiled_sql, params)
-                    if cached.operation_profile.returns_rows:
+                    if returns_rows:
                         assert fetchall is not None
                         fetched_data = fetchall()
                         data, column_names, row_count = self.collect_rows(cursor, fetched_data)
@@ -479,7 +479,7 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin):
                         sql, params, cached, params, params_are_simple=True, compiled_sql=cached.compiled_sql
                     )
                     execution_result = self.dispatch_execute(cursor, direct_statement)
-                    if cached.operation_profile.returns_rows:
+                    if returns_rows:
                         result = self.build_statement_result(direct_statement, execution_result)
                     else:
                         affected_rows = (

--- a/sqlspec/utils/type_guards.py
+++ b/sqlspec/utils/type_guards.py
@@ -473,6 +473,8 @@ def resolve_row_format(
         return default
 
     first_row = rows[0]
+    if type(first_row) is tuple:
+        return default
     if is_dict_row(first_row):
         return "dict"
     if is_mapping_like(first_row):

--- a/tests/integration/adapters/mssql/pymssql/test_transactions.py
+++ b/tests/integration/adapters/mssql/pymssql/test_transactions.py
@@ -1,0 +1,44 @@
+"""Caller-owned pymssql transaction boundaries around statement stacks."""
+
+from typing import Any
+
+import pytest
+
+from sqlspec import StatementStack
+from sqlspec.adapters.pymssql import PymssqlConfig
+from sqlspec.exceptions import StackExecutionError
+
+pytestmark = [pytest.mark.pymssql, pytest.mark.xdist_group("mssql")]
+
+
+@pytest.mark.parametrize("fails", [False, True])
+def test_execute_stack_preserves_caller_transaction(pymssql_connection_config: dict[str, Any], fails: bool) -> None:
+    config = PymssqlConfig(connection_config=pymssql_connection_config)
+    try:
+        with config.provide_session() as driver:
+            driver.execute_script("DROP TABLE IF EXISTS sqlspec_pymssql_stack_txn")
+            driver.execute_script("CREATE TABLE sqlspec_pymssql_stack_txn (id INT PRIMARY KEY)")
+            driver.commit()
+            try:
+                driver.begin()
+                driver.execute("INSERT INTO sqlspec_pymssql_stack_txn (id) VALUES (?)", (1,))
+                transaction_count = driver.select_value("SELECT @@TRANCOUNT")
+                stack = StatementStack().push_execute("INSERT INTO sqlspec_pymssql_stack_txn (id) VALUES (?)", (2,))
+                if fails:
+                    stack = stack.push_execute("INSERT INTO sqlspec_pymssql_stack_txn (id) VALUES (?)", (2,))
+                    with pytest.raises(StackExecutionError):
+                        driver.execute_stack(stack)
+                else:
+                    results = driver.execute_stack(stack)
+                    assert len(results) == 1
+                    assert results[0].rows_affected == 1
+                assert driver.select_value("SELECT @@TRANCOUNT") == transaction_count
+                assert driver.select_value("SELECT COUNT(*) FROM sqlspec_pymssql_stack_txn") == 2
+                driver.rollback()
+                assert driver.select_value("SELECT COUNT(*) FROM sqlspec_pymssql_stack_txn") == 0
+            finally:
+                driver.rollback()
+                driver.execute_script("DROP TABLE IF EXISTS sqlspec_pymssql_stack_txn")
+                driver.commit()
+    finally:
+        config.close_pool()

--- a/tests/integration/adapters/mssql/test_shared.py
+++ b/tests/integration/adapters/mssql/test_shared.py
@@ -3,12 +3,13 @@
 from collections.abc import Generator
 from contextlib import contextmanager
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from unittest.mock import Mock
 
 import pytest
 
 from sqlspec.adapters.arrow_odbc import ArrowOdbcDriver
+from sqlspec.adapters.arrow_odbc._typing import ArrowOdbcConnection
 from sqlspec.adapters.pymssql import PymssqlConfig
 from tests.integration.adapters._shared import install_shared_tests
 
@@ -57,7 +58,9 @@ def test_arrow_odbc_cached_select_executes_once(case: Any, request: pytest.Fixtu
         proxy = SimpleNamespace(
             execute=Mock(wraps=connection.execute), read_arrow_batches=Mock(wraps=connection.read_arrow_batches)
         )
-        driver = ArrowOdbcDriver(connection=proxy, driver_features={"dbms_name": "Microsoft SQL Server"})
+        driver = ArrowOdbcDriver(
+            connection=cast("ArrowOdbcConnection", proxy), driver_features={"dbms_name": "Microsoft SQL Server"}
+        )
         for count in range(1, 4):
             result = driver.execute("SELECT 1 AS x", ())
             assert result.get_data() == [{"x": 1}]

--- a/tests/integration/adapters/mssql/test_shared.py
+++ b/tests/integration/adapters/mssql/test_shared.py
@@ -1,5 +1,65 @@
 """Shared Microsoft SQL Server-family integration contracts."""
 
+from collections.abc import Generator
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from sqlspec.adapters.arrow_odbc import ArrowOdbcDriver
+from sqlspec.adapters.pymssql import PymssqlConfig
 from tests.integration.adapters._shared import install_shared_tests
 
 install_shared_tests(globals(), "mssql")
+
+
+@pytest.mark.parametrize(
+    "case", [SimpleNamespace(adapter="pymssql", fixture_name="pymssql_connection_config")], ids=["pymssql"]
+)
+def test_pymssql_cached_dictionary_rows(case: Any, request: pytest.FixtureRequest, monkeypatch: Any) -> None:
+    config = PymssqlConfig(connection_config={**request.getfixturevalue(case.fixture_name), "as_dict": True})
+    executions = Mock()
+    try:
+        with config.provide_session() as driver:
+            with_cursor = driver.with_cursor
+
+            @contextmanager
+            def counted_cursor(_driver: Any, connection: Any) -> Generator[Any, None, None]:
+                with with_cursor(connection) as cursor:
+                    proxy = SimpleNamespace(fetchall=cursor.fetchall, rowcount=cursor.rowcount)
+
+                    def execute(sql: str, params: Any) -> None:
+                        executions(sql, params)
+                        cursor.execute(sql, params)
+                        proxy.description = cursor.description
+                        proxy.rowcount = cursor.rowcount
+
+                    proxy.execute = execute
+                    yield proxy
+
+            monkeypatch.setattr(type(driver), "with_cursor", counted_cursor)
+            for count in range(1, 4):
+                result = driver.execute("SELECT 1 AS x UNION ALL SELECT 2 AS x ORDER BY x", ())
+                assert result.get_data() == [{"x": 1}, {"x": 2}]
+                assert executions.call_count == count
+    finally:
+        config.close_pool()
+
+
+@pytest.mark.parametrize(
+    "case", [SimpleNamespace(adapter="arrow_odbc", fixture_name="arrow_odbc_mssql_config")], ids=["arrow-odbc"]
+)
+def test_arrow_odbc_cached_select_executes_once(case: Any, request: pytest.FixtureRequest) -> None:
+    with request.getfixturevalue(case.fixture_name).provide_session() as session:
+        connection = session.connection
+        proxy = SimpleNamespace(
+            execute=Mock(wraps=connection.execute), read_arrow_batches=Mock(wraps=connection.read_arrow_batches)
+        )
+        driver = ArrowOdbcDriver(connection=proxy, driver_features={"dbms_name": "Microsoft SQL Server"})
+        for count in range(1, 4):
+            result = driver.execute("SELECT 1 AS x", ())
+            assert result.get_data() == [{"x": 1}]
+            assert proxy.read_arrow_batches.call_count == count
+            proxy.execute.assert_not_called()

--- a/tests/unit/adapters/test_pymssql/test_driver.py
+++ b/tests/unit/adapters/test_pymssql/test_driver.py
@@ -4,9 +4,10 @@ from typing import cast
 
 import pytest
 
+from sqlspec import StatementStack
 from sqlspec.adapters.pymssql._typing import PymssqlConnection, PymssqlRawCursor
 from sqlspec.core import SQL
-from sqlspec.exceptions import SQLSpecError, TransactionError, UniqueViolationError
+from sqlspec.exceptions import SQLSpecError, StackExecutionError, TransactionError, UniqueViolationError
 from tests.unit.adapters.test_pymssql._fakes import (
     FakeConnection,
     FakeCursor,
@@ -189,8 +190,71 @@ def test_select_stream_uses_fetchmany_chunks() -> None:
     assert cursor.closed is True
 
 
-def test_connection_in_transaction_is_false_without_supported_state() -> None:
-    """pymssql does not expose a reliable transaction-state flag."""
+@pytest.mark.parametrize("finish", ["commit", "rollback"])
+def test_connection_in_transaction_tracks_successful_boundaries(finish: str) -> None:
     from sqlspec.adapters.pymssql.driver import PymssqlDriver
 
-    assert PymssqlDriver(cast("PymssqlConnection", FakeConnection()))._connection_in_transaction() is False
+    driver = PymssqlDriver(cast("PymssqlConnection", FakeConnection()))
+    assert driver._connection_in_transaction() is False
+    driver.begin()
+    assert driver._connection_in_transaction() is True
+    getattr(driver, finish)()
+    assert driver._connection_in_transaction() is False
+
+
+@pytest.mark.parametrize("operation", ["begin", "commit", "rollback"])
+def test_failed_transaction_boundary_preserves_state(operation: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    import sqlspec.adapters.pymssql.driver as driver_module
+
+    connection = FakeConnection()
+    driver = driver_module.PymssqlDriver(cast("PymssqlConnection", connection))
+    if operation != "begin":
+        driver.begin()
+    failure = FakePymssqlIntegrityError("boundary failed")
+
+    def fail(*_args: object) -> None:
+        raise failure
+
+    monkeypatch.setattr(driver_module, "pymssql", FakePymssqlModule())
+    monkeypatch.setattr(
+        connection.cursor_obj if operation == "begin" else connection,
+        "execute" if operation == "begin" else operation,
+        fail,
+    )
+    with pytest.raises(SQLSpecError) as caught:
+        getattr(driver, operation)()
+    assert caught.value.__cause__ is failure
+    assert driver._connection_in_transaction() is (operation != "begin")
+
+
+@pytest.mark.parametrize("fails", [False, True])
+def test_execute_stack_preserves_caller_transaction(fails: bool, monkeypatch: pytest.MonkeyPatch) -> None:
+    from sqlspec.adapters.pymssql.driver import PymssqlDriver
+
+    connection = FakeConnection(FakeCursor(rowcount=1))
+    driver = PymssqlDriver(cast("PymssqlConnection", connection))
+    driver.begin()
+    stack = StatementStack().push_execute("INSERT INTO users (id) VALUES (1)")
+    if fails:
+        failure = RuntimeError("statement failed")
+        execute = connection.cursor_obj.execute
+
+        def fail(sql: str, parameters: object = None) -> None:
+            execute(sql, parameters)
+            if sql.startswith("INSERT"):
+                raise failure
+
+        monkeypatch.setattr(connection.cursor_obj, "execute", fail)
+        with pytest.raises(StackExecutionError) as caught:
+            driver.execute_stack(stack)
+        assert caught.value.__cause__ is failure
+    else:
+        result = driver.execute_stack(stack)
+        assert len(result) == 1
+        assert result[0].rows_affected == 1
+    assert connection.commits == 0
+    assert connection.rollbacks == 0
+    assert driver._connection_in_transaction() is True
+    assert sum(sql == "BEGIN TRANSACTION" for sql, _ in connection.cursor_obj.calls) == 1
+    driver.rollback()
+    assert connection.rollbacks == 1

--- a/tests/unit/driver/test_query_cache.py
+++ b/tests/unit/driver/test_query_cache.py
@@ -1,8 +1,11 @@
 # pyright: reportPrivateUsage = false
 """Tests for SQL query caching functionality."""
 
+from collections import UserDict
+from collections.abc import AsyncIterator, Generator
+from contextlib import asynccontextmanager
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from sqlglot import parse_one
@@ -477,6 +480,172 @@ async def test_async_execute_cache_hit_uses_cursor_fast_path(aiosqlite_async_dri
 
     assert result.operation_type == "INSERT"
     assert result.rows_affected == 1
+
+
+@pytest.fixture
+def cached_async_cursor(
+    sqlite_sync_driver: Any, aiosqlite_async_driver: Any, monkeypatch: Any
+) -> Generator[tuple[Any, Any, list[str], AsyncMock], None, None]:
+    raw_cursor = sqlite_sync_driver.connection.cursor()
+    cursor = Mock(spec=["execute", "fetchall", "rowcount", "description"])
+    cursor.rowcount = 0
+
+    def execute(sql: str, params: Any) -> None:
+        raw_cursor.execute(sql, params)
+        cursor.description = raw_cursor.description
+        cursor.rowcount = raw_cursor.rowcount
+
+    cursor.execute = Mock(side_effect=execute)
+    cursor.fetchall = raw_cursor.fetchall
+
+    @asynccontextmanager
+    async def with_cursor(_connection: Any) -> AsyncIterator[Any]:
+        yield cursor
+
+    async def dispatch(_cursor: Any, statement: SQL) -> Any:
+        return sqlite_sync_driver.dispatch_execute(raw_cursor, statement)
+
+    fallback = AsyncMock(side_effect=dispatch)
+    monkeypatch.setattr(aiosqlite_async_driver, "with_cursor", with_cursor)
+    monkeypatch.setattr(aiosqlite_async_driver, "dispatch_execute", fallback)
+    statements: list[str] = []
+    sqlite_sync_driver.connection.set_trace_callback(statements.append)
+    try:
+        yield aiosqlite_async_driver, cursor, statements, fallback
+    finally:
+        sqlite_sync_driver.connection.set_trace_callback(None)
+        raw_cursor.close()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("returns_rows", [True, False], ids=["select", "insert"])
+@pytest.mark.parametrize("awaitable_result", [False, True], ids=["sync", "awaitable-wrapper"])
+async def test_async_cache_hit_executes_once(
+    cached_async_cursor: Any, returns_rows: bool, awaitable_result: bool
+) -> None:
+    driver, cursor, statements, fallback = cached_async_cursor
+    if awaitable_result:
+        execute = cursor.execute
+
+        async def execute_async(sql: str, params: Any) -> None:
+            execute(sql, params)
+
+        cursor.execute = lambda sql, params: execute_async(sql, params)
+        if returns_rows:
+            fetchall = cursor.fetchall
+
+            async def fetchall_async() -> Any:
+                return fetchall()
+
+            cursor.fetchall = fetchall_async
+
+    sql = "SELECT ? AS value" if returns_rows else "INSERT INTO users (name) VALUES (?)"
+    cached = _make_cached(
+        compiled_sql=sql,
+        param_count=1,
+        operation_type="SELECT" if returns_rows else "INSERT",
+        operation_profile=OperationProfile(returns_rows=returns_rows, modifies_rows=not returns_rows),
+    )
+    result = await driver._execute_cache_hit_with_cursor(sql, ("once",), cached)
+
+    executed = [statement for statement in statements if statement.startswith(("SELECT", "INSERT"))]
+    assert len(executed) == 1
+    fallback.assert_not_called()
+    if returns_rows:
+        assert result.get_data() == [{"value": "once"}]
+    else:
+        assert result.rows_affected == 1
+        if awaitable_result:
+            await cursor.execute("SELECT COUNT(*) FROM users WHERE name = ?", ("once",))
+        else:
+            cursor.execute("SELECT COUNT(*) FROM users WHERE name = ?", ("once",))
+        assert cursor.fetchall() == [(1,)]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("error_type", [AttributeError, NotImplementedError])
+@pytest.mark.parametrize("stage", ["execute", "fetchall", "collect_rows", "resolve_rowcount", "build_statement_result"])
+async def test_async_cache_hit_does_not_retry_after_execute(
+    cached_async_cursor: Any, monkeypatch: Any, error_type: type[Exception], stage: str
+) -> None:
+    driver, cursor, statements, fallback = cached_async_cursor
+    error = error_type("failure after SQL execution")
+    execute = cursor.execute
+
+    async def execute_async(sql: str, params: Any) -> None:
+        execute(sql, params)
+        if stage == "execute":
+            raise error
+
+    cursor.execute = execute_async
+    if stage == "fetchall":
+        cursor.fetchall = Mock(side_effect=error)
+    elif stage != "execute":
+        monkeypatch.setattr(driver, stage, Mock(side_effect=error))
+
+    returns_rows = stage not in {"execute", "resolve_rowcount"}
+    sql = "SELECT ? AS value" if returns_rows else "INSERT INTO users (name) VALUES (?)"
+    cached = _make_cached(
+        compiled_sql=sql,
+        param_count=1,
+        operation_type="SELECT" if returns_rows else "INSERT",
+        operation_profile=OperationProfile(returns_rows=returns_rows, modifies_rows=not returns_rows),
+    )
+    with pytest.raises(error_type) as exc_info:
+        await driver._execute_cache_hit_with_cursor(sql, ("once",), cached)
+
+    assert exc_info.value is error
+    assert len([statement for statement in statements if statement.startswith(("SELECT", "INSERT"))]) == 1
+    fallback.assert_not_called()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("row_format", ["tuple", "dict", "record"])
+async def test_async_cache_hit_preserves_row_format(cached_async_cursor: Any, row_format: str) -> None:
+    driver, cursor, statements, fallback = cached_async_cursor
+    fetchall = cursor.fetchall
+
+    def fetch_rows() -> list[Any]:
+        rows = fetchall()
+        if row_format == "tuple":
+            return rows
+        mappings = [{"name": row[1], "id": row[0]} for row in rows]
+        return [UserDict(row) for row in mappings] if row_format == "record" else mappings
+
+    cursor.fetchall = Mock(side_effect=fetch_rows)
+    sql = "SELECT id, name FROM users ORDER BY id"
+    result = await driver._execute_cache_hit_with_cursor(sql, (), _make_cached(compiled_sql=sql))
+
+    assert result.get_data() == [{"id": 1, "name": "test"}, {"id": 2, "name": "example"}]
+    assert result.column_names == ["id", "name"]
+    assert statements == [sql]
+    cursor.fetchall.assert_called_once_with()
+    fallback.assert_not_called()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("returns_rows", [True, False], ids=["select", "insert"])
+async def test_async_cache_hit_missing_cursor_capability_dispatches_once(
+    cached_async_cursor: Any, returns_rows: bool
+) -> None:
+    driver, cursor, statements, fallback = cached_async_cursor
+    delattr(cursor, "fetchall" if returns_rows else "rowcount")
+    sql = "SELECT ? AS value" if returns_rows else "INSERT INTO users (name) VALUES (?)"
+    cached = _make_cached(
+        compiled_sql=sql,
+        param_count=1,
+        operation_type="SELECT" if returns_rows else "INSERT",
+        operation_profile=OperationProfile(returns_rows=returns_rows, modifies_rows=not returns_rows),
+    )
+    result = await driver._execute_cache_hit_with_cursor(sql, ("once",), cached)
+
+    assert len([statement for statement in statements if statement.startswith(("SELECT", "INSERT"))]) == 1
+    fallback.assert_awaited_once()
+    cursor.execute.assert_not_called()
+    if returns_rows:
+        assert result.get_data() == [{"value": "once"}]
+    else:
+        assert result.rows_affected == 1
 
 
 @pytest.mark.anyio

--- a/tests/unit/driver/test_query_cache.py
+++ b/tests/unit/driver/test_query_cache.py
@@ -3,7 +3,7 @@
 
 from collections import UserDict
 from collections.abc import AsyncIterator, Generator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 
@@ -24,6 +24,7 @@ from sqlspec.core import (
 )
 from sqlspec.core.parameters._processor import ParameterProcessor
 from sqlspec.driver._query_cache import CachedQuery, QueryCache
+from sqlspec.driver._sync import SyncDriverAdapterBase
 from sqlspec.exceptions import SQLSpecError
 
 
@@ -480,6 +481,136 @@ async def test_async_execute_cache_hit_uses_cursor_fast_path(aiosqlite_async_dri
 
     assert result.operation_type == "INSERT"
     assert result.rows_affected == 1
+
+
+@pytest.fixture
+def cached_sync_cursor(sqlite_sync_driver: Any, monkeypatch: Any) -> Generator[Any, None, None]:
+    raw_cursor = sqlite_sync_driver.connection.cursor()
+    cursor = Mock(spec=["execute", "fetchall", "rowcount", "description"])
+    cursor.rowcount = 0
+
+    def execute(sql: str, params: Any) -> None:
+        raw_cursor.execute(sql, params)
+        cursor.description = raw_cursor.description
+        cursor.rowcount = raw_cursor.rowcount
+
+    cursor.execute = Mock(side_effect=execute)
+    cursor.fetchall = raw_cursor.fetchall
+
+    @contextmanager
+    def with_cursor(_connection: Any) -> Generator[Any, None, None]:
+        yield cursor
+
+    dispatch = sqlite_sync_driver.dispatch_execute
+    fallback = Mock(side_effect=lambda _cursor, statement: dispatch(raw_cursor, statement))
+    monkeypatch.setattr(sqlite_sync_driver, "with_cursor", with_cursor)
+    monkeypatch.setattr(sqlite_sync_driver, "dispatch_execute", fallback)
+    statements: list[str] = []
+    sqlite_sync_driver.connection.set_trace_callback(statements.append)
+    try:
+        yield sqlite_sync_driver, cursor, statements, fallback
+    finally:
+        sqlite_sync_driver.connection.set_trace_callback(None)
+        raw_cursor.close()
+
+
+@pytest.mark.parametrize("error_type", [AttributeError, NotImplementedError])
+@pytest.mark.parametrize("stage", ["execute", "fetchall", "collect_rows", "resolve_rowcount", "build_statement_result"])
+def test_sync_cache_hit_does_not_retry_after_execute(
+    cached_sync_cursor: Any, monkeypatch: Any, error_type: type[Exception], stage: str
+) -> None:
+    driver, cursor, statements, fallback = cached_sync_cursor
+    error = error_type("failure after SQL execution")
+    execute = cursor.execute
+
+    def execute_then_error(sql: str, params: Any) -> None:
+        execute(sql, params)
+        if stage == "execute":
+            raise error
+
+    cursor.execute = execute_then_error
+    if stage == "fetchall":
+        cursor.fetchall = Mock(side_effect=error)
+    elif stage != "execute":
+        monkeypatch.setattr(driver, stage, Mock(side_effect=error))
+    returns_rows = stage not in {"execute", "resolve_rowcount"}
+    sql = "SELECT ? AS value" if returns_rows else "INSERT INTO users (name) VALUES (?)"
+    cached = _make_cached(
+        compiled_sql=sql,
+        operation_type="SELECT" if returns_rows else "INSERT",
+        operation_profile=OperationProfile(returns_rows=returns_rows, modifies_rows=not returns_rows),
+    )
+    with pytest.raises(error_type) as exc_info:
+        SyncDriverAdapterBase._execute_cache_hit(driver, sql, ("once",), cached)
+
+    assert exc_info.value is error
+    assert len([statement for statement in statements if statement.startswith(("SELECT", "INSERT"))]) == 1
+    fallback.assert_not_called()
+
+
+def test_sync_cache_hit_insert_executes_once(cached_sync_cursor: Any) -> None:
+    driver, cursor, statements, fallback = cached_sync_cursor
+    sql = "INSERT INTO users (name) VALUES (?)"
+    cached = _make_cached(
+        compiled_sql=sql,
+        operation_type="INSERT",
+        operation_profile=OperationProfile(returns_rows=False, modifies_rows=True),
+    )
+    result = SyncDriverAdapterBase._execute_cache_hit(driver, sql, ("once",), cached)
+
+    assert result.rows_affected == 1
+    assert len([statement for statement in statements if statement.startswith("INSERT")]) == 1
+    fallback.assert_not_called()
+    cursor.execute("SELECT COUNT(*) FROM users WHERE name = ?", ("once",))
+    assert cursor.fetchall() == [(1,)]
+
+
+@pytest.mark.parametrize("row_format", ["tuple", "dict", "record"])
+def test_sync_cache_hit_preserves_row_format(cached_sync_cursor: Any, row_format: str) -> None:
+    driver, cursor, statements, fallback = cached_sync_cursor
+    fetchall = cursor.fetchall
+
+    def fetch_rows() -> list[Any]:
+        rows = fetchall()
+        if row_format == "tuple":
+            return rows
+        mappings = [{"name": row[1], "id": row[0]} for row in rows]
+        return [UserDict(row) for row in mappings] if row_format == "record" else mappings
+
+    cursor.fetchall = Mock(side_effect=fetch_rows)
+    sql = "SELECT id, name FROM users ORDER BY id"
+    result = SyncDriverAdapterBase._execute_cache_hit(driver, sql, (), _make_cached(compiled_sql=sql))
+
+    assert result.get_data() == [{"id": 1, "name": "test"}, {"id": 2, "name": "example"}]
+    assert result.column_names == ["id", "name"]
+    assert statements == [sql]
+    cursor.fetchall.assert_called_once_with()
+    fallback.assert_not_called()
+
+
+@pytest.mark.parametrize("missing_capability", ["execute", "fetchall", "rowcount"])
+def test_sync_cache_hit_missing_cursor_capability_dispatches_once(
+    cached_sync_cursor: Any, missing_capability: str
+) -> None:
+    driver, cursor, statements, fallback = cached_sync_cursor
+    execute = cursor.execute
+    delattr(cursor, missing_capability)
+    returns_rows = missing_capability != "rowcount"
+    sql = "SELECT ? AS value" if returns_rows else "INSERT INTO users (name) VALUES (?)"
+    cached = _make_cached(
+        compiled_sql=sql,
+        operation_type="SELECT" if returns_rows else "INSERT",
+        operation_profile=OperationProfile(returns_rows=returns_rows, modifies_rows=not returns_rows),
+    )
+    result = SyncDriverAdapterBase._execute_cache_hit(driver, sql, ("once",), cached)
+
+    assert len([statement for statement in statements if statement.startswith(("SELECT", "INSERT"))]) == 1
+    fallback.assert_called_once()
+    execute.assert_not_called()
+    if returns_rows:
+        assert result.get_data() == [{"value": "once"}]
+    else:
+        assert result.rows_affected == 1
 
 
 @pytest.fixture

--- a/tests/unit/driver/test_query_cache.py
+++ b/tests/unit/driver/test_query_cache.py
@@ -571,7 +571,7 @@ def test_sync_cache_hit_preserves_row_format(cached_sync_cursor: Any, row_format
     fetchall = cursor.fetchall
 
     def fetch_rows() -> list[Any]:
-        rows = fetchall()
+        rows: list[Any] = fetchall()
         if row_format == "tuple":
             return rows
         mappings = [{"name": row[1], "id": row[0]} for row in rows]
@@ -737,7 +737,7 @@ async def test_async_cache_hit_preserves_row_format(cached_async_cursor: Any, ro
     fetchall = cursor.fetchall
 
     def fetch_rows() -> list[Any]:
-        rows = fetchall()
+        rows: list[Any] = fetchall()
         if row_format == "tuple":
             return rows
         mappings = [{"name": row[1], "id": row[0]} for row in rows]

--- a/tests/unit/utils/test_type_guards.py
+++ b/tests/unit/utils/test_type_guards.py
@@ -5,6 +5,7 @@ Uses function-based pytest approach as per AGENTS.md requirements.
 """
 
 import typing
+from collections import UserDict
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, cast
@@ -70,10 +71,33 @@ from sqlspec.utils.type_guards import (
     is_schema_without_field,
     is_string_literal,
     is_typed_dict,
+    resolve_row_format,
     supports_arrow_results,
 )
 
 _UNSET = object()
+
+
+@pytest.mark.parametrize("default", ["dict", "tuple", "record"])
+@pytest.mark.parametrize("rows", [None, [], [(1,)]], ids=["none", "empty", "tuple"])
+def test_resolve_row_format_preserves_default(rows: Any, default: Any) -> None:
+    assert resolve_row_format(rows, default=default) == default
+
+
+@pytest.mark.parametrize("default", ["dict", "tuple", "record"])
+@pytest.mark.parametrize("row, expected", [({"x": 1}, "dict"), (UserDict({"x": 1}), "record")])
+def test_resolve_row_format_detects_mappings(row: Any, expected: str, default: Any) -> None:
+    assert resolve_row_format([row], default=default) == expected
+
+
+def test_resolve_row_format_preserves_tuple_subclass_detection() -> None:
+    class TupleRecord(tuple[int, ...]):
+        __slots__ = ()
+
+        def keys(self) -> tuple[str, ...]:
+            return ("x",)
+
+    assert resolve_row_format([TupleRecord((1,))], default="dict") == "record"
 
 
 @dataclass


### PR DESCRIPTION
Preserve caller-owned pymssql transactions during statement-stack execution. Shared sync and async cache paths now reject unsupported cursors before execution and propagate execution or result errors without retrying SQL; cached dictionary and record rows retain their values.
