### PR TITLE
fix(litestar): run correlation middleware before user middleware

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,12 @@ Unreleased
 
 **Fixed:**
 
+* The Litestar plugin registers its correlation and SQLCommenter middleware at the
+  outermost position of the middleware stack instead of the innermost one. Requests
+  rejected by application middleware such as authentication or session handling now carry
+  a correlation ID in logs and error hooks, and application middleware keeps its original
+  relative order. (`#729 <https://github.com/litestar-org/sqlspec/issues/729>`_)
+
 * ``Select.group_by()`` accepts the ``sql.rollup()``, ``sql.cube()``, and
   ``sql.grouping_sets()`` factory expressions directly. The factory helpers and
   the ``group_by_rollup()``, ``group_by_cube()``, and

--- a/docs/usage/observability.rst
+++ b/docs/usage/observability.rst
@@ -123,7 +123,11 @@ The ``db_driver`` attribute is set automatically from the adapter's dialect (e.g
 
 All framework extensions automatically register SQLCommenter middleware that populates
 request-scoped attributes (``route``, ``action``, ``framework``, and ``controller`` for
-Litestar). To include these in the SQL comments, enable ``sqlcommenter_enable_context``:
+Litestar). The Litestar plugin installs its SQLCommenter and correlation middleware at the
+outermost position of the middleware stack, ahead of any middleware the application itself
+registers, so a correlation ID is available even for requests that authentication or
+session middleware rejects. To include these in the SQL comments, enable
+``sqlcommenter_enable_context``:
 
 .. code-block:: python
 

--- a/sqlspec/extensions/litestar/plugin.py
+++ b/sqlspec/extensions/litestar/plugin.py
@@ -399,7 +399,7 @@ class SQLSpecPlugin(InitPluginProtocol, CLIPlugin):
         if self._enable_sqlcommenter_middleware:
             new_middlewares.append(DefineMiddleware(SQLCommenterMiddleware))
         if new_middlewares:
-            app_config.middleware = [*(app_config.middleware or []), *new_middlewares]
+            app_config.middleware = [*new_middlewares, *(app_config.middleware or [])]
 
         log_with_context(
             logger,

--- a/tests/integration/extensions/litestar/test_correlation_middleware.py
+++ b/tests/integration/extensions/litestar/test_correlation_middleware.py
@@ -1,7 +1,9 @@
 from typing import Any, cast
 
 from litestar import Litestar, get
+from litestar.middleware import DefineMiddleware
 from litestar.testing import TestClient
+from litestar.types import ASGIApp, Receive, Scope, Send
 
 from sqlspec import SQLSpec
 from sqlspec.adapters.sqlite import SqliteConfig
@@ -45,6 +47,67 @@ def _build_app(
     spec.add_config(SqliteConfig(connection_config={"database": ":memory:"}, extension_config=extension_config))
 
     return Litestar(route_handlers=[correlation_handler], plugins=[SQLSpecPlugin(sqlspec=spec)])
+
+
+class _RejectingMiddleware:
+    """ASGI middleware that records the correlation ID and answers with 401.
+
+    Stands in for application auth or session middleware that refuses a request
+    before it reaches the route handler.
+    """
+
+    __slots__ = ("app", "recorder")
+
+    def __init__(self, app: "ASGIApp", *, recorder: "list[str | None]") -> None:
+        self.app = app
+        self.recorder = recorder
+
+    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+        if str(scope.get("type")) != "http":
+            await self.app(scope, receive, send)
+            return
+
+        self.recorder.append(CorrelationContext.get())
+        await send({"type": "http.response.start", "status": 401, "headers": [(b"content-length", b"0")]})
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+
+def _build_rejecting_app(recorder: "list[str | None]", *, enable: bool = True) -> Litestar:
+    extension_config = cast(
+        "ExtensionConfigs",
+        {"litestar": {"enable_correlation_middleware": enable, "correlation_headers": ["x-correlation-id"]}},
+    )
+
+    spec = SQLSpec()
+    spec.add_config(SqliteConfig(connection_config={"database": ":memory:"}, extension_config=extension_config))
+
+    return Litestar(
+        route_handlers=[correlation_handler],
+        plugins=[SQLSpecPlugin(sqlspec=spec)],
+        middleware=[DefineMiddleware(_RejectingMiddleware, recorder=recorder)],
+    )
+
+
+def test_correlation_middleware_runs_before_rejecting_application_middleware() -> None:
+    recorder: list[str | None] = []
+    app = _build_rejecting_app(recorder)
+
+    with TestClient(app) as client:
+        response = client.get("/correlation", headers={"X-Correlation-ID": "abc"})
+
+    assert response.status_code == 401
+    assert recorder == ["abc"]
+
+
+def test_rejected_request_has_no_correlation_id_when_middleware_disabled() -> None:
+    recorder: list[str | None] = []
+    app = _build_rejecting_app(recorder, enable=False)
+
+    with TestClient(app) as client:
+        response = client.get("/correlation", headers={"X-Correlation-ID": "abc"})
+
+    assert response.status_code == 401
+    assert recorder == [None]
 
 
 def test_correlation_middleware_uses_default_header() -> None:

--- a/tests/unit/extensions/test_litestar/test_plugin_ordering.py
+++ b/tests/unit/extensions/test_litestar/test_plugin_ordering.py
@@ -124,25 +124,25 @@ def _middleware_types(app_config: AppConfig) -> list[type[object]]:
     ]
 
 
-def test_on_app_init_middleware_on_app_init_appends_both_middlewares_when_enabled() -> None:
+def test_on_app_init_middleware_on_app_init_installs_both_middlewares_when_enabled() -> None:
     app_config = AppConfig()
     _build_plugin(correlation=True, sqlcommenter=True).on_app_init(app_config)
-    assert _middleware_types(app_config)[-2:] == [CorrelationMiddleware, SQLCommenterMiddleware]
+    assert _middleware_types(app_config)[:2] == [CorrelationMiddleware, SQLCommenterMiddleware]
 
 
-def test_on_app_init_middleware_on_app_init_appends_only_correlation_middleware() -> None:
+def test_on_app_init_middleware_on_app_init_installs_only_correlation_middleware() -> None:
     app_config = AppConfig()
     _build_plugin(correlation=True, sqlcommenter=False).on_app_init(app_config)
     assert _middleware_types(app_config) == [CorrelationMiddleware]
 
 
-def test_on_app_init_middleware_on_app_init_appends_only_sqlcommenter_middleware() -> None:
+def test_on_app_init_middleware_on_app_init_installs_only_sqlcommenter_middleware() -> None:
     app_config = AppConfig()
     _build_plugin(correlation=False, sqlcommenter=True).on_app_init(app_config)
     assert _middleware_types(app_config) == [SQLCommenterMiddleware]
 
 
-def test_on_app_init_middleware_on_app_init_appends_no_observability_middlewares_when_disabled() -> None:
+def test_on_app_init_middleware_on_app_init_installs_no_observability_middlewares_when_disabled() -> None:
     app_config = AppConfig()
     _build_plugin(correlation=False, sqlcommenter=False).on_app_init(app_config)
     assert app_config.middleware == []
@@ -152,5 +152,5 @@ def test_on_app_init_middleware_on_app_init_preserves_existing_middlewares() -> 
     existing = DefineMiddleware(_ExistingMiddleware)
     app_config = AppConfig(middleware=[existing])
     _build_plugin(correlation=True, sqlcommenter=True).on_app_init(app_config)
-    assert app_config.middleware[0] is existing
-    assert _middleware_types(app_config)[1:] == [CorrelationMiddleware, SQLCommenterMiddleware]
+    assert _middleware_types(app_config)[:2] == [CorrelationMiddleware, SQLCommenterMiddleware]
+    assert app_config.middleware[-1] is existing


### PR DESCRIPTION
The Litestar plugin added its correlation and SQLCommenter middleware to the **end** of the application middleware list, which makes them the innermost layers. Any auth, session, or rate-limit middleware the application registered ran first and could reject a request before a correlation id existed — so access logs and error hooks for exactly the requests you most want to trace had no id. The plugin now installs its middleware at the front, so it wraps everything else.

- **Rejected requests keep their correlation id.** A 401 from your own middleware is now logged with the same id as any other request.
- **Your middleware order is untouched.** Existing entries keep their original relative order, just behind the plugin's.
- **One-line change, no behavior rewrite.** Neither `CorrelationMiddleware` nor `SQLCommenterMiddleware` changed; ordering between those two never mattered, since the SQLCommenter never reads the correlation context.
- **Other integrations were already correct.** Starlette and FastAPI use `add_middleware`, which already inserts at the outer position; Flask and Sanic use request hooks.

## How you use it

Nothing to configure — registering `SQLSpecPlugin` is enough. Middleware you pass to `Litestar(middleware=[...])` now runs *inside* the correlation middleware:

```python
app = Litestar(
    route_handlers=[handler],
    middleware=[DefineMiddleware(AuthMiddleware)],  # runs after correlation is set
    plugins=[SQLSpecPlugin(sqlspec=spec)],
)
```

A request `AuthMiddleware` refuses with 401 now reaches your `before_send` and logging hooks with a correlation id already in context.

Fixes #729