### PR TITLE
feat(duckdb): transfer object-store data through DuckDB instead of Arrow

### DIFF
--- a/docs/reference/adapters/duckdb.rst
+++ b/docs/reference/adapters/duckdb.rst
@@ -6,6 +6,147 @@ Sync DuckDB adapter with full Arrow integration, extension management, and
 secret configuration. DuckDB excels at analytical workloads and can query
 Parquet, CSV, and JSON files directly.
 
+Native object-store transfers
+=============================
+
+``select_to_storage()`` can write a remote Parquet or CSV object with DuckDB
+``COPY``. ``load_from_storage()`` can append a remote Parquet object with
+``INSERT ... SELECT ... FROM read_parquet()``. Each successful native transfer
+executes one statement on the driver's existing connection and avoids
+materializing the data through Python Arrow buffers.
+
+Configure the required extension and secret through ``driver_features`` before
+opening a session. Native routing uses the settings successfully applied to that
+connection. A failed optional extension or secret does not enable the route.
+Pool recreation resets this record. A custom ``on_connection_create`` callback
+keeps storage transfers on the Arrow path because its settings are opaque.
+
+.. code-block:: python
+
+    import os
+
+    from sqlspec.adapters.duckdb import DuckDBConfig
+
+    config = DuckDBConfig(
+        driver_features={
+            "extensions": [{"name": "httpfs", "required": True}],
+            "secrets": [{
+                "name": "reports",
+                "secret_type": "s3",
+                "provider": "config",
+                "required": True,
+                "value": {
+                    "key_id": os.environ["AWS_ACCESS_KEY_ID"],
+                    "secret": os.environ["AWS_SECRET_ACCESS_KEY"],
+                    "region": "us-east-1",
+                },
+            }],
+        },
+    )
+    try:
+        with config.provide_session() as session:
+            session.select_to_storage(
+                "SELECT :day AS report_day",
+                "s3://example-bucket/reports/daily.parquet",
+                day="2026-01-01",
+            )
+            session.execute("CREATE TABLE reports (report_day VARCHAR)")
+            session.load_from_storage(
+                "reports", "s3://example-bucket/reports/daily.parquet",
+                file_format="parquet",
+            )
+    finally:
+        config.close_pool()
+
+Query values and object addresses remain bound parameters. Native import accepts
+one table identifier, optionally schema-qualified or quoted; SQL fragments are
+rejected. Parquet import disables automatic Hive partition columns. The API
+handles one object and does not expose reader projection or filter pushdown.
+
+Providers and aliases
+---------------------
+
+.. list-table:: Native provider prerequisites
+   :header-rows: 1
+   :widths: 20 20 60
+
+   * - URI schemes
+     - Extension
+     - Secret settings
+   * - ``s3``
+     - ``httpfs``
+     - ``secret_type="s3"`` with static credentials or a configured credential chain.
+   * - ``gs``, ``gcs``
+     - ``httpfs``
+     - ``secret_type="gcs"`` with HMAC ``key_id`` and ``secret``. GCS OAuth and
+       service-account backend options are not interchangeable with HMAC keys.
+   * - ``r2``
+     - ``httpfs``
+     - ``secret_type="r2"`` with ``key_id``, ``secret`` and ``account_id`` or
+       the matching R2 endpoint.
+   * - ``az``, ``azure``, ``abfss``
+     - ``azure``
+     - ``secret_type="azure"`` with a configured ``connection_string`` or
+       supported identity provider. Direct URI resolution also needs an account
+       name in the successful secret configuration.
+   * - ``http``, ``https``
+     - ``httpfs``
+     - Parquet reads only, with default backend options.
+
+Existing ``alias://name/path`` destinations use the storage registry. Native
+routing requires a known backend whose credentials, endpoint, region and access
+options match the configured DuckDB secret. Unknown options and credential
+mismatches keep the Arrow route. Alias names are not provider names: an alias
+named ``gcs`` can still refer to S3. Custom storage backend classes and custom
+``storage_pipeline_factory`` implementations retain their existing behavior.
+
+Fallbacks and failures
+----------------------
+
+Local paths, unsupported formats, explicit Arrow conversion options such as
+``arrow_schema``, and options that cannot be represented faithfully use Arrow.
+Import with ``overwrite=True`` also uses the existing Arrow truncate-and-insert
+path. CSV imports always use Arrow: DuckDB's CSV inference differs for values
+such as leading-zero strings, quoted empty strings and null markers.
+
+Names containing ``?`` or ``#`` retain the storage backend's interpretation
+instead of becoming DuckDB URL settings. Parquet reader names containing glob
+characters also use the single-object Arrow path. Repeated native exports replace
+the same object; they do not add a new overwrite argument or produce partitioned
+files. The ``partitioner`` argument continues to attach telemetry metadata.
+
+Routing is decided before the transfer statement. Once native execution starts,
+authentication, missing-object and database failures propagate through the
+adapter's exception mapping; they are never retried through Arrow.
+
+Native jobs report row counts, duration, format and ``backend="duckdb"``.
+``bytes_processed`` is omitted when DuckDB does not provide it; no extra object
+request is made solely to fill that field.
+
+Verification and performance
+----------------------------
+
+S3-compatible CSV/Parquet export and Parquet append are tested against local
+RustFS. Configured GCS, R2 and Azure routing is tested offline; transfers against
+those cloud services are not verified by the local tests. Extension installation
+may require access to DuckDB's official extension repository.
+
+``tools/scripts/bench_duckdb_storage.py`` compares native and Arrow Parquet
+export/import against the same local service. It verifies equal values and
+records object sizes, median and spread, connection/extension setup time,
+versions and source revision. Run the opt-in fixture-backed benchmark with:
+
+.. code-block:: console
+
+    SQLSPEC_DUCKDB_STORAGE_BENCHMARK=/tmp/duckdb-storage.json uv run pytest \
+      tests/integration/adapters/duckdb/duckdb/test_native_storage.py \
+      -k native_storage_benchmark
+
+The benchmark uses 100, 1,000 and 10,000 rows with four warmups and eight measured
+iterations. Results depend on object size, network and service configuration;
+native transfer is not a universal speedup. CSV import is excluded from native
+benchmarks because it retains Arrow inference.
+
 Configuration
 =============
 

--- a/docs/reference/adapters/duckdb.rst
+++ b/docs/reference/adapters/duckdb.rst
@@ -29,7 +29,7 @@ keeps storage transfers on the Arrow path because its settings are opaque.
 
     config = DuckDBConfig(
         driver_features={
-            "extensions": [{"name": "httpfs", "required": True}],
+            "extensions": [{"name": "httpfs", "install": True, "required": True}],
             "secrets": [{
                 "name": "reports",
                 "secret_type": "s3",

--- a/docs/reference/adapters/duckdb.rst
+++ b/docs/reference/adapters/duckdb.rst
@@ -18,8 +18,9 @@ materializing the data through Python Arrow buffers.
 Configure the required extension and secret through ``driver_features`` before
 opening a session. Native routing uses the settings successfully applied to that
 connection. A failed optional extension or secret does not enable the route.
-Pool recreation resets this record. A custom ``on_connection_create`` callback
-keeps storage transfers on the Arrow path because its settings are opaque.
+Pool recreation resets this record. Filesystems registered through
+``on_connection_create`` are discovered after the callback runs and participate
+without requiring a cloud extension.
 
 .. code-block:: python
 
@@ -84,6 +85,11 @@ Providers and aliases
      - ``httpfs``
      - ``secret_type="r2"`` with ``key_id``, ``secret`` and ``account_id`` or
        the matching R2 endpoint.
+       R2 uses the S3 API through DuckDB's ``httpfs`` extension.
+   * - ``gcss``
+     - Community ``gcs``
+     - DuckDB's ``gcp`` secret configuration, including application default
+       credentials. The original URI is passed to the extension unchanged.
    * - ``az``, ``azure``, ``abfss``
      - ``azure``
      - ``secret_type="azure"`` with a configured ``connection_string`` or
@@ -99,6 +105,30 @@ options match the configured DuckDB secret. Unknown options and credential
 mismatches keep the Arrow route. Alias names are not provider names: an alias
 named ``gcs`` can still refer to S3. Custom storage backend classes and custom
 ``storage_pipeline_factory`` implementations retain their existing behavior.
+
+Additional filesystems
+----------------------
+
+DuckDB's Python client supports registered fsspec filesystems, including
+``gcsfs``. Register an instance using ``connection.register_filesystem()`` in
+``on_connection_create``. Its advertised protocols are discovered automatically;
+eligible transfers use DuckDB's reader or ``COPY`` without materializing an
+Arrow payload in SQLSpec. The filesystem itself can still perform Python I/O.
+
+For additional DuckDB extensions, declare their URI schemes alongside the
+existing extension configuration, for example
+``{"name": "my_filesystem", "repository": "community",
+"storage_protocols": ["myfs", "myfs+alias"]}``. These schemes become available
+only after the extension loads successfully. SQLSpec passes direct addresses
+unchanged; the configured DuckDB filesystem owns authentication and reports
+transfer errors. No matching fsspec or obstore package is required for these
+direct routes. Aliases still resolve through SQLSpec's registry, and backend
+options that cannot be preserved keep the existing storage path.
+
+See DuckDB's `fsspec integration
+<https://duckdb.org/docs/current/guides/python/filesystems>`_ and the
+`community GCS extension
+<https://duckdb.org/community_extensions/extensions/gcs>`_.
 
 Fallbacks and failures
 ----------------------

--- a/docs/usage/bulk_ingest.rst
+++ b/docs/usage/bulk_ingest.rst
@@ -65,8 +65,8 @@ Capability matrix
      - ``register`` + ``INSERT ... SELECT``; ``load_from_storage`` appends
        remote Parquet through ``INSERT ... SELECT read_parquet``
      - Single connection transaction
-     - Native remote reads require matching loaded extensions and credentials;
-       CSV imports and overwrite retain the Arrow path
+     - Native remote reads use a configured DuckDB filesystem, through a loaded
+       extension or registered filesystem; CSV imports and overwrite retain Arrow
    * - sqlite / aiosqlite
      - ``executemany`` inside one ``BEGIN IMMEDIATE``
      - Atomic when the driver owns the transaction; rolls back on error

--- a/docs/usage/bulk_ingest.rst
+++ b/docs/usage/bulk_ingest.rst
@@ -62,8 +62,8 @@ Capability matrix
      - Driver-dependent; ``adbc_ingest`` is always attempted and unsupported drivers raise
      - Always on
    * - duckdb
-     - Remote Parquet append: ``INSERT ... SELECT read_parquet``;
-       otherwise Arrow ``register`` + ``INSERT ... SELECT``
+     - ``register`` + ``INSERT ... SELECT``; ``load_from_storage`` appends
+       remote Parquet through ``INSERT ... SELECT read_parquet``
      - Single connection transaction
      - Native remote reads require matching loaded extensions and credentials;
        CSV imports and overwrite retain the Arrow path

--- a/docs/usage/bulk_ingest.rst
+++ b/docs/usage/bulk_ingest.rst
@@ -62,9 +62,11 @@ Capability matrix
      - Driver-dependent; ``adbc_ingest`` is always attempted and unsupported drivers raise
      - Always on
    * - duckdb
-     - ``register`` + ``INSERT ... SELECT``
+     - Remote Parquet append: ``INSERT ... SELECT read_parquet``;
+       otherwise Arrow ``register`` + ``INSERT ... SELECT``
      - Single connection transaction
-     - Always on
+     - Native remote reads require matching loaded extensions and credentials;
+       CSV imports and overwrite retain the Arrow path
    * - sqlite / aiosqlite
      - ``executemany`` inside one ``BEGIN IMMEDIATE``
      - Atomic when the driver owns the transaction; rolls back on error

--- a/sqlspec/adapters/duckdb/config.py
+++ b/sqlspec/adapters/duckdb/config.py
@@ -331,6 +331,12 @@ class DuckDBConfig(SyncDatabaseConfig[DuckDBConnection, DuckDBConnectionPool, Du
         if self.connection_instance:
             self.connection_instance.close()
 
+    def _prepare_driver(self, driver: DuckDBDriver) -> DuckDBDriver:
+        driver = super()._prepare_driver(driver)
+        if self.connection_instance is not None:
+            driver.driver_features.update(self.connection_instance._storage_settings(driver.connection))
+        return driver
+
     def create_connection(self) -> DuckDBConnection:
         """Get a DuckDB connection from the pool.
 

--- a/sqlspec/adapters/duckdb/config.py
+++ b/sqlspec/adapters/duckdb/config.py
@@ -118,6 +118,14 @@ class DuckDBExtensionConfig(TypedDict):
     required: NotRequired[bool]
     """When True, install/load failure raises instead of best-effort WARNING."""
 
+    storage_protocols: NotRequired[Sequence[str]]
+    """Additional URI schemes handled by this extension's configured filesystem.
+
+    Addresses using these schemes are passed unchanged to DuckDB after the
+    extension loads. DuckDB owns credential selection and reports transfer
+    errors. Registered Python filesystems are discovered automatically.
+    """
+
 
 class DuckDBSecretConfig(TypedDict):
     """DuckDB secret configuration for AI/API integrations."""

--- a/sqlspec/adapters/duckdb/core.py
+++ b/sqlspec/adapters/duckdb/core.py
@@ -118,12 +118,15 @@ def _resolve_native_storage_target(
     from sqlspec.storage.backends.fsspec import FSSpecBackend
     from sqlspec.storage.backends.obstore import ObStoreBackend
 
-    if not driver_features.get("_duckdb_storage_extensions"):
+    protocols = driver_features.get("_duckdb_storage_protocols", ())
+    if not driver_features.get("_duckdb_storage_extensions") and not protocols:
         return None
     original = str(destination)
     if "?" in original or "#" in original:
         return None
     scheme, separator, suffix = original.partition("://")
+    if separator and scheme != "alias" and scheme in protocols:
+        return ResolvedStorageTarget(original, scheme)
     if not separator or scheme not in {"alias", "s3", "gs", "gcs", "r2", "az", "azure", "abfss", "http", "https"}:
         return None
     normalized = {"gcs": "gs", "r2": "s3"}.get(scheme)
@@ -161,6 +164,8 @@ def _resolve_native_storage_target(
         target = ResolvedStorageTarget(original, scheme)
     if "?" in target.uri or "#" in target.uri:
         return None
+    if target.protocol in protocols and options is not None and not options:
+        return target
     if not _native_storage_eligible(target.uri, target.protocol, options, driver_features, write=write):
         return None
     return target

--- a/sqlspec/adapters/duckdb/core.py
+++ b/sqlspec/adapters/duckdb/core.py
@@ -4,6 +4,7 @@ import contextlib
 from datetime import date, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Final, cast
+from urllib.parse import urlsplit
 
 from sqlspec.core import DriverParameterProfile, ParameterStyle, StatementConfig, build_statement_config_from_profile
 from sqlspec.exceptions import (
@@ -45,6 +46,171 @@ __all__ = (
 
 _TIME_TO_ISO = time_iso_convert
 _DECIMAL_TO_STRING = build_decimal_converter(mode="string")
+
+
+def _native_storage_eligible(
+    uri: str,
+    protocol: str,
+    backend_options: "Mapping[str, Any] | None",
+    driver_features: "Mapping[str, Any]",
+    *,
+    write: bool,
+) -> bool:
+    """Require completed provisioning and equivalent, understood backend settings.
+
+    Unknown credentials or options keep the existing storage path. This check
+    performs no SQL or I/O and never classifies an execution error for retry.
+    """
+    provider_type = {
+        "s3": "s3",
+        "gs": "gcs",
+        "gcs": "gcs",
+        "r2": "r2",
+        "az": "azure",
+        "azure": "azure",
+        "abfss": "azure",
+    }.get(protocol)
+    extension = "azure" if provider_type == "azure" else "httpfs"
+    if backend_options is None or extension not in driver_features.get("_duckdb_storage_extensions", ()):
+        return False
+    if protocol in {"http", "https"}:
+        return not write and not backend_options
+    if provider_type is None:
+        return False
+
+    secrets = driver_features.get("_duckdb_storage_secrets", ())
+    matching = [
+        secret
+        for secret in secrets
+        if secret.get("secret_type", "").lower() == provider_type
+        and (not secret.get("scope") or uri.startswith(secret["scope"]))
+    ]
+    if not matching:
+        return False
+    matching.sort(key=lambda secret: len(secret.get("scope") or ""), reverse=True)
+    selected = matching[0]
+    if len(matching) > 1 and len(selected.get("scope") or "") == len(matching[1].get("scope") or ""):
+        return False
+    provider = selected.get("provider", "config").lower()
+    native = {key.lower(): value for key, value in selected.get("value", {}).items()}
+    if not backend_options:
+        return provider in {"config", "credential_chain", "managed_identity", "service_principal"}
+    if provider != "config":
+        return False
+    if provider_type == "azure":
+        return _azure_storage_options_match(backend_options, native)
+    return _s3_storage_options_match(backend_options, native, provider_type)
+
+
+def _s3_storage_options_match(
+    backend_options: "Mapping[str, Any]", native: "Mapping[str, Any]", provider_type: str
+) -> bool:
+    """Compare static credentials and endpoint options for S3-compatible providers."""
+    if native.keys() - {
+        "key_id",
+        "secret",
+        "session_token",
+        "region",
+        "endpoint",
+        "url_style",
+        "use_ssl",
+        "account_id",
+    }:
+        return False
+
+    options: dict[str, Any] = {}
+    for key, value in backend_options.items():
+        normalized = key.removeprefix("aws_")
+        if normalized in options and options[normalized] != value:
+            return False
+        options[normalized] = value
+    client = options.pop("client_options", {})
+    if not isinstance(client, dict) or client.keys() - {"allow_http"}:
+        return False
+    if "allow_http" in client:
+        if "allow_http" in options and options["allow_http"] != client["allow_http"]:
+            return False
+        options["allow_http"] = client["allow_http"]
+    if options.keys() - {
+        "access_key_id",
+        "secret_access_key",
+        "session_token",
+        "region",
+        "endpoint",
+        "virtual_hosted_style_request",
+        "allow_http",
+    }:
+        return False
+    if not options.get("access_key_id") or not options.get("secret_access_key"):
+        return False
+    if any(
+        options.get(source) != native.get(target)
+        for source, target in (
+            ("access_key_id", "key_id"),
+            ("secret_access_key", "secret"),
+            ("session_token", "session_token"),
+        )
+    ):
+        return False
+    if options.get("region", "us-east-1") != native.get("region", "us-east-1"):
+        return False
+    style = "vhost" if options.get("virtual_hosted_style_request", False) else "path"
+    if native.get("url_style", "vhost" if provider_type == "s3" else "path") != style:
+        return False
+    native_endpoint = native.get("endpoint")
+    if native_endpoint is None and provider_type == "gcs":
+        native_endpoint = "storage.googleapis.com"
+    elif native_endpoint is None and provider_type == "r2" and native.get("account_id"):
+        native_endpoint = f"{native['account_id']}.r2.cloudflarestorage.com"
+    endpoint = options.get("endpoint")
+    if endpoint is None:
+        return not native_endpoint and native.get("use_ssl", True) is True
+    if not isinstance(endpoint, str) or not endpoint:
+        return False
+    parsed = urlsplit(endpoint)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc or parsed.path not in {"", "/"}:
+        return False
+    if parsed.query or parsed.fragment or parsed.username or parsed.password:
+        return False
+    if native_endpoint != parsed.netloc or native.get("use_ssl", True) != (parsed.scheme == "https"):
+        return False
+    return not (parsed.scheme == "http" and options.get("allow_http") is not True)
+
+
+def _azure_storage_options_match(options: "Mapping[str, Any]", native: "Mapping[str, Any]") -> bool:
+    """Recognize matching standard Azure account keys or a connection string."""
+    if set(options) == {"connection_string"}:
+        return bool(options["connection_string"] == native.get("connection_string"))
+    normalized: dict[str, Any] = {}
+    for key, value in options.items():
+        key = key.removeprefix("azure_storage_").removeprefix("azure_")
+        if key in normalized and normalized[key] != value:
+            return False
+        normalized[key] = value
+    if normalized.keys() - {"account_name", "access_key"}:
+        return False
+    connection_string = native.get("connection_string")
+    if not isinstance(connection_string, str) or native.keys() - {"connection_string", "account_name"}:
+        return False
+    parts: dict[str, str] = {}
+    for item in connection_string.split(";"):
+        if not item:
+            continue
+        key, separator, value = item.partition("=")
+        if not separator or key in parts:
+            return False
+        parts[key] = value
+    if parts.keys() - {"DefaultEndpointsProtocol", "AccountName", "AccountKey", "EndpointSuffix"}:
+        return False
+    return (
+        parts.get("DefaultEndpointsProtocol", "https") == "https"
+        and parts.get("EndpointSuffix", "core.windows.net") == "core.windows.net"
+        and bool(normalized.get("account_name"))
+        and bool(normalized.get("access_key"))
+        and normalized.get("account_name") == parts.get("AccountName")
+        and normalized.get("access_key") == parts.get("AccountKey")
+        and native.get("account_name", parts.get("AccountName")) == parts.get("AccountName")
+    )
 
 
 def collect_rows(fetched_data: "list[Any] | None", description: "list[Any] | None") -> "tuple[list[Any], list[str]]":

--- a/sqlspec/adapters/duckdb/core.py
+++ b/sqlspec/adapters/duckdb/core.py
@@ -6,6 +6,9 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Final, cast
 from urllib.parse import urlsplit
 
+from sqlglot import Dialect, exp, parse
+from sqlglot.errors import ParseError
+
 from sqlspec.core import DriverParameterProfile, ParameterStyle, StatementConfig, build_statement_config_from_profile
 from sqlspec.exceptions import (
     CheckViolationError,
@@ -29,6 +32,8 @@ from sqlspec.utils.uuids import uuid_from_string
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
+    from sqlspec.storage import ResolvedStorageTarget, StorageDestination, SyncStoragePipeline
+
 
 __all__ = (
     "apply_driver_features",
@@ -46,6 +51,116 @@ __all__ = (
 
 _TIME_TO_ISO = time_iso_convert
 _DECIMAL_TO_STRING = build_decimal_converter(mode="string")
+
+
+def _build_storage_copy_sql(sql: str, file_format: str) -> str | None:
+    """Wrap one compiled query in COPY with a separately bound filename."""
+    if file_format not in {"parquet", "csv"}:
+        return None
+    try:
+        statements = parse(sql, read="duckdb")
+    except ParseError:
+        return None
+    if len(statements) != 1 or not isinstance(statements[0], exp.Query):
+        return None
+    options = [exp.CopyParameter(this=exp.Var(this="FORMAT"), expression=exp.Var(this=file_format.upper()))]
+    if file_format == "csv":
+        options.append(exp.CopyParameter(this=exp.Var(this="HEADER"), expression=exp.Boolean(this=True)))
+    return exp.Copy(this=exp.Subquery(this=statements[0]), kind=False, files=[exp.Placeholder()], params=options).sql(
+        dialect="duckdb"
+    )
+
+
+def _build_storage_read_sql(table: str, uri: str, file_format: str) -> str | None:
+    """Build a single-object reader with a validated, quoted target identifier."""
+    if file_format != "parquet" or any(char in uri for char in "*?[]"):
+        return None
+    try:
+        targets = Dialect.get_or_raise("duckdb").parse_into(exp.Table, table)
+    except ParseError as exc:
+        msg = "Native storage import requires one qualified table identifier."
+        raise ValueError(msg) from exc
+    if (
+        len(targets) != 1
+        or not isinstance(targets[0], exp.Table)
+        or any(key not in {"this", "db", "catalog"} and value for key, value in targets[0].args.items())
+        or any(not isinstance(part, exp.Identifier) for part in targets[0].parts)
+    ):
+        msg = "Native storage import requires one qualified table identifier."
+        raise ValueError(msg)
+    target = targets[0]
+    for part in target.parts:
+        part.set("quoted", True)
+    reader = exp.Anonymous(
+        this="read_parquet",
+        expressions=[
+            exp.Placeholder(),
+            exp.Kwarg(this=exp.Var(this="hive_partitioning"), expression=exp.Boolean(this=False)),
+        ],
+    )
+    return exp.Insert(this=target, expression=exp.select("*").from_(reader)).sql(dialect="duckdb")
+
+
+def _resolve_native_storage_target(
+    pipeline: "SyncStoragePipeline",
+    destination: "StorageDestination",
+    driver_features: "Mapping[str, Any]",
+    *,
+    write: bool,
+) -> "ResolvedStorageTarget | None":
+    """Resolve explicit provider aliases without changing the native address."""
+    from sqlspec.storage import ResolvedStorageTarget
+    from sqlspec.storage.backends.fsspec import FSSpecBackend
+    from sqlspec.storage.backends.obstore import ObStoreBackend
+
+    if not driver_features.get("_duckdb_storage_extensions"):
+        return None
+    original = str(destination)
+    if "?" in original or "#" in original:
+        return None
+    scheme, separator, suffix = original.partition("://")
+    if not separator or scheme not in {"alias", "s3", "gs", "gcs", "r2", "az", "azure", "abfss", "http", "https"}:
+        return None
+    normalized = {"gcs": "gs", "r2": "s3"}.get(scheme)
+    resolved_input = f"{normalized}://{suffix}" if normalized else original
+    resolver_options: dict[str, Any] = {}
+    if scheme in {"az", "azure", "abfss"}:
+        for secret in driver_features.get("_duckdb_storage_secrets", ()):
+            if secret.get("secret_type", "").lower() != "azure" or (
+                secret.get("scope") and not original.startswith(secret["scope"])
+            ):
+                continue
+            values = {key.lower(): value for key, value in secret.get("value", {}).items()}
+            account = values.get("account_name")
+            if not account:
+                connection_parts = dict(
+                    item.split("=", 1) for item in str(values.get("connection_string", "")).split(";") if "=" in item
+                )
+                account = connection_parts.get("AccountName")
+            if account:
+                resolver_options["account_name"] = account
+                break
+        if not resolver_options:
+            return None
+    target = pipeline.resolve_destination(resolved_input, storage_options=resolver_options or None)
+    backend_key = suffix.partition("/")[0].strip() if scheme == "alias" else resolved_input
+    backend = pipeline.registry.get(backend_key, **resolver_options)
+    options: Mapping[str, Any] | None = None
+    if type(backend) is ObStoreBackend:
+        options = backend.store_options
+    elif type(backend) is FSSpecBackend:
+        options = backend.fs.storage_options
+    if resolver_options:
+        # These options only let the resolver construct the Azure URI backend;
+        # the already provisioned native secret remains the credential owner.
+        options = {}
+    if normalized:
+        target = ResolvedStorageTarget(original, scheme)
+    if "?" in target.uri or "#" in target.uri:
+        return None
+    if not _native_storage_eligible(target.uri, target.protocol, options, driver_features, write=write):
+        return None
+    return target
 
 
 def _native_storage_eligible(

--- a/sqlspec/adapters/duckdb/core.py
+++ b/sqlspec/adapters/duckdb/core.py
@@ -108,7 +108,12 @@ def _resolve_native_storage_target(
     *,
     write: bool,
 ) -> "ResolvedStorageTarget | None":
-    """Resolve explicit provider aliases without changing the native address."""
+    """Resolve explicit provider aliases without changing the native address.
+
+    Azure destinations resolve with the account name taken from the successful
+    native secret, and that account name is not treated as a backend option
+    because the provisioned secret owns the credentials.
+    """
     from sqlspec.storage import ResolvedStorageTarget
     from sqlspec.storage.backends.fsspec import FSSpecBackend
     from sqlspec.storage.backends.obstore import ObStoreBackend
@@ -151,8 +156,6 @@ def _resolve_native_storage_target(
     elif type(backend) is FSSpecBackend:
         options = backend.fs.storage_options
     if resolver_options:
-        # These options only let the resolver construct the Azure URI backend;
-        # the already provisioned native secret remains the credential owner.
         options = {}
     if normalized:
         target = ResolvedStorageTarget(original, scheme)

--- a/sqlspec/adapters/duckdb/driver.py
+++ b/sqlspec/adapters/duckdb/driver.py
@@ -1,14 +1,18 @@
 """DuckDB driver implementation."""
 
 import contextlib
-from typing import TYPE_CHECKING, Any, cast
+from time import perf_counter
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import duckdb
 from sqlglot import exp
 
 from sqlspec.adapters.duckdb._typing import DuckDBCursor, DuckDBSessionContext
 from sqlspec.adapters.duckdb.core import (
+    _build_storage_copy_sql,
+    _build_storage_read_sql,
     _DuckDBStreamSource,
+    _resolve_native_storage_target,
     _restore_uuid_columns,
     collect_rows,
     create_mapped_exception,
@@ -20,6 +24,7 @@ from sqlspec.adapters.duckdb.core import (
 from sqlspec.adapters.duckdb.data_dictionary import DuckDBDataDictionary
 from sqlspec.core import (
     SQL,
+    ParameterStyle,
     StatementConfig,
     build_arrow_result_from_reader,
     build_arrow_result_from_table,
@@ -380,12 +385,38 @@ class DuckDBDriver(SyncDriverAdapterBase):
         telemetry: "StorageTelemetry | None" = None,
         **kwargs: Any,
     ) -> "StorageBridgeJob":
-        """Persist DuckDB query output to a storage backend using Arrow fast paths."""
+        """Persist a query with native object-store COPY when settings are compatible."""
 
-        _ = kwargs
         self._require_capability("arrow_export_enabled")
-        arrow_result = self.select_to_arrow(statement, *parameters, statement_config=statement_config, **kwargs)
         sync_pipeline = self._storage_pipeline()
+        format_choice = format_hint or "parquet"
+        if (
+            self.storage_pipeline_factory is None
+            and format_choice in {"parquet", "csv"}
+            and not {"arrow_schema", "return_format", "batch_size", "native_only"}.intersection(kwargs)
+        ):
+            target = _resolve_native_storage_target(sync_pipeline, destination, self.driver_features, write=True)
+            if target is not None:
+                config = statement_config or self.statement_config
+                config = config.replace(
+                    parameter_config=config.parameter_config.replace(
+                        default_execution_parameter_style=ParameterStyle.QMARK
+                    )
+                )
+                prepared = self.prepare_statement(statement, parameters, statement_config=config, kwargs=kwargs)
+                sql, driver_params = self._compiled_sql(prepared, config)
+                copy_sql = _build_storage_copy_sql(sql, format_choice)
+                if copy_sql is not None:
+                    return self._native_storage_job(
+                        copy_sql,
+                        [target.uri, *cast("Sequence[Any]", driver_params or ())],
+                        destination=str(destination),
+                        format_choice=format_choice,
+                        operation="write",
+                        partitioner=partitioner,
+                        telemetry=telemetry,
+                    )
+        arrow_result = self.select_to_arrow(statement, *parameters, statement_config=statement_config, **kwargs)
         telemetry_payload = self._write_storage_result(
             arrow_result, destination, format_hint=format_hint, pipeline=sync_pipeline
         )
@@ -453,6 +484,21 @@ class DuckDBDriver(SyncDriverAdapterBase):
     ) -> "StorageBridgeJob":
         """Read an artifact from storage and load it into DuckDB."""
 
+        self._require_capability("arrow_import_enabled")
+        if not overwrite and file_format == "parquet" and self.storage_pipeline_factory is None:
+            pipeline = self._storage_pipeline()
+            target = _resolve_native_storage_target(pipeline, source, self.driver_features, write=False)
+            if target is not None:
+                read_sql = _build_storage_read_sql(table, target.uri, file_format)
+                if read_sql is not None:
+                    return self._native_storage_job(
+                        read_sql,
+                        [target.uri],
+                        destination=table,
+                        format_choice=file_format,
+                        operation="read",
+                        partitioner=partitioner,
+                    )
         arrow_table, inbound = self._read_storage_arrow(source, file_format=file_format)
         return self.load_from_arrow(table, arrow_table, partitioner=partitioner, overwrite=overwrite, telemetry=inbound)
 
@@ -474,6 +520,54 @@ class DuckDBDriver(SyncDriverAdapterBase):
     # ─────────────────────────────────────────────────────────────────────────────
     # PRIVATE / INTERNAL METHODS
     # ─────────────────────────────────────────────────────────────────────────────
+
+    def _native_storage_job(
+        self,
+        sql: str,
+        parameters: "list[Any]",
+        *,
+        destination: str,
+        format_choice: "StorageFormat",
+        operation: "Literal['read', 'write']",
+        partitioner: "dict[str, object] | None",
+        telemetry: "StorageTelemetry | None" = None,
+    ) -> "StorageBridgeJob":
+        runtime = self.observability
+        span = runtime.start_storage_span(operation, destination=destination, format_label=format_choice)
+        start = perf_counter()
+        try:
+            rows = self._execute_storage_sql(sql, parameters)
+            path = destination
+            if operation == "write":
+                path = destination.partition("://")[2]
+                if destination.startswith("alias://"):
+                    path = path.partition("/")[2].strip().lstrip("/")
+            payload: StorageTelemetry = {
+                "destination": path,
+                "rows_processed": rows,
+                "duration_s": perf_counter() - start,
+                "format": format_choice,
+                "backend": "duckdb",
+            }
+            payload = runtime.annotate_storage_telemetry(payload)
+        except Exception as exc:
+            runtime.end_storage_span(span, error=exc)
+            raise
+        runtime.end_storage_span(span, telemetry=payload)
+        self._attach_partition_telemetry(payload, partitioner)
+        return self._storage_job(payload, telemetry)
+
+    def _execute_storage_sql(self, sql: str, parameters: "list[Any]") -> int:
+        handler = self.handle_database_exceptions()
+        result = None
+        with self.with_cursor(self.connection) as cursor, handler:
+            cursor.execute(sql, parameters)
+            result = cursor.fetchone()
+        self._check_pending_exception(handler)
+        if result is None:
+            msg = "DuckDB storage transfer did not report its row count."
+            raise SQLSpecError(msg)
+        return int(result[0])
 
     def collect_rows(self, cursor: "DuckDBConnection", fetched: "list[Any]") -> "tuple[list[Any], list[str], int]":
         """Collect DuckDB rows for the direct execution path."""

--- a/sqlspec/adapters/duckdb/pool.py
+++ b/sqlspec/adapters/duckdb/pool.py
@@ -106,6 +106,9 @@ class DuckDBConnectionPool:
 
     def _create_connection(self) -> DuckDBConnection:
         """Create a new DuckDB connection with extensions and secrets."""
+        self._thread_local.storage_extensions = frozenset()
+        self._thread_local.storage_secrets = ()
+        loaded_extensions: set[str] = set()
         connect_parameters = {}
         config_dict = {}
 
@@ -169,6 +172,7 @@ class DuckDBConnectionPool:
                         error=str(exc),
                     )
             else:
+                loaded_extensions.add(ext_name)
                 if install_error is not None:
                     log_with_context(
                         logger,
@@ -181,13 +185,28 @@ class DuckDBConnectionPool:
                         error=install_error,
                     )
 
-        for secret_config in self._secrets:
-            _create_secret(connection, secret_config)
+        created_secrets: list[dict[str, Any]] = [
+            {**secret_config, "value": dict(secret_config.get("value") or {})}
+            for secret_config in self._secrets
+            if _create_secret(connection, secret_config)
+        ]
 
         if self._on_connection_create:
             self._on_connection_create(connection)
-
+        else:
+            self._thread_local.storage_extensions = frozenset(loaded_extensions)
+            self._thread_local.storage_secrets = tuple(created_secrets)
         return connection
+
+    def _storage_settings(self, connection: DuckDBConnection) -> "dict[str, Any]":
+        """Return storage setup completed for this thread's current connection."""
+        state = self._thread_local.__dict__
+        if state.get("connection") is not connection:
+            return {}
+        return {
+            "_duckdb_storage_extensions": state.get("storage_extensions", frozenset()),
+            "_duckdb_storage_secrets": state.get("storage_secrets", ()),
+        }
 
     def _install_extension_once(
         self,
@@ -306,6 +325,8 @@ class DuckDBConnectionPool:
     def _close_thread_connection(self) -> None:
         """Close the connection for the current thread."""
         thread_state = self._thread_local.__dict__
+        thread_state.pop("storage_extensions", None)
+        thread_state.pop("storage_secrets", None)
         if "connection" in thread_state:
             with suppress(Exception):
                 self._thread_local.connection.close()
@@ -399,11 +420,11 @@ def _validate_sql_identifier(value: str, field_name: str) -> None:
         raise ValueError(msg)
 
 
-def _create_secret(connection: DuckDBConnection, secret_config: dict[str, Any]) -> None:
+def _create_secret(connection: DuckDBConnection, secret_config: dict[str, Any]) -> bool:
     secret_name = secret_config.get("name")
     secret_type = secret_config.get("secret_type")
     if not (secret_name and secret_type):
-        return
+        return False
 
     required = bool(secret_config.get("required", False))
     try:
@@ -417,6 +438,8 @@ def _create_secret(connection: DuckDBConnection, secret_config: dict[str, Any]) 
         if required:
             raise
         logger.warning("DuckDB secret %r creation failed (best-effort)", secret_name)
+        return False
+    return True
 
 
 def _secret_sql(secret_config: dict[str, Any], secret_name: str, secret_type: str) -> str:

--- a/sqlspec/adapters/duckdb/pool.py
+++ b/sqlspec/adapters/duckdb/pool.py
@@ -108,7 +108,9 @@ class DuckDBConnectionPool:
         """Create a new DuckDB connection with extensions and secrets."""
         self._thread_local.storage_extensions = frozenset()
         self._thread_local.storage_secrets = ()
+        self._thread_local.storage_protocols = frozenset()
         loaded_extensions: set[str] = set()
+        storage_protocols: set[str] = set()
         connect_parameters = {}
         config_dict = {}
 
@@ -173,6 +175,9 @@ class DuckDBConnectionPool:
                     )
             else:
                 loaded_extensions.add(ext_name)
+                storage_protocols.update(ext_config.get("storage_protocols", ()))
+                if ext_name == "gcs":
+                    storage_protocols.add("gcss")
                 if install_error is not None:
                     log_with_context(
                         logger,
@@ -196,6 +201,8 @@ class DuckDBConnectionPool:
         else:
             self._thread_local.storage_extensions = frozenset(loaded_extensions)
             self._thread_local.storage_secrets = tuple(created_secrets)
+        storage_protocols.update(connection.list_filesystems())
+        self._thread_local.storage_protocols = frozenset(storage_protocols)
         return connection
 
     def _storage_settings(self, connection: DuckDBConnection) -> "dict[str, Any]":
@@ -206,6 +213,7 @@ class DuckDBConnectionPool:
         return {
             "_duckdb_storage_extensions": state.get("storage_extensions", frozenset()),
             "_duckdb_storage_secrets": state.get("storage_secrets", ()),
+            "_duckdb_storage_protocols": state.get("storage_protocols", frozenset()),
         }
 
     def _install_extension_once(
@@ -327,6 +335,7 @@ class DuckDBConnectionPool:
         thread_state = self._thread_local.__dict__
         thread_state.pop("storage_extensions", None)
         thread_state.pop("storage_secrets", None)
+        thread_state.pop("storage_protocols", None)
         if "connection" in thread_state:
             with suppress(Exception):
                 self._thread_local.connection.close()

--- a/tests/integration/adapters/duckdb/duckdb/test_native_storage.py
+++ b/tests/integration/adapters/duckdb/duckdb/test_native_storage.py
@@ -23,6 +23,37 @@ from sqlspec.storage.registry import storage_registry
 from tests.fixtures.rustfs import ensure_rustfs_bucket, rustfs_filesystem, rustfs_obstore_kwargs
 
 
+def test_registered_filesystem_transfers_without_cloud_extensions(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fsspec.implementations.memory import MemoryFileSystem
+
+    filesystem = MemoryFileSystem()
+
+    def configure(connection: duckdb.DuckDBPyConnection) -> None:
+        connection.register_filesystem(filesystem)
+
+    def reject_arrow(*args: Any, **kwargs: Any) -> Any:
+        pytest.fail("Registered filesystem transfer unexpectedly materialized Arrow")
+
+    config = DuckDBConfig(
+        connection_config={"database": f":memory:registered_{uuid4().hex}"},
+        driver_features={"on_connection_create": configure},
+    )
+    uri = f"memory://sqlspec-native/{uuid4().hex}.parquet"
+    monkeypatch.setattr(DuckDBDriver, "select_to_arrow", reject_arrow)
+    monkeypatch.setattr(DuckDBDriver, "load_from_arrow", reject_arrow)
+    try:
+        with config.provide_session() as session:
+            exported = session.select_to_storage("SELECT 7 AS value", uri)
+            session.connection.execute("CREATE TABLE target(value INTEGER)")
+            imported = session.load_from_storage("target", uri, file_format="parquet")
+            assert exported.telemetry["backend"] == imported.telemetry["backend"] == "duckdb"
+            assert session.connection.execute("SELECT * FROM target").fetchall() == [(7,)]
+    finally:
+        config.close_pool()
+        if filesystem.exists(uri):
+            filesystem.rm(uri)
+
+
 def test_native_http_parquet_read(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     pq.write_table(pa.table({"id": [1, 2], "name": ["001", None]}), tmp_path / "data.parquet")
     server = ThreadingHTTPServer(("127.0.0.1", 0), partial(SimpleHTTPRequestHandler, directory=str(tmp_path)))

--- a/tests/integration/adapters/duckdb/duckdb/test_native_storage.py
+++ b/tests/integration/adapters/duckdb/duckdb/test_native_storage.py
@@ -292,6 +292,16 @@ def test_native_export_does_not_materialize_arrow(
             assert session.connection.execute(read_sql, [f"s3://{bucket}/{key}"]).fetchall() == [
                 ("quote' and ?", 42, "quote' and ?")
             ]
+            replacement = session.select_to_storage(
+                "SELECT :first AS first, :second AS second, :first AS repeated",
+                f"alias://{alias}/{key}",
+                {"first": "replaced", "second": 7},
+                format_hint=cast("StorageFormat", file_format),
+            )
+            assert replacement.telemetry["rows_processed"] == 1
+            assert session.connection.execute(read_sql, [f"s3://{bucket}/{key}"]).fetchall() == [
+                ("replaced", 7, "replaced")
+            ]
     finally:
         config.close_pool()
         if fs.exists(f"{bucket}/{key}"):

--- a/tests/integration/adapters/duckdb/duckdb/test_native_storage.py
+++ b/tests/integration/adapters/duckdb/duckdb/test_native_storage.py
@@ -1,6 +1,12 @@
 """Local extension and S3-compatible behavior behind native storage eligibility."""
 
+import json
+import os
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from threading import Thread
+from typing import Any, cast
 from uuid import uuid4
 
 import duckdb
@@ -11,8 +17,56 @@ from pytest_databases.docker.rustfs import RustfsService
 
 from sqlspec.adapters.duckdb import DuckDBConfig
 from sqlspec.adapters.duckdb.core import _native_storage_eligible
-from sqlspec.storage import StorageRegistry, SyncStoragePipeline
+from sqlspec.adapters.duckdb.driver import DuckDBDriver
+from sqlspec.storage import StorageFormat, StorageRegistry, SyncStoragePipeline
+from sqlspec.storage.registry import storage_registry
 from tests.fixtures.rustfs import ensure_rustfs_bucket, rustfs_filesystem, rustfs_obstore_kwargs
+
+
+def test_native_http_parquet_read(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pq.write_table(pa.table({"id": [1, 2], "name": ["001", None]}), tmp_path / "data.parquet")
+    server = ThreadingHTTPServer(("127.0.0.1", 0), partial(SimpleHTTPRequestHandler, directory=str(tmp_path)))
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    config = DuckDBConfig(
+        connection_config={"database": f":memory:http_{uuid4().hex}"},
+        driver_features={"extensions": [{"name": "httpfs", "required": True}]},
+    )
+
+    def reject_arrow(*args: Any, **kwargs: Any) -> Any:
+        pytest.fail("HTTP Parquet import unexpectedly materialized Arrow")
+
+    monkeypatch.setattr(DuckDBDriver, "load_from_arrow", reject_arrow)
+    try:
+        with config.provide_session() as session:
+            session.connection.execute("CREATE TABLE target(id INTEGER, name VARCHAR)")
+            job = session.load_from_storage(
+                "target", f"http://127.0.0.1:{server.server_port}/data.parquet", file_format="parquet"
+            )
+            assert job.telemetry["backend"] == "duckdb"
+            assert job.telemetry["rows_processed"] == 2
+            assert session.connection.execute("SELECT * FROM target").fetchall() == [(1, "001"), (2, None)]
+    finally:
+        config.close_pool()
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+@pytest.mark.skipif(not os.getenv("SQLSPEC_DUCKDB_STORAGE_BENCHMARK"), reason="Opt-in local storage benchmark")
+def test_native_storage_benchmark(
+    rustfs_service: RustfsService, rustfs_bucket_name: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from tools.scripts.bench_duckdb_storage import run_benchmark
+
+    bucket = ensure_rustfs_bucket(rustfs_service, rustfs_bucket_name)
+    monkeypatch.setenv("SQLSPEC_STORAGE_ENDPOINT", f"http://{rustfs_service.endpoint}")
+    monkeypatch.setenv("SQLSPEC_STORAGE_BUCKET", bucket)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", rustfs_service.access_key)
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", rustfs_service.secret_key)
+    results = run_benchmark()
+    Path(os.environ["SQLSPEC_DUCKDB_STORAGE_BENCHMARK"]).write_text(json.dumps(results, indent=2) + "\n")
+    assert len(results["results"]) == 3
 
 
 @pytest.mark.parametrize("autoload", [False, True])
@@ -126,3 +180,120 @@ def test_local_object_success_missing_and_auth_errors(
         good.close_pool()
         wrong.close_pool()
         fs.rm(f"{bucket}/{key}")
+
+
+@pytest.mark.parametrize("file_format", ["parquet", "csv"])
+def test_arrow_and_native_copy_replace_single_local_object(
+    rustfs_service: RustfsService, rustfs_bucket_name: str, file_format: str
+) -> None:
+    bucket = ensure_rustfs_bucket(rustfs_service, rustfs_bucket_name)
+    alias = f"duckdb_copy_{uuid4().hex}"
+    key = f"duckdb-copy-probe/{uuid4().hex}.{file_format}"
+    options = rustfs_obstore_kwargs(rustfs_service)
+    storage_registry.register_alias(alias, f"s3://{bucket}", backend="obstore", **options)
+    config = _local_config(rustfs_service)
+    uri = f"s3://{bucket}/{key}"
+    fs = rustfs_filesystem(rustfs_service)
+    try:
+        with config.provide_session() as session:
+            for value in [1, 2]:
+                job = session.select_to_storage(
+                    "SELECT ? AS value",
+                    f"alias://{alias}/{key}",
+                    value,
+                    format_hint=cast("StorageFormat", file_format),
+                    arrow_schema=pa.schema([("value", pa.int32())]),
+                )
+                assert job.telemetry["rows_processed"] == 1
+                assert job.telemetry["bytes_processed"] > 0
+                assert job.telemetry["destination"] == key
+            copy_sql = (
+                "COPY (SELECT ? AS value) TO ? (FORMAT PARQUET)"
+                if file_format == "parquet"
+                else "COPY (SELECT ? AS value) TO ? (FORMAT CSV, HEADER TRUE)"
+            )
+            read_sql = "SELECT * FROM read_parquet(?)" if file_format == "parquet" else "SELECT * FROM read_csv(?)"
+            for value in [3, 4]:
+                assert session.connection.execute(copy_sql, [uri, value]).fetchone() == (1,)
+                assert session.connection.execute(read_sql, [uri]).fetchall() == [(value,)]
+    finally:
+        config.close_pool()
+        fs.rm(f"{bucket}/{key}")
+        storage_registry.clear_cache(alias)
+
+
+def test_native_parquet_append_and_overwrite_fallback(
+    rustfs_service: RustfsService, rustfs_bucket_name: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bucket = ensure_rustfs_bucket(rustfs_service, rustfs_bucket_name)
+    alias = f"duckdb_import_{uuid4().hex}"
+    key = f"duckdb-native-import/{uuid4().hex}.parquet"
+    destination = f"alias://{alias}/{key}"
+    storage_registry.register_alias(alias, f"s3://{bucket}", backend="obstore", **rustfs_obstore_kwargs(rustfs_service))
+    config = _local_config(rustfs_service)
+    fs = rustfs_filesystem(rustfs_service)
+
+    def reject_arrow(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("native append must not materialize Arrow")
+
+    try:
+        with config.provide_session() as session:
+            session.select_to_storage("SELECT 1 AS id, NULL::VARCHAR AS name", destination)
+            session.connection.execute('CREATE TABLE "target space" (id INTEGER, name VARCHAR)')
+            with monkeypatch.context() as patch:
+                patch.setattr(DuckDBDriver, "load_from_arrow", reject_arrow)
+                for _ in range(2):
+                    job = session.load_from_storage('"target space"', destination, file_format="parquet")
+                    assert job.telemetry["rows_processed"] == 1
+                    assert job.telemetry["backend"] == "duckdb"
+                    assert "bytes_processed" not in job.telemetry
+            assert session.connection.execute('SELECT * FROM "target space"').fetchall() == [(1, None), (1, None)]
+            job = session.load_from_storage('"target space"', destination, file_format="parquet", overwrite=True)
+            assert job.telemetry["rows_processed"] == 1
+            assert session.connection.execute('SELECT * FROM "target space"').fetchall() == [(1, None)]
+    finally:
+        config.close_pool()
+        if fs.exists(f"{bucket}/{key}"):
+            fs.rm(f"{bucket}/{key}")
+        storage_registry.clear_cache(alias)
+
+
+@pytest.mark.parametrize("file_format", ["parquet", "csv"])
+def test_native_export_does_not_materialize_arrow(
+    rustfs_service: RustfsService, rustfs_bucket_name: str, file_format: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    bucket = ensure_rustfs_bucket(rustfs_service, rustfs_bucket_name)
+    alias = f"duckdb_export_{uuid4().hex}"
+    key = f"duckdb-native-export/{uuid4().hex}-quote'.{file_format}"
+    storage_registry.register_alias(alias, f"s3://{bucket}", backend="obstore", **rustfs_obstore_kwargs(rustfs_service))
+    config = _local_config(rustfs_service)
+    fs = rustfs_filesystem(rustfs_service)
+
+    def reject_arrow(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("native export must not materialize Arrow")
+
+    monkeypatch.setattr(DuckDBDriver, "select_to_arrow", reject_arrow)
+    try:
+        with config.provide_session() as session:
+            job = session.select_to_storage(
+                "SELECT :first AS first, :second AS second, :first AS repeated",
+                f"alias://{alias}/{key}",
+                {"first": "quote' and ?", "second": 42},
+                format_hint=cast("StorageFormat", file_format),
+                telemetry={"extra": {"marker": "retained"}},
+            )
+            assert job.telemetry["rows_processed"] == 1
+            assert "bytes_processed" not in job.telemetry
+            assert job.telemetry["duration_s"] >= 0
+            assert job.telemetry["backend"] == "duckdb"
+            source_telemetry = cast("dict[str, Any]", job.telemetry["extra"]["source"])
+            assert source_telemetry["extra"]["marker"] == "retained"
+            read_sql = "SELECT * FROM read_parquet(?)" if file_format == "parquet" else "SELECT * FROM read_csv(?)"
+            assert session.connection.execute(read_sql, [f"s3://{bucket}/{key}"]).fetchall() == [
+                ("quote' and ?", 42, "quote' and ?")
+            ]
+    finally:
+        config.close_pool()
+        if fs.exists(f"{bucket}/{key}"):
+            fs.rm(f"{bucket}/{key}")
+        storage_registry.clear_cache(alias)

--- a/tests/integration/adapters/duckdb/duckdb/test_native_storage.py
+++ b/tests/integration/adapters/duckdb/duckdb/test_native_storage.py
@@ -29,8 +29,11 @@ def test_native_http_parquet_read(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     thread = Thread(target=server.serve_forever, daemon=True)
     thread.start()
     config = DuckDBConfig(
-        connection_config={"database": f":memory:http_{uuid4().hex}"},
-        driver_features={"extensions": [{"name": "httpfs", "required": True}]},
+        connection_config={
+            "database": f":memory:http_{uuid4().hex}",
+            "extension_directory": str(tmp_path / "extensions"),
+        },
+        driver_features={"extensions": [{"name": "httpfs", "install": True, "required": True}]},
     )
 
     def reject_arrow(*args: Any, **kwargs: Any) -> Any:
@@ -88,7 +91,7 @@ def test_unavailable_extension_is_distinct_from_object_failure(tmp_path: Path, a
 def test_pool_storage_snapshot_tracks_actual_connection(tmp_path: Path) -> None:
     config = DuckDBConfig(
         connection_config={"database": f":memory:storage_{uuid4().hex}", "autoload_known_extensions": False},
-        driver_features={"extensions": [{"name": "httpfs", "required": True}]},
+        driver_features={"extensions": [{"name": "httpfs", "install": True, "required": True}]},
     )
     try:
         with config.provide_session() as session:
@@ -128,7 +131,7 @@ def _local_config(service: RustfsService, *, wrong_key: bool = False) -> DuckDBC
             "autoinstall_known_extensions": False,
         },
         driver_features={
-            "extensions": [{"name": "httpfs", "required": True}],
+            "extensions": [{"name": "httpfs", "install": True, "required": True}],
             "secrets": [
                 {
                     "name": "local_storage",

--- a/tests/integration/adapters/duckdb/duckdb/test_native_storage.py
+++ b/tests/integration/adapters/duckdb/duckdb/test_native_storage.py
@@ -1,0 +1,128 @@
+"""Local extension and S3-compatible behavior behind native storage eligibility."""
+
+from pathlib import Path
+from uuid import uuid4
+
+import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from pytest_databases.docker.rustfs import RustfsService
+
+from sqlspec.adapters.duckdb import DuckDBConfig
+from sqlspec.adapters.duckdb.core import _native_storage_eligible
+from sqlspec.storage import StorageRegistry, SyncStoragePipeline
+from tests.fixtures.rustfs import ensure_rustfs_bucket, rustfs_filesystem, rustfs_obstore_kwargs
+
+
+@pytest.mark.parametrize("autoload", [False, True])
+def test_unavailable_extension_is_distinct_from_object_failure(tmp_path: Path, autoload: bool) -> None:
+    with duckdb.connect(
+        config={
+            "extension_directory": str(tmp_path),
+            "autoload_known_extensions": autoload,
+            "autoinstall_known_extensions": autoload,
+            "autoinstall_extension_repository": "http://127.0.0.1:9",
+        }
+    ) as connection:
+        with pytest.raises(duckdb.Error, match=r"extension.*httpfs") as exc:
+            connection.execute("SELECT * FROM read_parquet(?)", ["s3://sqlspec-probe/missing.parquet"])
+        assert type(exc.value) is duckdb.Error
+        assert connection.execute("SELECT 1").fetchone() == (1,)
+
+
+def test_pool_storage_snapshot_tracks_actual_connection(tmp_path: Path) -> None:
+    config = DuckDBConfig(
+        connection_config={"database": f":memory:storage_{uuid4().hex}", "autoload_known_extensions": False},
+        driver_features={"extensions": [{"name": "httpfs", "required": True}]},
+    )
+    try:
+        with config.provide_session() as session:
+            assert session.driver_features["_duckdb_storage_extensions"] == frozenset({"httpfs"})
+        pool = config.provide_pool()
+        pool.close()
+        pool._extensions.clear()
+        with config.provide_session() as session:
+            assert session.driver_features["_duckdb_storage_extensions"] == frozenset()
+    finally:
+        config.close_pool()
+
+
+def test_best_effort_extension_failure_does_not_enable_native_storage(tmp_path: Path) -> None:
+    config = DuckDBConfig(
+        connection_config={
+            "database": f":memory:storage_{uuid4().hex}",
+            "extension_directory": str(tmp_path),
+            "autoload_known_extensions": False,
+            "autoinstall_known_extensions": False,
+        },
+        driver_features={"extensions": [{"name": "httpfs"}]},
+    )
+    try:
+        with config.provide_session() as session:
+            assert session.driver_features.get("_duckdb_storage_extensions", frozenset()) == frozenset()
+            assert session.connection.execute("SELECT 1").fetchone() == (1,)
+    finally:
+        config.close_pool()
+
+
+def _local_config(service: RustfsService, *, wrong_key: bool = False) -> DuckDBConfig:
+    return DuckDBConfig(
+        connection_config={
+            "database": f":memory:duckdb_storage_{uuid4().hex}",
+            "autoload_known_extensions": False,
+            "autoinstall_known_extensions": False,
+        },
+        driver_features={
+            "extensions": [{"name": "httpfs", "required": True}],
+            "secrets": [
+                {
+                    "name": "local_storage",
+                    "secret_type": "s3",
+                    "required": True,
+                    "value": {
+                        "key_id": "invalid-local-key" if wrong_key else service.access_key,
+                        "secret": service.secret_key,
+                        "region": "us-east-1",
+                        "endpoint": service.endpoint,
+                        "use_ssl": service.secure,
+                        "url_style": "path",
+                    },
+                }
+            ],
+        },
+    )
+
+
+def test_local_object_success_missing_and_auth_errors(
+    rustfs_service: RustfsService, rustfs_bucket_name: str, tmp_path: Path
+) -> None:
+    bucket = ensure_rustfs_bucket(rustfs_service, rustfs_bucket_name)
+    key = f"duckdb-native-probe/{uuid4().hex}.parquet"
+    path = tmp_path / "source.parquet"
+    pq.write_table(pa.table({"value": [1, 2]}), path)
+    fs = rustfs_filesystem(rustfs_service)
+    fs.put_file(str(path), f"{bucket}/{key}")
+    uri = f"s3://{bucket}/{key}"
+    good = _local_config(rustfs_service)
+    wrong = _local_config(rustfs_service, wrong_key=True)
+    try:
+        with good.provide_session() as session:
+            registry = StorageRegistry()
+            options = rustfs_obstore_kwargs(rustfs_service)
+            registry.register_alias("native_probe", f"s3://{bucket}", backend="obstore", **options)
+            target = SyncStoragePipeline(registry=registry).resolve_destination(f"alias://native_probe/{key}")
+            assert target.uri == uri
+            assert _native_storage_eligible(target.uri, target.protocol, options, session.driver_features, write=False)
+            assert session.connection.execute("SELECT * FROM read_parquet(?)", [uri]).fetchall() == [(1,), (2,)]
+            with pytest.raises(duckdb.Error) as missing:
+                session.connection.execute("SELECT * FROM read_parquet(?)", [uri + ".missing"])
+            assert "404" in str(missing.value)
+        with wrong.provide_session() as session:
+            with pytest.raises(duckdb.Error) as denied:
+                session.connection.execute("SELECT * FROM read_parquet(?)", [uri])
+            assert "403" in str(denied.value)
+    finally:
+        good.close_pool()
+        wrong.close_pool()
+        fs.rm(f"{bucket}/{key}")

--- a/tests/unit/adapters/test_duckdb/test_extension_lifecycle.py
+++ b/tests/unit/adapters/test_duckdb/test_extension_lifecycle.py
@@ -62,6 +62,9 @@ class _SpyConnection:
     def close(self) -> None:
         pass
 
+    def list_filesystems(self) -> list[str]:
+        return []
+
 
 def _spy_connect(
     monkeypatch: pytest.MonkeyPatch, *, fail_install: bool = False, fail_load: bool = False
@@ -86,6 +89,23 @@ def test_name_only_extension_never_installs(monkeypatch: pytest.MonkeyPatch) -> 
 
     assert install_log == []
     assert load_log == ["postgres"]
+
+
+@pytest.mark.parametrize("fail_load", [False, True])
+@pytest.mark.parametrize(
+    ("extension", "protocols"),
+    [
+        ({"name": "gcs"}, {"gcss"}),
+        ({"name": "custom", "storage_protocols": ["custom", "custom+alias"]}, {"custom", "custom+alias"}),
+    ],
+)
+def test_filesystem_protocols_require_successful_extension_load(
+    monkeypatch: pytest.MonkeyPatch, extension: dict[str, Any], protocols: set[str], fail_load: bool
+) -> None:
+    _spy_connect(monkeypatch, fail_load=fail_load)
+    pool = DuckDBConnectionPool({"database": ":memory:"}, extensions=[extension])
+    pool._create_connection()
+    assert pool._thread_local.storage_protocols == (frozenset() if fail_load else frozenset(protocols))
 
 
 def test_explicit_install_runs_once_across_sessions(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:

--- a/tests/unit/adapters/test_duckdb/test_native_export.py
+++ b/tests/unit/adapters/test_duckdb/test_native_export.py
@@ -1,0 +1,48 @@
+"""Native COPY SQL keeps query values and object names bound."""
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from sqlspec.adapters.duckdb.core import _build_storage_copy_sql, _build_storage_read_sql
+
+
+@pytest.mark.parametrize("file_format", ["parquet", "csv"])
+def test_copy_filename_precedes_query_bindings(tmp_path: Path, file_format: str) -> None:
+    path = str(tmp_path / f"quote'and?question.{file_format}")
+    sql = _build_storage_copy_sql("SELECT ? AS first, ? AS second, ? AS repeated, '?' AS literal", file_format)
+    assert sql is not None
+    with duckdb.connect() as connection:
+        assert connection.execute(sql, [path, "first", 42, "first"]).fetchone() == (1,)
+        read_sql = "SELECT * FROM read_parquet(?)" if file_format == "parquet" else "SELECT * FROM read_csv(?)"
+        assert connection.execute(read_sql, [path]).fetchall() == [("first", 42, "first", "?")]
+
+
+@pytest.mark.parametrize("query", ["DELETE FROM t", "INSERT INTO t VALUES (1)", "SELECT 1; SELECT 2"])
+def test_non_query_or_multiple_statements_keep_original_path(query: str) -> None:
+    assert _build_storage_copy_sql(query, "parquet") is None
+
+
+def test_native_append_quotes_target_and_disables_hive_columns(tmp_path: Path) -> None:
+    parent = tmp_path / "partition=value"
+    parent.mkdir()
+    path = str(parent / "data.parquet")
+    sql = _build_storage_read_sql('"target space"', path, "parquet")
+    assert sql is not None
+    with duckdb.connect() as connection:
+        connection.execute("COPY (SELECT 1 AS id, NULL::VARCHAR AS name) TO ? (FORMAT PARQUET)", [path])
+        connection.execute('CREATE TABLE "target space" (id INTEGER, name VARCHAR)')
+        assert connection.execute(sql, [path]).fetchone() == (1,)
+        assert connection.execute('SELECT * FROM "target space"').fetchall() == [(1, None)]
+
+
+@pytest.mark.parametrize("table", ["target; DELETE FROM other", "target t", "target WHERE true", "target()"])
+def test_native_append_rejects_target_fragments(table: str) -> None:
+    with pytest.raises(ValueError, match="table"):
+        _build_storage_read_sql(table, "s3://bucket/data.parquet", "parquet")
+
+
+@pytest.mark.parametrize("uri", ["s3://bucket/a*.parquet", "s3://bucket/a?.parquet", "s3://bucket/[ab].parquet"])
+def test_native_append_globs_keep_single_object_fallback(uri: str) -> None:
+    assert _build_storage_read_sql("target", uri, "parquet") is None

--- a/tests/unit/adapters/test_duckdb/test_native_storage.py
+++ b/tests/unit/adapters/test_duckdb/test_native_storage.py
@@ -1,0 +1,294 @@
+"""Native storage eligibility preserves the selected backend's configuration."""
+
+from typing import Any
+
+import pytest
+
+from sqlspec.adapters.duckdb.core import _native_storage_eligible
+
+
+@pytest.fixture
+def storage_settings() -> dict[str, Any]:
+    return {
+        "_duckdb_storage_extensions": frozenset({"httpfs"}),
+        "_duckdb_storage_secrets": (
+            {
+                "secret_type": "s3",
+                "name": "local_store",
+                "scope": "s3://bucket/",
+                "value": {
+                    "key_id": "local-key",
+                    "secret": "local-secret",
+                    "region": "us-east-1",
+                    "endpoint": "127.0.0.1:9000",
+                    "url_style": "path",
+                    "use_ssl": False,
+                },
+            },
+        ),
+    }
+
+
+@pytest.fixture
+def backend_options() -> dict[str, Any]:
+    return {
+        "aws_access_key_id": "local-key",
+        "aws_secret_access_key": "local-secret",
+        "aws_region": "us-east-1",
+        "aws_endpoint": "http://127.0.0.1:9000",
+        "aws_virtual_hosted_style_request": False,
+        "allow_http": True,
+    }
+
+
+@pytest.mark.parametrize("write", [True, False])
+def test_matching_local_provider_is_eligible(
+    storage_settings: dict[str, Any], backend_options: dict[str, Any], write: bool
+) -> None:
+    assert _native_storage_eligible(
+        "s3://bucket/prefix/file.parquet", "s3", backend_options, storage_settings, write=write
+    )
+
+
+@pytest.mark.parametrize("protocol", ["file", "memory", "ftp", "unknown", ""])
+def test_unsupported_protocol_uses_arrow(
+    storage_settings: dict[str, Any], backend_options: dict[str, Any], protocol: str
+) -> None:
+    assert not _native_storage_eligible(
+        "s3://bucket/file.parquet", protocol, backend_options, storage_settings, write=False
+    )
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        ("aws_access_key_id", "different-key"),
+        ("aws_secret_access_key", "different-secret"),
+        ("aws_region", "eu-west-1"),
+        ("aws_endpoint", "http://127.0.0.1:9001"),
+        ("aws_virtual_hosted_style_request", True),
+        ("allow_http", False),
+        ("request_timeout", 1),
+        ("aws_skip_signature", True),
+    ],
+)
+def test_changed_or_unrepresented_backend_option_uses_arrow(
+    storage_settings: dict[str, Any], backend_options: dict[str, Any], key: str, value: Any
+) -> None:
+    backend_options[key] = value
+    assert not _native_storage_eligible("s3://bucket/file.parquet", "s3", backend_options, storage_settings, write=True)
+
+
+def test_opaque_backend_uses_arrow(storage_settings: dict[str, Any]) -> None:
+    assert not _native_storage_eligible("s3://bucket/file.parquet", "s3", None, storage_settings, write=False)
+
+
+@pytest.mark.parametrize(
+    ("protocol", "secret_type", "extension"),
+    [
+        ("s3", "s3", "httpfs"),
+        ("gs", "gcs", "httpfs"),
+        ("gcs", "gcs", "httpfs"),
+        ("r2", "r2", "httpfs"),
+        ("az", "azure", "azure"),
+        ("azure", "azure", "azure"),
+        ("abfss", "azure", "azure"),
+    ],
+)
+@pytest.mark.parametrize("provider", ["config", "credential_chain"])
+@pytest.mark.parametrize("write", [False, True])
+def test_configured_cloud_provider_without_conflicting_backend_options(
+    protocol: str, secret_type: str, extension: str, provider: str, write: bool
+) -> None:
+    settings = {
+        "_duckdb_storage_extensions": frozenset({extension}),
+        "_duckdb_storage_secrets": (
+            {"secret_type": secret_type, "name": "cloud", "provider": provider, "scope": f"{protocol}://bucket/"},
+        ),
+    }
+    uri = f"{protocol}://bucket/file.parquet"
+    assert _native_storage_eligible(uri, protocol, {}, settings, write=write)
+    assert not _native_storage_eligible(uri, protocol, {"unknown_option": True}, settings, write=write)
+
+
+def test_gcs_oauth_does_not_match_native_hmac() -> None:
+    settings = {
+        "_duckdb_storage_extensions": frozenset({"httpfs"}),
+        "_duckdb_storage_secrets": (
+            {"secret_type": "gcs", "name": "gcs", "value": {"key_id": "hmac-id", "secret": "hmac-secret"}},
+        ),
+    }
+    assert not _native_storage_eligible(
+        "gs://bucket/file.parquet", "gs", {"service_account_key": "oauth-json"}, settings, write=False
+    )
+
+
+def test_azure_account_key_matches_connection_string() -> None:
+    settings = {
+        "_duckdb_storage_extensions": frozenset({"azure"}),
+        "_duckdb_storage_secrets": (
+            {
+                "secret_type": "azure",
+                "name": "azure",
+                "value": {
+                    "connection_string": "DefaultEndpointsProtocol=https;AccountName=test;AccountKey=key==;EndpointSuffix=core.windows.net"
+                },
+            },
+        ),
+    }
+    options = {"azure_storage_account_name": "test", "azure_storage_access_key": "key=="}
+    assert _native_storage_eligible("az://bucket/file.parquet", "az", options, settings, write=True)
+    options["azure_storage_access_key"] = "other=="
+    assert not _native_storage_eligible("az://bucket/file.parquet", "az", options, settings, write=True)
+
+
+def test_extension_intent_does_not_imply_loaded(backend_options: dict[str, Any]) -> None:
+    assert not _native_storage_eligible(
+        "s3://bucket/file.parquet", "s3", backend_options, {"extensions": [{"name": "httpfs"}]}, write=False
+    )
+
+
+def test_secret_scope_must_match(storage_settings: dict[str, Any], backend_options: dict[str, Any]) -> None:
+    assert not _native_storage_eligible(
+        "s3://other-bucket/file.parquet", "s3", backend_options, storage_settings, write=True
+    )
+
+
+def test_more_specific_secret_controls_credentials(
+    storage_settings: dict[str, Any], backend_options: dict[str, Any]
+) -> None:
+    general = storage_settings["_duckdb_storage_secrets"][0]
+    specific = {**general, "name": "specific", "scope": "s3://bucket/private/", "value": {"key_id": "other"}}
+    storage_settings["_duckdb_storage_secrets"] += (specific,)
+    assert not _native_storage_eligible(
+        "s3://bucket/private/file.parquet", "s3", backend_options, storage_settings, write=False
+    )
+
+
+@pytest.mark.parametrize("protocol", ["http", "https"])
+def test_public_http_reads_only(storage_settings: dict[str, Any], protocol: str) -> None:
+    uri = f"{protocol}://127.0.0.1/file.parquet"
+    assert _native_storage_eligible(uri, protocol, {}, storage_settings, write=False)
+    assert not _native_storage_eligible(uri, protocol, {}, storage_settings, write=True)
+    assert not _native_storage_eligible(
+        uri, protocol, {"headers": {"Authorization": "x"}}, storage_settings, write=False
+    )
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "",
+        42,
+        "localhost:9000",
+        "ftp://localhost",
+        "https://host/prefix",
+        "https://user:pass@host",
+        "https://host?query=1",
+    ],
+)
+def test_unsupported_endpoint_semantics_use_arrow(
+    storage_settings: dict[str, Any], backend_options: dict[str, Any], endpoint: Any
+) -> None:
+    backend_options["aws_endpoint"] = endpoint
+    assert not _native_storage_eligible(
+        "s3://bucket/file.parquet", "s3", backend_options, storage_settings, write=False
+    )
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"access_key_id": "conflicting-key"},
+        {"client_options": {"allow_http": False}},
+        {"client_options": {"proxy_url": "https://proxy"}},
+        {"client_options": "opaque"},
+    ],
+)
+def test_conflicting_aliases_or_custom_client_options_use_arrow(
+    storage_settings: dict[str, Any], backend_options: dict[str, Any], extra: dict[str, Any]
+) -> None:
+    backend_options.update(extra)
+    assert not _native_storage_eligible(
+        "s3://bucket/file.parquet", "s3", backend_options, storage_settings, write=False
+    )
+
+
+def test_ambiguous_same_scope_secrets_use_arrow(
+    storage_settings: dict[str, Any], backend_options: dict[str, Any]
+) -> None:
+    storage_settings["_duckdb_storage_secrets"] *= 2
+    assert not _native_storage_eligible(
+        "s3://bucket/file.parquet", "s3", backend_options, storage_settings, write=False
+    )
+
+
+def test_static_backend_keys_cannot_override_native_credential_chain(
+    storage_settings: dict[str, Any], backend_options: dict[str, Any]
+) -> None:
+    storage_settings["_duckdb_storage_secrets"][0]["provider"] = "credential_chain"
+    assert not _native_storage_eligible(
+        "s3://bucket/file.parquet", "s3", backend_options, storage_settings, write=False
+    )
+
+
+@pytest.mark.parametrize(
+    "connection_string",
+    [
+        "AccountName=test;AccountKey=key==;AccountName=other",
+        "invalid",
+        "AccountName=test;AccountKey=key==;BlobEndpoint=https://other",
+    ],
+)
+def test_azure_custom_or_ambiguous_connection_strings_use_arrow(connection_string: str) -> None:
+    settings = {
+        "_duckdb_storage_extensions": frozenset({"azure"}),
+        "_duckdb_storage_secrets": (
+            {"secret_type": "azure", "name": "azure", "value": {"connection_string": connection_string}},
+        ),
+    }
+    assert not _native_storage_eligible(
+        "az://bucket/file.parquet", "az", {"account_name": "test", "access_key": "key=="}, settings, write=False
+    )
+
+
+def test_equal_azure_connection_strings_are_eligible() -> None:
+    value = "DefaultEndpointsProtocol=https;AccountName=test;AccountKey=key=="
+    settings = {
+        "_duckdb_storage_extensions": frozenset({"azure"}),
+        "_duckdb_storage_secrets": ({"secret_type": "azure", "name": "azure", "value": {"connection_string": value}},),
+    }
+    assert _native_storage_eligible(
+        "az://bucket/file.parquet", "az", {"connection_string": value}, settings, write=True
+    )
+
+
+@pytest.mark.parametrize(
+    ("protocol", "provider_type", "endpoint", "extra"),
+    [
+        ("gs", "gcs", "https://storage.googleapis.com", {}),
+        ("r2", "r2", "https://account.r2.cloudflarestorage.com", {"account_id": "account"}),
+    ],
+)
+def test_known_cloud_endpoint_defaults_match_explicit_backend_options(
+    protocol: str, provider_type: str, endpoint: str, extra: dict[str, str]
+) -> None:
+    settings = {
+        "_duckdb_storage_extensions": frozenset({"httpfs"}),
+        "_duckdb_storage_secrets": (
+            {"secret_type": provider_type, "name": "cloud", "value": {"key_id": "id", "secret": "key", **extra}},
+        ),
+    }
+    options = {"access_key_id": "id", "secret_access_key": "key", "endpoint": endpoint}
+    assert _native_storage_eligible(f"{protocol}://bucket/file.parquet", protocol, options, settings, write=True)
+
+
+def test_default_s3_endpoint_still_preserves_explicit_addressing_style() -> None:
+    settings = {
+        "_duckdb_storage_extensions": frozenset({"httpfs"}),
+        "_duckdb_storage_secrets": (
+            {"secret_type": "s3", "name": "cloud", "value": {"key_id": "id", "secret": "key", "url_style": "path"}},
+        ),
+    }
+    options = {"access_key_id": "id", "secret_access_key": "key", "virtual_hosted_style_request": True}
+    assert not _native_storage_eligible("s3://bucket/file.parquet", "s3", options, settings, write=True)

--- a/tests/unit/adapters/test_duckdb/test_native_storage.py
+++ b/tests/unit/adapters/test_duckdb/test_native_storage.py
@@ -8,6 +8,40 @@ from sqlspec.adapters.duckdb.core import _native_storage_eligible, _resolve_nati
 from sqlspec.storage import StorageRegistry, SyncStoragePipeline
 
 
+@pytest.mark.parametrize("scheme", ["gcss", "memory", "custom+storage"])
+@pytest.mark.parametrize("write", [True, False])
+def test_configured_filesystem_preserves_uri_without_python_backend(
+    scheme: str, write: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def reject_resolution(*args: Any, **kwargs: Any) -> Any:
+        pytest.fail("A configured DuckDB filesystem must not require a Python storage backend")
+
+    monkeypatch.setattr(StorageRegistry, "get", reject_resolution)
+    uri = f"{scheme}://bucket/prefix/file.parquet"
+    target = _resolve_native_storage_target(
+        SyncStoragePipeline(), uri, {"_duckdb_storage_protocols": frozenset({scheme})}, write=write
+    )
+    assert target is not None
+    assert target.uri == uri
+
+
+@pytest.mark.parametrize("options", [{}, {"custom_option": True}])
+def test_registered_filesystem_alias_preserves_backend_options(options: dict[str, Any]) -> None:
+    registry = StorageRegistry()
+    registry.register_alias("reports", "memory://", backend="fsspec", base_path="bucket/prefix", **options)
+    target = _resolve_native_storage_target(
+        SyncStoragePipeline(registry=registry),
+        "alias://reports/file.parquet",
+        {"_duckdb_storage_protocols": frozenset({"memory", "alias"})},
+        write=True,
+    )
+    if options:
+        assert target is None
+    else:
+        assert target is not None
+        assert target.uri == "memory://bucket/prefix/file.parquet"
+
+
 @pytest.fixture
 def storage_settings() -> dict[str, Any]:
     return {

--- a/tests/unit/adapters/test_duckdb/test_native_storage.py
+++ b/tests/unit/adapters/test_duckdb/test_native_storage.py
@@ -4,7 +4,8 @@ from typing import Any
 
 import pytest
 
-from sqlspec.adapters.duckdb.core import _native_storage_eligible
+from sqlspec.adapters.duckdb.core import _native_storage_eligible, _resolve_native_storage_target
+from sqlspec.storage import StorageRegistry, SyncStoragePipeline
 
 
 @pytest.fixture
@@ -47,6 +48,54 @@ def test_matching_local_provider_is_eligible(
 ) -> None:
     assert _native_storage_eligible(
         "s3://bucket/prefix/file.parquet", "s3", backend_options, storage_settings, write=write
+    )
+
+
+@pytest.mark.parametrize("scheme", ["s3", "gs", "gcs", "r2", "az", "azure", "abfss"])
+def test_configured_cloud_uri_resolves_offline_without_changing_spelling(scheme: str) -> None:
+    provider = {"gs": "gcs", "gcs": "gcs", "az": "azure", "abfss": "azure"}.get(scheme, scheme)
+    settings = {
+        "_duckdb_storage_extensions": frozenset({"httpfs", "azure"}),
+        "_duckdb_storage_secrets": (
+            {
+                "secret_type": provider,
+                "value": {"connection_string": "DefaultEndpointsProtocol=https;AccountName=example;AccountKey=ZmFrZQ=="}
+                if provider == "azure"
+                else {},
+            },
+        ),
+    }
+    uri = f"{scheme}://bucket/prefix/file.parquet"
+    target = _resolve_native_storage_target(SyncStoragePipeline(registry=StorageRegistry()), uri, settings, write=True)
+    assert target is not None
+    assert target.uri == uri
+    assert target.protocol == scheme
+
+
+def test_alias_named_gcs_retains_its_actual_backend(
+    storage_settings: dict[str, Any], backend_options: dict[str, Any]
+) -> None:
+    registry = StorageRegistry()
+    options = {key: value for key, value in backend_options.items() if key != "allow_http"}
+    options["client_options"] = {"allow_http": True}
+    registry.register_alias("gcs", "s3://bucket/prefix", **options)
+    target = _resolve_native_storage_target(
+        SyncStoragePipeline(registry=registry), "alias://gcs/file.parquet", storage_settings, write=True
+    )
+    assert target is not None
+    assert target.uri == "s3://bucket/prefix/file.parquet"
+    assert target.protocol == "s3"
+
+
+@pytest.mark.parametrize("destination", ["s3://bucket/a?b", "s3://bucket/a#b", "file:///tmp/a", "local.parquet"])
+def test_unrepresentable_object_names_and_local_paths_fall_back(
+    storage_settings: dict[str, Any], destination: str
+) -> None:
+    assert (
+        _resolve_native_storage_target(
+            SyncStoragePipeline(registry=StorageRegistry()), destination, storage_settings, write=True
+        )
+        is None
     )
 
 

--- a/tests/unit/adapters/test_duckdb/test_native_storage_driver.py
+++ b/tests/unit/adapters/test_duckdb/test_native_storage_driver.py
@@ -1,0 +1,141 @@
+"""Execute the native transfer statements with a counted in-memory connection."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import duckdb
+import pytest
+
+from sqlspec.adapters.duckdb._typing import DuckDBConnection
+from sqlspec.adapters.duckdb.driver import DuckDBDriver
+from sqlspec.exceptions import SQLSpecError
+from sqlspec.storage import ResolvedStorageTarget
+
+_FEATURES = {"storage_capabilities": {"arrow_export_enabled": True, "arrow_import_enabled": True}}
+
+
+def test_native_export_keeps_builder_and_statement_filter_parameters(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from sqlspec import sql
+    from sqlspec.core import LimitOffsetFilter
+
+    path = str(tmp_path / "filtered.parquet")
+    monkeypatch.setattr(
+        "sqlspec.adapters.duckdb.driver._resolve_native_storage_target",
+        lambda *args, **kwargs: ResolvedStorageTarget(path, "s3"),
+    )
+    with duckdb.connect() as connection:
+        connection.execute("CREATE TABLE dataset AS SELECT i AS id FROM range(5) t(i)")
+        driver = DuckDBDriver(connection, driver_features=_FEATURES)
+        query = sql.select("id").from_("dataset").where("id > :minimum", minimum=0).order_by("id")
+        job = driver.select_to_storage(query, "s3://bucket/filtered.parquet", LimitOffsetFilter(limit=2, offset=1))
+        assert job.telemetry["rows_processed"] == 2
+        assert connection.execute("SELECT * FROM read_parquet(?)", [path]).fetchall() == [(2,), (3,)]
+
+
+@pytest.mark.parametrize("empty", [False, True])
+def test_native_transfer_executes_one_statement_each(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, empty: bool
+) -> None:
+    path = str(tmp_path / "data.parquet")
+    monkeypatch.setattr(
+        "sqlspec.adapters.duckdb.driver._resolve_native_storage_target",
+        lambda *args, **kwargs: ResolvedStorageTarget(path, "s3"),
+    )
+    with duckdb.connect() as connection:
+        statements: list[str] = []
+
+        def execute(sql: str, parameters: Any = None) -> Any:
+            statements.append(sql)
+            return connection.execute(sql, parameters)
+
+        proxy = cast("DuckDBConnection", SimpleNamespace(execute=execute, fetchone=connection.fetchone))
+        driver = DuckDBDriver(proxy, driver_features=_FEATURES)
+        query = "SELECT :value AS value WHERE :include"
+        exported = driver.select_to_storage(
+            query,
+            "alias://objects/data.parquet",
+            {"value": "001", "include": not empty},
+            partitioner={"label": "retained"},
+        )
+        assert len(statements) == 1
+        assert exported.telemetry["rows_processed"] == int(not empty)
+        assert exported.telemetry["extra"]["partitioner"] == {"label": "retained"}
+        connection.execute("CREATE TABLE target(value VARCHAR)")
+        imported = driver.load_from_storage("target", "alias://objects/data.parquet", file_format="parquet")
+        assert len(statements) == 2
+        assert imported.telemetry["rows_processed"] == int(not empty)
+        assert connection.execute("SELECT * FROM target").fetchall() == ([] if empty else [("001",)])
+
+
+@pytest.mark.parametrize("operation", ["read", "write"])
+def test_native_failure_is_not_retried_through_arrow(monkeypatch: pytest.MonkeyPatch, operation: str) -> None:
+    monkeypatch.setattr(
+        "sqlspec.adapters.duckdb.driver._resolve_native_storage_target",
+        lambda *args, **kwargs: ResolvedStorageTarget("s3://bucket/object.parquet", "s3"),
+    )
+    attempts: list[str] = []
+
+    def execute(sql: str, parameters: Any = None) -> Any:
+        attempts.append(sql)
+        raise duckdb.IOException("storage authentication failed")
+
+    def reject_arrow(*args: Any, **kwargs: Any) -> Any:
+        pytest.fail("native execution failure retried through Arrow")
+
+    proxy = cast("DuckDBConnection", SimpleNamespace(execute=execute))
+    driver = DuckDBDriver(proxy, driver_features=_FEATURES)
+    monkeypatch.setattr(DuckDBDriver, "select_to_arrow", reject_arrow)
+    monkeypatch.setattr(DuckDBDriver, "load_from_arrow", reject_arrow)
+    with pytest.raises(SQLSpecError, match="authentication failed"):
+        if operation == "write":
+            driver.select_to_storage("SELECT 1", "s3://bucket/object.parquet")
+        else:
+            driver.load_from_storage("target", "s3://bucket/object.parquet", file_format="parquet")
+    assert len(attempts) == 1
+
+
+def test_custom_pipeline_and_arrow_schema_keep_existing_export(tmp_path: Path) -> None:
+    import pyarrow as pa
+
+    from sqlspec.storage import SyncStoragePipeline
+
+    class CustomPipeline(SyncStoragePipeline):
+        def __init__(self) -> None:
+            super().__init__(storage_options={"write_options": {"delimiter": ";"}})
+
+    class CustomDriver(DuckDBDriver):
+        storage_pipeline_factory = CustomPipeline
+
+    with duckdb.connect() as connection:
+        driver = CustomDriver(connection, driver_features=_FEATURES)
+        destination = tmp_path / "data.csv"
+        driver.select_to_storage(
+            "SELECT 1 AS a, 2 AS b",
+            destination,
+            format_hint="csv",
+            arrow_schema=pa.schema([("a", pa.int32()), ("b", pa.int32())]),
+        )
+        assert destination.read_text() == '"a";"b"\n1;2\n'
+
+
+def test_csv_import_preserves_arrow_inference(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "inference.csv"
+    path.write_text('"123",code,date,empty,null\n1,001,2024-01-01,"",\n2,002,2024-01-02,"x",NA\n')
+
+    def reject_native(*args: Any, **kwargs: Any) -> Any:
+        pytest.fail("CSV inference cannot safely select the native reader")
+
+    monkeypatch.setattr("sqlspec.adapters.duckdb.driver._resolve_native_storage_target", reject_native)
+    with duckdb.connect() as connection:
+        connection.execute(
+            'CREATE TABLE target("123" VARCHAR, code VARCHAR, date VARCHAR, empty VARCHAR, null_value VARCHAR)'
+        )
+        driver = DuckDBDriver(connection, driver_features=_FEATURES)
+        driver.load_from_storage("target", path, file_format="csv")
+        assert connection.execute("SELECT * FROM target").fetchall() == [
+            ("1", "1", "2024-01-01", "", None),
+            ("2", "2", "2024-01-02", "x", None),
+        ]

--- a/tests/unit/adapters/test_duckdb/test_pool.py
+++ b/tests/unit/adapters/test_duckdb/test_pool.py
@@ -30,6 +30,9 @@ class _FakeDuckDBConnection:
     def fetchone(self) -> tuple[Any, ...] | None:
         return self.verification_row
 
+    def list_filesystems(self) -> list[str]:
+        return []
+
 
 @pytest.mark.parametrize("identifier", ["my_openai_secret", "openai", "S3", "s3", "r2", "secret_1"])
 def test_validate_sql_identifier_accepts_safe_identifiers(identifier: str) -> None:

--- a/tests/unit/builder/test_sqlglot_arg_contracts.py
+++ b/tests/unit/builder/test_sqlglot_arg_contracts.py
@@ -28,6 +28,7 @@ EXP_MODULE_ALIASES = frozenset({"exp", "expressions", "sge"})
 
 KNOWN_SET_SITES: frozenset[tuple[str, str, str]] = frozenset({
     ("sqlspec/adapters/bigquery/core.py", "statement_values", "expressions"),
+    ("sqlspec/adapters/duckdb/core.py", "part", "quoted"),
     ("sqlspec/builder/_base.py", "final_expression", "with_"),
     ("sqlspec/builder/_base.py", "node", "quoted"),
     ("sqlspec/builder/_dml.py", "current_expr", "expression"),

--- a/tools/scripts/bench_duckdb_storage.py
+++ b/tools/scripts/bench_duckdb_storage.py
@@ -1,0 +1,209 @@
+"""Compare native Parquet transfers with Arrow against a provisioned local S3 service.
+
+Provision RustFS with pytest-databases; export SQLSPEC_STORAGE_ENDPOINT,
+SQLSPEC_STORAGE_BUCKET, AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. This script
+does not create services or cloud resources. Run with ``python -m
+tools.scripts.bench_duckdb_storage --output results.json``.
+"""
+
+import argparse
+import json
+import os
+import platform
+import shutil
+import statistics
+import subprocess
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+from urllib.parse import urlsplit
+from uuid import uuid4
+
+import duckdb
+import pyarrow as pa
+
+from sqlspec.adapters.duckdb import DuckDBConfig
+from sqlspec.storage import SyncStoragePipeline
+from sqlspec.storage.registry import storage_registry
+
+__all__ = ("run_benchmark",)
+
+
+def _measure(action: Callable[[], None], warmup: int, iterations: int) -> dict[str, Any]:
+    for _ in range(warmup):
+        action()
+    samples = []
+    for _ in range(iterations):
+        start = perf_counter()
+        action()
+        samples.append(perf_counter() - start)
+    return {
+        "median_s": statistics.median(samples),
+        "min_s": min(samples),
+        "max_s": max(samples),
+        "stdev_s": statistics.stdev(samples) if len(samples) > 1 else 0.0,
+        "samples_s": samples,
+    }
+
+
+def run_benchmark(*, sizes: Sequence[int] = (100, 1000, 10000), warmup: int = 4, iterations: int = 8) -> dict[str, Any]:
+    """Measure equivalent native and Arrow Parquet transfers on a local endpoint.
+
+    Args:
+        sizes: Dataset row counts.
+        warmup: Untimed repetitions per scenario.
+        iterations: Timed repetitions per scenario.
+
+    Returns:
+        JSON-compatible environment, verification and timing results.
+
+    Raises:
+        ValueError: Endpoint is not local or sample counts are invalid.
+        KeyError: Required environment configuration is absent.
+    """
+    endpoint = urlsplit(os.environ["SQLSPEC_STORAGE_ENDPOINT"])
+    if endpoint.hostname not in {"127.0.0.1", "localhost", "::1"} or endpoint.scheme not in {"http", "https"}:
+        msg = "The benchmark requires a local HTTP(S) object-store endpoint."
+        raise ValueError(msg)
+    if warmup < 0 or iterations < 1 or not sizes or min(sizes) < 1:
+        msg = "Dataset sizes and iterations must be positive; warmup must be nonnegative."
+        raise ValueError(msg)
+    bucket = os.environ["SQLSPEC_STORAGE_BUCKET"]
+    key = os.environ["AWS_ACCESS_KEY_ID"]
+    secret = os.environ["AWS_SECRET_ACCESS_KEY"]
+    alias = f"duckdb_bench_{uuid4().hex}"
+    storage_registry.register_alias(
+        alias,
+        f"s3://{bucket}",
+        backend="obstore",
+        aws_endpoint=endpoint.geturl(),
+        aws_access_key_id=key,
+        aws_secret_access_key=secret,
+        aws_virtual_hosted_style_request=False,
+        client_options={"allow_http": endpoint.scheme == "http"},
+    )
+    config = DuckDBConfig(
+        connection_config={"database": f":memory:benchmark_{uuid4().hex}"},
+        driver_features={
+            "extensions": [{"name": "httpfs", "required": True}],
+            "secrets": [
+                {
+                    "name": "benchmark",
+                    "secret_type": "s3",
+                    "required": True,
+                    "value": {
+                        "key_id": key,
+                        "secret": secret,
+                        "endpoint": endpoint.netloc,
+                        "region": "us-east-1",
+                        "url_style": "path",
+                        "use_ssl": endpoint.scheme == "https",
+                    },
+                }
+            ],
+        },
+    )
+    pipeline = SyncStoragePipeline()
+    objects: list[str] = []
+    results: list[dict[str, Any]] = []
+    cold_start = perf_counter()
+    try:
+        with config.provide_session() as driver:
+            provisioning_s = perf_counter() - cold_start
+            for rows in sizes:
+                driver.connection.execute(
+                    "CREATE OR REPLACE TABLE dataset AS SELECT i AS id, 'value-' || i AS label FROM range(?) t(i)",
+                    [rows],
+                )
+                driver.connection.execute("CREATE OR REPLACE TABLE imported AS SELECT * FROM dataset WHERE false")
+                native_key = f"sqlspec-benchmark/{alias}/{rows}-native.parquet"
+                arrow_key = f"sqlspec-benchmark/{alias}/{rows}-arrow.parquet"
+                objects.extend((native_key, arrow_key))
+                native_uri = f"alias://{alias}/{native_key}"
+                arrow_uri = f"alias://{alias}/{arrow_key}"
+
+                def native_export(native_uri: str = native_uri, rows: int = rows) -> None:
+                    job = driver.select_to_storage("SELECT * FROM dataset", native_uri)
+                    assert job.telemetry["backend"] == "duckdb"
+                    assert job.telemetry["rows_processed"] == rows
+
+                def arrow_export(arrow_uri: str = arrow_uri) -> None:
+                    table = driver.select_to_arrow("SELECT * FROM dataset").get_data()
+                    pipeline.write_arrow(table, arrow_uri, compression="snappy")
+
+                native_export()
+                arrow_export()
+                native_table, native_meta = pipeline.read_arrow(native_uri, file_format="parquet")
+                arrow_table, arrow_meta = pipeline.read_arrow(arrow_uri, file_format="parquet")
+                assert native_table.equals(arrow_table)
+
+                def native_import(native_uri: str = native_uri, rows: int = rows) -> None:
+                    job = driver.load_from_storage("imported", native_uri, file_format="parquet")
+                    assert job.telemetry["backend"] == "duckdb"
+                    assert job.telemetry["rows_processed"] == rows
+
+                def arrow_import(arrow_uri: str = arrow_uri) -> None:
+                    table, meta = pipeline.read_arrow(arrow_uri, file_format="parquet")
+                    driver.load_from_arrow("imported", table, telemetry=meta)
+
+                measurements: dict[str, Any] = {}
+                for name, action in (
+                    ("native_export", native_export),
+                    ("arrow_export", arrow_export),
+                    ("native_import", native_import),
+                    ("arrow_import", arrow_import),
+                ):
+                    driver.connection.execute("TRUNCATE imported")
+                    measurements[name] = _measure(action, warmup, iterations)
+                    if name.endswith("import"):
+                        count = driver.connection.execute("SELECT count(*) FROM imported").fetchone()
+                        assert count == (rows * (warmup + iterations),)
+                        differences = driver.connection.execute(
+                            "SELECT * FROM imported EXCEPT SELECT * FROM dataset"
+                        ).fetchall()
+                        assert differences == []
+                results.append({
+                    "rows": rows,
+                    "arrow_memory_bytes": native_table.nbytes,
+                    "native_object_bytes": native_meta["bytes_processed"],
+                    "arrow_object_bytes": arrow_meta["bytes_processed"],
+                    "measurements": measurements,
+                })
+    finally:
+        config.close_pool()
+        backend = storage_registry.get(alias)
+        for object_key in objects:
+            backend.delete_sync(object_key)
+        storage_registry.clear_cache(alias)
+    git = shutil.which("git")
+    if git is None:
+        msg = "Git is required to record the benchmark source revision."
+        raise RuntimeError(msg)
+    revision = subprocess.check_output([git, "rev-parse", "HEAD"], text=True).strip()
+    dirty = bool(subprocess.check_output([git, "status", "--porcelain"], text=True).strip())
+    return {
+        "source_revision": revision,
+        "working_tree_dirty": dirty,
+        "machine": platform.platform(),
+        "processor": platform.processor(),
+        "cpu_count": os.cpu_count(),
+        "python": platform.python_version(),
+        "duckdb": duckdb.__version__,
+        "pyarrow": pa.__version__,
+        "format": "parquet",
+        "compression": "snappy",
+        "warmup": warmup,
+        "iterations": iterations,
+        "cold_connection_and_extension_s": provisioning_s,
+        "cloud_verified": False,
+        "csv_import": "Arrow fallback; inference differs",
+        "results": results,
+    }
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, required=True)
+    arguments = parser.parse_args()
+    arguments.output.write_text(json.dumps(run_benchmark(), indent=2) + "\n")

--- a/tools/scripts/bench_duckdb_storage.py
+++ b/tools/scripts/bench_duckdb_storage.py
@@ -86,7 +86,7 @@ def run_benchmark(*, sizes: Sequence[int] = (100, 1000, 10000), warmup: int = 4,
     config = DuckDBConfig(
         connection_config={"database": f":memory:benchmark_{uuid4().hex}"},
         driver_features={
-            "extensions": [{"name": "httpfs", "required": True}],
+            "extensions": [{"name": "httpfs", "install": True, "required": True}],
             "secrets": [
                 {
                     "name": "benchmark",


### PR DESCRIPTION
DuckDB now reads and writes object-store data itself instead of routing every transfer through a Python Arrow table. Imports get meaningfully faster on large Parquet files, and neither direction materializes the whole payload in memory.

- **Imports append straight from remote Parquet.** `load_from_storage` issues a single `INSERT ... SELECT * FROM read_parquet(...)` instead of downloading, decoding and re-inserting.
- **Exports write straight to the object store.** `select_to_storage` issues a single `COPY (...) TO ...` for Parquet and CSV.
- **Everything else behaves exactly as before.** Local paths, unsupported formats, CSV imports, `overwrite=True`, custom Arrow schemas and storage options DuckDB can't represent all keep the existing path, and that choice is made before anything executes.
- **Target table names are validated.** The import path parses and quotes the qualified identifier and rejects anything that isn't a plain table name.
- **A failed native transfer is never silently retried**, since it may already have written data.

## How you use it

There is nothing to turn on. If a DuckDB connection already has the matching extension loaded and credentials configured — `httpfs` for `s3`/`gs`/`gcs`/`r2`, `azure` for `az`/`abfss` — eligible transfers take the native route automatically:

```python
driver.load_from_storage("events", "s3://bucket/events.parquet")
driver.select_to_storage("SELECT * FROM events", "s3://bucket/report.parquet")
```

When a request can't be represented natively, the call falls back to the previous behavior and returns the same result.

## Performance

Measured against a local S3-compatible store with snappy Parquet, native relative to the previous path (lower is faster):

| rows | export | import |
|---|---|---|
| 1,000 | 1.29x slower | 0.92x |
| 10,000 | 0.98x | 0.76x |
| 200,000 | 0.81x | 0.58x |
| 2,000,000 | 1.01x | 0.25x |

Import is the real gain and it scales with size. Export is a wash on wall-clock — its benefit is not building the payload in Python, which matters for memory rather than latency. The adapter documentation says so directly rather than implying a universal speedup.

Routing for GCS, R2 and Azure is covered, but transfers against those live services are not exercised here; the documentation marks them as unverified.
