### PR TITLE
fix: support grouping expressions consistently

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,13 @@ Unreleased
 
 **Fixed:**
 
+* ``Select.group_by()`` accepts the ``sql.rollup()``, ``sql.cube()``, and
+  ``sql.grouping_sets()`` factory expressions directly. The factory helpers and
+  the ``group_by_rollup()``, ``group_by_cube()``, and
+  ``group_by_grouping_sets()`` methods now build the same expressions, and each
+  grouping set must be a tuple or list of columns; a bare string raises
+  ``SQLBuilderError`` instead of producing incorrect SQL.
+
 * MySQL adapters accept either ``local_infile=True`` or
   ``allow_local_infile=True`` to enable eligible native bulk loads. A separate
   bulk-load opt-in is no longer required; set

--- a/sqlspec/builder/_factory.py
+++ b/sqlspec/builder/_factory.py
@@ -44,6 +44,9 @@ from sqlspec.builder._insert import Insert
 from sqlspec.builder._join import JoinBuilder, create_join_builder
 from sqlspec.builder._merge import Merge
 from sqlspec.builder._parsing_utils import (
+    _build_cube,
+    _build_grouping_sets,
+    _build_rollup,
     _coerce_column,
     _normalize_order_by,
     _normalize_partition_by,
@@ -1155,8 +1158,7 @@ class SQLFactory:
         Returns:
             ROLLUP expression.
         """
-        column_exprs = [_coerce_column(col) for col in columns]
-        return FunctionExpression(exp.Rollup(expressions=column_exprs))
+        return FunctionExpression(_build_rollup(*columns))
 
     @staticmethod
     def cube(*columns: str | exp.Expr) -> FunctionExpression:
@@ -1168,8 +1170,7 @@ class SQLFactory:
         Returns:
             CUBE expression.
         """
-        column_exprs = [_coerce_column(col) for col in columns]
-        return FunctionExpression(exp.Cube(expressions=column_exprs))
+        return FunctionExpression(_build_cube(*columns))
 
     @staticmethod
     def grouping_sets(*column_sets: tuple[str, ...] | list[str]) -> FunctionExpression:
@@ -1180,19 +1181,11 @@ class SQLFactory:
 
         Returns:
             GROUPING SETS expression.
-        """
-        set_expressions = []
-        for column_set in column_sets:
-            if isinstance(column_set, (tuple, list)):
-                if len(column_set) == 0:
-                    set_expressions.append(exp.Tuple(expressions=[]))
-                else:
-                    columns = [exp.column(col) for col in column_set]
-                    set_expressions.append(exp.Tuple(expressions=columns))
-            else:
-                set_expressions.append(exp.column(column_set))
 
-        return FunctionExpression(exp.GroupingSets(expressions=set_expressions))
+        Raises:
+            SQLBuilderError: If a grouping set is not a tuple or list.
+        """
+        return FunctionExpression(_build_grouping_sets(*column_sets))
 
     @staticmethod
     def any(values: list[Any] | exp.Expr | str) -> FunctionExpression:

--- a/sqlspec/builder/_factory.py
+++ b/sqlspec/builder/_factory.py
@@ -44,13 +44,13 @@ from sqlspec.builder._insert import Insert
 from sqlspec.builder._join import JoinBuilder, create_join_builder
 from sqlspec.builder._merge import Merge
 from sqlspec.builder._parsing_utils import (
-    _build_cube,
-    _build_grouping_sets,
-    _build_rollup,
     _coerce_column,
+    _cube_expression,
+    _grouping_sets_expression,
     _normalize_order_by,
     _normalize_partition_by,
     _resolve_dialect,
+    _rollup_expression,
     extract_expression,
     to_expression,
 )
@@ -1158,7 +1158,7 @@ class SQLFactory:
         Returns:
             ROLLUP expression.
         """
-        return FunctionExpression(_build_rollup(*columns))
+        return FunctionExpression(_rollup_expression(*columns))
 
     @staticmethod
     def cube(*columns: str | exp.Expr) -> FunctionExpression:
@@ -1170,7 +1170,7 @@ class SQLFactory:
         Returns:
             CUBE expression.
         """
-        return FunctionExpression(_build_cube(*columns))
+        return FunctionExpression(_cube_expression(*columns))
 
     @staticmethod
     def grouping_sets(*column_sets: tuple[str, ...] | list[str]) -> FunctionExpression:
@@ -1185,7 +1185,7 @@ class SQLFactory:
         Raises:
             SQLBuilderError: If a grouping set is not a tuple or list.
         """
-        return FunctionExpression(_build_grouping_sets(*column_sets))
+        return FunctionExpression(_grouping_sets_expression(*column_sets))
 
     @staticmethod
     def any(values: list[Any] | exp.Expr | str) -> FunctionExpression:

--- a/sqlspec/builder/_parsing_utils.py
+++ b/sqlspec/builder/_parsing_utils.py
@@ -14,6 +14,7 @@ from sqlglot import exp, maybe_parse
 from sqlspec.builder._column import Column
 from sqlspec.builder._expression_wrappers import ExpressionWrapper
 from sqlspec.core import ParameterStyle, ParameterValidator
+from sqlspec.exceptions import SQLBuilderError
 from sqlspec.utils.type_guards import (
     has_expression_and_parameters,
     has_expression_and_sql,
@@ -412,6 +413,24 @@ def _normalize_order_by(order_by: str | list[str] | exp.Expr | None) -> exp.Orde
 
 def _coerce_column(value: str | exp.Expr) -> exp.Expr:
     return exp.column(value) if isinstance(value, str) else value
+
+
+def _build_rollup(*columns: str | exp.Expr) -> exp.Rollup:
+    return exp.Rollup(expressions=[_coerce_column(column) for column in columns])
+
+
+def _build_cube(*columns: str | exp.Expr) -> exp.Cube:
+    return exp.Cube(expressions=[_coerce_column(column) for column in columns])
+
+
+def _build_grouping_sets(*column_sets: tuple[str, ...] | list[str]) -> exp.GroupingSets:
+    sets: list[exp.Tuple] = []
+    for column_set in column_sets:
+        if not isinstance(column_set, (tuple, list)):
+            msg = "Each grouping set must be a tuple or list of columns."
+            raise SQLBuilderError(msg)
+        sets.append(exp.Tuple(expressions=[_coerce_column(column) for column in column_set]))
+    return exp.GroupingSets(expressions=sets)
 
 
 def _resolve_dialect(dialect: "DialectType | None", default: "DialectType | None") -> "DialectType | None":

--- a/sqlspec/builder/_parsing_utils.py
+++ b/sqlspec/builder/_parsing_utils.py
@@ -415,15 +415,15 @@ def _coerce_column(value: str | exp.Expr) -> exp.Expr:
     return exp.column(value) if isinstance(value, str) else value
 
 
-def _build_rollup(*columns: str | exp.Expr) -> exp.Rollup:
+def _rollup_expression(*columns: str | exp.Expr) -> exp.Rollup:
     return exp.Rollup(expressions=[_coerce_column(column) for column in columns])
 
 
-def _build_cube(*columns: str | exp.Expr) -> exp.Cube:
+def _cube_expression(*columns: str | exp.Expr) -> exp.Cube:
     return exp.Cube(expressions=[_coerce_column(column) for column in columns])
 
 
-def _build_grouping_sets(*column_sets: tuple[str, ...] | list[str]) -> exp.GroupingSets:
+def _grouping_sets_expression(*column_sets: tuple[str, ...] | list[str]) -> exp.GroupingSets:
     sets: list[exp.Tuple] = []
     for column_set in column_sets:
         if not isinstance(column_set, (tuple, list)):

--- a/sqlspec/builder/_select.py
+++ b/sqlspec/builder/_select.py
@@ -18,10 +18,10 @@ from sqlspec.builder._explain import ExplainMixin
 from sqlspec.builder._join import JoinClauseMixin, _attach_as_of_version
 from sqlspec.builder._parsing_utils import (
     _PARAMETER_VALIDATOR,
-    _build_cube,
-    _build_grouping_sets,
-    _build_rollup,
     _coerce_column,
+    _cube_expression,
+    _grouping_sets_expression,
+    _rollup_expression,
     extract_column_name,
     extract_expression,
     extract_sql_object_expression,
@@ -356,7 +356,7 @@ class SelectClauseMixin:
         builder.set_expression(select_expr.from_(from_expr, copy=False))
         return cast("Self", builder)
 
-    def group_by(self, *columns: Union[str, exp.Expr, "ExpressionWrapper"]) -> Self:
+    def group_by(self, *columns: Union[str, exp.Expr, "Column", "ExpressionWrapper"]) -> Self:
         builder = cast("SQLBuilderProtocol", self)
         select_expr = builder.get_expression()
         if select_expr is None or not isinstance(select_expr, exp.Select):
@@ -369,13 +369,13 @@ class SelectClauseMixin:
         return cast("Self", builder)
 
     def group_by_rollup(self, *columns: str | exp.Expr) -> Self:
-        return self.group_by(_build_rollup(*columns))
+        return self.group_by(_rollup_expression(*columns))
 
     def group_by_cube(self, *columns: str | exp.Expr) -> Self:
-        return self.group_by(_build_cube(*columns))
+        return self.group_by(_cube_expression(*columns))
 
     def group_by_grouping_sets(self, *column_sets: tuple[str, ...] | list[str]) -> Self:
-        return self.group_by(_build_grouping_sets(*column_sets))
+        return self.group_by(_grouping_sets_expression(*column_sets))
 
 
 @trait

--- a/sqlspec/builder/_select.py
+++ b/sqlspec/builder/_select.py
@@ -18,6 +18,9 @@ from sqlspec.builder._explain import ExplainMixin
 from sqlspec.builder._join import JoinClauseMixin, _attach_as_of_version
 from sqlspec.builder._parsing_utils import (
     _PARAMETER_VALIDATOR,
+    _build_cube,
+    _build_grouping_sets,
+    _build_rollup,
     _coerce_column,
     extract_column_name,
     extract_expression,
@@ -353,34 +356,26 @@ class SelectClauseMixin:
         builder.set_expression(select_expr.from_(from_expr, copy=False))
         return cast("Self", builder)
 
-    def group_by(self, *columns: str | exp.Expr) -> Self:
+    def group_by(self, *columns: Union[str, exp.Expr, "ExpressionWrapper"]) -> Self:
         builder = cast("SQLBuilderProtocol", self)
         select_expr = builder.get_expression()
         if select_expr is None or not isinstance(select_expr, exp.Select):
             return cast("Self", builder)
 
         for column in columns:
-            column_expr = _coerce_column(column)
+            column_expr = extract_expression(column)
             select_expr = select_expr.group_by(column_expr, copy=False)
         builder.set_expression(select_expr)
         return cast("Self", builder)
 
     def group_by_rollup(self, *columns: str | exp.Expr) -> Self:
-        column_exprs = [_coerce_column(column) for column in columns]
-        rollup_expr = exp.Rollup(expressions=column_exprs)
-        return self.group_by(rollup_expr)
+        return self.group_by(_build_rollup(*columns))
 
     def group_by_cube(self, *columns: str | exp.Expr) -> Self:
-        column_exprs = [_coerce_column(column) for column in columns]
-        cube_expr = exp.Cube(expressions=column_exprs)
-        return self.group_by(cube_expr)
+        return self.group_by(_build_cube(*columns))
 
     def group_by_grouping_sets(self, *column_sets: tuple[str, ...] | list[str]) -> Self:
-        grouping_sets = [
-            exp.Tuple(expressions=[_coerce_column(col) for col in column_set]) for column_set in column_sets
-        ]
-        grouping_expr = exp.GroupingSets(expressions=grouping_sets)
-        return self.group_by(grouping_expr)
+        return self.group_by(_build_grouping_sets(*column_sets))
 
 
 @trait

--- a/tests/unit/builder/test_select_group_by.py
+++ b/tests/unit/builder/test_select_group_by.py
@@ -1,4 +1,7 @@
-from typing import cast
+"""Tests for GROUP BY extensions shared by the factory and the Select builder."""
+
+from collections.abc import Callable
+from typing import Any, cast
 
 import pytest
 from sqlglot import exp
@@ -9,6 +12,7 @@ from sqlspec.exceptions import SQLBuilderError
 
 @pytest.mark.parametrize("name", ["rollup", "cube"])
 def test_group_by_factory_extension_matches_select_method(name: str) -> None:
+    """Factory ROLLUP/CUBE wrappers compose into group_by and match the Select methods."""
     wrapper = getattr(sql, name)("a", exp.column("b"))
     composed = sql.select("a").from_("t").group_by(wrapper)
     direct = getattr(sql.select("a").from_("t"), f"group_by_{name}")("a", exp.column("b"))
@@ -19,6 +23,7 @@ def test_group_by_factory_extension_matches_select_method(name: str) -> None:
 
 @pytest.mark.parametrize("columns", [("a", "b"), ["a", "b"]])
 def test_group_by_factory_grouping_sets_preserves_grand_total(columns: tuple[str, ...] | list[str]) -> None:
+    """Tuple and list grouping sets, including the empty grand-total set, agree between both entry points."""
     composed = sql.select("a").from_("t").group_by(sql.grouping_sets(columns, ()))
     direct = sql.select("a").from_("t").group_by_grouping_sets(columns, ())
 
@@ -26,17 +31,18 @@ def test_group_by_factory_grouping_sets_preserves_grand_total(columns: tuple[str
     assert " ".join(composed.to_sql().split()).endswith('GROUP BY GROUPING SETS ( ("t"."a", "t"."b"), () )')
 
 
-@pytest.mark.parametrize("factory", [True, False])
-def test_grouping_sets_rejects_bare_string(factory: bool) -> None:
+@pytest.mark.parametrize(
+    "grouping_sets", [sql.grouping_sets, sql.select("a").from_("t").group_by_grouping_sets], ids=["factory", "select"]
+)
+def test_grouping_sets_rejects_bare_string(grouping_sets: Callable[..., Any]) -> None:
+    """A bare string is rejected instead of being iterated character by character."""
     invalid_columns = cast("tuple[str, ...]", "ab")
     with pytest.raises(SQLBuilderError, match="tuple or list"):
-        if factory:
-            sql.grouping_sets(invalid_columns)
-        else:
-            sql.select("a").from_("t").group_by_grouping_sets(invalid_columns)
+        grouping_sets(invalid_columns)
 
 
 def test_group_by_preserves_string_and_raw_expression_columns() -> None:
+    """Plain strings and raw sqlglot expressions keep their existing group_by rendering."""
     query = sql.select("a").from_("t").group_by("a", exp.column("b"))
     assert " ".join(query.to_sql().split()).endswith('GROUP BY "t"."a", "t"."b"')
 
@@ -46,5 +52,6 @@ def test_group_by_preserves_string_and_raw_expression_columns() -> None:
     [("a", '"t"."a"'), ("schema.col", '"t"."schema.col"'), ('"Quoted Name"', '"t"."""Quoted Name"""')],
 )
 def test_group_by_preserves_literal_column_identifiers(column: str, expected: str) -> None:
+    """String group_by inputs are treated as literal column names."""
     query = sql.select("*").from_("t").group_by(column)
     assert " ".join(query.to_sql().split()) == f'SELECT * FROM "t" AS "t" GROUP BY {expected}'

--- a/tests/unit/builder/test_select_group_by.py
+++ b/tests/unit/builder/test_select_group_by.py
@@ -1,0 +1,50 @@
+from typing import cast
+
+import pytest
+from sqlglot import exp
+
+from sqlspec import sql
+from sqlspec.exceptions import SQLBuilderError
+
+
+@pytest.mark.parametrize("name", ["rollup", "cube"])
+def test_group_by_factory_extension_matches_select_method(name: str) -> None:
+    wrapper = getattr(sql, name)("a", exp.column("b"))
+    composed = sql.select("a").from_("t").group_by(wrapper)
+    direct = getattr(sql.select("a").from_("t"), f"group_by_{name}")("a", exp.column("b"))
+
+    assert composed.to_sql() == direct.to_sql()
+    assert " ".join(composed.to_sql().split()).endswith(f'GROUP BY {name.upper()} ( "t"."a", "t"."b" )')
+
+
+@pytest.mark.parametrize("columns", [("a", "b"), ["a", "b"]])
+def test_group_by_factory_grouping_sets_preserves_grand_total(columns: tuple[str, ...] | list[str]) -> None:
+    composed = sql.select("a").from_("t").group_by(sql.grouping_sets(columns, ()))
+    direct = sql.select("a").from_("t").group_by_grouping_sets(columns, ())
+
+    assert composed.to_sql() == direct.to_sql()
+    assert " ".join(composed.to_sql().split()).endswith('GROUP BY GROUPING SETS ( ("t"."a", "t"."b"), () )')
+
+
+@pytest.mark.parametrize("factory", [True, False])
+def test_grouping_sets_rejects_bare_string(factory: bool) -> None:
+    invalid_columns = cast("tuple[str, ...]", "ab")
+    with pytest.raises(SQLBuilderError, match="tuple or list"):
+        if factory:
+            sql.grouping_sets(invalid_columns)
+        else:
+            sql.select("a").from_("t").group_by_grouping_sets(invalid_columns)
+
+
+def test_group_by_preserves_string_and_raw_expression_columns() -> None:
+    query = sql.select("a").from_("t").group_by("a", exp.column("b"))
+    assert " ".join(query.to_sql().split()).endswith('GROUP BY "t"."a", "t"."b"')
+
+
+@pytest.mark.parametrize(
+    ("column", "expected"),
+    [("a", '"t"."a"'), ("schema.col", '"t"."schema.col"'), ('"Quoted Name"', '"t"."""Quoted Name"""')],
+)
+def test_group_by_preserves_literal_column_identifiers(column: str, expected: str) -> None:
+    query = sql.select("*").from_("t").group_by(column)
+    assert " ".join(query.to_sql().split()) == f'SELECT * FROM "t" AS "t" GROUP BY {expected}'

--- a/tests/unit/builder/test_sql_factory.py
+++ b/tests/unit/builder/test_sql_factory.py
@@ -1791,38 +1791,19 @@ def test_sql_factory_copy_helpers() -> None:
     assert parsed.args["kind"] is False
 
 
-def test_row_number_method_partition_order_and_composition() -> None:
-    expression = sql.row_number(partition_by="department", order_by="salary")
-    assert str(expression) == "ROW_NUMBER() OVER (PARTITION BY department ORDER BY salary)"
+@pytest.mark.parametrize(
+    ("method_name", "function_name"), [("row_number", "ROW_NUMBER"), ("rank", "RANK"), ("dense_rank", "DENSE_RANK")]
+)
+def test_ranking_method_partition_order_and_composition(method_name: str, function_name: str) -> None:
+    """Test ranking method forms render OVER clauses, compose in SELECT, and match the property forms."""
+    expression = getattr(sql, method_name)(partition_by="department", order_by="salary")
+    assert str(expression) == f"{function_name}() OVER (PARTITION BY department ORDER BY salary)"
     query = sql.select(expression.as_("position")).from_("employees")
-    property_expression = sql.row_number_.partition_by("department").order_by("salary").as_("position")
+    property_form = getattr(sql, f"{method_name}_")
+    property_expression = property_form.partition_by("department").order_by("salary").as_("position")
     assert query.to_sql() == sql.select(property_expression).from_("employees").to_sql()
     assert " ".join(query.to_sql().split()) == (
-        'SELECT ROW_NUMBER() OVER (PARTITION BY "employees"."department" ORDER BY "employees"."salary") '
-        'AS "position" FROM "employees" AS "employees"'
-    )
-
-
-def test_rank_method_partition_order_and_composition() -> None:
-    expression = sql.rank(partition_by="department", order_by="salary")
-    assert str(expression) == "RANK() OVER (PARTITION BY department ORDER BY salary)"
-    query = sql.select(expression.as_("position")).from_("employees")
-    property_expression = sql.rank_.partition_by("department").order_by("salary").as_("position")
-    assert query.to_sql() == sql.select(property_expression).from_("employees").to_sql()
-    assert " ".join(query.to_sql().split()) == (
-        'SELECT RANK() OVER (PARTITION BY "employees"."department" ORDER BY "employees"."salary") '
-        'AS "position" FROM "employees" AS "employees"'
-    )
-
-
-def test_dense_rank_method_partition_order_and_composition() -> None:
-    expression = sql.dense_rank(partition_by="department", order_by="salary")
-    assert str(expression) == "DENSE_RANK() OVER (PARTITION BY department ORDER BY salary)"
-    query = sql.select(expression.as_("position")).from_("employees")
-    property_expression = sql.dense_rank_.partition_by("department").order_by("salary").as_("position")
-    assert query.to_sql() == sql.select(property_expression).from_("employees").to_sql()
-    assert " ".join(query.to_sql().split()) == (
-        'SELECT DENSE_RANK() OVER (PARTITION BY "employees"."department" ORDER BY "employees"."salary") '
+        f'SELECT {function_name}() OVER (PARTITION BY "employees"."department" ORDER BY "employees"."salary") '
         'AS "position" FROM "employees" AS "employees"'
     )
 

--- a/tests/unit/builder/test_sql_factory.py
+++ b/tests/unit/builder/test_sql_factory.py
@@ -1791,6 +1791,42 @@ def test_sql_factory_copy_helpers() -> None:
     assert parsed.args["kind"] is False
 
 
+def test_row_number_method_partition_order_and_composition() -> None:
+    expression = sql.row_number(partition_by="department", order_by="salary")
+    assert str(expression) == "ROW_NUMBER() OVER (PARTITION BY department ORDER BY salary)"
+    query = sql.select(expression.as_("position")).from_("employees")
+    property_expression = sql.row_number_.partition_by("department").order_by("salary").as_("position")
+    assert query.to_sql() == sql.select(property_expression).from_("employees").to_sql()
+    assert " ".join(query.to_sql().split()) == (
+        'SELECT ROW_NUMBER() OVER (PARTITION BY "employees"."department" ORDER BY "employees"."salary") '
+        'AS "position" FROM "employees" AS "employees"'
+    )
+
+
+def test_rank_method_partition_order_and_composition() -> None:
+    expression = sql.rank(partition_by="department", order_by="salary")
+    assert str(expression) == "RANK() OVER (PARTITION BY department ORDER BY salary)"
+    query = sql.select(expression.as_("position")).from_("employees")
+    property_expression = sql.rank_.partition_by("department").order_by("salary").as_("position")
+    assert query.to_sql() == sql.select(property_expression).from_("employees").to_sql()
+    assert " ".join(query.to_sql().split()) == (
+        'SELECT RANK() OVER (PARTITION BY "employees"."department" ORDER BY "employees"."salary") '
+        'AS "position" FROM "employees" AS "employees"'
+    )
+
+
+def test_dense_rank_method_partition_order_and_composition() -> None:
+    expression = sql.dense_rank(partition_by="department", order_by="salary")
+    assert str(expression) == "DENSE_RANK() OVER (PARTITION BY department ORDER BY salary)"
+    query = sql.select(expression.as_("position")).from_("employees")
+    property_expression = sql.dense_rank_.partition_by("department").order_by("salary").as_("position")
+    assert query.to_sql() == sql.select(property_expression).from_("employees").to_sql()
+    assert " ".join(query.to_sql().split()) == (
+        'SELECT DENSE_RANK() OVER (PARTITION BY "employees"."department" ORDER BY "employees"."salary") '
+        'AS "position" FROM "employees" AS "employees"'
+    )
+
+
 def test_count_over_method_basic() -> None:
     """Test count_over() method generates COUNT(*) OVER()."""
     count_expr = sql.count_over()


### PR DESCRIPTION
Allow `group_by()` to accept the factory's ROLLUP, CUBE, and GROUPING SETS expressions. Both entry points now share construction logic and reject bare strings passed as grouping sets consistently. Add coverage for the existing window-function methods.