### PR TITLE
fix(migrations): allow interpreted tracker subclasses under mypyc

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -132,7 +132,7 @@ jobs:
           # hatchling versions track the locked dev environment.
           CIBW_BEFORE_BUILD: "pip install -c {project}/build-constraints.txt hatch-mypyc hatchling"
 
-          CIBW_TEST_REQUIRES: "aiosqlite cloud-sql-python-connector google-cloud-alloydb-connector"
+          CIBW_TEST_REQUIRES: "aiosqlite pymssql cloud-sql-python-connector google-cloud-alloydb-connector"
           CIBW_TEST_COMMAND: >-
             python {project}/tools/scripts/mypyc_smoke.py --require-compiled
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -311,7 +311,7 @@ jobs:
 
           CIBW_BEFORE_BUILD: "pip install -c {project}/build-constraints.txt hatch-mypyc hatchling"
 
-          CIBW_TEST_REQUIRES: "aiosqlite cloud-sql-python-connector google-cloud-alloydb-connector"
+          CIBW_TEST_REQUIRES: "aiosqlite pymssql cloud-sql-python-connector google-cloud-alloydb-connector"
           CIBW_TEST_COMMAND: >-
             python {project}/tools/scripts/mypyc_smoke.py --require-compiled
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,6 +30,12 @@ Unreleased
   configuration, including ``session_table=True``, through the same type as
   ``sqlspec.config.LitestarConfig``.
 
+* ``PymssqlConfig`` and ``MssqlPythonConfig`` construct again when SQLSpec is
+  installed from a compiled wheel. Both raised
+  ``TypeError: interpreted classes cannot inherit from compiled`` while setting
+  up their migration tracker.
+  (`#747 <https://github.com/litestar-org/sqlspec/issues/747>`_)
+
 **Removed:**
 
 * Removed the undocumented ``sqlspec.exceptions.wrap_exceptions`` helper,

--- a/sqlspec/migrations/tracker.py
+++ b/sqlspec/migrations/tracker.py
@@ -7,6 +7,7 @@ import logging
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, cast
 
+from mypy_extensions import mypyc_attr
 from rich.console import Console
 
 from sqlspec.migrations.base import BaseMigrationTracker
@@ -24,6 +25,7 @@ logger = get_logger("sqlspec.migrations.tracker")
 _console = Console()
 
 
+@mypyc_attr(allow_interpreted_subclasses=True)
 class SyncMigrationTracker(BaseMigrationTracker["SyncDriverAdapterBase"]):
     """Synchronous migration version tracker."""
 
@@ -245,6 +247,7 @@ class SyncMigrationTracker(BaseMigrationTracker["SyncDriverAdapterBase"]):
                 raise
 
 
+@mypyc_attr(allow_interpreted_subclasses=True)
 class AsyncMigrationTracker(BaseMigrationTracker["AsyncDriverAdapterBase"]):
     """Asynchronous migration version tracker."""
 

--- a/tests/unit/adapters/test_pymssql/test_migrations.py
+++ b/tests/unit/adapters/test_pymssql/test_migrations.py
@@ -1,0 +1,48 @@
+"""Unit tests for the pymssql migration tracker."""
+
+from typing import Any, cast
+
+from sqlspec.adapters.pymssql.config import PymssqlConfig
+from sqlspec.adapters.pymssql.migrations import PymssqlSyncMigrationTracker, _split_schema_table
+
+
+class FakeSyncMigrationDriver:
+    """Minimal sync driver for migration tracker tests."""
+
+    def __init__(self) -> None:
+        self.scripts: list[str] = []
+        self.commits = 0
+
+    def execute_script(self, statement: str) -> None:
+        self.scripts.append(statement)
+
+    def select(self, _statement: Any, **_kwargs: Any) -> list[dict[str, str]]:
+        return [{"column_name": "version_num"}, {"column_name": "version_type"}]
+
+    def commit(self) -> None:
+        self.commits += 1
+
+
+def test_sync_tracker_uses_tsql_idempotent_create_table() -> None:
+    """The sync tracker should create the version table with T-SQL-safe DDL."""
+    driver = FakeSyncMigrationDriver()
+    tracker = PymssqlSyncMigrationTracker(version_table_name="__migrations_test")
+
+    tracker.ensure_tracking_table(cast("Any", driver))
+
+    ddl = "\n".join(driver.scripts)
+    assert "IF NOT EXISTS (SELECT 1 FROM sys.tables" in ddl
+    assert "SCHEMA_ID('dbo')" in ddl
+    assert "NVARCHAR(32)" in ddl
+    assert "DATETIME2(6)" in ddl
+    assert "TIMESTAMP" not in ddl
+    assert driver.commits >= 1
+
+
+def test_pymssql_configs_use_tsql_migration_trackers() -> None:
+    """The sync config should use the MSSQL migration tracker type."""
+    assert PymssqlConfig.migration_tracker_type is PymssqlSyncMigrationTracker
+
+
+def test_split_schema_table_preserves_bracket_quoted_dots() -> None:
+    assert _split_schema_table("[dbo.schema].[migration.table]") == ("dbo.schema", "migration.table")

--- a/tests/unit/utils/test_mypyc_smoke.py
+++ b/tests/unit/utils/test_mypyc_smoke.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from types import ModuleType
 
+import pytest
 from pytest import MonkeyPatch
 
 try:
@@ -250,3 +251,35 @@ def test_smoke_runner_skips_missing_optional_parent_package(monkeypatch: MonkeyP
     assert results[0]["error"] is None
     assert results[0]["skip_reason"] == "optional dependency missing: google.adk"
     assert module._failed_results(results) == []
+
+
+def test_adapter_discovery_reports_missing_optional_driver(monkeypatch: MonkeyPatch) -> None:
+    module = _load_mypyc_smoke_module()
+    original_import = importlib.import_module
+
+    def import_without_adbc(name: str) -> ModuleType:
+        if name == "sqlspec.adapters.adbc.config":
+            raise ModuleNotFoundError("No module named 'adbc_driver_manager'", name="adbc_driver_manager")
+        return original_import(name)
+
+    monkeypatch.setattr(module.importlib, "import_module", import_without_adbc)
+    result = module._check_adapter_config_construction()
+    assert result["error"] is None
+    assert result["skipped_adapters"] == [
+        "sqlspec.adapters.adbc.config: optional dependency missing: adbc_driver_manager"
+    ]
+    assert "- SKIP sqlspec.adapters.adbc.config" in module._format_text([result])
+
+
+def test_adapter_discovery_does_not_hide_internal_import_errors(monkeypatch: MonkeyPatch) -> None:
+    module = _load_mypyc_smoke_module()
+    original_import = importlib.import_module
+
+    def import_broken_adapter(name: str) -> ModuleType:
+        if name == "sqlspec.adapters.adbc.config":
+            raise ModuleNotFoundError("broken internal import", name="sqlspec.missing")
+        return original_import(name)
+
+    monkeypatch.setattr(module.importlib, "import_module", import_broken_adapter)
+    with pytest.raises(ModuleNotFoundError, match="broken internal import"):
+        module._discover_adapter_config_classes(skipped=[])

--- a/tests/unit/utils/test_mypyc_smoke.py
+++ b/tests/unit/utils/test_mypyc_smoke.py
@@ -253,22 +253,25 @@ def test_smoke_runner_skips_missing_optional_parent_package(monkeypatch: MonkeyP
     assert module._failed_results(results) == []
 
 
-def test_adapter_discovery_reports_missing_optional_driver(monkeypatch: MonkeyPatch) -> None:
+@pytest.mark.parametrize("adapter, dependency", [("adbc", "adbc_driver_manager"), ("aiosqlite", "aiosqlite")])
+def test_adapter_discovery_reports_missing_optional_driver(
+    monkeypatch: MonkeyPatch, adapter: str, dependency: str
+) -> None:
     module = _load_mypyc_smoke_module()
     original_import = importlib.import_module
 
-    def import_without_adbc(name: str) -> ModuleType:
-        if name == "sqlspec.adapters.adbc.config":
-            raise ModuleNotFoundError("No module named 'adbc_driver_manager'", name="adbc_driver_manager")
+    def import_without_driver(name: str) -> ModuleType:
+        if name == f"sqlspec.adapters.{adapter}.config":
+            raise ModuleNotFoundError(f"No module named {dependency!r}", name=dependency)
         return original_import(name)
 
-    monkeypatch.setattr(module.importlib, "import_module", import_without_adbc)
+    monkeypatch.setattr(module.importlib, "import_module", import_without_driver)
     result = module._check_adapter_config_construction()
     assert result["error"] is None
     assert result["skipped_adapters"] == [
-        "sqlspec.adapters.adbc.config: optional dependency missing: adbc_driver_manager"
+        f"sqlspec.adapters.{adapter}.config: optional dependency missing: {dependency}"
     ]
-    assert "- SKIP sqlspec.adapters.adbc.config" in module._format_text([result])
+    assert f"- SKIP sqlspec.adapters.{adapter}.config" in module._format_text([result])
 
 
 def test_adapter_discovery_does_not_hide_internal_import_errors(monkeypatch: MonkeyPatch) -> None:

--- a/tests/unit/utils/test_mypyc_smoke.py
+++ b/tests/unit/utils/test_mypyc_smoke.py
@@ -141,6 +141,7 @@ def test_construction_checks_build_provider_signatures_without_requiring_compila
 
     assert all(result["imported"] or result["skipped"] for result in results)
     assert {result["name"] for result in results} == {
+        "adapter_config_construction",
         "aiosqlite_ambient_exception",
         "aiosqlite_exception_mapping",
         "fastapi_filter_construction",
@@ -151,6 +152,40 @@ def test_construction_checks_build_provider_signatures_without_requiring_compila
     }
     sqlspec_result = next(result for result in results if result["name"] == "sqlspec_construction")
     assert sqlspec_result["error"] is None
+    adapter_result = next(result for result in results if result["name"] == "adapter_config_construction")
+    assert adapter_result["error"] is None
+
+
+def test_adapter_config_construction_check_covers_every_database_config() -> None:
+    module = _load_mypyc_smoke_module()
+
+    discovered = {qualified_name for qualified_name, _ in module._discover_adapter_config_classes()}
+
+    assert discovered == {
+        "sqlspec.adapters.adbc.config.AdbcConfig",
+        "sqlspec.adapters.aiomysql.config.AiomysqlConfig",
+        "sqlspec.adapters.aiosqlite.config.AiosqliteConfig",
+        "sqlspec.adapters.arrow_odbc.config.ArrowOdbcConfig",
+        "sqlspec.adapters.asyncmy.config.AsyncmyConfig",
+        "sqlspec.adapters.asyncpg.config.AsyncpgConfig",
+        "sqlspec.adapters.bigquery.config.BigQueryConfig",
+        "sqlspec.adapters.cockroach_asyncpg.config.CockroachAsyncpgConfig",
+        "sqlspec.adapters.cockroach_psycopg.config.CockroachPsycopgAsyncConfig",
+        "sqlspec.adapters.cockroach_psycopg.config.CockroachPsycopgSyncConfig",
+        "sqlspec.adapters.duckdb.config.DuckDBConfig",
+        "sqlspec.adapters.mssql_python.config.MssqlPythonConfig",
+        "sqlspec.adapters.mysqlconnector.config.MysqlConnectorAsyncConfig",
+        "sqlspec.adapters.mysqlconnector.config.MysqlConnectorSyncConfig",
+        "sqlspec.adapters.oracledb.config.OracleAsyncConfig",
+        "sqlspec.adapters.oracledb.config.OracleSyncConfig",
+        "sqlspec.adapters.psqlpy.config.PsqlpyConfig",
+        "sqlspec.adapters.psycopg.config.PsycopgAsyncConfig",
+        "sqlspec.adapters.psycopg.config.PsycopgSyncConfig",
+        "sqlspec.adapters.pymssql.config.PymssqlConfig",
+        "sqlspec.adapters.pymysql.config.PyMysqlConfig",
+        "sqlspec.adapters.spanner.config.SpannerSyncConfig",
+        "sqlspec.adapters.sqlite.config.SqliteConfig",
+    }
 
 
 def test_statement_construction_checks_pass_without_requiring_compilation() -> None:

--- a/tools/scripts/mypyc_smoke.py
+++ b/tools/scripts/mypyc_smoke.py
@@ -2,6 +2,7 @@
 
 import argparse
 import importlib
+import inspect
 import json
 import subprocess
 import sys
@@ -549,10 +550,68 @@ def _check_fastapi_filter_construction(*, require_compiled: bool = False) -> dic
     return result
 
 
+def _discover_adapter_config_classes() -> "list[tuple[str, type[Any]]]":
+    """Return every database config class defined by an adapter ``config`` module.
+
+    A class qualifies when it is defined in ``sqlspec.adapters.<name>.config`` and
+    carries ``migration_tracker_type``, which excludes the pool, connection and
+    extension helper classes that share those modules.
+    """
+    adapters_package = importlib.import_module("sqlspec.adapters")
+    package_root = Path(next(iter(adapters_package.__path__)))
+    discovered: list[tuple[str, type[Any]]] = []
+    for config_path in sorted(package_root.glob("*/config.py")):
+        module_name = f"sqlspec.adapters.{config_path.parent.name}.config"
+        module = importlib.import_module(module_name)
+        discovered.extend(
+            (f"{module_name}.{candidate.__name__}", candidate)
+            for candidate in vars(module).values()
+            if inspect.isclass(candidate)
+            and candidate.__module__ == module_name
+            and hasattr(candidate, "migration_tracker_type")
+        )
+    return discovered
+
+
+def _adapter_config_construction_failure(qualified_name: str, config_cls: "type[Any]") -> "str | None":
+    """Return a failure description when an adapter config cannot be constructed."""
+    try:
+        config_cls()
+    except Exception as exc:
+        return f"{qualified_name}: {exc!r}"
+    return None
+
+
+def _check_adapter_config_construction() -> dict[str, Any]:
+    """Construct every adapter database config with no arguments."""
+    result = _new_smoke_result(
+        name="adapter_config_construction", module="sqlspec.adapters", attribute="migration_tracker_type"
+    )
+    try:
+        discovered = _discover_adapter_config_classes()
+    except Exception as exc:
+        result["error"] = f"{type(exc).__name__}: {exc}"
+        return result
+
+    result["imported"] = True
+    failures = [
+        failure
+        for failure in (
+            _adapter_config_construction_failure(qualified_name, config_cls)
+            for qualified_name, config_cls in discovered
+        )
+        if failure is not None
+    ]
+    if failures:
+        result["error"] = "; ".join(failures)
+    return result
+
+
 def run_construction_checks(*, require_compiled: bool = False) -> list[dict[str, Any]]:
     """Run construction-time smoke checks for provider classes."""
     return [
         _check_sqlspec_construction(),
+        _check_adapter_config_construction(),
         _check_statement_sentinel_identity(require_compiled=require_compiled),
         _check_statement_cache_rebind(require_compiled=require_compiled),
         _check_aiosqlite_ambient_exception(require_compiled=require_compiled),

--- a/tools/scripts/mypyc_smoke.py
+++ b/tools/scripts/mypyc_smoke.py
@@ -550,7 +550,7 @@ def _check_fastapi_filter_construction(*, require_compiled: bool = False) -> dic
     return result
 
 
-def _discover_adapter_config_classes() -> "list[tuple[str, type[Any]]]":
+def _discover_adapter_config_classes(*, skipped: "list[str] | None" = None) -> "list[tuple[str, type[Any]]]":
     """Return every database config class defined by an adapter ``config`` module.
 
     A class qualifies when it is defined in ``sqlspec.adapters.<name>.config`` and
@@ -562,7 +562,29 @@ def _discover_adapter_config_classes() -> "list[tuple[str, type[Any]]]":
     discovered: list[tuple[str, type[Any]]] = []
     for config_path in sorted(package_root.glob("*/config.py")):
         module_name = f"sqlspec.adapters.{config_path.parent.name}.config"
-        module = importlib.import_module(module_name)
+        try:
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError as exc:
+            if skipped is None or (exc.name or "").split(".")[0] not in {
+                "adbc_driver_manager",
+                "aiomysql",
+                "arrow_odbc",
+                "asyncmy",
+                "asyncpg",
+                "duckdb",
+                "google",
+                "mssql_python",
+                "mysql",
+                "oracledb",
+                "psqlpy",
+                "psycopg",
+                "psycopg_pool",
+                "pymssql",
+                "pymysql",
+            }:
+                raise
+            skipped.append(f"{module_name}: optional dependency missing: {exc.name}")
+            continue
         discovered.extend(
             (f"{module_name}.{candidate.__name__}", candidate)
             for candidate in vars(module).values()
@@ -588,7 +610,9 @@ def _check_adapter_config_construction() -> dict[str, Any]:
         name="adapter_config_construction", module="sqlspec.adapters", attribute="migration_tracker_type"
     )
     try:
-        discovered = _discover_adapter_config_classes()
+        skipped: list[str] = []
+        discovered = _discover_adapter_config_classes(skipped=skipped)
+        result["skipped_adapters"] = skipped
     except Exception as exc:
         result["error"] = f"{type(exc).__name__}: {exc}"
         return result
@@ -639,6 +663,7 @@ def _format_text(results: list[dict[str, Any]]) -> str:
         compiled = "compiled" if result["compiled"] else "interpreted"
         required = " required" if result["compiled_required"] else ""
         lines.append(f"- {status} {result['module']} ({compiled}{required})")
+        lines.extend(f"- SKIP {adapter}" for adapter in result.get("skipped_adapters", []))
         if result["error"] is not None:
             lines.append(f"  {result['error']}")
     return "\n".join(lines)

--- a/tools/scripts/mypyc_smoke.py
+++ b/tools/scripts/mypyc_smoke.py
@@ -568,6 +568,7 @@ def _discover_adapter_config_classes(*, skipped: "list[str] | None" = None) -> "
             if skipped is None or (exc.name or "").split(".")[0] not in {
                 "adbc_driver_manager",
                 "aiomysql",
+                "aiosqlite",
                 "arrow_odbc",
                 "asyncmy",
                 "asyncpg",


### PR DESCRIPTION
Constructing `PymssqlConfig` or `MssqlPythonConfig` against a compiled wheel raised `TypeError: interpreted classes cannot inherit from compiled` before you could do anything with it. The SQL Server adapters define their migration trackers in interpreted modules that subclass the tracker in `sqlspec.migrations.tracker`, which mypyc compiles — and a compiled class rejects interpreted subclasses unless it opts in.

- **Both trackers now opt in.** `SyncMigrationTracker` and `AsyncMigrationTracker` carry `allow_interpreted_subclasses`, matching the shared base tracker that already had it — which is exactly why the Oracle adapters were never affected.
- **The compiled module set is unchanged.** No adapter module was moved into the build and nothing was taken out of it.
- **Three lines of production code.** The rest of the change is the gate below.

## What stopped this from being caught

The compiled test run skips `tests/unit/adapters/` entirely, and the compiled smoke script constructed only the SQLite configs — so no gate ever built a SQL Server config against a compiled wheel. The smoke script now discovers **every** database config class across the adapter packages (23 across 19 modules) and constructs each one, reporting any failure by qualified class name and exception. A companion test pins the discovered set, so a new adapter or a narrowed filter fails loudly rather than quietly shrinking coverage.

The gate was verified to actually catch this: removing the new decorator locally makes it fail with both qualified class names and the original `TypeError`.

Fixes #747