### PR TITLE
fix: accept documented squash version range formats

### DIFF
--- a/sqlspec/cli.py
+++ b/sqlspec/cli.py
@@ -13,6 +13,7 @@ from rich.table import Table
 
 from sqlspec.config import AsyncDatabaseConfig, SyncDatabaseConfig
 from sqlspec.exceptions import SQLSpecError
+from sqlspec.migrations.squash import parse_version_range
 from sqlspec.utils.config_tools import discover_config_from_pyproject, resolve_config_sync
 from sqlspec.utils.module_loader import import_string
 from sqlspec.utils.sync_tools import run_
@@ -830,7 +831,7 @@ def add_migration_commands(database_group: "Group | None" = None) -> "Group":
         sqlspec_config = get_config_by_bind_key(ctx, bind_key)
         _dispatch_migration_call(sqlspec_config, "fix", dry_run=dry_run, update_database=not no_database, yes=yes)
 
-    @database_group.command(name="squash", help="Squash multiple migrations into a single file.")
+    @database_group.command(name="squash")
     @bind_key_option
     @click.argument("version_range", required=True)
     @click.option("-m", "--message", required=True, help="Description for squashed migration")
@@ -856,17 +857,15 @@ def add_migration_commands(database_group: "Group | None" = None) -> "Group":
     ) -> None:
         """Squash multiple sequential migrations into a single file.
 
-        VERSION_RANGE should be in START:END format:0004".
+        VERSION_RANGE accepts START:END, START..END, or START-END, for example 1:7.
         """
         ctx = _ensure_click_context()
 
-        if ":" not in version_range:
-            console.print("[red]Error: VERSION_RANGE must be in START:END format[/]")
-            raise SystemExit(1)
-
-        start_version, end_version = version_range.split(":", 1)
-        start_version = start_version.strip().zfill(4)
-        end_version = end_version.strip().zfill(4)
+        try:
+            start_version, end_version = parse_version_range(version_range)
+        except ValueError as exc:
+            console.print(f"[red]Error: {escape(str(exc))}[/]")
+            raise SystemExit(1) from None
 
         console.rule("[yellow]Migration Squash Command[/]", align="left")
         sqlspec_config = get_config_by_bind_key(ctx, bind_key)

--- a/tests/unit/cli/test_migration_commands.py
+++ b/tests/unit/cli/test_migration_commands.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 import pytest
 from click.testing import CliRunner
 
+from sqlspec.adapters.sqlite import SqliteConfig
 from sqlspec.cli import add_migration_commands
 
 MODULE_PREFIX = "cli_test_config_"
@@ -763,3 +764,54 @@ def get_multi_configs():
     mock_commands.upgrade.assert_called_once_with(
         revision="head", auto_sync=True, dry_run=False, use_logger=False, echo=None, summary_only=None
     )
+
+
+@pytest.mark.parametrize("version_range", ["1:7", "1..7", "1-7"])
+def test_squash_version_range_formats(version_range: str) -> None:
+    config = SqliteConfig(connection_config={"database": ":memory:"})
+    with (
+        patch("sqlspec.cli.resolve_config_sync", return_value=config),
+        patch("sqlspec.migrations.commands.create_migration_commands") as create_commands,
+    ):
+        result = CliRunner().invoke(
+            add_migration_commands(),
+            ["--config", "test.config", "squash", version_range, "-m", "consolidated", "--yes", "--no-database"],
+        )
+
+    assert result.exit_code == 0, result.output
+    create_commands.return_value.squash.assert_called_once_with(
+        start_version="0001",
+        end_version="0007",
+        description="consolidated",
+        dry_run=False,
+        update_database=False,
+        yes=True,
+        allow_gaps=False,
+        output_format="sql",
+    )
+
+
+@pytest.mark.parametrize("version_range", ["1to7", "[bold]"])
+def test_squash_invalid_version_range(version_range: str) -> None:
+    config = SqliteConfig(connection_config={"database": ":memory:"})
+    with (
+        patch("sqlspec.cli.resolve_config_sync", return_value=config),
+        patch("sqlspec.migrations.commands.create_migration_commands") as create_commands,
+    ):
+        result = CliRunner().invoke(
+            add_migration_commands(), ["--config", "test.config", "squash", version_range, "-m", "consolidated"]
+        )
+
+    assert result.exit_code == 1
+    assert f"Invalid VERSION_RANGE format: '{version_range}'. Use START:END, START..END, or START-END" in " ".join(
+        result.output.split()
+    )
+    create_commands.assert_not_called()
+
+
+def test_squash_help_version_range_formats() -> None:
+    result = CliRunner().invoke(add_migration_commands().commands["squash"], ["--help"])
+
+    assert result.exit_code == 0
+    for value in ("START:END", "START..END", "START-END", "1:7"):
+        assert value in result.output


### PR DESCRIPTION
The squash command rejected `START..END` and `START-END` even though the shared parser already supported them. Delegate to that parser, preserve its error messages as literal text, and show all three formats in command help.
