### PR TITLE
feat: export BigQuery queries directly to object storage

### DIFF
--- a/docs/reference/adapters/bigquery.rst
+++ b/docs/reference/adapters/bigquery.rst
@@ -39,15 +39,103 @@ where retrying invalid or unsupported jobs would only extend failures.
 Result Exports
 ==============
 
-BigQuery result export uses the existing ``select_to_storage()`` method. There
-is no public ``export_table_to_storage()`` API. ``select_to_storage()`` runs the
-query with the configured job controls, waits for the query job according to the
-configured result timeout, and then writes through the selected storage bridge
-destination.
+``select_to_storage()`` exports eligible remote destinations through BigQuery
+``EXPORT DATA``. Its destination becomes a wildcard result set, which may
+contain several objects. The returned job's ``telemetry["destination"]`` gives
+the actual wildcard URI, rather than a single downloadable object.
 
-Billing follows BigQuery query-job behavior: exporting query results still runs
-the SQL statement, so the query can scan and bill data before SQLSpec writes the
-result to local or object storage.
+Destination rules
+-----------------
+
+SQLSpec inserts ``-*`` before the final filename suffix. A suffix does not
+select the encoding: ``format_hint`` defaults to ``parquet``.
+
+.. list-table:: Example destinations with the default Parquet format
+   :header-rows: 1
+
+   * - Requested destination
+     - Native destination
+   * - ``gs://reports/daily.parquet``
+     - ``gs://reports/daily-*.parquet``
+   * - ``gs://reports/daily``
+     - ``gs://reports/daily-*``
+   * - ``gs://reports/daily/``
+     - ``gs://reports/daily/part-*.parquet``
+   * - ``gs://reports``
+     - ``gs://reports/part-*.parquet``
+   * - ``gs://reports/daily-*.parquet``
+     - ``gs://reports/daily-*.parquet``
+
+One wildcard is allowed in the leaf filename. Wildcards in parent paths,
+multiple wildcards, quotes, control characters, and query or fragment components
+are rejected before submission. ``gcs://`` becomes ``gs://`` for export;
+registered ``alias://`` destinations resolve through the storage registry.
+
+Configuration and formats
+-------------------------
+
+``BigQueryConfig.driver_features["enable_native_storage"]`` defaults to
+``True``. Set it to ``False`` to retain the client Arrow writer. Local emulator
+endpoints, custom storage pipeline factories, local paths, and unsupported
+destinations or formats also use the client path before query submission.
+
+Google Cloud Storage needs no connection identifier. S3 and Azure require
+``driver_features["native_export_connection"]`` containing an existing
+``project.location.connection`` identifier. Missing connections select the
+client path; malformed supplied identifiers raise a configuration error.
+Azure destinations must include the account, as in
+``azure://account.blob.core.windows.net/container/result.parquet``.
+Accountless ``az://`` or ``abfss://`` addresses do not select native export.
+
+The caller supplies the provider connection, permissions, compatible location,
+and existing BigQuery Omni resources. See the provider's
+`EXPORT DATA connection requirements <https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/export-statements>`_
+and `Azure export setup <https://docs.cloud.google.com/bigquery/docs/omni-azure-export-results-to-azure-storage>`_.
+
+Native formats are ``parquet``, ``csv``, ``json``, and ``jsonl``. Both JSON names
+use BigQuery's newline-delimited JSON export; ``arrow-ipc`` uses the client path.
+CSV includes a header. Native export overwrites matching shard names but never
+deletes stale shards. Choose a fresh prefix when readers need an exact new
+result set. There is no public ``overwrite`` or compression argument on
+``select_to_storage()``; native exports use provider compression defaults.
+Custom pipeline settings remain on the client path.
+
+Query behavior and telemetry
+----------------------------
+
+Query parameters remain bound through the SDK's query-job configuration.
+SQLSpec submits one export job and applies the configured retry, request timeout,
+and result timeout. A submitted native job failure propagates through normal
+exception mapping; it does not retry through the client writer.
+
+BigQuery forbids ``INFORMATION_SCHEMA``, system-table, and wildcard-table queries
+inside ``EXPORT DATA``. CSV cannot represent nested or repeated fields.
+Query execution still incurs the provider's query costs and capacity limits;
+see `export options and restrictions <https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/export-statements>`_.
+
+Native telemetry includes the wildcard destination and a job identifier in
+``extra``. Unknown exported rows, bytes, and file counts are omitted. Bytes
+scanned or billed by a query are not exported-byte measurements.
+
+Validation and measurement
+--------------------------
+
+Local tests cover URI rules, SDK parameter objects, job controls, errors, and
+emulator client export/readback. Real GCS, S3, and Azure export/readback and
+provider-side parameter execution remain unverified. No native service latency
+or crossover claim follows from the local tests.
+
+The contributor harness ``tools/scripts/bench_bigquery_storage.py`` compares
+native and client export controls with explicit project, endpoint, and output
+arguments. It reports unsupported native routes separately and retains exported
+objects for inspection. Run its ``--help`` for options.
+
+Its ``--mode ingest-local`` measures local Parquet encoding and temporary-file
+writes at several sizes. Both direct-file upload and GCS landing require the
+client to upload the encoded payload; landing also needs storage configuration
+and cleanup. Real GCS landing throughput remains unverified.
+``load_from_arrow()``, its optional Storage Write API route, and
+``load_from_storage()`` retain their existing behavior.
 
 Configuration
 =============

--- a/sqlspec/adapters/bigquery/config.py
+++ b/sqlspec/adapters/bigquery/config.py
@@ -107,6 +107,12 @@ class BigQueryDriverFeatures(TypedDict):
         enable_storage_write_api: Route ``load_from_arrow`` (append, ``overwrite=False``) through the
             BigQuery Storage Write API using native Arrow instead of a Parquet load job. Falls back to
             the Parquet path on any ``bigquery_storage`` import/availability failure. Defaults to False.
+        enable_native_storage: Export eligible remote destinations through EXPORT DATA.
+            Defaults to True. False retains the client Arrow writer. Local emulator endpoints,
+            custom storage pipelines, and unsupported destinations/formats use the client path.
+        native_export_connection: Existing project.location.connection identifier required for
+            S3 and account-qualified Azure exports. Google Cloud Storage needs no connection.
+            The caller supplies the provider permissions and existing cross-cloud resources.
     """
 
     connection_instance: NotRequired["BigQueryConnection"]
@@ -122,6 +128,8 @@ class BigQueryDriverFeatures(TypedDict):
     query_page_size: NotRequired[int]
     query_max_results: NotRequired[int]
     enable_storage_write_api: NotRequired[bool]
+    enable_native_storage: NotRequired[bool]
+    native_export_connection: NotRequired[str]
 
 
 class BigQueryConnectionContext(SyncPoolConnectionContext):

--- a/sqlspec/adapters/bigquery/core.py
+++ b/sqlspec/adapters/bigquery/core.py
@@ -22,6 +22,7 @@ from sqlspec.core import (
 )
 from sqlspec.exceptions import (
     DataError,
+    ImproperConfigurationError,
     NotFoundError,
     OperationalError,
     OperationCancelledError,
@@ -47,7 +48,7 @@ if TYPE_CHECKING:
 
     from sqlspec.adapters.bigquery._typing import BigQueryConnection, BigQueryParam
     from sqlspec.driver._common import SyncExceptionHandler
-    from sqlspec.storage import StorageTelemetry
+    from sqlspec.storage import StorageFormat, StorageTelemetry
     from sqlspec.typing import StatementParameters
 
     BigQueryLoadFormat = Literal["jsonl", "json", "parquet", "arrow-ipc", "csv", "avro", "orc"]
@@ -85,6 +86,67 @@ HTTP_BAD_REQUEST = 400
 HTTP_FORBIDDEN = 403
 HTTP_SERVER_ERROR = 500
 COLUMN_CACHE_MAX_SIZE = 256
+
+
+def _resolve_export_format(format_hint: "StorageFormat | None") -> str | None:
+    """Map the Arrow writer's format default to a native export format."""
+    if format_hint is None or format_hint == "parquet":
+        return "PARQUET"
+    if format_hint == "csv":
+        return "CSV"
+    if format_hint in {"json", "jsonl"}:
+        return "JSON"
+    return None
+
+
+def _build_export_uri(uri: str, format_hint: "StorageFormat | None" = None) -> str:
+    """Build a single-leaf-wildcard URI from a resolved storage destination.
+
+    The filename suffix is preserved independently of the selected encoding.
+    Directory destinations receive a filename matching the actual format.
+    """
+    format_name = _resolve_export_format(format_hint)
+    if format_name is None:
+        msg = "Unsupported native BigQuery export format."
+        raise ImproperConfigurationError(msg)
+    if not uri.isprintable() or any(character in uri for character in ("'", '"', "\\", "?", "#")):
+        msg = "BigQuery export URI contains unsafe characters."
+        raise ImproperConfigurationError(msg)
+
+    parsed = urlparse(uri)
+    scheme = "gs" if parsed.scheme == "gcs" else parsed.scheme
+    authority = parsed.netloc
+    if (
+        scheme not in {"gs", "s3", "azure"}
+        or not authority
+        or any(not (character.isalnum() or character in ".-_") for character in authority)
+    ):
+        msg = "BigQuery export requires a supported URI with a valid storage authority."
+        raise ImproperConfigurationError(msg)
+
+    path = parsed.path
+    if scheme == "azure":
+        account = authority.removesuffix(".blob.core.windows.net")
+        container = path.lstrip("/").split("/", 1)[0]
+        if account == authority or not account or not container or "*" in container:
+            msg = "BigQuery Azure export requires an account-qualified Blob Storage URI and container."
+            raise ImproperConfigurationError(msg)
+        if path.count("/") == 1:
+            path += "/"
+
+    parent, _, leaf = path.rpartition("/")
+    if "*" in parent or path.count("*") > 1:
+        msg = "BigQuery export URI must contain at most one wildcard, in the leaf object name."
+        raise ImproperConfigurationError(msg)
+    if "*" not in leaf:
+        if not leaf:
+            extension = "jsonl" if format_name == "JSON" else format_name.lower()
+            leaf = f"part-*.{extension}"
+        else:
+            stem, separator, suffix = leaf.rpartition(".")
+            leaf = f"{stem}-*.{suffix}" if stem and separator and suffix else f"{leaf}-*"
+    return f"{scheme}://{authority}{parent}/{leaf}"
+
 
 DEFAULT_REQUEST_TIMEOUT = 120.0
 """Fallback per-request HTTP timeout (seconds) for job API calls.

--- a/sqlspec/adapters/bigquery/core.py
+++ b/sqlspec/adapters/bigquery/core.py
@@ -86,6 +86,7 @@ HTTP_BAD_REQUEST = 400
 HTTP_FORBIDDEN = 403
 HTTP_SERVER_ERROR = 500
 COLUMN_CACHE_MAX_SIZE = 256
+_CONNECTION_NAME_PARTS = 3
 
 
 def _resolve_export_format(format_hint: "StorageFormat | None") -> str | None:
@@ -97,6 +98,23 @@ def _resolve_export_format(format_hint: "StorageFormat | None") -> str | None:
     if format_hint in {"json", "jsonl"}:
         return "JSON"
     return None
+
+
+def _build_export_statement(sql: str, uri: str, export_format: str, connection: str | None) -> str:
+    """Wrap compiled SQL without changing its bound query parameters."""
+    connection_clause = ""
+    if connection is not None:
+        parts = connection.split(".")
+        if len(parts) != _CONNECTION_NAME_PARTS or any(
+            not part or not all(char.isascii() and (char.isalnum() or char in "-_") for char in part) for part in parts
+        ):
+            msg = "native_export_connection must be a project.location.connection identifier"
+            raise ImproperConfigurationError(msg)
+        connection_clause = f" WITH CONNECTION `{connection}`"
+    options = f"uri='{uri}', format='{export_format}', overwrite=true"
+    if export_format == "CSV":
+        options += ", header=true"
+    return f"EXPORT DATA{connection_clause} OPTIONS ({options}) AS {sql}"
 
 
 def _build_export_uri(uri: str, format_hint: "StorageFormat | None" = None) -> str:

--- a/sqlspec/adapters/bigquery/driver.py
+++ b/sqlspec/adapters/bigquery/driver.py
@@ -22,6 +22,9 @@ from sqlspec.adapters.bigquery._typing import (
 from sqlspec.adapters.bigquery.core import (
     DEFAULT_REQUEST_TIMEOUT,
     BigQueryStreamSource,
+    _build_export_statement,
+    _build_export_uri,
+    _resolve_export_format,
     _run_query_and_wait,
     _uses_local_bigquery_endpoint,
     build_arrow_write_stream_payload,
@@ -495,9 +498,55 @@ class BigQueryDriver(SyncDriverAdapterBase):
         telemetry: "StorageTelemetry | None" = None,
         **kwargs: Any,
     ) -> "StorageBridgeJob":
-        """Execute a query and persist Arrow results to a storage backend."""
+        """Export eligible remote queries natively, or persist client Arrow results.
+
+        Native exports overwrite matching shards but do not remove stale shards.
+        Set ``enable_native_storage=False`` to force the client storage writer.
+        """
 
         self._require_capability("arrow_export_enabled")
+        export_format = _resolve_export_format(format_hint)
+        native_uri = str(destination)
+        if (
+            self.driver_features.get("enable_native_storage", True)
+            and export_format is not None
+            and self.storage_pipeline_factory is None
+            and not _uses_local_bigquery_endpoint(self.connection)
+        ):
+            if native_uri.startswith("alias://"):
+                native_uri = self._storage_pipeline().resolve_destination(destination).uri
+            scheme = native_uri.partition("://")[0]
+            connection = self.driver_features.get("native_export_connection")
+            if scheme in {"gs", "gcs"} or (scheme in {"s3", "azure"} and connection is not None):
+                native_uri = _build_export_uri(native_uri, format_hint)
+                config = statement_config or self.statement_config
+                prepared = self.prepare_statement(statement, parameters, statement_config=config, kwargs=kwargs)
+                sql, driver_params = self._compiled_sql(prepared, config)
+                export_sql = _build_export_statement(sql, native_uri, export_format, connection)
+                handler = self.handle_database_exceptions()
+                native_telemetry: StorageTelemetry = {
+                    "destination": native_uri,
+                    "format": format_hint or "parquet",
+                    "extra": {"native_export": True},
+                }
+                span = self.observability.start_storage_span("write", destination=native_uri, format_label=format_hint)
+                try:
+                    with handler:
+                        job = self._run_query_job(self.connection, export_sql, driver_params)
+                        job.result(
+                            job_retry=self._job_retry, timeout=self._job_result_timeout, **self._job_result_kwargs()
+                        )
+                        native_telemetry["extra"]["job_id"] = job.job_id
+                except Exception as exc:
+                    self.observability.end_storage_span(span, error=exc)
+                    raise
+                if handler.pending_exception is not None:
+                    self.observability.end_storage_span(span, error=handler.pending_exception)
+                    raise handler.pending_exception from None
+                native_telemetry = self.observability.annotate_storage_telemetry(native_telemetry)
+                self.observability.end_storage_span(span, telemetry=native_telemetry)
+                self._attach_partition_telemetry(native_telemetry, partitioner)
+                return self._storage_job(native_telemetry, telemetry)
         arrow_result = self.select_to_arrow(statement, *parameters, statement_config=statement_config, **kwargs)
         sync_pipeline = self._storage_pipeline()
         telemetry_payload = self._write_storage_result(

--- a/tests/integration/adapters/_shared/_driver_type_system.py
+++ b/tests/integration/adapters/_shared/_driver_type_system.py
@@ -149,6 +149,8 @@ DRIVER_FEATURE_CONSUMED_KEYS.update({
         "query_page_size",
         "query_max_results",
         "enable_storage_write_api",
+        "enable_native_storage",
+        "native_export_connection",
     ),
     "duckdb": (
         "extensions",

--- a/tests/integration/adapters/bigquery/bigquery/test_native_export.py
+++ b/tests/integration/adapters/bigquery/bigquery/test_native_export.py
@@ -1,0 +1,24 @@
+"""Local fallback coverage; cloud EXPORT DATA/readback is intentionally unverified."""
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pyarrow.parquet as pq
+import pytest
+
+if TYPE_CHECKING:
+    from sqlspec.adapters.bigquery.driver import BigQueryDriver
+
+pytestmark = pytest.mark.xdist_group("bigquery")
+
+
+def test_emulator_storage_export_preserves_bound_values(
+    bigquery_session: "BigQueryDriver", tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The local emulator uses the existing Arrow writer, not cloud EXPORT DATA."""
+    destination = tmp_path / "result.parquet"
+    monkeypatch.setitem(bigquery_session.driver_features, "storage_capabilities", {"arrow_export_enabled": True})
+    result = bigquery_session.select_to_storage("SELECT :value AS value", destination, {"value": "local export"})
+    assert pq.read_table(destination).to_pylist() == [{"value": "local export"}]
+    assert result.telemetry["rows_processed"] == 1
+    assert not result.telemetry.get("extra", {}).get("native_export", False)

--- a/tests/unit/adapters/test_bigquery/test_export_destination.py
+++ b/tests/unit/adapters/test_bigquery/test_export_destination.py
@@ -1,0 +1,108 @@
+"""Native BigQuery export URI and format contracts."""
+
+from typing import Any
+
+import pytest
+
+from sqlspec.adapters.bigquery.core import _build_export_uri, _resolve_export_format
+from sqlspec.exceptions import ImproperConfigurationError
+
+
+@pytest.mark.parametrize(
+    ("uri", "expected"),
+    [
+        ("gs://bucket/out.parquet", "gs://bucket/out-*.parquet"),
+        ("gcs://bucket/out.parquet", "gs://bucket/out-*.parquet"),
+        ("gs://bucket/out", "gs://bucket/out-*"),
+        ("gs://bucket/prefix/", "gs://bucket/prefix/part-*.parquet"),
+        ("gs://bucket", "gs://bucket/part-*.parquet"),
+        ("gs://bucket/", "gs://bucket/part-*.parquet"),
+        ("gs://bucket/out-*.parquet", "gs://bucket/out-*.parquet"),
+        ("gs://bucket/*", "gs://bucket/*"),
+        ("gs://bucket/prefix/a*b.parquet", "gs://bucket/prefix/a*b.parquet"),
+        ("gs://bucket/out.tar.gz", "gs://bucket/out.tar-*.gz"),
+        ("gs://bucket/.hidden", "gs://bucket/.hidden-*"),
+        ("gs://bucket/out.", "gs://bucket/out.-*"),
+        ("s3://bucket/out.csv", "s3://bucket/out-*.csv"),
+        (
+            "azure://account.blob.core.windows.net/container/out.jsonl",
+            "azure://account.blob.core.windows.net/container/out-*.jsonl",
+        ),
+        (
+            "azure://account.blob.core.windows.net/container/",
+            "azure://account.blob.core.windows.net/container/part-*.parquet",
+        ),
+        (
+            "azure://account.blob.core.windows.net/container",
+            "azure://account.blob.core.windows.net/container/part-*.parquet",
+        ),
+    ],
+)
+def test_export_uri_has_one_leaf_wildcard(uri: str, expected: str) -> None:
+    assert _build_export_uri(uri) == expected
+    assert expected.count("*") == 1
+    assert "*" in expected.rsplit("/", 1)[-1]
+
+
+@pytest.mark.parametrize(
+    ("format_hint", "native_format", "extension"),
+    [
+        (None, "PARQUET", "parquet"),
+        ("parquet", "PARQUET", "parquet"),
+        ("csv", "CSV", "csv"),
+        ("json", "JSON", "jsonl"),
+        ("jsonl", "JSON", "jsonl"),
+    ],
+)
+def test_export_format_and_directory_extension(format_hint: Any, native_format: str, extension: str) -> None:
+    assert _resolve_export_format(format_hint) == native_format
+    assert _build_export_uri("gs://bucket/prefix/", format_hint) == f"gs://bucket/prefix/part-*.{extension}"
+
+
+def test_export_format_does_not_infer_encoding_from_filename() -> None:
+    assert _resolve_export_format(None) == "PARQUET"
+    assert _build_export_uri("gs://bucket/out.csv") == "gs://bucket/out-*.csv"
+    assert _build_export_uri("gs://bucket/out.parquet", "csv") == "gs://bucket/out-*.parquet"
+
+
+@pytest.mark.parametrize("format_hint", ["arrow-ipc", "avro", "unknown"])
+def test_unsupported_native_export_format_selects_fallback(format_hint: Any) -> None:
+    assert _resolve_export_format(format_hint) is None
+    with pytest.raises(ImproperConfigurationError, match="format"):
+        _build_export_uri("gs://bucket/", format_hint)
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "",
+        "gs:///out.parquet",
+        "gs://*/out.parquet",
+        "gs://bucket/pre*/out.parquet",
+        "gs://bucket/a**.parquet",
+        "gs://bucket/*/",
+        "gs://bucket/out?token=value",
+        "gs://bucket/out?",
+        "gs://bucket/out#fragment",
+        "gs://bucket/out#",
+        "gs://bucket/out'file.parquet",
+        'gs://bucket/out"file.parquet',
+        "gs://bucket/out\\file.parquet",
+        "gs://bucket/out\nfile.parquet",
+        "gs://bucket/out\tfile.parquet",
+        "gs://bucket/out\x00file.parquet",
+        "gs://user@bucket/out.parquet",
+        "gs://bucket:443/out.parquet",
+        "file:///tmp/out.parquet",
+        "az://container/out.parquet",
+        "abfss://container/out.parquet",
+        "azure://container/out.parquet",
+        "azure://account.blob.core.windows.net/",
+        "azure://account.blob.core.windows.net",
+        "azure://account.blob.core.windows.net/con*ainer/out.parquet",
+        "gs://bucket/out\x7ffile.parquet",
+    ],
+)
+def test_export_uri_rejects_invalid_or_unsafe_destination(uri: str) -> None:
+    with pytest.raises(ImproperConfigurationError):
+        _build_export_uri(uri)

--- a/tests/unit/adapters/test_bigquery/test_native_export.py
+++ b/tests/unit/adapters/test_bigquery/test_native_export.py
@@ -90,7 +90,7 @@ def test_native_failure_never_redispatches(monkeypatch: pytest.MonkeyPatch) -> N
 
 def test_native_api_failure_keeps_exception_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
     connection = _RecordingConnection()
-    query = Mock(side_effect=Forbidden("denied"))
+    query = Mock(side_effect=Forbidden("denied"))  # type: ignore[no-untyped-call]
     monkeypatch.setattr(connection, "query", query)
     arrow = Mock()
     monkeypatch.setattr(BigQueryDriver, "select_to_arrow", arrow)

--- a/tests/unit/adapters/test_bigquery/test_native_export.py
+++ b/tests/unit/adapters/test_bigquery/test_native_export.py
@@ -1,0 +1,170 @@
+"""Local SDK contracts for native exports; no cloud jobs are submitted."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import Mock
+
+import pytest
+from google.api_core.exceptions import Forbidden
+from google.cloud.bigquery import QueryJobConfig
+
+from sqlspec.adapters.bigquery.driver import BigQueryDriver
+from sqlspec.exceptions import ImproperConfigurationError, PermissionDeniedError
+from sqlspec.storage import SyncStoragePipeline
+from tests.unit.adapters.test_bigquery.test_job_controls import CAPABILITIES, _RecordingConnection
+
+
+@pytest.mark.parametrize("uri", ["gs://bucket/report.csv", "gcs://bucket/report.csv"])
+def test_native_export_binds_parameters_and_preserves_job_controls(uri: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    connection = _RecordingConnection()
+    default = QueryJobConfig(labels={"owner": "export"}, maximum_bytes_billed=123)
+    driver = BigQueryDriver(
+        cast(Any, connection),
+        driver_features={
+            "storage_capabilities": CAPABILITIES,
+            "default_query_job_config": default,
+            "request_timeout": 4,
+            "job_result_timeout": 7,
+        },
+    )
+    arrow = Mock(side_effect=AssertionError("native export must not encode Arrow"))
+    monkeypatch.setattr(BigQueryDriver, "select_to_arrow", arrow)
+    result = driver.select_to_storage("SELECT :name AS name", uri, {"name": "O'Reilly"}, format_hint="csv")
+    assert len(connection.query_calls) == 1
+    sql, options = connection.query_calls[0]
+    assert sql.startswith("EXPORT DATA OPTIONS (")
+    assert "uri='gs://bucket/report-*.csv'" in sql
+    assert "format='CSV'" in sql and "header=true" in sql and "overwrite=true" in sql
+    assert "O'Reilly" not in sql
+    assert "@name" in sql
+    assert options["job_config"].query_parameters[0].value == "O'Reilly"
+    assert options["job_config"].labels == default.labels
+    assert options["job_config"].maximum_bytes_billed == 123
+    assert options["timeout"] == 4
+    assert connection.query_job.result_calls[0]["timeout"] == 7
+    assert result.telemetry["destination"] == "gs://bucket/report-*.csv"
+    assert "bytes_processed" not in result.telemetry
+    assert "rows_processed" not in result.telemetry
+    arrow.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "uri", ["s3://bucket/report.parquet", "azure://account.blob.core.windows.net/container/report.parquet"]
+)
+def test_native_export_uses_explicit_provider_connection(uri: str) -> None:
+    connection = _RecordingConnection()
+    driver = BigQueryDriver(
+        cast(Any, connection),
+        driver_features={
+            "storage_capabilities": CAPABILITIES,
+            "native_export_connection": "my-project.us.connection_1",
+        },
+    )
+    driver.select_to_storage("SELECT 1", uri)
+    assert connection.query_calls[0][0].startswith("EXPORT DATA WITH CONNECTION `my-project.us.connection_1`")
+
+
+@pytest.mark.parametrize("connection_name", ["bad", "a.b.c.d", "a.b.`x`", "a.b.x;SELECT 1"])
+def test_invalid_export_connection_fails_before_query(connection_name: str) -> None:
+    connection = _RecordingConnection()
+    driver = BigQueryDriver(
+        cast(Any, connection),
+        driver_features={"storage_capabilities": CAPABILITIES, "native_export_connection": connection_name},
+    )
+    with pytest.raises(ImproperConfigurationError):
+        driver.select_to_storage("SELECT 1", "s3://bucket/out.parquet")
+    assert not connection.query_calls
+
+
+def test_native_failure_never_redispatches(monkeypatch: pytest.MonkeyPatch) -> None:
+    connection = _RecordingConnection()
+    monkeypatch.setattr(connection.query_job, "result", Mock(side_effect=RuntimeError("job failed")))
+    arrow = Mock(side_effect=AssertionError("must not fall back"))
+    monkeypatch.setattr(BigQueryDriver, "select_to_arrow", arrow)
+    driver = BigQueryDriver(cast(Any, connection), driver_features={"storage_capabilities": CAPABILITIES})
+    with pytest.raises(RuntimeError, match="job failed"):
+        driver.select_to_storage("SELECT 1", "gs://bucket/out.parquet")
+    assert len(connection.query_calls) == 1
+    arrow.assert_not_called()
+
+
+def test_native_api_failure_keeps_exception_mapping(monkeypatch: pytest.MonkeyPatch) -> None:
+    connection = _RecordingConnection()
+    query = Mock(side_effect=Forbidden("denied"))
+    monkeypatch.setattr(connection, "query", query)
+    arrow = Mock()
+    monkeypatch.setattr(BigQueryDriver, "select_to_arrow", arrow)
+    driver = BigQueryDriver(cast(Any, connection), driver_features={"storage_capabilities": CAPABILITIES})
+    with pytest.raises(PermissionDeniedError):
+        driver.select_to_storage("SELECT 1", "gs://bucket/out.parquet")
+    query.assert_called_once()
+    arrow.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("format_hint", "expected"), [(None, "PARQUET"), ("parquet", "PARQUET"), ("json", "JSON"), ("jsonl", "JSON")]
+)
+def test_native_format_is_independent_of_suffix(format_hint: Any, expected: str) -> None:
+    connection = _RecordingConnection()
+    driver = BigQueryDriver(cast(Any, connection), driver_features={"storage_capabilities": CAPABILITIES})
+    driver.select_to_storage("SELECT 1", "gs://bucket/out.csv", format_hint=format_hint)
+    sql = connection.query_calls[0][0]
+    assert f"format='{expected}'" in sql
+    assert "out-*.csv" in sql
+    assert "header=" not in sql
+
+
+@pytest.mark.parametrize(
+    ("destination", "features", "format_hint"),
+    [
+        ("gs://bucket/out.parquet", {"enable_native_storage": False}, "parquet"),
+        ("s3://bucket/out.parquet", {}, "parquet"),
+        ("azure://account.blob.core.windows.net/container/out.parquet", {}, "parquet"),
+        ("az://container/out.parquet", {}, "parquet"),
+        ("file:///tmp/out.parquet", {}, "parquet"),
+        ("gs://bucket/out.arrow", {}, "arrow-ipc"),
+    ],
+)
+def test_ineligible_export_uses_client_before_submission(
+    destination: str, features: dict[str, Any], format_hint: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    connection = _RecordingConnection()
+    driver = BigQueryDriver(cast(Any, connection), driver_features={"storage_capabilities": CAPABILITIES, **features})
+    arrow = Mock()
+    monkeypatch.setattr(BigQueryDriver, "select_to_arrow", arrow)
+    writer = Mock(return_value={"destination": destination, "rows_processed": 2})
+    monkeypatch.setattr(BigQueryDriver, "_write_storage_result", writer)
+    result = driver.select_to_storage("SELECT :x", destination, {"x": 2}, format_hint=format_hint)
+    assert result.telemetry["rows_processed"] == 2
+    assert not connection.query_calls
+    arrow.assert_called_once()
+    writer.assert_called_once()
+
+
+def test_alias_export_resolves_once_without_storage_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    connection = _RecordingConnection()
+    resolver = Mock(return_value=SimpleNamespace(uri="gs://bucket/prefix/result.parquet"))
+    monkeypatch.setattr(SyncStoragePipeline, "resolve_destination", resolver)
+    driver = BigQueryDriver(cast(Any, connection), driver_features={"storage_capabilities": CAPABILITIES})
+    result = driver.select_to_storage("SELECT 1", "alias://exports/result.parquet", partitioner={"strategy": "fixed"})
+    resolver.assert_called_once_with("alias://exports/result.parquet")
+    assert len(connection.query_calls) == 1
+    assert result.telemetry["destination"] == "gs://bucket/prefix/result-*.parquet"
+
+
+@pytest.mark.parametrize("custom_pipeline", [False, True])
+def test_emulator_or_custom_pipeline_preserves_client_path(
+    custom_pipeline: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    connection = _RecordingConnection()
+    if custom_pipeline:
+        monkeypatch.setattr(BigQueryDriver, "storage_pipeline_factory", SyncStoragePipeline)
+    else:
+        cast(Any, connection)._connection = SimpleNamespace(API_BASE_URL="http://localhost:9050")
+    arrow = Mock()
+    monkeypatch.setattr(BigQueryDriver, "select_to_arrow", arrow)
+    monkeypatch.setattr(BigQueryDriver, "_write_storage_result", Mock(return_value={"destination": "gs://bucket/out"}))
+    driver = BigQueryDriver(cast(Any, connection), driver_features={"storage_capabilities": CAPABILITIES})
+    driver.select_to_storage("SELECT 1", "gs://bucket/out")
+    arrow.assert_called_once()
+    assert not connection.query_calls

--- a/tests/unit/adapters/test_bigquery/test_storage_benchmark.py
+++ b/tests/unit/adapters/test_bigquery/test_storage_benchmark.py
@@ -1,12 +1,13 @@
 """Local harness contracts; fake timings do not measure provider performance."""
 
 from contextlib import contextmanager
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import Mock
 
 import pytest
-from tools.scripts.bench_bigquery_storage import QUERY, run_benchmark
+from tools.scripts.bench_bigquery_storage import QUERY, characterize_ingest, run_benchmark
 
 
 def test_benchmark_controls_sizes_accounting_and_closes_resources() -> None:
@@ -74,3 +75,33 @@ def test_benchmark_reports_failure_or_unsupported_without_successful_native_timi
     assert all(record["status"] == ("unsupported" if mode == "fallback" else "failed") for record in native_records)
     if mode == "fallback":
         assert all("total_s" not in record for record in native_records)
+
+
+@pytest.mark.parametrize("fail", [False, True])
+def test_ingest_characterization_counts_upload_payloads_and_cleans_landing(fail: bool) -> None:
+    paths: list[Path] = []
+    uploads: list[tuple[str, int]] = []
+
+    def consume(route: str, source: bytes | Path) -> None:
+        if isinstance(source, Path):
+            paths.append(source)
+            uploads.append((route, len(source.read_bytes())))
+            if fail:
+                raise RuntimeError("simulated URI load failure")
+        else:
+            uploads.append((route, len(source)))
+
+    if fail:
+        with pytest.raises(RuntimeError, match="simulated URI load failure"):
+            characterize_ingest(consume=consume)
+    else:
+        records = characterize_ingest(consume=consume)
+        assert [record["input_rows"] for record in records] == [100, 1000, 10000]
+        assert len(uploads) == 6
+        for index, record in enumerate(records):
+            assert record["encoded_bytes"] == uploads[index * 2][1] == uploads[index * 2 + 1][1]
+            assert record["direct_client_upload_bytes"] == record["landing_client_upload_bytes"]
+            assert record["encoding_s"] >= 0
+            assert record["cloud_performance_verified"] is False
+    assert paths
+    assert all(not path.exists() and not path.parent.exists() for path in paths)

--- a/tests/unit/adapters/test_bigquery/test_storage_benchmark.py
+++ b/tests/unit/adapters/test_bigquery/test_storage_benchmark.py
@@ -1,0 +1,76 @@
+"""Local harness contracts; fake timings do not measure provider performance."""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import Mock
+
+import pytest
+from tools.scripts.bench_bigquery_storage import QUERY, run_benchmark
+
+
+def test_benchmark_controls_sizes_accounting_and_closes_resources() -> None:
+    calls: list[tuple[bool, int]] = []
+    closed: list[bool] = []
+
+    @contextmanager
+    def factory(native: bool) -> Any:
+        def export(query: str, destination: str, parameters: dict[str, int], **kwargs: Any) -> Any:
+            assert query == QUERY
+            assert kwargs["format_hint"] == "parquet"
+            calls.append((native, parameters["row_count"]))
+            telemetry: dict[str, Any] = {"destination": destination, "extra": {"native_export": native}}
+            if not native:
+                telemetry["bytes_processed"] = 42
+            return SimpleNamespace(telemetry=telemetry)
+
+        try:
+            yield cast(Any, SimpleNamespace(select_to_storage=export))
+        finally:
+            closed.append(native)
+
+    records = run_benchmark(factory, destination="gs://bucket/bench", environment="fake-contract", repetitions=2)
+    assert len(records) == 12
+    assert len(calls) == 18
+    assert closed == [True, False]
+    assert {record["input_rows"] for record in records} == {100, 1000, 10000}
+    for record in records:
+        assert record["status"] == "ok"
+        assert record["scenario"] == "bigquery_storage_export"
+        assert record["environment"] == "fake-contract"
+        assert record["total_s"] >= 0
+        assert record["cloud_performance_verified"] is False
+        if record["route"] == "native":
+            assert "output_bytes" not in record
+        else:
+            assert record["output_bytes"] == 42
+            assert record["bytes_source"] == "storage_telemetry"
+
+
+@pytest.mark.parametrize("mode", ["exception", "fallback", "missing", "bad_bytes"])
+def test_benchmark_reports_failure_or_unsupported_without_successful_native_timing(mode: str) -> None:
+    closed: list[bool] = []
+
+    @contextmanager
+    def factory(native: bool) -> Any:
+        telemetry: dict[str, Any] = {"destination": "gs://bucket/out", "extra": {"native_export": native}}
+        if mode == "fallback":
+            telemetry["extra"]["native_export"] = False
+        elif mode == "missing":
+            telemetry.pop("destination")
+        elif mode == "bad_bytes":
+            telemetry["bytes_processed"] = "unknown"
+        export = Mock(return_value=SimpleNamespace(telemetry=telemetry))
+        if mode == "exception":
+            export.side_effect = RuntimeError("native job failed")
+        try:
+            yield cast(Any, SimpleNamespace(select_to_storage=export))
+        finally:
+            closed.append(native)
+
+    records = run_benchmark(factory, destination="gs://bucket/bench", environment="fake-contract", warmup=0)
+    assert closed == [True, False]
+    native_records = [record for record in records if record["route"] == "native"]
+    assert all(record["status"] == ("unsupported" if mode == "fallback" else "failed") for record in native_records)
+    if mode == "fallback":
+        assert all("total_s" not in record for record in native_records)

--- a/tools/scripts/bench_bigquery_storage.py
+++ b/tools/scripts/bench_bigquery_storage.py
@@ -7,10 +7,13 @@ as a successful native export. Exported objects are retained for inspection.
 """
 
 import argparse
+import io
 import json
 import sys
+import tempfile
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import AbstractContextManager, contextmanager
+from pathlib import Path
 from time import perf_counter
 from typing import Any
 from urllib.parse import urlparse
@@ -21,10 +24,56 @@ from google.cloud.bigquery import Client
 from sqlspec.adapters.bigquery.driver import BigQueryDriver
 from sqlspec.storage import StorageFormat
 
-__all__ = ("main", "run_benchmark")
+__all__ = ("characterize_ingest", "main", "run_benchmark")
 
 SCENARIO = "bigquery_storage_export"
 QUERY = "SELECT value FROM UNNEST(GENERATE_ARRAY(1, :row_count)) AS value"
+
+
+def characterize_ingest(
+    sizes: Sequence[int] = (100, 1000, 10000), *, consume: Callable[[str, bytes | Path], None] | None = None
+) -> list[dict[str, Any]]:
+    """Measure local encoding; model both paths' client upload responsibility.
+
+    Optional consumers are local test doubles, not BigQuery or GCS clients.
+    No service transfer/job latency is measured. Temporary landing files are
+    removed after consumers return, including when a consumer raises.
+    """
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    if not sizes or any(size <= 0 for size in sizes):
+        raise ValueError("Sizes must be positive")
+    records: list[dict[str, Any]] = []
+    for size in sizes:
+        table = pa.table({"value": range(size)})
+        buffer = io.BytesIO()
+        started = perf_counter()
+        pq.write_table(table, buffer)
+        payload = buffer.getvalue()
+        encoding_s = perf_counter() - started
+        with tempfile.TemporaryDirectory(prefix="sqlspec-bigquery-ingest-") as directory:
+            landing = Path(directory) / "landing.parquet"
+            started = perf_counter()
+            landing.write_bytes(payload)
+            local_write_s = perf_counter() - started
+            if consume is not None:
+                consume("direct-file", payload)
+                consume("landing-plus-uri", landing)
+            records.append({
+                "scenario": "bigquery_arrow_ingest_characterization",
+                "environment": "local-codec-filesystem",
+                "input_rows": size,
+                "encoded_bytes": len(payload),
+                "encoding_s": encoding_s,
+                "local_landing_write_s": local_write_s,
+                "direct_client_upload_bytes": len(payload),
+                "landing_client_upload_bytes": landing.stat().st_size,
+                "upload_accounting": "payload responsibility; no network transfer measured",
+                "landing_requires": ["storage configuration", "object cleanup", "URI load job"],
+                "cloud_performance_verified": False,
+            })
+    return records
 
 
 def run_benchmark(
@@ -88,13 +137,20 @@ def run_benchmark(
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--project", required=True)
-    parser.add_argument("--endpoint", required=True, help="Explicit BigQuery API endpoint; no implicit cloud target")
-    parser.add_argument("--destination", required=True, help="Output prefix; artifacts are retained")
+    parser.add_argument("--mode", choices=["export", "ingest-local"], default="export")
+    parser.add_argument("--project")
+    parser.add_argument("--endpoint", help="Explicit BigQuery API endpoint; no implicit cloud target")
+    parser.add_argument("--destination", help="Output prefix; artifacts are retained")
     parser.add_argument("--sizes", nargs="+", type=int, default=[100, 1000, 10000])
     parser.add_argument("--warmup", type=int, default=1)
     parser.add_argument("--repetitions", type=int, default=3)
     args = parser.parse_args(argv)
+    if args.mode == "ingest-local":
+        json.dump(characterize_ingest(args.sizes), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return 0
+    if not args.project or not args.endpoint or not args.destination:
+        parser.error("export requires --project, --endpoint and --destination")
     local = urlparse(args.endpoint).hostname in {"localhost", "127.0.0.1", "::1"}
 
     @contextmanager

--- a/tools/scripts/bench_bigquery_storage.py
+++ b/tools/scripts/bench_bigquery_storage.py
@@ -1,0 +1,129 @@
+"""Compare BigQuery export routes with explicit endpoints and honest measurements.
+
+Run as ``uv run python -m tools.scripts.bench_bigquery_storage --help``.
+Cloud latency and crossover have not been verified. Local emulator results are
+local-only; an unavailable native route is reported as unsupported, never timed
+as a successful native export. Exported objects are retained for inspection.
+"""
+
+import argparse
+import json
+import sys
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import AbstractContextManager, contextmanager
+from time import perf_counter
+from typing import Any
+from urllib.parse import urlparse
+
+from google.auth.credentials import AnonymousCredentials
+from google.cloud.bigquery import Client
+
+from sqlspec.adapters.bigquery.driver import BigQueryDriver
+from sqlspec.storage import StorageFormat
+
+__all__ = ("main", "run_benchmark")
+
+SCENARIO = "bigquery_storage_export"
+QUERY = "SELECT value FROM UNNEST(GENERATE_ARRAY(1, :row_count)) AS value"
+
+
+def run_benchmark(
+    driver_factory: Callable[[bool], AbstractContextManager[BigQueryDriver]],
+    *,
+    destination: str,
+    environment: str,
+    sizes: Sequence[int] = (100, 1000, 10000),
+    warmup: int = 1,
+    repetitions: int = 3,
+    format_hint: StorageFormat = "parquet",
+) -> list[dict[str, Any]]:
+    """Measure complete export calls; no submission-only timer is available."""
+    if not sizes or any(size <= 0 for size in sizes) or warmup < 0 or repetitions <= 0:
+        raise ValueError("Sizes and repetitions must be positive; warmup cannot be negative")
+    records: list[dict[str, Any]] = []
+    for native in (True, False):
+        route = "native" if native else "client"
+        with driver_factory(native) as driver:
+            for size in sizes:
+                for iteration in range(-warmup, repetitions):
+                    record: dict[str, Any] = {
+                        "scenario": SCENARIO,
+                        "environment": environment,
+                        "route": route,
+                        "input_rows": size,
+                        "format": format_hint,
+                        "iteration": iteration,
+                        "cloud_performance_verified": False,
+                    }
+                    target = f"{destination.rstrip('/')}/{route}/{size}/{iteration}/result.{format_hint}"
+                    started = perf_counter()
+                    try:
+                        job = driver.select_to_storage(QUERY, target, {"row_count": size}, format_hint=format_hint)
+                        elapsed = perf_counter() - started
+                        telemetry = job.telemetry
+                        if native != bool(telemetry.get("extra", {}).get("native_export", False)):
+                            record.update(status="unsupported", reason="requested export route was not used")
+                        elif not isinstance(telemetry.get("destination"), str):
+                            record.update(status="failed", reason="missing export destination telemetry")
+                        else:
+                            record.update(status="ok", total_s=elapsed, destination=telemetry["destination"])
+                            output_bytes = telemetry.get("bytes_processed")
+                            if output_bytes is not None:
+                                if (
+                                    isinstance(output_bytes, bool)
+                                    or not isinstance(output_bytes, int)
+                                    or output_bytes < 0
+                                ):
+                                    record.update(status="failed", reason="invalid output byte measurement")
+                                else:
+                                    record.update(output_bytes=output_bytes, bytes_source="storage_telemetry")
+                    except Exception as exc:
+                        record.update(status="failed", reason=f"{type(exc).__name__}: {exc}")
+                    if iteration >= 0 or record["status"] != "ok":
+                        records.append(record)
+                    if record["status"] != "ok":
+                        break
+    return records
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project", required=True)
+    parser.add_argument("--endpoint", required=True, help="Explicit BigQuery API endpoint; no implicit cloud target")
+    parser.add_argument("--destination", required=True, help="Output prefix; artifacts are retained")
+    parser.add_argument("--sizes", nargs="+", type=int, default=[100, 1000, 10000])
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--repetitions", type=int, default=3)
+    args = parser.parse_args(argv)
+    local = urlparse(args.endpoint).hostname in {"localhost", "127.0.0.1", "::1"}
+
+    @contextmanager
+    def factory(native: bool) -> Iterator[BigQueryDriver]:
+        with Client(
+            project=args.project,
+            client_options={"api_endpoint": args.endpoint},
+            credentials=AnonymousCredentials() if local else None,
+        ) as client:
+            yield BigQueryDriver(
+                client,
+                driver_features={
+                    "enable_native_storage": native,
+                    "storage_capabilities": {"arrow_export_enabled": True},
+                },
+            )
+
+    records = run_benchmark(
+        factory,
+        destination=args.destination,
+        environment="local-emulator" if local else "explicit-provider",
+        sizes=args.sizes,
+        warmup=args.warmup,
+        repetitions=args.repetitions,
+    )
+    json.dump(records, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return int(any(record["status"] == "failed" for record in records))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
BigQuery can export query results directly to eligible object-storage destinations through `select_to_storage()`, preserving bound parameters and job controls. Native exports return the actual wildcard destination; configured S3/Azure connections are supported, and `enable_native_storage=False` retains the client writer.

Adds focused SDK/emulator regressions, an explicit export benchmark, local ingest characterization, and adapter documentation. Targeted tests and lint pass. Real cloud export/readback and performance remain unverified; local emulator results are identified separately.
