### PR TITLE
fix(migrations): record migrations that return no statements

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,12 @@ Unreleased
 
 **Fixed:**
 
+* A migration whose ``up()`` returns an empty list is now recorded in the
+  tracking table instead of being reported as applied and then staying pending
+  forever (`#748 <https://github.com/litestar-org/sqlspec/issues/748>`_). An
+  empty list is the supported no-op for conditional migrations; omitting
+  ``down()`` still marks a migration irreversible.
+
 * ``Select.group_by()`` accepts the ``sql.rollup()``, ``sql.cube()``, and
   ``sql.grouping_sets()`` factory expressions directly. The factory helpers and
   the ``group_by_rollup()``, ``group_by_cube()``, and

--- a/docs/usage/migrations.rst
+++ b/docs/usage/migrations.rst
@@ -377,6 +377,32 @@ description is read back from, and takes a string or a list of strings.
 
 See :class:`~sqlspec.config.MigrationTemplates` for the full override shape.
 
+Return Values in Python Migrations
+----------------------------------
+
+``up()`` and ``down()`` return either a string or an iterable of strings. Each
+statement is executed in order, and blank or whitespace-only statements are
+skipped. Returning anything else raises
+:class:`~sqlspec.migrations.MigrationLoadError`.
+
+Returning an empty list executes nothing, but the migration is still recorded
+in the tracking table and is not reported as pending again. This is the
+supported way to write a conditional migration that inspects the database and
+finds nothing to do:
+
+.. code-block:: python
+
+    def up(context: object | None = None) -> list[str]:
+        """Add the audit column only where it is missing."""
+        if _has_audit_column(context):
+            return []
+        return ["ALTER TABLE orders ADD COLUMN audited_at TIMESTAMP"]
+
+The same holds for ``down()``: an empty list reverses nothing and removes the
+tracking record. Omitting ``down()`` entirely is different -- it marks the
+migration irreversible, and a downgrade skips it with a warning rather than
+removing its record.
+
 Output and Logging
 ------------------
 

--- a/sqlspec/migrations/loaders.py
+++ b/sqlspec/migrations/loaders.py
@@ -47,15 +47,15 @@ class BaseMigrationLoader:
         ...
 
     @abc.abstractmethod
-    async def get_down_sql(self, path: Path) -> list[str]:
+    async def get_down_sql(self, path: Path) -> "list[str] | None":
         """Load and return the 'down' SQL statements from a migration file.
 
         Args:
             path: Path to the migration file.
 
         Returns:
-            List of SQL statements to execute for downgrade.
-            Empty list if no downgrade is available.
+            List of SQL statements to execute for downgrade, which may be empty.
+            None if the migration has no downgrade direction.
 
         Raises:
             MigrationLoadError: If loading fails.
@@ -115,7 +115,7 @@ class SQLFileLoader(BaseMigrationLoader):
         sql_obj = self.sql_loader.get_sql(up_query)
         return [sql_obj.raw_sql]
 
-    async def get_down_sql(self, path: Path) -> list[str]:
+    async def get_down_sql(self, path: Path) -> "list[str] | None":
         """Extract the 'down' SQL from a SQL migration file.
 
         The SQL file must already be loaded via validate_migration_file()
@@ -126,13 +126,14 @@ class SQLFileLoader(BaseMigrationLoader):
             path: Path to SQL migration file.
 
         Returns:
-            List containing single SQL statement for downgrade, or empty list.
+            List containing single SQL statement for downgrade, or None when the
+            file has no down block.
         """
         version = self._extract_version(path.name)
         down_query = f"migrate-{version}-down"
 
         if not self.sql_loader.has_query(down_query):
-            return []
+            return None
 
         sql_obj = self.sql_loader.get_sql(down_query)
         return [sql_obj.raw_sql]
@@ -241,14 +242,15 @@ class PythonFileLoader(BaseMigrationLoader):
 
             return self._normalize_and_validate_sql(sql_result, path)
 
-    async def get_down_sql(self, path: Path) -> list[str]:
+    async def get_down_sql(self, path: Path) -> "list[str] | None":
         """Load Python migration and execute downgrade function.
 
         Args:
             path: Path to Python migration file.
 
         Returns:
-            List of SQL statements for downgrade, or empty list if not available.
+            List of SQL statements for downgrade, which may be empty. None when the
+            module defines no downgrade function.
         """
         with self._temporary_project_path():
             module = self._load_module_from_path(path)
@@ -258,7 +260,7 @@ class PythonFileLoader(BaseMigrationLoader):
                 downgrade_func = _get_callable_attr(module, "migrate_down")
 
             if downgrade_func is None:
-                return []
+                return None
 
             if isinstance(self.context, MigrationContext):
                 self.context.validate_async_usage(downgrade_func)
@@ -450,10 +452,10 @@ def _get_callable_attr(module: types.ModuleType, name: str) -> "Callable[..., An
     return None
 
 
-def _load_migration_sql(loader: BaseMigrationLoader, path: Path, direction: str) -> list[str]:
+def _load_migration_sql(loader: BaseMigrationLoader, path: Path, direction: str) -> "list[str] | None":
     """Bridge the async loader contract for synchronous migration consumers."""
     method = loader.get_up_sql if direction == "up" else loader.get_down_sql
     if inspect.iscoroutinefunction(method):
         return await_(method, raise_sync_error=False)(path)
-    sync_method = cast("Callable[[Path], list[str]]", method)
+    sync_method = cast("Callable[[Path], list[str] | None]", method)
     return sync_method(path)

--- a/sqlspec/migrations/runner.py
+++ b/sqlspec/migrations/runner.py
@@ -614,10 +614,13 @@ class BaseMigrationRunner:
         raise ValueError(msg) from error
 
     def _finalize_migration_sql(self, sql_statements: Any) -> "list[str] | None":
-        """Normalize loader output into a SQL statement list or None."""
-        if sql_statements:
-            return cast("list[str]", sql_statements)
-        return None
+        """Normalize loader output into a SQL statement list, or None when absent.
+
+        An empty list is preserved as a no-op the caller still records.
+        """
+        if sql_statements is None:
+            return None
+        return cast("list[str]", sql_statements)
 
     def _migration_sql_loader(self, file_path: Path, version: "str | None") -> SQLFileLoader:
         """Return the isolated core SQL loader for an extension migration."""
@@ -668,12 +671,12 @@ class SyncMigrationRunner(BaseMigrationRunner):
 
         if file_path.suffix == ".sql":
             partial = cast("LoadedMigrationMetadata", {"loader": loader, "file_path": file_path})
-            has_upgrade = bool(self._migration_sql(partial, "up"))
-            has_downgrade = bool(self._migration_sql(partial, "down"))
+            has_upgrade = self._migration_sql(partial, "up") is not None
+            has_downgrade = self._migration_sql(partial, "down") is not None
         else:
             try:
                 partial = cast("LoadedMigrationMetadata", {"loader": loader, "file_path": file_path})
-                has_downgrade = bool(self._migration_sql(partial, "down"))
+                has_downgrade = self._migration_sql(partial, "down") is not None
             except Exception:
                 has_downgrade = False
 
@@ -912,12 +915,12 @@ class AsyncMigrationRunner(BaseMigrationRunner):
 
         if file_path.suffix == ".sql":
             partial = cast("LoadedMigrationMetadata", {"loader": loader, "file_path": file_path})
-            has_upgrade = bool(await self._migration_sql(partial, "up"))
-            has_downgrade = bool(await self._migration_sql(partial, "down"))
+            has_upgrade = (await self._migration_sql(partial, "up")) is not None
+            has_downgrade = (await self._migration_sql(partial, "down")) is not None
         else:
             try:
                 partial = cast("LoadedMigrationMetadata", {"loader": loader, "file_path": file_path})
-                has_downgrade = bool(await self._migration_sql(partial, "down"))
+                has_downgrade = (await self._migration_sql(partial, "down")) is not None
             except Exception:
                 has_downgrade = False
 

--- a/tests/integration/migrations/test_async_migrations.py
+++ b/tests/integration/migrations/test_async_migrations.py
@@ -63,6 +63,7 @@ async def down(context):
         assert "CREATE TABLE users" in up_sql[0]
 
         down_sql = await loader.get_down_sql(migration_file)
+        assert down_sql is not None
         assert len(down_sql) == 1
         assert "DROP TABLE users" in down_sql[0]
 

--- a/tests/unit/migrations/test_migration.py
+++ b/tests/unit/migrations/test_migration.py
@@ -698,4 +698,4 @@ def test_migration_sql_empty_statements() -> None:
     }
 
     result = runner._migration_sql(cast("LoadedMigrationMetadata", migration), "up")
-    assert result is None
+    assert result == []

--- a/tests/unit/migrations/test_migration_execution.py
+++ b/tests/unit/migrations/test_migration_execution.py
@@ -600,3 +600,62 @@ CREATE TABLE second (id INTEGER);
 
     versions = [version for version, _ in files]
     assert versions.count("0001") == 2
+
+
+def test_upgrade_records_migration_returning_no_statements(temp_workspace_with_migrations: Path) -> None:
+    """A migration whose up() returns no statements is recorded and never re-applied."""
+    from sqlspec.adapters.sqlite.config import SqliteConfig
+    from sqlspec.migrations.commands import SyncMigrationCommands
+
+    migrations_dir = temp_workspace_with_migrations / "migrations"
+    (migrations_dir / "0001_create_table.py").write_text(
+        '''"""Create the example table."""
+
+
+def up() -> list[str]:
+    return ["CREATE TABLE example (id INTEGER)"]
+
+
+def down() -> list[str]:
+    return ["DROP TABLE example"]
+'''
+    )
+    (migrations_dir / "0002_conditional_noop.py").write_text(
+        '''"""Conditional migration with nothing to do."""
+
+
+def up() -> list[str]:
+    return []
+
+
+def down() -> list[str]:
+    return []
+'''
+    )
+
+    config = SqliteConfig(
+        connection_config={"database": ":memory:"}, migration_config={"script_location": str(migrations_dir)}
+    )
+    commands = SyncMigrationCommands(config)
+    commands.tracker = MockMigrationTracker()
+
+    commands.upgrade()
+
+    with config.provide_session() as driver:
+        applied = {record["version_num"] for record in commands.tracker.get_applied_migrations(driver)}
+    assert applied == {"0001", "0002"}
+
+    commands.upgrade()
+
+    with config.provide_session() as driver:
+        all_migrations = commands.runner.get_migration_files()
+        applied_after = {record["version_num"] for record in commands.tracker.get_applied_migrations(driver)}
+        pending = commands._collect_pending_migrations(all_migrations, applied_after, "head")
+    assert applied_after == {"0001", "0002"}
+    assert pending == []
+
+    commands.downgrade("0001")
+
+    with config.provide_session() as driver:
+        remaining = {record["version_num"] for record in commands.tracker.get_applied_migrations(driver)}
+    assert remaining == {"0001"}

--- a/tests/unit/migrations/test_migration_runner.py
+++ b/tests/unit/migrations/test_migration_runner.py
@@ -915,7 +915,7 @@ def test_migration_sql_empty_statements() -> None:
 
     result = runner._migration_sql(cast("LoadedMigrationMetadata", migration), "up")
 
-    assert result is None
+    assert result == []
 
 
 def test_migration_sql_none_statements() -> None:
@@ -1235,6 +1235,7 @@ DROP TABLE test_table;
         file_count_after_down = len(sql_loader.sql_loader._files)
 
         assert file_count_before_down == file_count_after_down, "get_down_sql() should not load additional files"
+        assert down_sql is not None
         assert len(down_sql) == 1
         assert "DROP TABLE test_table" in down_sql[0]
 
@@ -1328,3 +1329,207 @@ def test_migration_context_resolves_multi_underscore_extension_settings(tmp_path
 
     assert context is not None
     assert context.extension_config == settings
+
+
+class _EmptyMigrationLoader:
+    async def get_up_sql(self, _file_path: Path) -> list[str]:
+        return []
+
+    async def get_down_sql(self, _file_path: Path) -> list[str]:
+        return []
+
+
+def _write_python_migration(path: Path, body: str) -> None:
+    path.write_text(body.strip() + "\n")
+
+
+def test_finalize_migration_sql_distinguishes_absent_from_empty(tmp_path: Path) -> None:
+    """None means the direction is absent; an empty list is a real no-op."""
+    runner = _sync_runner(tmp_path, {})
+
+    assert runner._finalize_migration_sql(None) is None
+    assert runner._finalize_migration_sql([]) == []
+    assert runner._finalize_migration_sql(["SELECT 1"]) == ["SELECT 1"]
+
+
+def test_sync_execute_upgrade_records_empty_statement_list(tmp_path: Path) -> None:
+    """An upgrade returning no statements still reports success so it can be recorded."""
+    migration_file = tmp_path / "0001_noop.sql"
+    _write_basic_sql(migration_file, "0001")
+    runner = _sync_runner(tmp_path, {})
+    driver = Mock()
+    on_success = Mock()
+
+    _, execution_time = runner.execute_upgrade(
+        driver, _migration(migration_file, _EmptyMigrationLoader()), use_transaction=True, on_success=on_success
+    )
+
+    driver.execute_script.assert_not_called()
+    on_success.assert_called_once()
+    recorded_time = on_success.call_args.args[0]
+    assert isinstance(recorded_time, int)
+    assert recorded_time >= 0
+    assert execution_time >= 0
+
+
+def test_sync_execute_downgrade_records_empty_statement_list(tmp_path: Path) -> None:
+    """A present-but-empty downgrade still fires the tracking callback."""
+    migration_file = tmp_path / "0001_noop.sql"
+    _write_basic_sql(migration_file, "0001")
+    runner = _sync_runner(tmp_path, {})
+    driver = Mock()
+    on_success = Mock()
+
+    _, execution_time = runner.execute_downgrade(
+        driver, _migration(migration_file, _EmptyMigrationLoader()), use_transaction=True, on_success=on_success
+    )
+
+    driver.execute_script.assert_not_called()
+    on_success.assert_called_once()
+    assert on_success.call_args.args[0] >= 0
+    assert execution_time >= 0
+
+
+def test_sync_execute_downgrade_skips_absent_direction(tmp_path: Path) -> None:
+    """A migration flagged without a downgrade must not be treated as a no-op."""
+    migration_file = tmp_path / "0001_noop.sql"
+    _write_basic_sql(migration_file, "0001")
+    runner = _sync_runner(tmp_path, {})
+    driver = Mock()
+    on_success = Mock()
+    migration = _migration(migration_file, _EmptyMigrationLoader())
+    migration["has_downgrade"] = False
+
+    result = runner.execute_downgrade(driver, migration, use_transaction=True, on_success=on_success)
+
+    assert result == (None, 0)
+    on_success.assert_not_called()
+    driver.execute_script.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_async_execute_upgrade_records_empty_statement_list(tmp_path: Path) -> None:
+    """Async upgrades returning no statements still report success."""
+    migration_file = tmp_path / "0001_noop.sql"
+    _write_basic_sql(migration_file, "0001")
+    runner = _async_runner(tmp_path, {})
+    driver = AsyncMock()
+    on_success = AsyncMock()
+
+    _, execution_time = await runner.execute_upgrade(
+        driver, _migration(migration_file, _EmptyMigrationLoader()), use_transaction=True, on_success=on_success
+    )
+
+    driver.execute_script.assert_not_called()
+    on_success.assert_awaited_once()
+    assert on_success.call_args.args[0] >= 0
+    assert execution_time >= 0
+
+
+@pytest.mark.anyio
+async def test_async_execute_downgrade_records_empty_statement_list(tmp_path: Path) -> None:
+    """Async present-but-empty downgrades still fire the tracking callback."""
+    migration_file = tmp_path / "0001_noop.sql"
+    _write_basic_sql(migration_file, "0001")
+    runner = _async_runner(tmp_path, {})
+    driver = AsyncMock()
+    on_success = AsyncMock()
+
+    _, execution_time = await runner.execute_downgrade(
+        driver, _migration(migration_file, _EmptyMigrationLoader()), use_transaction=True, on_success=on_success
+    )
+
+    driver.execute_script.assert_not_called()
+    on_success.assert_awaited_once()
+    assert on_success.call_args.args[0] >= 0
+    assert execution_time >= 0
+
+
+@pytest.mark.anyio
+async def test_async_execute_downgrade_skips_absent_direction(tmp_path: Path) -> None:
+    """Async downgrades on a flagged-absent direction return the missing sentinel."""
+    migration_file = tmp_path / "0001_noop.sql"
+    _write_basic_sql(migration_file, "0001")
+    runner = _async_runner(tmp_path, {})
+    driver = AsyncMock()
+    on_success = AsyncMock()
+    migration = _migration(migration_file, _EmptyMigrationLoader())
+    migration["has_downgrade"] = False
+
+    result = await runner.execute_downgrade(driver, migration, use_transaction=True, on_success=on_success)
+
+    assert result == (None, 0)
+    on_success.assert_not_awaited()
+    driver.execute_script.assert_not_called()
+
+
+def test_load_migration_flags_empty_python_downgrade_as_present(tmp_path: Path) -> None:
+    """A Python down() returning an empty list is a reversible no-op."""
+    migration_file = tmp_path / "0001_empty_down.py"
+    _write_python_migration(
+        migration_file,
+        """
+def up() -> list[str]:
+    return ["CREATE TABLE example (id INTEGER)"]
+
+
+def down() -> list[str]:
+    return []
+""",
+    )
+    runner = _sync_runner(tmp_path, {})
+
+    migration = runner.load_migration(migration_file)
+
+    assert migration["has_downgrade"] is True
+
+
+def test_load_migration_flags_missing_python_downgrade_as_absent(tmp_path: Path) -> None:
+    """A Python migration without down() stays irreversible."""
+    migration_file = tmp_path / "0001_no_down.py"
+    _write_python_migration(
+        migration_file,
+        """
+def up() -> list[str]:
+    return ["CREATE TABLE example (id INTEGER)"]
+""",
+    )
+    runner = _sync_runner(tmp_path, {})
+
+    migration = runner.load_migration(migration_file)
+
+    assert migration["has_downgrade"] is False
+
+
+def test_load_migration_flags_missing_sql_downgrade_as_absent(tmp_path: Path) -> None:
+    """A SQL migration without a down block stays irreversible."""
+    migration_file = tmp_path / "0001_up_only.sql"
+    migration_file.write_text("-- name: migrate-0001-up\nSELECT 1;\n")
+    runner = _sync_runner(tmp_path, {})
+
+    migration = runner.load_migration(migration_file)
+
+    assert migration["has_upgrade"] is True
+    assert migration["has_downgrade"] is False
+
+
+@pytest.mark.anyio
+async def test_async_load_migration_flags_empty_python_downgrade_as_present(tmp_path: Path) -> None:
+    """The async runner agrees that an empty down() is a present direction."""
+    migration_file = tmp_path / "0001_empty_down.py"
+    _write_python_migration(
+        migration_file,
+        """
+def up() -> list[str]:
+    return ["CREATE TABLE example (id INTEGER)"]
+
+
+def down() -> list[str]:
+    return []
+""",
+    )
+    runner = _async_runner(tmp_path, {})
+
+    migration = await runner.load_migration(migration_file)
+
+    assert migration["has_downgrade"] is True


### PR DESCRIPTION
A migration whose `up()` returned an empty list executed nothing and was never written to the version table, so the CLI reported `✓ Applied` while the migration stayed pending on every subsequent run — forever. The same defect left a tracking row in place when `down()` returned an empty list. An absent direction and an empty one had collapsed into the same `None`; they are now distinct.

- **Empty means "nothing to do", and it is recorded.** An empty statement list runs no statements but still fires the success callback, so the version is written on upgrade and removed on downgrade.
- **Absent still means irreversible.** Loaders return `None` when a migration has no down direction at all, and a list — possibly empty — when it does.
- **`has_downgrade` reflects presence, not output.** It previously tested whether the direction produced any SQL, which is why a conditional no-op `down()` looked like no `down()` at all.
- **One widened signature.** `get_down_sql` now returns `list[str] | None`. This is the mechanism the issue itself proposes, and it is the only signature change.
- **`.sql` migrations are unaffected.** An empty `-- migrate-XXXX-up` block behaves exactly as before.

## How you use it

A conditional migration that decides at runtime it has nothing to do can now simply return an empty list, and it will be recorded as applied:

```python
def up() -> list[str]:
    if already_migrated():
        return []          # recorded, reported once, never pending again
    return ["ALTER TABLE ..."]
```

Omitting `down()` entirely still marks the migration irreversible — that is the distinction the fix preserves.

Fixes #748