### PR TITLE
feat: construct services from database configs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,6 +30,11 @@ Unreleased
 
 **Added:**
 
+* Services can now open a short session for each query. Pass ``config=`` and,
+  if needed, ``loader=``. Use ``session=`` to borrow a driver or
+  ``begin_transaction()`` to keep several calls in one transaction. Existing
+  code that passes a driver still works. See :doc:`/recipes/service_layer`.
+
 * Storage pipelines expose ``resolve_destination()``, returning a
   ``ResolvedStorageTarget(uri, protocol)`` without opening a database session.
   Direct remote URIs retain their address, alias paths resolve relative to the

--- a/docs/examples/drivers/service_config.py
+++ b/docs/examples/drivers/service_config.py
@@ -1,0 +1,94 @@
+"""Config-built services keep helper sessions short and transactions explicit."""
+
+from pathlib import Path
+
+__all__ = ("test_async_service_config", "test_sync_service_config")
+
+
+def test_sync_service_config(tmp_path: Path) -> None:
+    # start-sync-example
+    from sqlspec import sql
+    from sqlspec.adapters.sqlite import SqliteConfig
+    from sqlspec.loader import SQLFileLoader
+    from sqlspec.service import SQLSpecSyncService
+
+    config = SqliteConfig(connection_config={"database": str(tmp_path / "users.sqlite")})
+    service = SQLSpecSyncService(config=config, loader=SQLFileLoader())
+    users = sql.select("name").from_("users")
+
+    try:
+        with service.begin_transaction() as session:
+            session.execute("CREATE TABLE users (name TEXT)")
+            session.execute("INSERT INTO users VALUES (:name)", {"name": "Ada"})
+
+        # Each bare helper acquires and releases its own session.
+        assert service.get_one(users) == {"name": "Ada"}
+        assert service.exists(users)
+        assert service.paginate(users).total == 1
+
+        # Explicit reuse borrows this session without starting a transaction.
+        with service.provide_session() as session:
+            assert service.exists(users, session=session)
+            assert service.get_one(users, session=session) == {"name": "Ada"}
+
+        # Both helpers see the same uncommitted transaction.
+        with service.begin_transaction() as session:
+            session.execute("INSERT INTO users VALUES (:name)", {"name": "Grace"})
+            assert service.exists(sql.select("name").from_("users").where_eq("name", "Grace"))
+            assert service.paginate(users).total == 2
+
+        try:
+            with service.begin_transaction() as session:
+                session.execute("INSERT INTO users VALUES (:name)", {"name": "Rolled back"})
+                msg = "Cancel this change"
+                raise ValueError(msg)  # noqa: TRY301 - Demonstrate an application error rolling back the block.
+        except ValueError:
+            pass
+
+        assert service.paginate(users).total == 2
+    finally:
+        config.close_pool()
+    # end-sync-example
+
+
+async def test_async_service_config(tmp_path: Path) -> None:
+    # start-async-example
+    from sqlspec import sql
+    from sqlspec.adapters.aiosqlite import AiosqliteConfig
+    from sqlspec.loader import SQLFileLoader
+    from sqlspec.service import SQLSpecAsyncService
+
+    config = AiosqliteConfig(connection_config={"database": str(tmp_path / "users.sqlite")})
+    service = SQLSpecAsyncService(config=config, loader=SQLFileLoader())
+    users = sql.select("name").from_("users")
+
+    try:
+        async with service.begin_transaction() as session:
+            await session.execute("CREATE TABLE users (name TEXT)")
+            await session.execute("INSERT INTO users VALUES (:name)", {"name": "Ada"})
+
+        assert await service.get_one(users) == {"name": "Ada"}
+        assert await service.exists(users)
+        assert (await service.paginate(users)).total == 1
+
+        async with service.provide_session() as session:
+            assert await service.exists(users, session=session)
+            assert await service.get_one(users, session=session) == {"name": "Ada"}
+
+        async with service.begin_transaction() as session:
+            await session.execute("INSERT INTO users VALUES (:name)", {"name": "Grace"})
+            assert await service.exists(sql.select("name").from_("users").where_eq("name", "Grace"))
+            assert (await service.paginate(users)).total == 2
+
+        try:
+            async with service.begin_transaction() as session:
+                await session.execute("INSERT INTO users VALUES (:name)", {"name": "Rolled back"})
+                msg = "Cancel this change"
+                raise ValueError(msg)  # noqa: TRY301 - Demonstrate an application error rolling back the block.
+        except ValueError:
+            pass
+
+        assert (await service.paginate(users)).total == 2
+    finally:
+        await config.close_pool()
+    # end-async-example

--- a/docs/recipes/service_layer.rst
+++ b/docs/recipes/service_layer.rst
@@ -97,6 +97,7 @@ to that session.
          :dedent: 4
          :start-after: # start-sync-example
          :end-before: # end-sync-example
+         :no-upgrade:
 
    .. tab-item:: Async
 
@@ -105,6 +106,7 @@ to that session.
          :dedent: 4
          :start-after: # start-async-example
          :end-before: # end-async-example
+         :no-upgrade:
 
 Both examples leave Ada and Grace in the table. The last transaction rolls back
 its insert when the block raises. Query helpers do not add commits between calls;

--- a/docs/recipes/service_layer.rst
+++ b/docs/recipes/service_layer.rst
@@ -2,9 +2,12 @@
 Service Layer Pattern
 =====================
 
-SQLSpec ships a base service class that wraps a driver and provides pagination,
-single-row fetching, existence checks, and transaction helpers. Import it and
-subclass it — you do not need to write your own.
+Build a service from a database config to fetch rows and run transactions.
+Each query helper opens a short session and releases it before it returns,
+even when the query raises.
+
+The service can then outlive a single session. You can still pass a session
+as the first argument when the caller should own its lifetime.
 
 Parameters and filters passed as ``*parameters`` are forwarded directly to the
 driver, which applies filters to the statement and binds parameters automatically.
@@ -20,8 +23,9 @@ identical class::
 
    from sqlspec.service import SQLSpecAsyncService, SQLSpecSyncService
 
-Each takes a driver session in its constructor and exposes it as both
-``.session`` and ``.driver``:
+Pass exactly one of ``Service(config=cfg)`` or ``Service(session)``. An optional
+``loader=SQLFileLoader()`` is available through ``service.loader``; the service
+does not resolve named SQL for you.
 
 .. list-table::
    :header-rows: 1
@@ -29,18 +33,20 @@ Each takes a driver session in its constructor and exposes it as both
 
    * - Member
      - Purpose
-   * - ``paginate(statement, *parameters, schema_type=None, count_with_window=False)``
+   * - ``paginate(statement, *parameters, schema_type=None, count_with_window=False, session=None)``
      - Runs the query and returns an ``OffsetPagination`` with a total count.
-   * - ``get_one(statement, *parameters, schema_type=None, error_message=None)``
-     - Returns exactly one row, raising if there is not exactly one.
-   * - ``exists(statement, *parameters)``
+   * - ``get_one(statement, *parameters, schema_type=None, error_message=None, session=None)``
+     - Returns a row or raises ``NotFoundError`` when no row matches.
+   * - ``exists(statement, *parameters, session=None)``
      - Returns ``True`` when the query matches at least one row.
    * - ``begin_transaction()``
-     - Context manager that commits on success and rolls back on error.
-   * - ``begin()`` / ``commit()`` / ``rollback()``
-     - Pass straight through to the driver for manual control.
+     - Holds one session across helpers, commits on success, and rolls back on error.
+   * - ``provide_session(session=None)``
+     - Yields a session for explicit reuse. Acquired sessions are released on exit.
+   * - ``begin(session=None)`` / ``commit(session=None)`` / ``rollback(session=None)``
+     - Control an available session; they never acquire a disposable session.
    * - ``session`` / ``driver``
-     - The wrapped driver session.
+     - The caller's session or the active transaction's driver.
 
 Subclass whichever matches your driver and add your own query methods:
 
@@ -70,11 +76,67 @@ Subclass whichever matches your driver and add your own query methods:
 
 See :doc:`/reference/service` for the full signatures.
 
-Domain Services
-===============
+Use a Config for Short Sessions
+==============================
+
+The examples below use a local SQLite file. Install ``sqlspec`` for the sync
+example or ``sqlspec[aiosqlite]`` for the async example. ``tmp_path`` is a pytest
+temporary directory; use your application's database path outside a test.
+
+Bare helpers each acquire their own session. To share one session without
+starting a transaction, use ``provide_session()`` and pass the yielded driver
+as ``session=``. Merely entering ``provide_session()`` does not bind later helpers
+to that session.
+
+.. tab-set::
+
+   .. tab-item:: Sync
+
+      .. literalinclude:: /examples/drivers/service_config.py
+         :language: python
+         :dedent: 4
+         :start-after: # start-sync-example
+         :end-before: # end-sync-example
+
+   .. tab-item:: Async
+
+      .. literalinclude:: /examples/drivers/service_config.py
+         :language: python
+         :dedent: 4
+         :start-after: # start-async-example
+         :end-before: # end-async-example
+
+Both examples leave Ada and Grace in the table. The last transaction rolls back
+its insert when the block raises. Query helpers do not add commits between calls;
+``begin_transaction()`` commits once when its block succeeds.
+
+Session Ownership
+=================
+
+A passed ``session=`` wins over the active transaction. The service borrows it;
+the caller decides when to commit and release it.
+Without an override, helpers use the active transaction, then the constructor
+session, or acquire a new session from the config.
+
+Outside a config service's transaction, ``session`` and ``driver`` raise
+``ImproperConfigurationError``. Manual ``begin()``, ``commit()``, and
+``rollback()`` also require an available session. Use ``begin_transaction()``
+or pass a driver explicitly with ``session=`` for manual control.
+
+Config services do not allow nested transaction blocks. Tasks and threads can
+use the same service, within the adapter's concurrency limits. A child
+task cannot implicitly reuse its parent's transaction, even after that
+transaction exits. Start independent work outside the parent's transaction
+context, or pass a session whose use you control.
+
+Domain Services with a Caller-Owned Session
+==========================================
 
 Inherit from the base and use the ``sql`` builder or SQL file loader for queries.
-Filters from Litestar dependencies flow straight through ``*filters`` to the driver:
+Filters from Litestar dependencies flow straight through ``*filters`` to the driver.
+These examples receive a caller-owned session, so direct ``self.driver`` calls
+remain available. For a config-built service, perform direct driver operations
+inside ``begin_transaction()`` or through an explicitly provided session.
 
 .. tab-set::
 

--- a/docs/reference/service.rst
+++ b/docs/reference/service.rst
@@ -2,8 +2,14 @@
 Service
 =======
 
-Base service classes that wrap a driver session and add pagination, single-row
-fetching, existence checks, and transaction helpers.
+Base service classes provide pagination, single-row fetching, existence checks,
+and transactions. Construct them with a caller-owned driver session or a database
+``config=``. Config-built helpers acquire short sessions; ``begin_transaction()``
+holds one session across calls and releases it on exit.
+
+Each query helper accepts a borrowed ``session=`` override. ``provide_session()``
+yields a driver for explicit reuse. The optional ``loader=`` is exposed without
+resolving named queries. See the recipe for ownership and concurrency rules.
 
 The five web-framework extensions — ``litestar``, ``fastapi``, ``flask``,
 ``starlette``, and ``sanic`` — each re-export these two objects, so

--- a/sqlspec/service.py
+++ b/sqlspec/service.py
@@ -1,6 +1,10 @@
 """Service base classes for SQLSpec application services."""
 
-from contextlib import AbstractAsyncContextManager, AbstractContextManager, nullcontext
+import asyncio
+import sys
+from contextlib import AbstractAsyncContextManager, AbstractContextManager, AsyncExitStack, ExitStack, nullcontext
+from contextvars import ContextVar, Token
+from threading import get_ident
 from typing import TYPE_CHECKING, Any, Generic, Literal, cast, overload
 
 from mypy_extensions import mypyc_attr
@@ -30,6 +34,54 @@ AsyncDriverT = TypeVar("AsyncDriverT", bound=AsyncDriverAdapterBase, default=Asy
 SyncDriverT = TypeVar("SyncDriverT", bound=SyncDriverAdapterBase, default=SyncDriverAdapterBase)
 
 
+class _TransactionState:
+    __slots__ = ("driver", "owner")
+
+    def __init__(self, driver: AsyncDriverAdapterBase | SyncDriverAdapterBase) -> None:
+        self.driver: AsyncDriverAdapterBase | SyncDriverAdapterBase | None = driver
+        self.owner = _execution_owner()
+
+
+_TRANSACTIONS: ContextVar[dict[object, _TransactionState] | None] = ContextVar(
+    "sqlspec_service_transactions", default=None
+)
+
+
+def _execution_owner() -> tuple[int, object]:
+    try:
+        task = asyncio.current_task()
+    except RuntimeError:
+        task = None
+    return get_ident(), task
+
+
+def _transaction_session(key: object) -> AsyncDriverAdapterBase | SyncDriverAdapterBase | None:
+    state = (_TRANSACTIONS.get() or {}).get(key)
+    if state is None:
+        return None
+    if state.driver is None:
+        msg = "The inherited service transaction is no longer active."
+        raise ImproperConfigurationError(msg)
+    if state.owner != _execution_owner():
+        msg = "A service transaction cannot be implicitly reused by another task or thread; pass session= explicitly."
+        raise ImproperConfigurationError(msg)
+    return state.driver
+
+
+def _bind_transaction(
+    key: object, driver: AsyncDriverAdapterBase | SyncDriverAdapterBase
+) -> tuple[_TransactionState, Token[dict[object, _TransactionState] | None]]:
+    state = _TransactionState(driver)
+    token = _TRANSACTIONS.set({**(_TRANSACTIONS.get() or {}), key: state})
+    return state, token
+
+
+def _release_transaction(state: _TransactionState, token: Token[dict[object, _TransactionState] | None]) -> None:
+    state.driver = None
+    state.owner = (0, None)
+    _TRANSACTIONS.reset(token)
+
+
 @mypyc_attr(allow_interpreted_subclasses=True)
 class SQLSpecAsyncService(Generic[AsyncDriverT]):
     """Base class for asynchronous SQLSpec services.
@@ -43,7 +95,7 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
         loader: Optional SQL file loader to expose without resolving named queries.
     """
 
-    __slots__ = ("_config", "_loader", "_session")
+    __slots__ = ("_config", "_loader", "_session", "_transaction_key")
 
     def __init__(
         self,
@@ -61,10 +113,14 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
         self._session = session
         self._config = config
         self._loader = loader
+        self._transaction_key = object()
 
     @property
     def session(self) -> AsyncDriverT:
         """Return the driver session."""
+        active = _transaction_session(self._transaction_key)
+        if active is not None:
+            return cast("AsyncDriverT", active)
         if self._session is None:
             msg = "No session is available; use begin_transaction() or pass session=."
             raise ImproperConfigurationError(msg)
@@ -91,6 +147,9 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
         """
         if session is not None:
             return nullcontext(session)
+        active = _transaction_session(self._transaction_key)
+        if active is not None:
+            return nullcontext(cast("AsyncDriverT", active))
         if self._config is not None:
             return self._config.provide_session()
         return nullcontext(self.session)
@@ -305,7 +364,7 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
         loader: Optional SQL file loader to expose without resolving named queries.
     """
 
-    __slots__ = ("_config", "_loader", "_session")
+    __slots__ = ("_config", "_loader", "_session", "_transaction_key")
 
     def __init__(
         self,
@@ -323,10 +382,14 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
         self._session = session
         self._config = config
         self._loader = loader
+        self._transaction_key = object()
 
     @property
     def session(self) -> SyncDriverT:
         """Return the driver session."""
+        active = _transaction_session(self._transaction_key)
+        if active is not None:
+            return cast("SyncDriverT", active)
         if self._session is None:
             msg = "No session is available; use begin_transaction() or pass session=."
             raise ImproperConfigurationError(msg)
@@ -353,6 +416,9 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
         """
         if session is not None:
             return nullcontext(session)
+        active = _transaction_session(self._transaction_key)
+        if active is not None:
+            return nullcontext(cast("SyncDriverT", active))
         if self._config is not None:
             return self._config.provide_session()
         return nullcontext(self.session)
@@ -555,44 +621,102 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
 
 
 class _AsyncBeginTransactionContext(Generic[AsyncDriverT]):
-    __slots__ = ("_service",)
+    __slots__ = ("_service", "_stack")
 
     def __init__(self, service: "SQLSpecAsyncService[AsyncDriverT]") -> None:
         self._service = service
+        self._stack: AsyncExitStack | None = None
 
     async def __aenter__(self) -> AsyncDriverT:
         service = self._service
-        await service.begin()
-        return service.session
+        if service._config is None:
+            await service.begin()
+            return service.session
+        if _transaction_session(service._transaction_key) is not None:
+            msg = "Nested config-service transactions are not supported."
+            raise ImproperConfigurationError(msg)
+        stack = AsyncExitStack()
+        try:
+            driver = await stack.enter_async_context(service.provide_session())
+            await driver.begin()
+            state, token = _bind_transaction(service._transaction_key, driver)
+            stack.callback(_release_transaction, state, token)
+        except BaseException:
+            await stack.__aexit__(*sys.exc_info())
+            raise
+        self._stack = stack
+        return driver
 
     async def __aexit__(
         self, exc_type: "type[BaseException] | None", exc: "BaseException | None", traceback: "TracebackType | None"
     ) -> "Literal[False]":
         service = self._service
-        if exc_type is None:
-            await service.commit()
-        else:
-            await service.rollback()
+        stack = self._stack
+        if stack is None:
+            if exc_type is None:
+                await service.commit()
+            else:
+                await service.rollback()
+            return False
+        self._stack = None
+        try:
+            if exc_type is None:
+                await service.session.commit()
+            else:
+                await service.session.rollback()
+        except BaseException:
+            await stack.__aexit__(*sys.exc_info())
+            raise
+        await stack.__aexit__(exc_type, exc, traceback)
         return False
 
 
 class _SyncBeginTransactionContext(Generic[SyncDriverT]):
-    __slots__ = ("_service",)
+    __slots__ = ("_service", "_stack")
 
     def __init__(self, service: "SQLSpecSyncService[SyncDriverT]") -> None:
         self._service = service
+        self._stack: ExitStack | None = None
 
     def __enter__(self) -> SyncDriverT:
         service = self._service
-        service.begin()
-        return service.session
+        if service._config is None:
+            service.begin()
+            return service.session
+        if _transaction_session(service._transaction_key) is not None:
+            msg = "Nested config-service transactions are not supported."
+            raise ImproperConfigurationError(msg)
+        stack = ExitStack()
+        try:
+            driver = stack.enter_context(service.provide_session())
+            driver.begin()
+            state, token = _bind_transaction(service._transaction_key, driver)
+            stack.callback(_release_transaction, state, token)
+        except BaseException:
+            stack.__exit__(*sys.exc_info())
+            raise
+        self._stack = stack
+        return driver
 
     def __exit__(
         self, exc_type: "type[BaseException] | None", exc: "BaseException | None", traceback: "TracebackType | None"
     ) -> "Literal[False]":
         service = self._service
-        if exc_type is None:
-            service.commit()
-        else:
-            service.rollback()
+        stack = self._stack
+        if stack is None:
+            if exc_type is None:
+                service.commit()
+            else:
+                service.rollback()
+            return False
+        self._stack = None
+        try:
+            if exc_type is None:
+                service.session.commit()
+            else:
+                service.session.rollback()
+        except BaseException:
+            stack.__exit__(*sys.exc_info())
+            raise
+        stack.__exit__(exc_type, exc, traceback)
         return False

--- a/sqlspec/service.py
+++ b/sqlspec/service.py
@@ -1,5 +1,6 @@
 """Service base classes for SQLSpec application services."""
 
+from contextlib import AbstractAsyncContextManager, AbstractContextManager, nullcontext
 from typing import TYPE_CHECKING, Any, Generic, Literal, cast, overload
 
 from mypy_extensions import mypyc_attr
@@ -9,15 +10,17 @@ from sqlspec.core import OffsetPagination
 from sqlspec.core.filters import LimitOffsetFilter
 from sqlspec.driver._async import AsyncDriverAdapterBase
 from sqlspec.driver._sync import SyncDriverAdapterBase
-from sqlspec.exceptions import NotFoundError
+from sqlspec.exceptions import ImproperConfigurationError, NotFoundError
 from sqlspec.typing import SchemaT
 
 if TYPE_CHECKING:
     from types import TracebackType
 
     from sqlspec.builder import QueryBuilder
+    from sqlspec.config import AsyncDatabaseConfig, NoPoolAsyncConfig, NoPoolSyncConfig, SyncDatabaseConfig
     from sqlspec.core.filters import StatementFilter
     from sqlspec.core.statement import Statement
+    from sqlspec.loader import SQLFileLoader
     from sqlspec.typing import StatementParameters
 
 
@@ -31,26 +34,66 @@ SyncDriverT = TypeVar("SyncDriverT", bound=SyncDriverAdapterBase, default=SyncDr
 class SQLSpecAsyncService(Generic[AsyncDriverT]):
     """Base class for asynchronous SQLSpec services.
 
-    Provides common database operations and pagination support using a driver session.
+    Config-built services acquire and release a short session for each query helper.
+    Session-built services borrow the caller's session without closing it.
 
     Args:
-        session: The driver session instance.
+        session: The caller-owned driver session, mutually exclusive with config.
+        config: Database configuration used to acquire sessions per helper call.
+        loader: Optional SQL file loader to expose without resolving named queries.
     """
 
-    __slots__ = ("_session",)
+    __slots__ = ("_config", "_loader", "_session")
 
-    def __init__(self, session: AsyncDriverT) -> None:
+    def __init__(
+        self,
+        session: AsyncDriverT | None = None,
+        *,
+        config: "AsyncDatabaseConfig[Any, Any, AsyncDriverT] | NoPoolAsyncConfig[Any, AsyncDriverT] | None" = None,
+        loader: "SQLFileLoader | None" = None,
+    ) -> None:
+        if (session is None) == (config is None):
+            msg = "Provide exactly one of session or config."
+            raise ImproperConfigurationError(msg)
+        if config is not None and not config.is_async:
+            msg = "SQLSpecAsyncService requires an async database config."
+            raise ImproperConfigurationError(msg)
         self._session = session
+        self._config = config
+        self._loader = loader
 
     @property
     def session(self) -> AsyncDriverT:
         """Return the driver session."""
+        if self._session is None:
+            msg = "No session is available; use begin_transaction() or pass session=."
+            raise ImproperConfigurationError(msg)
         return self._session
 
     @property
     def driver(self) -> AsyncDriverT:
         """Alias for :attr:`session` matching the recipe-doc terminology."""
-        return self._session
+        return self.session
+
+    @property
+    def loader(self) -> "SQLFileLoader | None":
+        """Return the optional SQL file loader."""
+        return self._loader
+
+    def provide_session(self, session: AsyncDriverT | None = None) -> AbstractAsyncContextManager[AsyncDriverT]:
+        """Borrow an available session or acquire a short config-owned session.
+
+        Args:
+            session: Caller-owned override, which this context does not close.
+
+        Returns:
+            A context yielding the driver and releasing only an acquired session.
+        """
+        if session is not None:
+            return nullcontext(session)
+        if self._config is not None:
+            return self._config.provide_session()
+        return nullcontext(self.session)
 
     @overload
     async def paginate(
@@ -60,6 +103,7 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
         *parameters: "StatementParameters | StatementFilter",
         schema_type: "type[SchemaT]",
         count_with_window: bool = False,
+        session: AsyncDriverT | None = None,
         **kwargs: Any,
     ) -> OffsetPagination[SchemaT]: ...
 
@@ -71,6 +115,7 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
         *parameters: "StatementParameters | StatementFilter",
         schema_type: None = None,
         count_with_window: bool = False,
+        session: AsyncDriverT | None = None,
         **kwargs: Any,
     ) -> OffsetPagination[dict[str, Any]]: ...
 
@@ -81,6 +126,7 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
         *parameters: "StatementParameters | StatementFilter",
         schema_type: "type[SchemaT] | None" = None,
         count_with_window: bool = False,
+        session: AsyncDriverT | None = None,
         **kwargs: Any,
     ) -> "OffsetPagination[SchemaT] | OffsetPagination[dict[str, Any]]":
         """Execute a paginated query and return an OffsetPagination container.
@@ -90,31 +136,33 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
             *parameters: Statement parameters or filters.
             schema_type: The schema type to map results to.
             count_with_window: Whether to use COUNT(*) OVER() for total count.
+            session: Caller-owned driver override; no new session is acquired.
             **kwargs: Additional keyword arguments for the driver.
 
         Returns:
             An OffsetPagination instance containing items and total count.
         """
-        limit_offset: LimitOffsetFilter | None = self._session.find_filter(LimitOffsetFilter, parameters)
+        async with self.provide_session(session) as driver:
+            limit_offset: LimitOffsetFilter | None = driver.find_filter(LimitOffsetFilter, parameters)
 
-        items, total = await self._session.select_with_total(
-            statement, *parameters, schema_type=schema_type, count_with_window=count_with_window, **kwargs
-        )
+            items, total = await driver.select_with_total(
+                statement, *parameters, schema_type=schema_type, count_with_window=count_with_window, **kwargs
+            )
 
-        if schema_type is None:
+            if schema_type is None:
+                return OffsetPagination(
+                    items=cast("list[dict[str, Any]]", items),
+                    limit=limit_offset.limit if limit_offset is not None else len(items),
+                    offset=limit_offset.offset if limit_offset is not None else 0,
+                    total=total,
+                )
+
             return OffsetPagination(
-                items=cast("list[dict[str, Any]]", items),
+                items=cast("list[SchemaT]", items),
                 limit=limit_offset.limit if limit_offset is not None else len(items),
                 offset=limit_offset.offset if limit_offset is not None else 0,
                 total=total,
             )
-
-        return OffsetPagination(
-            items=cast("list[SchemaT]", items),
-            limit=limit_offset.limit if limit_offset is not None else len(items),
-            offset=limit_offset.offset if limit_offset is not None else 0,
-            total=total,
-        )
 
     @overload
     async def get_one(
@@ -124,6 +172,7 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
         *parameters: "StatementParameters | StatementFilter",
         schema_type: "type[SchemaT]",
         error_message: str | None = None,
+        session: AsyncDriverT | None = None,
         **kwargs: Any,
     ) -> SchemaT: ...
 
@@ -135,6 +184,7 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
         *parameters: "StatementParameters | StatementFilter",
         schema_type: None = None,
         error_message: str | None = None,
+        session: AsyncDriverT | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]: ...
 
@@ -146,6 +196,7 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
         *parameters: "StatementParameters | StatementFilter",
         schema_type: "type[SchemaT] | None" = None,
         error_message: str | None = None,
+        session: AsyncDriverT | None = None,
         **kwargs: Any,
     ) -> "SchemaT | dict[str, Any]": ...
 
@@ -156,6 +207,7 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
         *parameters: "StatementParameters | StatementFilter",
         schema_type: "type[SchemaT] | None" = None,
         error_message: str | None = None,
+        session: AsyncDriverT | None = None,
         **kwargs: Any,
     ) -> "SchemaT | dict[str, Any]":
         """Fetch one row or raise :class:`~sqlspec.exceptions.NotFoundError`.
@@ -170,6 +222,7 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
             *parameters: Statement parameters or filters.
             schema_type: The schema type to map the row to.
             error_message: Optional message for the raised :class:`NotFoundError`.
+            session: Caller-owned driver override; no new session is acquired.
             **kwargs: Additional keyword arguments for the driver.
 
         Returns:
@@ -178,16 +231,18 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
         Raises:
             NotFoundError: If the query returns zero rows.
         """
-        result = await self._session.select_one_or_none(statement, *parameters, schema_type=schema_type, **kwargs)
-        if result is None:
-            raise NotFoundError(error_message or "Record not found")
-        return result
+        async with self.provide_session(session) as driver:
+            result = await driver.select_one_or_none(statement, *parameters, schema_type=schema_type, **kwargs)
+            if result is None:
+                raise NotFoundError(error_message or "Record not found")
+            return result
 
     async def exists(
         self,
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
+        session: AsyncDriverT | None = None,
         **kwargs: Any,
     ) -> bool:
         """Check if any rows exist for the given query.
@@ -195,24 +250,38 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
         Args:
             statement: The SQL statement or QueryBuilder instance.
             *parameters: Statement parameters or filters.
+            session: Caller-owned driver override; no new session is acquired.
             **kwargs: Additional keyword arguments for the driver.
 
         Returns:
             True if at least one row exists, False otherwise.
         """
-        return await self._session.select_one_or_none(statement, *parameters, **kwargs) is not None
+        async with self.provide_session(session) as driver:
+            return await driver.select_one_or_none(statement, *parameters, **kwargs) is not None
 
-    async def begin(self) -> None:
-        """Begin a database transaction on the underlying session."""
-        await self._session.begin()
+    async def begin(self, *, session: AsyncDriverT | None = None) -> None:
+        """Begin a database transaction on the underlying session.
 
-    async def commit(self) -> None:
-        """Commit the current database transaction."""
-        await self._session.commit()
+        Args:
+            session: Caller-owned driver override for manual transaction control.
+        """
+        await (session if session is not None else self.session).begin()
 
-    async def rollback(self) -> None:
-        """Roll back the current database transaction."""
-        await self._session.rollback()
+    async def commit(self, *, session: AsyncDriverT | None = None) -> None:
+        """Commit the current database transaction.
+
+        Args:
+            session: Caller-owned driver override for manual transaction control.
+        """
+        await (session if session is not None else self.session).commit()
+
+    async def rollback(self, *, session: AsyncDriverT | None = None) -> None:
+        """Roll back the current database transaction.
+
+        Args:
+            session: Caller-owned driver override for manual transaction control.
+        """
+        await (session if session is not None else self.session).rollback()
 
     def begin_transaction(self) -> "_AsyncBeginTransactionContext[AsyncDriverT]":
         """Context manager that commits on success and rolls back on error.
@@ -227,26 +296,66 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
 class SQLSpecSyncService(Generic[SyncDriverT]):
     """Base class for synchronous SQLSpec services.
 
-    Provides common database operations and pagination support using a driver session.
+    Config-built services acquire and release a short session for each query helper.
+    Session-built services borrow the caller's session without closing it.
 
     Args:
-        session: The driver session instance.
+        session: The caller-owned driver session, mutually exclusive with config.
+        config: Database configuration used to acquire sessions per helper call.
+        loader: Optional SQL file loader to expose without resolving named queries.
     """
 
-    __slots__ = ("_session",)
+    __slots__ = ("_config", "_loader", "_session")
 
-    def __init__(self, session: SyncDriverT) -> None:
+    def __init__(
+        self,
+        session: SyncDriverT | None = None,
+        *,
+        config: "SyncDatabaseConfig[Any, Any, SyncDriverT] | NoPoolSyncConfig[Any, SyncDriverT] | None" = None,
+        loader: "SQLFileLoader | None" = None,
+    ) -> None:
+        if (session is None) == (config is None):
+            msg = "Provide exactly one of session or config."
+            raise ImproperConfigurationError(msg)
+        if config is not None and config.is_async:
+            msg = "SQLSpecSyncService requires a sync database config."
+            raise ImproperConfigurationError(msg)
         self._session = session
+        self._config = config
+        self._loader = loader
 
     @property
     def session(self) -> SyncDriverT:
         """Return the driver session."""
+        if self._session is None:
+            msg = "No session is available; use begin_transaction() or pass session=."
+            raise ImproperConfigurationError(msg)
         return self._session
 
     @property
     def driver(self) -> SyncDriverT:
         """Alias for :attr:`session` matching the recipe-doc terminology."""
-        return self._session
+        return self.session
+
+    @property
+    def loader(self) -> "SQLFileLoader | None":
+        """Return the optional SQL file loader."""
+        return self._loader
+
+    def provide_session(self, session: SyncDriverT | None = None) -> AbstractContextManager[SyncDriverT]:
+        """Borrow an available session or acquire a short config-owned session.
+
+        Args:
+            session: Caller-owned override, which this context does not close.
+
+        Returns:
+            A context yielding the driver and releasing only an acquired session.
+        """
+        if session is not None:
+            return nullcontext(session)
+        if self._config is not None:
+            return self._config.provide_session()
+        return nullcontext(self.session)
 
     @overload
     def paginate(
@@ -256,6 +365,7 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
         *parameters: "StatementParameters | StatementFilter",
         schema_type: "type[SchemaT]",
         count_with_window: bool = False,
+        session: SyncDriverT | None = None,
         **kwargs: Any,
     ) -> OffsetPagination[SchemaT]: ...
 
@@ -267,6 +377,7 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
         *parameters: "StatementParameters | StatementFilter",
         schema_type: None = None,
         count_with_window: bool = False,
+        session: SyncDriverT | None = None,
         **kwargs: Any,
     ) -> OffsetPagination[dict[str, Any]]: ...
 
@@ -277,6 +388,7 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
         *parameters: "StatementParameters | StatementFilter",
         schema_type: "type[SchemaT] | None" = None,
         count_with_window: bool = False,
+        session: SyncDriverT | None = None,
         **kwargs: Any,
     ) -> "OffsetPagination[SchemaT] | OffsetPagination[dict[str, Any]]":
         """Execute a paginated query and return an OffsetPagination container.
@@ -286,31 +398,33 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
             *parameters: Statement parameters or filters.
             schema_type: The schema type to map results to.
             count_with_window: Whether to use COUNT(*) OVER() for total count.
+            session: Caller-owned driver override; no new session is acquired.
             **kwargs: Additional keyword arguments for the driver.
 
         Returns:
             An OffsetPagination instance containing items and total count.
         """
-        limit_offset: LimitOffsetFilter | None = self._session.find_filter(LimitOffsetFilter, parameters)
+        with self.provide_session(session) as driver:
+            limit_offset: LimitOffsetFilter | None = driver.find_filter(LimitOffsetFilter, parameters)
 
-        items, total = self._session.select_with_total(
-            statement, *parameters, schema_type=schema_type, count_with_window=count_with_window, **kwargs
-        )
+            items, total = driver.select_with_total(
+                statement, *parameters, schema_type=schema_type, count_with_window=count_with_window, **kwargs
+            )
 
-        if schema_type is None:
+            if schema_type is None:
+                return OffsetPagination(
+                    items=cast("list[dict[str, Any]]", items),
+                    limit=limit_offset.limit if limit_offset is not None else len(items),
+                    offset=limit_offset.offset if limit_offset is not None else 0,
+                    total=total,
+                )
+
             return OffsetPagination(
-                items=cast("list[dict[str, Any]]", items),
+                items=cast("list[SchemaT]", items),
                 limit=limit_offset.limit if limit_offset is not None else len(items),
                 offset=limit_offset.offset if limit_offset is not None else 0,
                 total=total,
             )
-
-        return OffsetPagination(
-            items=cast("list[SchemaT]", items),
-            limit=limit_offset.limit if limit_offset is not None else len(items),
-            offset=limit_offset.offset if limit_offset is not None else 0,
-            total=total,
-        )
 
     @overload
     def get_one(
@@ -320,6 +434,7 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
         *parameters: "StatementParameters | StatementFilter",
         schema_type: "type[SchemaT]",
         error_message: str | None = None,
+        session: SyncDriverT | None = None,
         **kwargs: Any,
     ) -> SchemaT: ...
 
@@ -331,6 +446,7 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
         *parameters: "StatementParameters | StatementFilter",
         schema_type: None = None,
         error_message: str | None = None,
+        session: SyncDriverT | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]: ...
 
@@ -342,6 +458,7 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
         *parameters: "StatementParameters | StatementFilter",
         schema_type: "type[SchemaT] | None" = None,
         error_message: str | None = None,
+        session: SyncDriverT | None = None,
         **kwargs: Any,
     ) -> "SchemaT | dict[str, Any]": ...
 
@@ -352,6 +469,7 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
         *parameters: "StatementParameters | StatementFilter",
         schema_type: "type[SchemaT] | None" = None,
         error_message: str | None = None,
+        session: SyncDriverT | None = None,
         **kwargs: Any,
     ) -> "SchemaT | dict[str, Any]":
         """Fetch one row or raise :class:`~sqlspec.exceptions.NotFoundError`.
@@ -366,6 +484,7 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
             *parameters: Statement parameters or filters.
             schema_type: The schema type to map the row to.
             error_message: Optional message for the raised :class:`NotFoundError`.
+            session: Caller-owned driver override; no new session is acquired.
             **kwargs: Additional keyword arguments for the driver.
 
         Returns:
@@ -374,16 +493,18 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
         Raises:
             NotFoundError: If the query returns zero rows.
         """
-        result = self._session.select_one_or_none(statement, *parameters, schema_type=schema_type, **kwargs)
-        if result is None:
-            raise NotFoundError(error_message or "Record not found")
-        return result
+        with self.provide_session(session) as driver:
+            result = driver.select_one_or_none(statement, *parameters, schema_type=schema_type, **kwargs)
+            if result is None:
+                raise NotFoundError(error_message or "Record not found")
+            return result
 
     def exists(
         self,
         statement: "Statement | QueryBuilder",
         /,
         *parameters: "StatementParameters | StatementFilter",
+        session: SyncDriverT | None = None,
         **kwargs: Any,
     ) -> bool:
         """Check if any rows exist for the given query.
@@ -391,24 +512,38 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
         Args:
             statement: The SQL statement or QueryBuilder instance.
             *parameters: Statement parameters or filters.
+            session: Caller-owned driver override; no new session is acquired.
             **kwargs: Additional keyword arguments for the driver.
 
         Returns:
             True if at least one row exists, False otherwise.
         """
-        return self._session.select_one_or_none(statement, *parameters, **kwargs) is not None
+        with self.provide_session(session) as driver:
+            return driver.select_one_or_none(statement, *parameters, **kwargs) is not None
 
-    def begin(self) -> None:
-        """Begin a database transaction on the underlying session."""
-        self._session.begin()
+    def begin(self, *, session: SyncDriverT | None = None) -> None:
+        """Begin a database transaction on the underlying session.
 
-    def commit(self) -> None:
-        """Commit the current database transaction."""
-        self._session.commit()
+        Args:
+            session: Caller-owned driver override for manual transaction control.
+        """
+        (session if session is not None else self.session).begin()
 
-    def rollback(self) -> None:
-        """Roll back the current database transaction."""
-        self._session.rollback()
+    def commit(self, *, session: SyncDriverT | None = None) -> None:
+        """Commit the current database transaction.
+
+        Args:
+            session: Caller-owned driver override for manual transaction control.
+        """
+        (session if session is not None else self.session).commit()
+
+    def rollback(self, *, session: SyncDriverT | None = None) -> None:
+        """Roll back the current database transaction.
+
+        Args:
+            session: Caller-owned driver override for manual transaction control.
+        """
+        (session if session is not None else self.session).rollback()
 
     def begin_transaction(self) -> "_SyncBeginTransactionContext[SyncDriverT]":
         """Context manager that commits on success and rolls back on error.

--- a/sqlspec/service.py
+++ b/sqlspec/service.py
@@ -108,7 +108,7 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
             msg = "Provide exactly one of session or config."
             raise ImproperConfigurationError(msg)
         if config is not None and not config.is_async:
-            msg = "SQLSpecAsyncService requires an async database config."
+            msg = f"{type(self).__name__} requires an async database config."
             raise ImproperConfigurationError(msg)
         self._session = session
         self._config = config
@@ -117,7 +117,11 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
 
     @property
     def session(self) -> AsyncDriverT:
-        """Return the driver session."""
+        """Return the active transaction driver or the constructor session.
+
+        Raises:
+            ImproperConfigurationError: If a config-built service has no active transaction.
+        """
         active = _transaction_session(self._transaction_key)
         if active is not None:
             return cast("AsyncDriverT", active)
@@ -377,7 +381,7 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
             msg = "Provide exactly one of session or config."
             raise ImproperConfigurationError(msg)
         if config is not None and config.is_async:
-            msg = "SQLSpecSyncService requires a sync database config."
+            msg = f"{type(self).__name__} requires a sync database config."
             raise ImproperConfigurationError(msg)
         self._session = session
         self._config = config
@@ -386,7 +390,11 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
 
     @property
     def session(self) -> SyncDriverT:
-        """Return the driver session."""
+        """Return the active transaction driver or the constructor session.
+
+        Raises:
+            ImproperConfigurationError: If a config-built service has no active transaction.
+        """
         active = _transaction_session(self._transaction_key)
         if active is not None:
             return cast("SyncDriverT", active)

--- a/tests/typing/typing_service_config.py
+++ b/tests/typing/typing_service_config.py
@@ -1,0 +1,34 @@
+"""Config constructors preserve the driver and schema result types."""
+
+from dataclasses import dataclass
+
+from sqlspec import sql
+from sqlspec.adapters.aiosqlite import AiosqliteConfig, AiosqliteDriver
+from sqlspec.adapters.sqlite import SqliteConfig, SqliteDriver
+from sqlspec.core import OffsetPagination
+from sqlspec.service import SQLSpecAsyncService, SQLSpecSyncService
+
+
+@dataclass
+class ServiceRow:
+    value: int
+
+
+def sync_rows(config: SqliteConfig) -> tuple[OffsetPagination[ServiceRow], ServiceRow]:
+    service = SQLSpecSyncService(config=config)
+    with service.provide_session() as session:
+        driver: SqliteDriver = session
+        page = service.paginate(sql.select("value").from_("service_values"), schema_type=ServiceRow, session=driver)
+        row = service.get_one(sql.select("value").from_("service_values"), schema_type=ServiceRow, session=driver)
+        return page, row
+
+
+async def async_rows(config: AiosqliteConfig) -> tuple[OffsetPagination[ServiceRow], ServiceRow]:
+    service = SQLSpecAsyncService(config=config)
+    async with service.provide_session() as session:
+        driver: AiosqliteDriver = session
+        page = await service.paginate(
+            sql.select("value").from_("service_values"), schema_type=ServiceRow, session=driver
+        )
+        row = await service.get_one(sql.select("value").from_("service_values"), schema_type=ServiceRow, session=driver)
+        return page, row

--- a/tests/unit/test_service_config.py
+++ b/tests/unit/test_service_config.py
@@ -1,7 +1,12 @@
 """Config-built service lifetime and borrowing contracts."""
 
+import asyncio
+import sqlite3
+import threading
 from collections.abc import AsyncIterator, Iterator
-from contextlib import asynccontextmanager, contextmanager
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import asynccontextmanager, closing, contextmanager
+from contextvars import copy_context
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -15,7 +20,7 @@ from sqlspec.adapters.mysqlconnector import MysqlConnectorAsyncConfig
 from sqlspec.adapters.sqlite import SqliteConfig, SqliteDriver
 from sqlspec.exceptions import ImproperConfigurationError, NotFoundError, SQLSpecError
 from sqlspec.loader import SQLFileLoader
-from sqlspec.service import SQLSpecAsyncService, SQLSpecSyncService
+from sqlspec.service import _TRANSACTIONS, SQLSpecAsyncService, SQLSpecSyncService
 
 pytestmark = pytest.mark.anyio
 
@@ -247,3 +252,366 @@ async def test_async_service_manual_control_requires_session(method: str) -> Non
     session = AsyncMock()
     await getattr(service, method)(session=session)
     getattr(session, method).assert_awaited_once_with()
+
+
+@pytest.mark.parametrize("fail", [False, True])
+def test_sync_config_transaction_spans_helpers(
+    sync_config: tuple[SqliteConfig, list[tuple[str, SqliteDriver]]], fail: bool
+) -> None:
+    config, events = sync_config
+    service = SQLSpecSyncService(config=config)
+    try:
+        with service.begin_transaction() as session:
+            assert service.session is service.driver is session
+            session.execute("INSERT INTO service_values VALUES (2)")
+            assert service.get_one(sql.select("value").from_("service_values").where("value = 2")) == {"value": 2}
+            assert service.paginate(sql.select("value").from_("service_values")).total == 2
+            assert [event for event, _ in events] == ["enter"]
+            with closing(sqlite3.connect(config.connection_config["database"])) as outside:
+                assert outside.execute("SELECT COUNT(*) FROM service_values WHERE value = 2").fetchone() == (0,)
+            if fail:
+                raise ValueError("rollback")
+    except ValueError:
+        assert fail
+    assert events[-1] == ("exit", events[0][1])
+    with pytest.raises(ImproperConfigurationError, match="begin_transaction"):
+        _ = service.session
+    assert service.exists(sql.select("value").from_("service_values").where("value = 2")) is not fail
+
+
+@pytest.mark.parametrize("fail", [False, True])
+async def test_async_config_transaction_spans_helpers(
+    async_config: tuple[AiosqliteConfig, list[tuple[str, AiosqliteDriver]]], fail: bool
+) -> None:
+    config, events = async_config
+    service = SQLSpecAsyncService(config=config)
+    try:
+        async with service.begin_transaction() as session:
+            assert service.session is service.driver is session
+            await session.execute("INSERT INTO service_values VALUES (2)")
+            assert await service.get_one(sql.select("value").from_("service_values").where("value = 2")) == {"value": 2}
+            assert (await service.paginate(sql.select("value").from_("service_values"))).total == 2
+            assert [event for event, _ in events] == ["enter"]
+            async with config.provide_session() as outside:
+                assert not await service.exists(
+                    sql.select("value").from_("service_values").where("value = 2"), session=outside
+                )
+            if fail:
+                raise ValueError("rollback")
+    except ValueError:
+        assert fail
+    assert events[-1] == ("exit", events[0][1])
+    with pytest.raises(ImproperConfigurationError, match="begin_transaction"):
+        _ = service.driver
+    assert await service.exists(sql.select("value").from_("service_values").where("value = 2")) is not fail
+
+
+@pytest.mark.parametrize("stage", ["begin", "commit", "rollback", "provider"])
+def test_sync_transaction_failure_releases_and_resets(
+    sync_config: tuple[SqliteConfig, list[tuple[str, SqliteDriver]]], monkeypatch: pytest.MonkeyPatch, stage: str
+) -> None:
+    config, events = sync_config
+    service = SQLSpecSyncService(config=config)
+    error = RuntimeError(stage)
+    received: list[BaseException] = []
+    original_provider = SqliteConfig.provide_session
+
+    @contextmanager
+    def provider(self: SqliteConfig) -> Iterator[SqliteDriver]:
+        try:
+            with original_provider(self) as driver:
+                yield driver
+        except BaseException as exc:
+            received.append(exc)
+            raise
+        if stage == "provider":
+            raise error
+
+    def fail(self: SqliteDriver) -> None:
+        raise error
+
+    with monkeypatch.context() as patch:
+        patch.setattr(SqliteConfig, "provide_session", provider)
+        if stage != "provider":
+            patch.setattr(SqliteDriver, stage, fail)
+        with pytest.raises(RuntimeError) as raised:
+            with service.begin_transaction():
+                if stage == "rollback":
+                    raise ValueError("body")
+        assert raised.value is error
+    assert [event for event, _ in events] == ["enter", "exit"]
+    if stage != "provider":
+        assert received == [error]
+    with pytest.raises(ImproperConfigurationError, match="begin_transaction"):
+        _ = service.session
+    assert service.exists(sql.select("value").from_("service_values"))
+
+
+@pytest.mark.parametrize("stage", ["begin", "commit", "rollback", "provider"])
+async def test_async_transaction_failure_releases_and_resets(
+    async_config: tuple[AiosqliteConfig, list[tuple[str, AiosqliteDriver]]], monkeypatch: pytest.MonkeyPatch, stage: str
+) -> None:
+    config, events = async_config
+    service = SQLSpecAsyncService(config=config)
+    error = RuntimeError(stage)
+    received: list[BaseException] = []
+    original_provider = AiosqliteConfig.provide_session
+
+    @asynccontextmanager
+    async def provider(self: AiosqliteConfig) -> AsyncIterator[AiosqliteDriver]:
+        try:
+            async with original_provider(self) as driver:
+                yield driver
+        except BaseException as exc:
+            received.append(exc)
+            raise
+        if stage == "provider":
+            raise error
+
+    async def fail(self: AiosqliteDriver) -> None:
+        raise error
+
+    with monkeypatch.context() as patch:
+        patch.setattr(AiosqliteConfig, "provide_session", provider)
+        if stage != "provider":
+            patch.setattr(AiosqliteDriver, stage, fail)
+        with pytest.raises(RuntimeError) as raised:
+            async with service.begin_transaction():
+                if stage == "rollback":
+                    raise ValueError("body")
+        assert raised.value is error
+    assert [event for event, _ in events] == ["enter", "exit"]
+    if stage != "provider":
+        assert received == [error]
+    with pytest.raises(ImproperConfigurationError, match="begin_transaction"):
+        _ = service.session
+    assert await service.exists(sql.select("value").from_("service_values"))
+
+
+def test_sync_nested_transaction_does_not_commit(
+    sync_config: tuple[SqliteConfig, list[tuple[str, SqliteDriver]]],
+) -> None:
+    config, events = sync_config
+    service = SQLSpecSyncService(config=config)
+    with pytest.raises(ValueError, match="outer"):
+        with service.begin_transaction() as session:
+            session.execute("INSERT INTO service_values VALUES (2)")
+            with pytest.raises(ImproperConfigurationError, match="Nested"):
+                with service.begin_transaction():
+                    pytest.fail("nested entry")
+            assert service.session is session
+            assert [event for event, _ in events] == ["enter"]
+            raise ValueError("outer")
+    assert not service.exists(sql.select("value").from_("service_values").where("value = 2"))
+
+
+async def test_async_nested_transaction_does_not_commit(
+    async_config: tuple[AiosqliteConfig, list[tuple[str, AiosqliteDriver]]],
+) -> None:
+    config, events = async_config
+    service = SQLSpecAsyncService(config=config)
+    with pytest.raises(ValueError, match="outer"):
+        async with service.begin_transaction() as session:
+            await session.execute("INSERT INTO service_values VALUES (2)")
+            with pytest.raises(ImproperConfigurationError, match="Nested"):
+                async with service.begin_transaction():
+                    pytest.fail("nested entry")
+            assert service.session is session
+            assert [event for event, _ in events] == ["enter"]
+            raise ValueError("outer")
+    assert not await service.exists(sql.select("value").from_("service_values").where("value = 2"))
+
+
+async def test_async_independent_transactions_do_not_share_sessions(
+    async_config: tuple[AiosqliteConfig, list[tuple[str, AiosqliteDriver]]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config, events = async_config
+    service = SQLSpecAsyncService(config=config)
+    ready = [asyncio.Event(), asyncio.Event()]
+
+    async def begin_read_transaction(self: AiosqliteDriver) -> None:
+        # The adapter's BEGIN IMMEDIATE serializes writers; overlap two real read transactions.
+        await self.connection.execute("BEGIN")
+
+    monkeypatch.setattr(AiosqliteDriver, "begin", begin_read_transaction)
+
+    async def work(index: int) -> AiosqliteDriver:
+        async with service.begin_transaction() as session:
+            ready[index].set()
+            await ready[1 - index].wait()
+            assert service.session is session
+            assert await service.exists(sql.select("value").from_("service_values"))
+            return session
+
+    first, second = await asyncio.gather(work(0), work(1))
+    assert first is not second
+    assert sorted(event for event, _ in events) == ["enter", "enter", "exit", "exit"]
+
+
+async def test_async_inherited_transaction_refuses_implicit_reuse(
+    async_config: tuple[AiosqliteConfig, list[tuple[str, AiosqliteDriver]]],
+) -> None:
+    config, events = async_config
+    service = SQLSpecAsyncService(config=config)
+    released = asyncio.Event()
+
+    async def child() -> None:
+        with pytest.raises(ImproperConfigurationError, match="another task"):
+            await service.exists(sql.select("value").from_("service_values"))
+        async with config.provide_session() as explicit:
+            assert await service.exists(sql.select("value").from_("service_values"), session=explicit)
+        released.set()
+        await finished.wait()
+        with pytest.raises(ImproperConfigurationError, match="no longer active"):
+            _ = service.session
+
+    finished = asyncio.Event()
+    async with service.begin_transaction():
+        task = asyncio.create_task(child())
+        await released.wait()
+        assert len(events) == 3  # Parent acquire and the explicit child's acquire/release only.
+    finished.set()
+    await task
+    assert await service.exists(sql.select("value").from_("service_values"))
+
+
+async def test_async_transaction_cancellation_rolls_back_and_releases(
+    async_config: tuple[AiosqliteConfig, list[tuple[str, AiosqliteDriver]]],
+) -> None:
+    config, events = async_config
+    service = SQLSpecAsyncService(config=config)
+    ready = asyncio.Event()
+
+    async def work() -> None:
+        async with service.begin_transaction() as session:
+            await session.execute("INSERT INTO service_values VALUES (2)")
+            ready.set()
+            await asyncio.Event().wait()
+
+    task = asyncio.create_task(work())
+    await ready.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert [event for event, _ in events] == ["enter", "exit"]
+    assert not await service.exists(sql.select("value").from_("service_values").where("value = 2"))
+
+
+def test_sync_transactions_are_independent_between_threads(
+    sync_config: tuple[SqliteConfig, list[tuple[str, SqliteDriver]]],
+) -> None:
+    config, _ = sync_config
+    service = SQLSpecSyncService(config=config)
+    barrier = threading.Barrier(2)
+
+    def work() -> SqliteDriver:
+        with service.begin_transaction() as session:
+            barrier.wait(timeout=10)
+            assert service.session is session
+            assert service.exists(sql.select("value").from_("service_values"))
+        session.connection.close()
+        return session
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(work) for _ in range(2)]
+        first, second = (future.result(timeout=15) for future in futures)
+    assert first is not second
+
+
+def test_service_transaction_context_releases_retained_driver(
+    sync_config: tuple[SqliteConfig, list[tuple[str, SqliteDriver]]],
+) -> None:
+    config, _ = sync_config
+    initial = _TRANSACTIONS.get()
+    for _ in range(10):
+        service = SQLSpecSyncService(config=config)
+        with service.begin_transaction():
+            inherited = copy_context()
+        assert _TRANSACTIONS.get() is initial
+        assert all(state.driver is None for state in (inherited.run(_TRANSACTIONS.get) or {}).values())
+        with pytest.raises(ImproperConfigurationError, match="no longer active"):
+            inherited.run(lambda: service.session)
+
+
+def test_sync_inherited_transaction_rejects_another_thread(
+    sync_config: tuple[SqliteConfig, list[tuple[str, SqliteDriver]]],
+) -> None:
+    config, events = sync_config
+    service = SQLSpecSyncService(config=config)
+    with service.begin_transaction():
+        inherited = copy_context()
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(inherited.run, lambda: service.exists(sql.select("1")))
+            with pytest.raises(ImproperConfigurationError, match="another task or thread"):
+                future.result(timeout=10)
+        assert [event for event, _ in events] == ["enter"]
+
+
+@pytest.mark.parametrize("fail", [False, True])
+def test_sync_session_service_preserves_subclass_transaction_hooks(
+    sync_config: tuple[SqliteConfig, list[tuple[str, SqliteDriver]]], fail: bool
+) -> None:
+    config, _ = sync_config
+    calls: list[str] = []
+
+    # Legacy overrides intentionally predate the additive session keyword.
+    class CustomService(SQLSpecSyncService[SqliteDriver]):
+        def begin(self) -> None:  # type: ignore[override]
+            calls.append("begin")
+            super().begin()
+
+        def commit(self) -> None:  # type: ignore[override]
+            calls.append("commit")
+            super().commit()
+
+        def rollback(self) -> None:  # type: ignore[override]
+            calls.append("rollback")
+            super().rollback()
+
+    with config.provide_session() as session:
+        service = CustomService(session)
+        try:
+            with service.begin_transaction() as bound:
+                assert bound is session
+                assert service.exists(sql.select("value").from_("service_values"))
+                if fail:
+                    raise ValueError("body")
+        except ValueError:
+            assert fail
+        assert service.session is session
+        assert calls == ["begin", "rollback" if fail else "commit"]
+
+
+@pytest.mark.parametrize("fail", [False, True])
+async def test_async_session_service_preserves_subclass_transaction_hooks(
+    async_config: tuple[AiosqliteConfig, list[tuple[str, AiosqliteDriver]]], fail: bool
+) -> None:
+    config, _ = async_config
+    calls: list[str] = []
+
+    # Legacy overrides intentionally predate the additive session keyword.
+    class CustomService(SQLSpecAsyncService[AiosqliteDriver]):
+        async def begin(self) -> None:  # type: ignore[override]
+            calls.append("begin")
+            await super().begin()
+
+        async def commit(self) -> None:  # type: ignore[override]
+            calls.append("commit")
+            await super().commit()
+
+        async def rollback(self) -> None:  # type: ignore[override]
+            calls.append("rollback")
+            await super().rollback()
+
+    async with config.provide_session() as session:
+        service = CustomService(session)
+        try:
+            async with service.begin_transaction() as bound:
+                assert bound is session
+                assert await service.exists(sql.select("value").from_("service_values"))
+                if fail:
+                    raise ValueError("body")
+        except ValueError:
+            assert fail
+        assert service.session is session
+        assert calls == ["begin", "rollback" if fail else "commit"]

--- a/tests/unit/test_service_config.py
+++ b/tests/unit/test_service_config.py
@@ -469,7 +469,7 @@ async def test_async_independent_transactions_do_not_share_sessions(
     ready = [asyncio.Event(), asyncio.Event()]
 
     async def begin_read_transaction(self: AiosqliteDriver) -> None:
-        # The adapter's BEGIN IMMEDIATE serializes writers; overlap two real read transactions.
+        """Start a deferred read transaction so two transactions can overlap."""
         await self.connection.execute("BEGIN")
 
     monkeypatch.setattr(AiosqliteDriver, "begin", begin_read_transaction)
@@ -508,7 +508,7 @@ async def test_async_inherited_transaction_refuses_implicit_reuse(
     async with service.begin_transaction():
         task = asyncio.create_task(child())
         await released.wait()
-        assert len(events) == 3  # Parent acquire and the explicit child's acquire/release only.
+        assert [event for event, _ in events] == ["enter", "enter", "exit"]
     finished.set()
     await task
     assert await service.exists(sql.select("value").from_("service_values"))
@@ -593,8 +593,9 @@ def test_sync_session_service_preserves_subclass_transaction_hooks(
     config, _ = sync_config
     calls: list[str] = []
 
-    # Legacy overrides intentionally predate the additive session keyword.
     class CustomService(SQLSpecSyncService[SqliteDriver]):
+        """Subclass whose transaction hooks predate the session keyword."""
+
         def begin(self) -> None:  # type: ignore[override]
             calls.append("begin")
             super().begin()
@@ -628,8 +629,9 @@ async def test_async_session_service_preserves_subclass_transaction_hooks(
     config, _ = async_config
     calls: list[str] = []
 
-    # Legacy overrides intentionally predate the additive session keyword.
     class CustomService(SQLSpecAsyncService[AiosqliteDriver]):
+        """Subclass whose transaction hooks predate the session keyword."""
+
         async def begin(self) -> None:  # type: ignore[override]
             calls.append("begin")
             await super().begin()

--- a/tests/unit/test_service_config.py
+++ b/tests/unit/test_service_config.py
@@ -9,7 +9,6 @@ from contextlib import asynccontextmanager, closing, contextmanager
 from contextvars import copy_context
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -170,15 +169,18 @@ async def test_async_service_borrows_explicit_session(
 
 
 @pytest.mark.parametrize("config", [SqliteConfig(), AdbcConfig()])
-def test_sync_service_constructor_and_loader(config: Any) -> None:
+def test_sync_service_constructor_and_loader(
+    config: Any, sync_config: tuple[SqliteConfig, list[tuple[str, SqliteDriver]]]
+) -> None:
     loader = SQLFileLoader()
     service = SQLSpecSyncService(config=config, loader=loader)
     assert service.loader is loader
-    assert SQLSpecSyncService(MagicMock()).loader is None
     with pytest.raises(ImproperConfigurationError, match="exactly one"):
         SQLSpecSyncService()
-    with pytest.raises(ImproperConfigurationError, match="exactly one"):
-        SQLSpecSyncService(MagicMock(), config=config)
+    with sync_config[0].provide_session() as session:
+        assert SQLSpecSyncService(session).loader is None
+        with pytest.raises(ImproperConfigurationError, match="exactly one"):
+            SQLSpecSyncService(session, config=config)
     with pytest.raises(ImproperConfigurationError, match="sync"):
         SQLSpecSyncService(config=AiosqliteConfig())  # type: ignore[arg-type]
 
@@ -190,68 +192,105 @@ def test_service_uses_local_no_pool_config() -> None:
         _ = service.driver
 
 
-def test_session_built_service_borrows_and_forwards_kwargs() -> None:
-    original = MagicMock()
-    explicit = MagicMock()
-    explicit.select_one_or_none.return_value = {"value": 1}
-    service: SQLSpecSyncService = SQLSpecSyncService(original)
+def test_session_built_service_borrows_and_forwards_kwargs(
+    sync_config: tuple[SqliteConfig, list[tuple[str, SqliteDriver]]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config, _ = sync_config
     statement = sql.select("1 AS value")
-    with service.provide_session() as borrowed:
-        assert borrowed is original
-    assert service.session is service.driver is original
-    assert service.get_one(statement, session=explicit, value=1) == {"value": 1}
-    explicit.select_one_or_none.assert_called_once_with(statement, schema_type=None, value=1)
-    original.select_one_or_none.assert_not_called()
-    original.close.assert_not_called()
+    calls: list[tuple[SqliteDriver, object, dict[str, Any]]] = []
+
+    def select(self: SqliteDriver, query: object, **kwargs: Any) -> dict[str, int]:
+        calls.append((self, query, kwargs))
+        return {"value": 1}
+
+    monkeypatch.setattr(SqliteDriver, "select_one_or_none", select)
+    with config.provide_session() as original, config.provide_session() as explicit:
+        service = SQLSpecSyncService(original)
+        with service.provide_session() as borrowed:
+            assert borrowed is original
+        assert service.session is service.driver is original
+        assert service.get_one(statement, session=explicit, value=1) == {"value": 1}
+        assert calls == [(explicit, statement, {"schema_type": None, "value": 1})]
+        original.execute("SELECT 1")
 
 
-async def test_async_session_built_service_borrows_and_forwards_kwargs() -> None:
-    original = AsyncMock()
-    explicit = AsyncMock()
-    explicit.select_one_or_none.return_value = {"value": 1}
-    service: SQLSpecAsyncService = SQLSpecAsyncService(original)
+async def test_async_session_built_service_borrows_and_forwards_kwargs(
+    async_config: tuple[AiosqliteConfig, list[tuple[str, AiosqliteDriver]]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config, _ = async_config
     statement = sql.select("1 AS value")
-    async with service.provide_session() as borrowed:
-        assert borrowed is original
-    assert service.session is service.driver is original
-    assert await service.get_one(statement, session=explicit, value=1) == {"value": 1}
-    explicit.select_one_or_none.assert_awaited_once_with(statement, schema_type=None, value=1)
-    original.select_one_or_none.assert_not_awaited()
-    original.close.assert_not_awaited()
+    calls: list[tuple[AiosqliteDriver, object, dict[str, Any]]] = []
+
+    async def select(self: AiosqliteDriver, query: object, **kwargs: Any) -> dict[str, int]:
+        calls.append((self, query, kwargs))
+        return {"value": 1}
+
+    monkeypatch.setattr(AiosqliteDriver, "select_one_or_none", select)
+    async with config.provide_session() as original, config.provide_session() as explicit:
+        service = SQLSpecAsyncService(original)
+        async with service.provide_session() as borrowed:
+            assert borrowed is original
+        assert service.session is service.driver is original
+        assert await service.get_one(statement, session=explicit, value=1) == {"value": 1}
+        assert calls == [(explicit, statement, {"schema_type": None, "value": 1})]
+        await original.execute("SELECT 1")
 
 
 @pytest.mark.parametrize("config", [AiosqliteConfig(), MysqlConnectorAsyncConfig()])
-def test_async_service_constructor_and_loader(config: Any) -> None:
+async def test_async_service_constructor_and_loader(
+    config: Any, async_config: tuple[AiosqliteConfig, list[tuple[str, AiosqliteDriver]]]
+) -> None:
     loader = SQLFileLoader()
     service = SQLSpecAsyncService(config=config, loader=loader)
     assert service.loader is loader
-    assert SQLSpecAsyncService(AsyncMock()).loader is None
     with pytest.raises(ImproperConfigurationError, match="exactly one"):
         SQLSpecAsyncService()
-    with pytest.raises(ImproperConfigurationError, match="exactly one"):
-        SQLSpecAsyncService(AsyncMock(), config=config)
+    async with async_config[0].provide_session() as session:
+        assert SQLSpecAsyncService(session).loader is None
+        with pytest.raises(ImproperConfigurationError, match="exactly one"):
+            SQLSpecAsyncService(session, config=config)
     with pytest.raises(ImproperConfigurationError, match="async"):
         SQLSpecAsyncService(config=SqliteConfig())  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize("method", ["begin", "commit", "rollback"])
-def test_sync_service_manual_control_requires_session(method: str) -> None:
-    service = SQLSpecSyncService(config=SqliteConfig())
+def test_sync_service_manual_control_requires_session(
+    method: str, sync_config: tuple[SqliteConfig, list[tuple[str, SqliteDriver]]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config, _ = sync_config
+    service = SQLSpecSyncService(config=config)
     with pytest.raises(ImproperConfigurationError, match=r"begin_transaction\(\).*session="):
         getattr(service, method)()
-    session = MagicMock()
-    getattr(service, method)(session=session)
-    getattr(session, method).assert_called_once_with()
+    calls: list[SqliteDriver] = []
+
+    def control(self: SqliteDriver) -> None:
+        calls.append(self)
+
+    monkeypatch.setattr(SqliteDriver, method, control)
+    with config.provide_session() as session:
+        getattr(service, method)(session=session)
+    assert calls == [session]
 
 
 @pytest.mark.parametrize("method", ["begin", "commit", "rollback"])
-async def test_async_service_manual_control_requires_session(method: str) -> None:
-    service = SQLSpecAsyncService(config=AiosqliteConfig())
+async def test_async_service_manual_control_requires_session(
+    method: str,
+    async_config: tuple[AiosqliteConfig, list[tuple[str, AiosqliteDriver]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config, _ = async_config
+    service = SQLSpecAsyncService(config=config)
     with pytest.raises(ImproperConfigurationError, match=r"begin_transaction\(\).*session="):
         await getattr(service, method)()
-    session = AsyncMock()
-    await getattr(service, method)(session=session)
-    getattr(session, method).assert_awaited_once_with()
+    calls: list[AiosqliteDriver] = []
+
+    async def control(self: AiosqliteDriver) -> None:
+        calls.append(self)
+
+    monkeypatch.setattr(AiosqliteDriver, method, control)
+    async with config.provide_session() as session:
+        await getattr(service, method)(session=session)
+    assert calls == [session]
 
 
 @pytest.mark.parametrize("fail", [False, True])

--- a/tests/unit/test_service_config.py
+++ b/tests/unit/test_service_config.py
@@ -1,0 +1,249 @@
+"""Config-built service lifetime and borrowing contracts."""
+
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager, contextmanager
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from sqlspec import sql
+from sqlspec.adapters.adbc import AdbcConfig
+from sqlspec.adapters.aiosqlite import AiosqliteConfig, AiosqliteDriver
+from sqlspec.adapters.mysqlconnector import MysqlConnectorAsyncConfig
+from sqlspec.adapters.sqlite import SqliteConfig, SqliteDriver
+from sqlspec.exceptions import ImproperConfigurationError, NotFoundError, SQLSpecError
+from sqlspec.loader import SQLFileLoader
+from sqlspec.service import SQLSpecAsyncService, SQLSpecSyncService
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def sync_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[tuple[SqliteConfig, list[tuple[str, SqliteDriver]]]]:
+    config = SqliteConfig(connection_config={"database": str(tmp_path / "service.sqlite")})
+    events: list[tuple[str, SqliteDriver]] = []
+    original = SqliteConfig.provide_session
+    with original(config) as session:
+        session.execute("CREATE TABLE service_values (value INTEGER)")
+        session.execute("INSERT INTO service_values VALUES (1)")
+        session.commit()
+
+    @contextmanager
+    def observed(self: SqliteConfig, *args: Any, **kwargs: Any) -> Iterator[SqliteDriver]:
+        driver: SqliteDriver | None = None
+        try:
+            with original(self, *args, **kwargs) as driver:
+                events.append(("enter", driver))
+                yield driver
+        finally:
+            if driver is not None:
+                events.append(("exit", driver))
+
+    monkeypatch.setattr(SqliteConfig, "provide_session", observed)
+    yield config, events
+    config.close_pool()
+
+
+@pytest.fixture
+async def async_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> AsyncIterator[tuple[AiosqliteConfig, list[tuple[str, AiosqliteDriver]]]]:
+    config = AiosqliteConfig(connection_config={"database": str(tmp_path / "service.sqlite")})
+    events: list[tuple[str, AiosqliteDriver]] = []
+    original = AiosqliteConfig.provide_session
+    async with original(config) as session:
+        await session.execute("CREATE TABLE service_values (value INTEGER)")
+        await session.execute("INSERT INTO service_values VALUES (1)")
+        await session.commit()
+
+    @asynccontextmanager
+    async def observed(self: AiosqliteConfig, *args: Any, **kwargs: Any) -> AsyncIterator[AiosqliteDriver]:
+        driver: AiosqliteDriver | None = None
+        try:
+            async with original(self, *args, **kwargs) as driver:
+                events.append(("enter", driver))
+                yield driver
+        finally:
+            if driver is not None:
+                events.append(("exit", driver))
+
+    monkeypatch.setattr(AiosqliteConfig, "provide_session", observed)
+    yield config, events
+    await config.close_pool()
+
+
+@pytest.mark.parametrize("method", ["paginate", "get_one", "exists"])
+def test_sync_service_opens_short_sessions(
+    sync_config: tuple[SqliteConfig, list[tuple[str, SqliteDriver]]], method: str
+) -> None:
+    config, events = sync_config
+    service = SQLSpecSyncService(config=config)
+    for _ in range(2):
+        result = getattr(service, method)(sql.select("value").from_("service_values"))
+        assert result
+        assert events[-1][0] == "exit"
+        with pytest.raises(ImproperConfigurationError, match="begin_transaction"):
+            _ = service.session
+    assert [event for event, _ in events] == ["enter", "exit", "enter", "exit"]
+    assert events[0][1] is not events[2][1]
+
+
+@pytest.mark.parametrize("method", ["paginate", "get_one", "exists"])
+async def test_async_service_opens_short_sessions(
+    async_config: tuple[AiosqliteConfig, list[tuple[str, AiosqliteDriver]]], method: str
+) -> None:
+    config, events = async_config
+    service = SQLSpecAsyncService(config=config)
+    for _ in range(2):
+        result = await getattr(service, method)(sql.select("value").from_("service_values"))
+        assert result
+        assert events[-1][0] == "exit"
+        with pytest.raises(ImproperConfigurationError, match="begin_transaction"):
+            _ = service.driver
+    assert [event for event, _ in events] == ["enter", "exit", "enter", "exit"]
+    assert events[0][1] is not events[2][1]
+
+
+@pytest.mark.parametrize("method", ["paginate", "get_one", "exists"])
+def test_sync_service_releases_failed_query(
+    sync_config: tuple[SqliteConfig, list[tuple[str, SqliteDriver]]], method: str
+) -> None:
+    config, events = sync_config
+    service = SQLSpecSyncService(config=config)
+    with pytest.raises(SQLSpecError):
+        getattr(service, method)(sql.select("value").from_("missing_service_table"))
+    assert [event for event, _ in events] == ["enter", "exit"]
+    with pytest.raises(NotFoundError):
+        service.get_one(sql.select("value").from_("service_values").where("1 = 0"))
+    assert events[-1][0] == "exit"
+    assert service.exists(sql.select("value").from_("service_values"))
+
+
+@pytest.mark.parametrize("method", ["paginate", "get_one", "exists"])
+async def test_async_service_releases_failed_query(
+    async_config: tuple[AiosqliteConfig, list[tuple[str, AiosqliteDriver]]], method: str
+) -> None:
+    config, events = async_config
+    service = SQLSpecAsyncService(config=config)
+    with pytest.raises(SQLSpecError):
+        await getattr(service, method)(sql.select("value").from_("missing_service_table"))
+    assert [event for event, _ in events] == ["enter", "exit"]
+    with pytest.raises(NotFoundError):
+        await service.get_one(sql.select("value").from_("service_values").where("1 = 0"))
+    assert events[-1][0] == "exit"
+    assert await service.exists(sql.select("value").from_("service_values"))
+
+
+def test_sync_service_borrows_explicit_session(
+    sync_config: tuple[SqliteConfig, list[tuple[str, SqliteDriver]]],
+) -> None:
+    config, events = sync_config
+    service = SQLSpecSyncService(config=config)
+    with service.provide_session() as session:
+        assert service.get_one(sql.select("value").from_("service_values"), session=session) == {"value": 1}
+        assert service.exists(sql.select("value").from_("service_values"), session=session)
+        assert service.paginate(sql.select("value").from_("service_values"), session=session).total == 1
+        assert [event for event, _ in events] == ["enter"]
+    assert [event for event, _ in events] == ["enter", "exit"]
+
+
+async def test_async_service_borrows_explicit_session(
+    async_config: tuple[AiosqliteConfig, list[tuple[str, AiosqliteDriver]]],
+) -> None:
+    config, events = async_config
+    service = SQLSpecAsyncService(config=config)
+    async with service.provide_session() as session:
+        assert await service.get_one(sql.select("value").from_("service_values"), session=session) == {"value": 1}
+        assert await service.exists(sql.select("value").from_("service_values"), session=session)
+        assert (await service.paginate(sql.select("value").from_("service_values"), session=session)).total == 1
+        assert [event for event, _ in events] == ["enter"]
+    assert [event for event, _ in events] == ["enter", "exit"]
+
+
+@pytest.mark.parametrize("config", [SqliteConfig(), AdbcConfig()])
+def test_sync_service_constructor_and_loader(config: Any) -> None:
+    loader = SQLFileLoader()
+    service = SQLSpecSyncService(config=config, loader=loader)
+    assert service.loader is loader
+    assert SQLSpecSyncService(MagicMock()).loader is None
+    with pytest.raises(ImproperConfigurationError, match="exactly one"):
+        SQLSpecSyncService()
+    with pytest.raises(ImproperConfigurationError, match="exactly one"):
+        SQLSpecSyncService(MagicMock(), config=config)
+    with pytest.raises(ImproperConfigurationError, match="sync"):
+        SQLSpecSyncService(config=AiosqliteConfig())  # type: ignore[arg-type]
+
+
+def test_service_uses_local_no_pool_config() -> None:
+    service = SQLSpecSyncService(config=AdbcConfig())
+    assert service.get_one(sql.select("1 AS value")) == {"value": 1}
+    with pytest.raises(ImproperConfigurationError, match="begin_transaction"):
+        _ = service.driver
+
+
+def test_session_built_service_borrows_and_forwards_kwargs() -> None:
+    original = MagicMock()
+    explicit = MagicMock()
+    explicit.select_one_or_none.return_value = {"value": 1}
+    service: SQLSpecSyncService = SQLSpecSyncService(original)
+    statement = sql.select("1 AS value")
+    with service.provide_session() as borrowed:
+        assert borrowed is original
+    assert service.session is service.driver is original
+    assert service.get_one(statement, session=explicit, value=1) == {"value": 1}
+    explicit.select_one_or_none.assert_called_once_with(statement, schema_type=None, value=1)
+    original.select_one_or_none.assert_not_called()
+    original.close.assert_not_called()
+
+
+async def test_async_session_built_service_borrows_and_forwards_kwargs() -> None:
+    original = AsyncMock()
+    explicit = AsyncMock()
+    explicit.select_one_or_none.return_value = {"value": 1}
+    service: SQLSpecAsyncService = SQLSpecAsyncService(original)
+    statement = sql.select("1 AS value")
+    async with service.provide_session() as borrowed:
+        assert borrowed is original
+    assert service.session is service.driver is original
+    assert await service.get_one(statement, session=explicit, value=1) == {"value": 1}
+    explicit.select_one_or_none.assert_awaited_once_with(statement, schema_type=None, value=1)
+    original.select_one_or_none.assert_not_awaited()
+    original.close.assert_not_awaited()
+
+
+@pytest.mark.parametrize("config", [AiosqliteConfig(), MysqlConnectorAsyncConfig()])
+def test_async_service_constructor_and_loader(config: Any) -> None:
+    loader = SQLFileLoader()
+    service = SQLSpecAsyncService(config=config, loader=loader)
+    assert service.loader is loader
+    assert SQLSpecAsyncService(AsyncMock()).loader is None
+    with pytest.raises(ImproperConfigurationError, match="exactly one"):
+        SQLSpecAsyncService()
+    with pytest.raises(ImproperConfigurationError, match="exactly one"):
+        SQLSpecAsyncService(AsyncMock(), config=config)
+    with pytest.raises(ImproperConfigurationError, match="async"):
+        SQLSpecAsyncService(config=SqliteConfig())  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("method", ["begin", "commit", "rollback"])
+def test_sync_service_manual_control_requires_session(method: str) -> None:
+    service = SQLSpecSyncService(config=SqliteConfig())
+    with pytest.raises(ImproperConfigurationError, match=r"begin_transaction\(\).*session="):
+        getattr(service, method)()
+    session = MagicMock()
+    getattr(service, method)(session=session)
+    getattr(session, method).assert_called_once_with()
+
+
+@pytest.mark.parametrize("method", ["begin", "commit", "rollback"])
+async def test_async_service_manual_control_requires_session(method: str) -> None:
+    service = SQLSpecAsyncService(config=AiosqliteConfig())
+    with pytest.raises(ImproperConfigurationError, match=r"begin_transaction\(\).*session="):
+        await getattr(service, method)()
+    session = AsyncMock()
+    await getattr(service, method)(session=session)
+    getattr(session, method).assert_awaited_once_with()


### PR DESCRIPTION
Services can now be built from a database config and an optional SQL file loader. Query helpers borrow short sessions, accept explicit session overrides, and share one session inside a transaction, with task/thread ownership checks and cleanup on errors or cancellation. Existing session-based construction remains supported.

Adds a service guide and runnable SQLite/AioSQLite examples. Validated 60 service tests, 4 documentation examples, 51 new native service cases, and lint/type checks. Four existing mock-based native failures also reproduce on the unchanged baseline. Full suites were not run.
