### PR TITLE
feat(cockroach): add opt-in native EXPORT INTO and IMPORT INTO transfers

### DIFF
--- a/docs/reference/adapters/cockroach_asyncpg.rst
+++ b/docs/reference/adapters/cockroach_asyncpg.rst
@@ -35,3 +35,66 @@ Data Dictionary
 .. autoclass:: sqlspec.adapters.cockroach_asyncpg.data_dictionary.CockroachAsyncpgDataDictionary
    :members:
    :show-inheritance:
+
+Native object storage
+=====================
+
+Set ``driver_features={"enable_native_storage": True}`` to use CockroachDB
+EXPORT/IMPORT for remote CSV and Parquet. The feature is disabled by default.
+Exports create generated files below a prefix; imports append into existing
+tables, take them offline and invalidate foreign keys. Asyncpg requires no
+additional autocommit setting. Calls made inside an active transaction use the
+inherited client-side path.
+
+.. code-block:: python
+
+    import os
+    from urllib.parse import urlsplit, urlunsplit
+    from uuid import uuid4
+
+    from sqlspec.adapters.cockroach_asyncpg import CockroachAsyncpgConfig
+
+    config = CockroachAsyncpgConfig(
+        connection_config={"dsn": os.environ["DATABASE_URL"]},
+        driver_features={
+            "enable_native_storage": True,
+            "native_storage_csv_options": {"skip": 0},
+        },
+    )
+    parts = urlsplit(os.environ["COCKROACH_STORAGE_URI"])
+    destination = urlunsplit(
+        parts._replace(path=parts.path.rstrip("/") + "/" + uuid4().hex)
+    )
+    try:
+        async with config.provide_session() as driver:
+            exported = await driver.select_to_storage(
+                "SELECT :id::INT8 AS id, :label::STRING AS label",
+                destination,
+                {"id": 7, "label": "O'Reilly"},
+                format_hint="csv",
+            )
+            prefix = urlsplit(exported.telemetry["destination"])
+            for filename in exported.telemetry["extra"]["files"]:
+                source = urlunsplit(
+                    prefix._replace(path=prefix.path.rstrip("/") + "/" + filename)
+                )
+                await driver.load_from_storage("archive_items", source, file_format="csv")
+    finally:
+        await config.close_pool()
+
+The example assumes an existing ``archive_items(id INT8, label STRING)`` table
+and a server-readable storage URI. CSV export is headerless: ``skip=0`` imports
+all rows. Use ``skip=1`` for an external file with one header. Without explicit
+``skip``, CSV import uses the inherited header-aware reader. NULL markers
+(``nullas`` for export, ``nullif`` for import) are optional explicit strings;
+choose values absent from literal data. Unconfigured NULL export fails.
+Parquet avoids marker collisions and is the default export format.
+
+Remote aliases resolve through the storage registry. Disabled, local,
+unsupported-format/protocol and ``overwrite=True`` calls use the inherited
+path. Native failures propagate without an inherited retry. File metadata,
+privileges, cleanup, supported query forms, server restrictions and benchmark
+measurement details match :doc:`cockroach_psycopg`.
+
+Local tests cover CockroachDB CCL v26.2.5 with RustFS. CockroachDB Cloud tiers,
+hosted privileges, cloud credentials, GCS and Azure remain unverified.

--- a/docs/reference/adapters/cockroach_psycopg.rst
+++ b/docs/reference/adapters/cockroach_psycopg.rst
@@ -53,3 +53,167 @@ Async Data Dictionary
 .. autoclass:: sqlspec.adapters.cockroach_psycopg.data_dictionary.CockroachPsycopgAsyncDataDictionary
    :members:
    :show-inheritance:
+
+Native object storage
+=====================
+
+Set ``driver_features={"enable_native_storage": True}`` to let CockroachDB
+write or read CSV and Parquet directly. This changes the storage contract:
+``select_to_storage`` writes generated files below a destination prefix;
+``load_from_storage`` appends into an existing table and takes it offline.
+Imports invalidate foreign keys, which must be validated afterward.
+The feature is disabled by default.
+Install ``sqlspec[cockroachdb,obstore]`` for both drivers and URI resolution.
+The inherited CSV/Parquet paths additionally require ``pyarrow``.
+
+Both psycopg configurations require ``connection_config={"autocommit": True}``
+when native storage is enabled. SQLSpec never enables autocommit automatically.
+The driver also checks the actual connection before each native call. Active
+transactions, disabled features, unsupported formats/protocols, and
+``overwrite=True`` imports use the inherited client-side path. Native execution
+or result errors propagate once; SQLSpec does not retry them through that path.
+
+Native export supports a single SELECT, including query builders, filters and
+bound parameters that compile to positional driver parameters. Scripts,
+executemany statements and other statement types use the inherited path.
+Parquet is the default export format. Eligible resolved protocols are ``s3``,
+``gs``, ``gcs`` and ``azure``; the URI itself must use a scheme and credentials
+CockroachDB understands. Local paths and local aliases use client-side storage.
+Aliases resolve through the storage registry before database execution.
+
+The destination must be reachable by every CockroachDB node. Credentials stored
+only in a Python storage backend are not transferred to the database. Supply a
+server-readable URI or configure the server's external-storage identity.
+
+Export and import filenames
+---------------------------
+
+This example assumes an existing ``archive_items(id INT8, label STRING)`` table
+and a server-readable destination in ``COCKROACH_STORAGE_URI``. Use a fresh
+prefix for each export. ``extra["files"]`` contains the generated relative
+filenames; preserve URI query parameters when constructing import sources.
+
+.. code-block:: python
+
+    import os
+    from urllib.parse import urlsplit, urlunsplit
+    from uuid import uuid4
+
+    from sqlspec.adapters.cockroach_psycopg import CockroachPsycopgSyncConfig
+
+    config = CockroachPsycopgSyncConfig(
+        connection_config={
+            "conninfo": os.environ["DATABASE_URL"],
+            "autocommit": True,
+        },
+        driver_features={"enable_native_storage": True},
+    )
+    parts = urlsplit(os.environ["COCKROACH_STORAGE_URI"])
+    destination = urlunsplit(
+        parts._replace(path=parts.path.rstrip("/") + "/" + uuid4().hex)
+    )
+    try:
+        with config.provide_session() as driver:
+            exported = driver.select_to_storage(
+                "SELECT :id::INT8 AS id, :label::STRING AS label",
+                destination,
+                {"id": 7, "label": "O'Reilly"},
+                format_hint="parquet",
+            )
+            prefix = urlsplit(exported.telemetry["destination"])
+            for filename in exported.telemetry["extra"]["files"]:
+                source = urlunsplit(
+                    prefix._replace(path=prefix.path.rstrip("/") + "/" + filename)
+                )
+                driver.load_from_storage("archive_items", source, file_format="parquet")
+    finally:
+        config.close_pool()
+
+Export telemetry sums server-reported rows and file bytes. Import telemetry
+reports rows and ``extra["job_id"]``; its logical job byte count is not reported
+as an artifact size. Partition metadata and supplied export telemetry retain
+the standard storage job merge behavior. Generated files, including partial
+files after failure, remain the caller's responsibility to clean up.
+
+CSV conventions
+---------------
+
+Native CSV exports have no header. For the non-NULL example above, select CSV
+and configure ``native_storage_csv_options={"skip": 0}``; import the returned
+files with ``file_format="csv"``. ``skip=1`` instead acknowledges one header
+in an externally produced CSV file. Without an explicit ``skip``, CSV import
+uses the inherited header-aware reader. A boolean is not a valid skip count.
+
+``nullas`` sets an export NULL marker; ``nullif`` sets an import NULL marker.
+Both accept strings, including an explicit empty string. No marker is inferred:
+CSV export with NULL values and no ``nullas`` fails at the server. When using
+markers, choose matching values that cannot occur as literal data. In particular,
+using an empty marker can turn an empty string into NULL. Use Parquet to preserve
+arbitrary NULL, empty-string and literal-marker values without this convention.
+Only ``skip``, ``nullas`` and ``nullif`` are accepted; option values are bound.
+
+Privileges and validation boundary
+----------------------------------
+
+Export requires SELECT on the source table; import requires INSERT and DROP on
+the target. Custom S3 endpoints and implicit cloud credentials require the admin
+role or ``EXTERNALIOIMPLICITACCESS``. Explicit credentials for standard cloud
+storage have different privileges. Storage-provider permissions still apply.
+Import cannot run during a rolling upgrade. Consult CockroachDB's
+`EXPORT reference <https://docs.cockroachlabs.com/docs/stable/export>`_ and
+`IMPORT INTO reference <https://docs.cockroachlabs.com/docs/stable/import-into>`_
+for server-version restrictions and foreign-key revalidation.
+The import reference documents Parquet support as subject to change.
+
+Local validation used CockroachDB CCL v26.2.5 and RustFS. It covers all three
+SQLSpec Cockroach drivers, CSV/Parquet roundtrips, bound values, transaction
+refusal, NULL conventions and custom-endpoint privileges. CockroachDB Cloud
+tiers, hosted privileges, cloud identity chains, GCS and Azure are unverified.
+Local results do not establish support on every hosted tier.
+
+Performance measurement
+-----------------------
+
+``tools/scripts/bench_cockroach_storage.py`` compares native and inherited
+Parquet export/import with explicit local connection and storage configuration.
+Run ``--help`` for environment variables, row counts, warmups and iterations.
+It records per-sample timings, medians and ranges. A second connection samples
+table availability; its polling interval and query timeout limit the resolution.
+Zero failed probes does not prove the table was never offline. Each run removes
+only its generated tables and random storage prefix. Native job startup can
+outweigh avoided client transfers; benchmark the intended workload.
+
+A local Python 3.14 run against the services above used an INT8 key and a
+64-character string, one warmup and three measured samples per case. Times below
+are median milliseconds (minimum–maximum). Native operations were slower at
+all three sizes in this run; these small local samples do not predict cloud or
+large distributed workloads.
+
+.. list-table:: Local Parquet measurements
+   :header-rows: 1
+
+   * - Rows
+     - Client export
+     - Native export
+     - Client import
+     - Native import
+   * - 100
+     - 5.64 (5.44–5.65)
+     - 13.71 (13.43–15.61)
+     - 8.65 (8.53–9.54)
+     - 108.38 (107.40–112.24)
+   * - 1,000
+     - 6.54 (6.36–6.68)
+     - 15.39 (14.56–15.54)
+     - 20.15 (17.49–33.71)
+     - 113.81 (108.55–115.33)
+   * - 10,000
+     - 17.62 (15.51–54.69)
+     - 22.38 (20.88–26.84)
+     - 77.37 (74.92–90.20)
+     - 125.41 (124.19–129.62)
+
+Native imports produced two or three failed availability probes per sample;
+observed spans ranged from 21.4 to 42.3 ms. Client imports produced none.
+Polling was every 20 ms with a 250 ms query timeout. These spans are sampled
+observations, not exact table-offline durations.

--- a/docs/reference/adapters/cockroach_psycopg.rst
+++ b/docs/reference/adapters/cockroach_psycopg.rst
@@ -198,22 +198,23 @@ large distributed workloads.
      - Client import
      - Native import
    * - 100
-     - 5.64 (5.44–5.65)
-     - 13.71 (13.43–15.61)
-     - 8.65 (8.53–9.54)
-     - 108.38 (107.40–112.24)
+     - 5.34 (4.89–5.36)
+     - 12.78 (12.11–13.06)
+     - 8.61 (7.83–9.08)
+     - 107.03 (103.43–108.72)
    * - 1,000
-     - 6.54 (6.36–6.68)
-     - 15.39 (14.56–15.54)
-     - 20.15 (17.49–33.71)
-     - 113.81 (108.55–115.33)
+     - 6.59 (6.24–6.73)
+     - 13.55 (13.25–13.73)
+     - 18.92 (18.75–21.98)
+     - 112.92 (110.56–119.71)
    * - 10,000
-     - 17.62 (15.51–54.69)
-     - 22.38 (20.88–26.84)
-     - 77.37 (74.92–90.20)
-     - 125.41 (124.19–129.62)
+     - 16.62 (16.50–17.99)
+     - 23.18 (20.85–28.36)
+     - 76.41 (75.57–92.64)
+     - 129.86 (122.95–139.74)
 
-Native imports produced two or three failed availability probes per sample;
-observed spans ranged from 21.4 to 42.3 ms. Client imports produced none.
-Polling was every 20 ms with a 250 ms query timeout. These spans are sampled
-observations, not exact table-offline durations.
+Native imports produced two to four failed availability probes per sample, with
+observed spans between 21.3 and 63.2 ms. Client imports produced none. Polling
+was every 20 ms with a 250 ms query timeout. These spans are sampled
+observations of one run, not exact table-offline durations, and repeated runs
+move both the probe counts and the spans.

--- a/sqlspec/adapters/cockroach_asyncpg/config.py
+++ b/sqlspec/adapters/cockroach_asyncpg/config.py
@@ -22,6 +22,7 @@ from sqlspec.adapters.cockroach_asyncpg._typing import (
 from sqlspec.adapters.cockroach_asyncpg.driver import CockroachAsyncpgDriver, CockroachAsyncpgExceptionHandler
 from sqlspec.config import AsyncDatabaseConfig, ExtensionConfigs
 from sqlspec.driver._async import AsyncPoolConnectionContext, AsyncPoolSessionFactory
+from sqlspec.exceptions import ImproperConfigurationError
 from sqlspec.extensions.events import EventRuntimeHints
 from sqlspec.utils.config_tools import normalize_connection_config
 from sqlspec.utils.serializers import from_json, to_json
@@ -90,14 +91,46 @@ class CockroachAsyncpgPoolConfig(CockroachAsyncpgConnectionConfig):
     extra: NotRequired["dict[str, Any]"]
 
 
+class _NativeStorageCSVOptions(TypedDict):
+    """Explicit CSV conventions; no header or NULL marker is inferred."""
+
+    nullas: NotRequired[str]
+    nullif: NotRequired[str]
+    skip: NotRequired[int]
+
+
+def _validate_native_storage_options(driver_features: "dict[str, Any]") -> None:
+    if "native_storage_csv_options" not in driver_features:
+        return
+    options = driver_features["native_storage_csv_options"]
+    if not isinstance(options, dict) or options.keys() - {"nullas", "nullif", "skip"}:
+        msg = "native_storage_csv_options must contain only nullas, nullif, and skip."
+        raise ImproperConfigurationError(msg)
+    for key in ("nullas", "nullif"):
+        if key in options and not isinstance(options[key], str):
+            msg = "native_storage_csv_options nullas and nullif must be strings."
+            raise ImproperConfigurationError(msg)
+    if "skip" in options and (type(options["skip"]) is not int or options["skip"] < 0):
+        msg = "native_storage_csv_options skip must be a nonnegative integer, excluding bool."
+        raise ImproperConfigurationError(msg)
+    driver_features["native_storage_csv_options"] = dict(options)
+
+
 class CockroachAsyncpgDriverFeatures(TypedDict):
     """Driver feature flags for CockroachDB AsyncPG adapter.
 
+    enable_native_storage: Opt in to server-side storage operations. Exports create
+     generated files under a prefix; imports temporarily take the table offline.
+    native_storage_csv_options: Explicit nullas/nullif markers and skip count.
+     Export is headerless; native CSV import requires an explicit skip count.
+     Markers must not occur as literal data. No NULL marker is inferred.
     on_connection_create: Async callback executed when a connection is acquired from pool.
      Receives the raw asyncpg connection for low-level driver configuration.
      Called after internal setup (JSON codecs, pgvector registration).
     """
 
+    enable_native_storage: NotRequired[bool]
+    native_storage_csv_options: NotRequired[_NativeStorageCSVOptions]
     enable_auto_retry: NotRequired[bool]
     max_retries: NotRequired[int]
     retry_delay_base_ms: NotRequired[float]
@@ -183,6 +216,8 @@ class CockroachAsyncpgConfig(
         statement_config, driver_features = apply_driver_features(statement_config, driver_features)
         driver_features["enable_pgvector"] = raw_enable_pgvector
 
+        driver_features.setdefault("enable_native_storage", False)
+        _validate_native_storage_options(driver_features)
         driver_features.setdefault("enable_auto_retry", True)
 
         # Extract user connection hook before storing driver_features

--- a/sqlspec/adapters/cockroach_asyncpg/core.py
+++ b/sqlspec/adapters/cockroach_asyncpg/core.py
@@ -4,13 +4,27 @@ import secrets
 from typing import TYPE_CHECKING, Any, Final
 
 from mypy_extensions import mypyc_attr
+from sqlglot import tokenize
+from sqlglot.tokenizer_core import TokenType
 
+from sqlspec.utils.text import quote_identifier, split_qualified_identifier
 from sqlspec.utils.type_guards import has_sqlstate
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-__all__ = ("CockroachAsyncpgRetryConfig", "calculate_backoff_seconds", "is_retryable_error")
+    from sqlspec.storage import StorageTelemetry
+
+__all__ = (
+    "CockroachAsyncpgRetryConfig",
+    "build_native_export",
+    "build_native_import",
+    "calculate_backoff_seconds",
+    "is_retryable_error",
+    "native_export_telemetry",
+    "native_import_telemetry",
+    "normalize_native_export_query",
+)
 
 # Retry configuration defaults (module-level for mypyc compatibility)
 _DEFAULT_MAX_RETRIES: Final[int] = 10
@@ -63,3 +77,82 @@ def calculate_backoff_seconds(attempt: int, config: "CockroachAsyncpgRetryConfig
     jitter: float = secrets.randbelow(max_jitter + 1) / scale if max_jitter else 0.0
     delay_ms: float = min(base + jitter, config.max_delay_ms)
     return delay_ms / 1000.0
+
+
+def build_native_export(
+    query: str, parameters: "list[Any]", uri: str, file_format: str, options: "dict[str, Any]"
+) -> "tuple[str, list[Any]]":
+    """Wrap compiled query SQL without embedding destination or CSV values."""
+    format_sql = {"csv": "CSV", "parquet": "PARQUET"}[file_format]
+    values = [*parameters, uri]
+    command = "EXPORT INTO " + format_sql + " " + ("$" + str(len(values)))
+    if file_format == "csv" and "nullas" in options:
+        values.append(options["nullas"])
+        command += " WITH nullas = " + ("$" + str(len(values)))
+    return command + " FROM (" + query.rstrip().removesuffix(";") + "\n)", values
+
+
+def build_native_import(table: str, uri: str, file_format: str, options: "dict[str, Any]") -> "tuple[str, list[Any]]":
+    """Quote the target identifier and bind explicit CSV conventions."""
+    parts = split_qualified_identifier(table, quote_chars='"', allow_bracket_quotes=False)
+    if not parts:
+        msg = "Table name must not be empty"
+        raise ValueError(msg)
+    target = ".".join(quote_identifier(part) for part in parts)
+    format_sql = {"csv": "CSV", "parquet": "PARQUET"}[file_format]
+    values: list[Any] = [uri]
+    command = "IMPORT INTO " + target + " " + format_sql + " DATA (" + "$1" + ")"
+    clauses = []
+    if file_format == "csv":
+        for key in ("skip", "nullif"):
+            if key in options:
+                values.append(str(options[key]))
+                clauses.append(key + " = " + ("$" + str(len(values))))
+    if clauses:
+        command += " WITH " + ", ".join(clauses)
+    return command, values
+
+
+def native_export_telemetry(
+    rows: "list[dict[str, Any]]", destination: str, backend: str, file_format: str
+) -> "StorageTelemetry":
+    """Retain measured export metadata and generated relative filenames."""
+    return {
+        "destination": destination,
+        "backend": backend,
+        "format": file_format,
+        "rows_processed": sum(int(row["rows"]) for row in rows),
+        "bytes_processed": sum(int(row["bytes"]) for row in rows),
+        "extra": {"files": [str(row["filename"]) for row in rows]},
+    }
+
+
+def native_import_telemetry(
+    rows: "list[dict[str, Any]]", table: str, backend: str, file_format: str
+) -> "StorageTelemetry":
+    """Expose import job metadata without treating logical bytes as file size."""
+    row = rows[0]
+    if row["status"] != "succeeded":
+        msg = "Native storage import did not succeed"
+        raise ValueError(msg)
+    return {
+        "destination": table,
+        "backend": backend,
+        "format": file_format,
+        "rows_processed": int(row["rows"]),
+        "extra": {"job_id": row["job_id"], "status": row["status"]},
+    }
+
+
+def normalize_native_export_query(query: str) -> str | None:
+    """Remove a terminal delimiter, preserving comments; refuse raw scripts."""
+    if ";" not in query:
+        return query
+    tokens = tokenize(query, read="postgres")
+    delimiters = [token for token in tokens if token.token_type == TokenType.SEMICOLON]
+    if not delimiters:
+        return query
+    if len(delimiters) != 1 or delimiters[0] is not tokens[-1]:
+        return None
+    delimiter = delimiters[0]
+    return query[: delimiter.start] + query[delimiter.end + 1 :]

--- a/sqlspec/adapters/cockroach_asyncpg/driver.py
+++ b/sqlspec/adapters/cockroach_asyncpg/driver.py
@@ -9,8 +9,13 @@ from sqlspec.adapters.asyncpg.driver import AsyncpgDriver
 from sqlspec.adapters.cockroach_asyncpg._typing import CockroachAsyncpgPostgresError, CockroachAsyncpgSessionContext
 from sqlspec.adapters.cockroach_asyncpg.core import (
     CockroachAsyncpgRetryConfig,
+    build_native_export,
+    build_native_import,
     calculate_backoff_seconds,
     is_retryable_error,
+    native_export_telemetry,
+    native_import_telemetry,
+    normalize_native_export_query,
 )
 from sqlspec.adapters.cockroach_asyncpg.data_dictionary import CockroachAsyncpgDataDictionary
 from sqlspec.core import SQL, register_driver_profile
@@ -25,6 +30,7 @@ if TYPE_CHECKING:
     from sqlspec.adapters.cockroach_asyncpg._typing import CockroachAsyncpgConnection
     from sqlspec.core import StatementConfig
     from sqlspec.driver import ExecutionResult
+    from sqlspec.storage import StorageBridgeJob, StorageDestination, StorageFormat, StorageTelemetry
 
 __all__ = ("CockroachAsyncpgDriver", "CockroachAsyncpgExceptionHandler", "CockroachAsyncpgSessionContext")
 
@@ -66,6 +72,106 @@ class CockroachAsyncpgDriver(AsyncpgDriver):
         self._follower_staleness = cast("str | None", self.driver_features.get("default_staleness"))
         # Data dictionary is lazily initialized in property; use parent slot
         self._data_dictionary = None
+
+    async def select_to_storage(
+        self,
+        statement: "SQL | str",
+        destination: "StorageDestination",
+        /,
+        *parameters: Any,
+        statement_config: "StatementConfig | None" = None,
+        partitioner: "dict[str, object] | None" = None,
+        format_hint: "StorageFormat | None" = None,
+        telemetry: "StorageTelemetry | None" = None,
+        **kwargs: Any,
+    ) -> "StorageBridgeJob":
+        """Export native CSV/Parquet to generated files under a remote prefix.
+
+        CSV is headerless. NULL values require an explicit nullas convention;
+        server failures propagate without replay through the inherited path.
+        """
+        file_format = format_hint or "parquet"
+        resolved = None
+        if self._native_storage_ready() and file_format in {"csv", "parquet"}:
+            resolved = self._storage_pipeline().resolve_destination(destination)
+        if resolved is not None and resolved.protocol in {"s3", "gs", "gcs", "azure"}:
+            prepared = self.prepare_statement(statement, parameters, statement_config=statement_config, kwargs=kwargs)
+            prepared.compile()
+            compiled_query, values = self._compiled_sql(prepared, prepared.statement_config)
+            query = normalize_native_export_query(compiled_query)
+            if (
+                query is not None
+                and not prepared.is_script
+                and not prepared.is_many
+                and prepared.operation_type == "SELECT"
+                and isinstance(values, (list, tuple))
+            ):
+                command, bound = build_native_export(
+                    query,
+                    list(values),
+                    resolved.uri,
+                    file_format,
+                    self.driver_features.get("native_storage_csv_options", {}),
+                )
+                rows = await self._execute_native_storage(command, bound)
+                produced = native_export_telemetry(rows, resolved.uri, resolved.protocol, file_format)
+                self._attach_partition_telemetry(produced, partitioner)
+                return self._storage_job(produced, telemetry)
+        return await super().select_to_storage(
+            statement,
+            destination,
+            *parameters,
+            statement_config=statement_config,
+            partitioner=partitioner,
+            format_hint=format_hint,
+            telemetry=telemetry,
+            **kwargs,
+        )
+
+    async def load_from_storage(
+        self,
+        table: str,
+        source: "StorageDestination",
+        *,
+        file_format: "StorageFormat",
+        partitioner: "dict[str, object] | None" = None,
+        overwrite: bool = False,
+    ) -> "StorageBridgeJob":
+        """Append via native IMPORT when eligible, taking the table offline.
+
+        CockroachDB invalidates foreign keys during IMPORT. Overwrite and active
+        transactions use the inherited path. CSV needs explicit skip (0 for no
+        header); nullif is never inferred. Native failures are never replayed.
+        """
+        options = self.driver_features.get("native_storage_csv_options", {})
+        resolved = None
+        if (
+            self._native_storage_ready()
+            and not overwrite
+            and (file_format == "parquet" or (file_format == "csv" and "skip" in options))
+        ):
+            resolved = self._storage_pipeline().resolve_destination(source)
+        if resolved is not None and resolved.protocol in {"s3", "gs", "gcs", "azure"}:
+            command, bound = build_native_import(table, resolved.uri, file_format, options)
+            rows = await self._execute_native_storage(command, bound)
+            produced = native_import_telemetry(rows, table, resolved.protocol, file_format)
+            self._attach_partition_telemetry(produced, partitioner)
+            return self._storage_job(produced)
+        return await super().load_from_storage(
+            table, source, file_format=file_format, partitioner=partitioner, overwrite=overwrite
+        )
+
+    def _native_storage_ready(self) -> bool:
+        return bool(self.driver_features.get("enable_native_storage")) and not self._connection_in_transaction()
+
+    async def _execute_native_storage(self, command: str, parameters: "list[Any]") -> "list[dict[str, Any]]":
+        handler = self.handle_database_exceptions()
+        rows = []
+        async with handler:
+            rows = [dict(row) for row in await self.connection.fetch(command, *parameters)]
+        if handler.pending_exception is not None:
+            raise handler.pending_exception
+        return rows
 
     async def run_transaction_with_retry(self, operation: "Callable[[], Awaitable[_T]]") -> _T:
         """Execute a full CockroachDB transaction callback with serialization retries."""

--- a/sqlspec/adapters/cockroach_psycopg/config.py
+++ b/sqlspec/adapters/cockroach_psycopg/config.py
@@ -51,6 +51,17 @@ def _validate_driver_features(driver_features: "CockroachPsycopgDriverFeatures |
         raise ImproperConfigurationError(msg)
 
 
+def _validate_native_storage_autocommit(connection_config: "dict[str, Any]", driver_features: "dict[str, Any]") -> None:
+    if not driver_features.get("enable_native_storage"):
+        return
+    autocommit = connection_config.get("autocommit")
+    if autocommit is None:
+        autocommit = connection_config.get("kwargs", {}).get("autocommit")
+    if autocommit is not True:
+        msg = "enable_native_storage requires connection_config autocommit=True."
+        raise ImproperConfigurationError(msg)
+
+
 class CockroachPsycopgConnectionConfig(TypedDict):
     """CockroachDB connection parameters."""
 
@@ -97,15 +108,47 @@ class CockroachPsycopgPoolConfig(CockroachPsycopgConnectionConfig):
     kwargs: NotRequired["dict[str, Any]"]
 
 
+class _NativeStorageCSVOptions(TypedDict):
+    """Explicit CSV conventions; no header or NULL marker is inferred."""
+
+    nullas: NotRequired[str]
+    nullif: NotRequired[str]
+    skip: NotRequired[int]
+
+
+def _validate_native_storage_options(driver_features: "dict[str, Any]") -> None:
+    if "native_storage_csv_options" not in driver_features:
+        return
+    options = driver_features["native_storage_csv_options"]
+    if not isinstance(options, dict) or options.keys() - {"nullas", "nullif", "skip"}:
+        msg = "native_storage_csv_options must contain only nullas, nullif, and skip."
+        raise ImproperConfigurationError(msg)
+    for key in ("nullas", "nullif"):
+        if key in options and not isinstance(options[key], str):
+            msg = "native_storage_csv_options nullas and nullif must be strings."
+            raise ImproperConfigurationError(msg)
+    if "skip" in options and (type(options["skip"]) is not int or options["skip"] < 0):
+        msg = "native_storage_csv_options skip must be a nonnegative integer, excluding bool."
+        raise ImproperConfigurationError(msg)
+    driver_features["native_storage_csv_options"] = dict(options)
+
+
 class CockroachPsycopgDriverFeatures(TypedDict):
     """CockroachDB driver feature configuration.
 
+    enable_native_storage: Opt in to server-side storage operations. Exports create
+     generated files under a prefix; imports temporarily take the table offline.
+    native_storage_csv_options: Explicit nullas/nullif markers and skip count.
+     Export is headerless; native CSV import requires an explicit skip count.
+     Markers must not occur as literal data. No NULL marker is inferred.
     on_connection_create: Callback executed when a connection is acquired from pool.
      For sync: Callable[[CockroachSyncConnection], None]
      For async: Callable[[CockroachAsyncConnection], Awaitable[None]]
      Called after internal setup.
     """
 
+    enable_native_storage: NotRequired[bool]
+    native_storage_csv_options: NotRequired[_NativeStorageCSVOptions]
     enable_auto_retry: NotRequired[bool]
     max_retries: NotRequired[int]
     retry_delay_base_ms: NotRequired[float]
@@ -210,6 +253,9 @@ class CockroachPsycopgSyncConfig(
         _validate_driver_features(driver_features)
         statement_config, driver_features = apply_driver_features(statement_config, driver_features)
 
+        driver_features.setdefault("enable_native_storage", False)
+        _validate_native_storage_options(driver_features)
+        _validate_native_storage_autocommit(connection_config, driver_features)
         driver_features.setdefault("enable_auto_retry", True)
 
         # Extract user connection hook before storing driver_features
@@ -419,6 +465,9 @@ class CockroachPsycopgAsyncConfig(
         _validate_driver_features(driver_features)
         statement_config, driver_features = apply_driver_features(statement_config, driver_features)
 
+        driver_features.setdefault("enable_native_storage", False)
+        _validate_native_storage_options(driver_features)
+        _validate_native_storage_autocommit(connection_config, driver_features)
         driver_features.setdefault("enable_auto_retry", True)
 
         # Extract user connection hook before storing driver_features

--- a/sqlspec/adapters/cockroach_psycopg/core.py
+++ b/sqlspec/adapters/cockroach_psycopg/core.py
@@ -4,20 +4,30 @@ import secrets
 from typing import TYPE_CHECKING, Any, Final
 
 from mypy_extensions import mypyc_attr
+from sqlglot import tokenize
+from sqlglot.tokenizer_core import TokenType
 
 from sqlspec.adapters.psycopg.core import apply_driver_features, build_statement_config, driver_profile
+from sqlspec.utils.text import quote_identifier, split_qualified_identifier
 from sqlspec.utils.type_guards import has_sqlstate
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from sqlspec.storage import StorageTelemetry
+
 __all__ = (
     "CockroachPsycopgRetryConfig",
     "apply_driver_features",
+    "build_native_export",
+    "build_native_import",
     "build_statement_config",
     "calculate_backoff_seconds",
     "driver_profile",
     "is_retryable_error",
+    "native_export_telemetry",
+    "native_import_telemetry",
+    "normalize_native_export_query",
 )
 
 # Retry configuration defaults (module-level for mypyc compatibility)
@@ -72,3 +82,84 @@ def calculate_backoff_seconds(attempt: int, config: "CockroachPsycopgRetryConfig
     jitter: float = secrets.randbelow(max_jitter + 1) / scale if max_jitter else 0.0
     delay_ms: float = min(base + jitter, config.max_delay_ms)
     return delay_ms / 1000.0
+
+
+def build_native_export(
+    query: str, parameters: "list[Any]", uri: str, file_format: str, options: "dict[str, Any]"
+) -> "tuple[str, list[Any]]":
+    """Wrap compiled query SQL without embedding destination or CSV values."""
+    format_sql = {"csv": "CSV", "parquet": "PARQUET"}[file_format]
+    if not parameters:
+        query = query.replace("%", "%%")
+    values: list[Any] = [uri]
+    command = "EXPORT INTO " + format_sql + " " + "%s"
+    if file_format == "csv" and "nullas" in options:
+        values.append(options["nullas"])
+        command += " WITH nullas = " + "%s"
+    return command + " FROM (" + query.rstrip().removesuffix(";") + "\n)", [*values, *parameters]
+
+
+def build_native_import(table: str, uri: str, file_format: str, options: "dict[str, Any]") -> "tuple[str, list[Any]]":
+    """Quote the target identifier and bind explicit CSV conventions."""
+    parts = split_qualified_identifier(table, quote_chars='"', allow_bracket_quotes=False)
+    if not parts:
+        msg = "Table name must not be empty"
+        raise ValueError(msg)
+    target = ".".join(quote_identifier(part) for part in parts).replace("%", "%%")
+    format_sql = {"csv": "CSV", "parquet": "PARQUET"}[file_format]
+    values: list[Any] = [uri]
+    command = "IMPORT INTO " + target + " " + format_sql + " DATA (" + "%s" + ")"
+    clauses = []
+    if file_format == "csv":
+        for key in ("skip", "nullif"):
+            if key in options:
+                values.append(str(options[key]))
+                clauses.append(key + " = " + "%s")
+    if clauses:
+        command += " WITH " + ", ".join(clauses)
+    return command, values
+
+
+def native_export_telemetry(
+    rows: "list[dict[str, Any]]", destination: str, backend: str, file_format: str
+) -> "StorageTelemetry":
+    """Retain measured export metadata and generated relative filenames."""
+    return {
+        "destination": destination,
+        "backend": backend,
+        "format": file_format,
+        "rows_processed": sum(int(row["rows"]) for row in rows),
+        "bytes_processed": sum(int(row["bytes"]) for row in rows),
+        "extra": {"files": [str(row["filename"]) for row in rows]},
+    }
+
+
+def native_import_telemetry(
+    rows: "list[dict[str, Any]]", table: str, backend: str, file_format: str
+) -> "StorageTelemetry":
+    """Expose import job metadata without treating logical bytes as file size."""
+    row = rows[0]
+    if row["status"] != "succeeded":
+        msg = "Native storage import did not succeed"
+        raise ValueError(msg)
+    return {
+        "destination": table,
+        "backend": backend,
+        "format": file_format,
+        "rows_processed": int(row["rows"]),
+        "extra": {"job_id": row["job_id"], "status": row["status"]},
+    }
+
+
+def normalize_native_export_query(query: str) -> str | None:
+    """Remove a terminal delimiter, preserving comments; refuse raw scripts."""
+    if ";" not in query:
+        return query
+    tokens = tokenize(query, read="postgres")
+    delimiters = [token for token in tokens if token.token_type == TokenType.SEMICOLON]
+    if not delimiters:
+        return query
+    if len(delimiters) != 1 or delimiters[0] is not tokens[-1]:
+        return None
+    delimiter = delimiters[0]
+    return query[: delimiter.start] + query[delimiter.end + 1 :]

--- a/sqlspec/adapters/cockroach_psycopg/driver.py
+++ b/sqlspec/adapters/cockroach_psycopg/driver.py
@@ -6,6 +6,7 @@ import time
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import psycopg
+from psycopg.rows import dict_row
 
 from sqlspec.adapters.cockroach_psycopg._typing import (
     CockroachAsyncConnection,
@@ -15,10 +16,15 @@ from sqlspec.adapters.cockroach_psycopg._typing import (
 )
 from sqlspec.adapters.cockroach_psycopg.core import (
     CockroachPsycopgRetryConfig,
+    build_native_export,
+    build_native_import,
     build_statement_config,
     calculate_backoff_seconds,
     driver_profile,
     is_retryable_error,
+    native_export_telemetry,
+    native_import_telemetry,
+    normalize_native_export_query,
 )
 from sqlspec.adapters.cockroach_psycopg.data_dictionary import (
     CockroachPsycopgAsyncDataDictionary,
@@ -37,6 +43,7 @@ if TYPE_CHECKING:
 
     from sqlspec.adapters.cockroach_psycopg._typing import CockroachAsyncCursor, CockroachSyncCursor
     from sqlspec.driver import ExecutionResult
+    from sqlspec.storage import StorageBridgeJob, StorageDestination, StorageFormat, StorageTelemetry
 
 __all__ = (
     "CockroachPsycopgAsyncDriver",
@@ -109,6 +116,112 @@ class CockroachPsycopgSyncDriver(PsycopgSyncDriver):
         self._follower_staleness = cast("str | None", self.driver_features.get("default_staleness"))
         # Data dictionary is lazily initialized in property; use parent slot
         self._data_dictionary = None
+
+    def select_to_storage(
+        self,
+        statement: "SQL | str",
+        destination: "StorageDestination",
+        /,
+        *parameters: Any,
+        statement_config: "StatementConfig | None" = None,
+        partitioner: "dict[str, object] | None" = None,
+        format_hint: "StorageFormat | None" = None,
+        telemetry: "StorageTelemetry | None" = None,
+        **kwargs: Any,
+    ) -> "StorageBridgeJob":
+        """Export native CSV/Parquet to generated files under a remote prefix.
+
+        CSV is headerless. NULL values require an explicit nullas convention;
+        server failures propagate without replay through the inherited path.
+        """
+        file_format = format_hint or "parquet"
+        resolved = None
+        if self._native_storage_ready() and file_format in {"csv", "parquet"}:
+            resolved = self._storage_pipeline().resolve_destination(destination)
+        if resolved is not None and resolved.protocol in {"s3", "gs", "gcs", "azure"}:
+            prepared = self.prepare_statement(statement, parameters, statement_config=statement_config, kwargs=kwargs)
+            prepared.compile()
+            compiled_query, values = self._compiled_sql(prepared, prepared.statement_config)
+            query = normalize_native_export_query(compiled_query)
+            if (
+                query is not None
+                and not prepared.is_script
+                and not prepared.is_many
+                and prepared.operation_type == "SELECT"
+                and isinstance(values, (list, tuple))
+            ):
+                command, bound = build_native_export(
+                    query,
+                    list(values),
+                    resolved.uri,
+                    file_format,
+                    self.driver_features.get("native_storage_csv_options", {}),
+                )
+                rows = self._execute_native_storage(command, bound)
+                produced = native_export_telemetry(rows, resolved.uri, resolved.protocol, file_format)
+                self._attach_partition_telemetry(produced, partitioner)
+                return self._storage_job(produced, telemetry)
+        return super().select_to_storage(
+            statement,
+            destination,
+            *parameters,
+            statement_config=statement_config,
+            partitioner=partitioner,
+            format_hint=format_hint,
+            telemetry=telemetry,
+            **kwargs,
+        )
+
+    def load_from_storage(
+        self,
+        table: str,
+        source: "StorageDestination",
+        *,
+        file_format: "StorageFormat",
+        partitioner: "dict[str, object] | None" = None,
+        overwrite: bool = False,
+    ) -> "StorageBridgeJob":
+        """Append via native IMPORT when eligible, taking the table offline.
+
+        CockroachDB invalidates foreign keys during IMPORT. Overwrite and active
+        transactions use the inherited path. CSV needs explicit skip (0 for no
+        header); nullif is never inferred. Native failures are never replayed.
+        """
+        options = self.driver_features.get("native_storage_csv_options", {})
+        resolved = None
+        if (
+            self._native_storage_ready()
+            and not overwrite
+            and (file_format == "parquet" or (file_format == "csv" and "skip" in options))
+        ):
+            resolved = self._storage_pipeline().resolve_destination(source)
+        if resolved is not None and resolved.protocol in {"s3", "gs", "gcs", "azure"}:
+            command, bound = build_native_import(table, resolved.uri, file_format, options)
+            rows = self._execute_native_storage(command, bound)
+            produced = native_import_telemetry(rows, table, resolved.protocol, file_format)
+            self._attach_partition_telemetry(produced, partitioner)
+            return self._storage_job(produced)
+        return super().load_from_storage(
+            table, source, file_format=file_format, partitioner=partitioner, overwrite=overwrite
+        )
+
+    def _native_storage_ready(self) -> bool:
+        return (
+            bool(self.driver_features.get("enable_native_storage"))
+            and self.connection.autocommit
+            and not self._connection_in_transaction()
+        )
+
+    def _execute_native_storage(self, command: str, parameters: "list[Any]") -> "list[dict[str, Any]]":
+        handler = self.handle_database_exceptions()
+        rows = []
+        with self.with_cursor(self.connection) as cursor, handler:
+            cursor.row_factory = dict_row
+            cursor.execute(command.encode("utf-8"), parameters)
+            rows = cursor.fetchall()
+        if handler.pending_exception is not None:
+            raise handler.pending_exception
+        return rows
 
     def run_transaction_with_retry(self, operation: "Callable[[], _T]") -> _T:
         """Execute a full CockroachDB transaction callback with serialization retries."""
@@ -200,6 +313,112 @@ class CockroachPsycopgAsyncDriver(PsycopgAsyncDriver):
         self._follower_staleness = cast("str | None", self.driver_features.get("default_staleness"))
         # Data dictionary is lazily initialized in property; use parent slot
         self._data_dictionary = None
+
+    async def select_to_storage(
+        self,
+        statement: "SQL | str",
+        destination: "StorageDestination",
+        /,
+        *parameters: Any,
+        statement_config: "StatementConfig | None" = None,
+        partitioner: "dict[str, object] | None" = None,
+        format_hint: "StorageFormat | None" = None,
+        telemetry: "StorageTelemetry | None" = None,
+        **kwargs: Any,
+    ) -> "StorageBridgeJob":
+        """Export native CSV/Parquet to generated files under a remote prefix.
+
+        CSV is headerless. NULL values require an explicit nullas convention;
+        server failures propagate without replay through the inherited path.
+        """
+        file_format = format_hint or "parquet"
+        resolved = None
+        if self._native_storage_ready() and file_format in {"csv", "parquet"}:
+            resolved = self._storage_pipeline().resolve_destination(destination)
+        if resolved is not None and resolved.protocol in {"s3", "gs", "gcs", "azure"}:
+            prepared = self.prepare_statement(statement, parameters, statement_config=statement_config, kwargs=kwargs)
+            prepared.compile()
+            compiled_query, values = self._compiled_sql(prepared, prepared.statement_config)
+            query = normalize_native_export_query(compiled_query)
+            if (
+                query is not None
+                and not prepared.is_script
+                and not prepared.is_many
+                and prepared.operation_type == "SELECT"
+                and isinstance(values, (list, tuple))
+            ):
+                command, bound = build_native_export(
+                    query,
+                    list(values),
+                    resolved.uri,
+                    file_format,
+                    self.driver_features.get("native_storage_csv_options", {}),
+                )
+                rows = await self._execute_native_storage(command, bound)
+                produced = native_export_telemetry(rows, resolved.uri, resolved.protocol, file_format)
+                self._attach_partition_telemetry(produced, partitioner)
+                return self._storage_job(produced, telemetry)
+        return await super().select_to_storage(
+            statement,
+            destination,
+            *parameters,
+            statement_config=statement_config,
+            partitioner=partitioner,
+            format_hint=format_hint,
+            telemetry=telemetry,
+            **kwargs,
+        )
+
+    async def load_from_storage(
+        self,
+        table: str,
+        source: "StorageDestination",
+        *,
+        file_format: "StorageFormat",
+        partitioner: "dict[str, object] | None" = None,
+        overwrite: bool = False,
+    ) -> "StorageBridgeJob":
+        """Append via native IMPORT when eligible, taking the table offline.
+
+        CockroachDB invalidates foreign keys during IMPORT. Overwrite and active
+        transactions use the inherited path. CSV needs explicit skip (0 for no
+        header); nullif is never inferred. Native failures are never replayed.
+        """
+        options = self.driver_features.get("native_storage_csv_options", {})
+        resolved = None
+        if (
+            self._native_storage_ready()
+            and not overwrite
+            and (file_format == "parquet" or (file_format == "csv" and "skip" in options))
+        ):
+            resolved = self._storage_pipeline().resolve_destination(source)
+        if resolved is not None and resolved.protocol in {"s3", "gs", "gcs", "azure"}:
+            command, bound = build_native_import(table, resolved.uri, file_format, options)
+            rows = await self._execute_native_storage(command, bound)
+            produced = native_import_telemetry(rows, table, resolved.protocol, file_format)
+            self._attach_partition_telemetry(produced, partitioner)
+            return self._storage_job(produced)
+        return await super().load_from_storage(
+            table, source, file_format=file_format, partitioner=partitioner, overwrite=overwrite
+        )
+
+    def _native_storage_ready(self) -> bool:
+        return (
+            bool(self.driver_features.get("enable_native_storage"))
+            and self.connection.autocommit
+            and not self._connection_in_transaction()
+        )
+
+    async def _execute_native_storage(self, command: str, parameters: "list[Any]") -> "list[dict[str, Any]]":
+        handler = self.handle_database_exceptions()
+        rows = []
+        async with self.with_cursor(self.connection) as cursor, handler:
+            cursor.row_factory = dict_row
+            await cursor.execute(command.encode("utf-8"), parameters)
+            rows = await cursor.fetchall()
+        if handler.pending_exception is not None:
+            raise handler.pending_exception
+        return rows
 
     async def run_transaction_with_retry(self, operation: "Callable[[], Awaitable[_T]]") -> _T:
         """Execute a full CockroachDB transaction callback with serialization retries."""

--- a/tests/integration/adapters/cockroach/test_native_storage.py
+++ b/tests/integration/adapters/cockroach/test_native_storage.py
@@ -1,0 +1,110 @@
+"""SQLSpec native Cockroach storage on local pytest-databases services."""
+
+from typing import TYPE_CHECKING, Any, Literal
+from uuid import uuid4
+
+import asyncpg
+import psycopg
+import pytest
+from psycopg import sql
+
+from sqlspec.adapters.cockroach_asyncpg import CockroachAsyncpgDriver
+from sqlspec.adapters.cockroach_psycopg import CockroachPsycopgAsyncDriver, CockroachPsycopgSyncDriver
+from tests.integration.adapters.cockroach.test_native_storage_capabilities import _file_uri
+from tests.integration.adapters.cockroach.test_native_storage_capabilities import native_connection as native_connection
+from tests.integration.adapters.cockroach.test_native_storage_capabilities import (
+    native_storage_uri as native_storage_uri,
+)
+
+if TYPE_CHECKING:
+    from pytest_databases.docker.cockroachdb import CockroachDBService
+
+
+@pytest.mark.parametrize("file_format", ["csv", "parquet"])
+@pytest.mark.parametrize("adapter", ["sync", "async", "asyncpg"])
+async def test_native_storage_export_import_roundtrip(
+    native_connection: psycopg.Connection,
+    native_storage_uri: str,
+    cockroachdb_service: "CockroachDBService",
+    adapter: str,
+    file_format: Literal["csv", "parquet"],
+) -> None:
+    features = {
+        "enable_native_storage": True,
+        "native_storage_csv_options": {"skip": 0, "nullas": "NULL", "nullif": "NULL"},
+    }
+    config = {"host": cockroachdb_service.host, "port": cockroachdb_service.port, "user": "root"}
+    connection: Any = native_connection
+    if adapter == "async":
+        connection = await psycopg.AsyncConnection.connect(
+            **config, dbname=cockroachdb_service.database, sslmode="disable", autocommit=True
+        )
+        driver: Any = CockroachPsycopgAsyncDriver(connection, driver_features=features)
+    elif adapter == "asyncpg":
+        connection = await asyncpg.connect(**config, database=cockroachdb_service.database, ssl=False)
+        driver = CockroachAsyncpgDriver(connection, driver_features=features)
+    else:
+        driver = CockroachPsycopgSyncDriver(connection, driver_features=features)
+    table = "native_driver_" + uuid4().hex
+    native_connection.execute(
+        sql.SQL("CREATE TABLE {} (id INT8 PRIMARY KEY, label STRING)").format(sql.Identifier(table))
+    )
+    try:
+        exported = driver.select_to_storage(
+            "SELECT :id::INT8 AS id, :label::STRING AS label",
+            native_storage_uri,
+            {"id": 7, "label": "O'Reilly"},
+            format_hint=file_format,
+            partitioner={"test": True},
+        )
+        if adapter != "sync":
+            exported = await exported
+        assert exported.telemetry["rows_processed"] == 1
+        assert exported.telemetry["bytes_processed"] > 0
+        assert exported.telemetry["extra"]["partitioner"] == {"test": True}
+        files = exported.telemetry["extra"]["files"]
+        assert files
+        for filename in files:
+            imported = driver.load_from_storage(table, _file_uri(native_storage_uri, filename), file_format=file_format)
+            if adapter != "sync":
+                imported = await imported
+            assert imported.telemetry["rows_processed"] == 1
+            assert "bytes_processed" not in imported.telemetry
+        assert native_connection.execute(sql.SQL("SELECT * FROM {}").format(sql.Identifier(table))).fetchall() == [
+            (7, "O'Reilly")
+        ]
+    finally:
+        native_connection.execute(sql.SQL("DROP TABLE {}").format(sql.Identifier(table)))
+        if adapter != "sync":
+            await connection.close()
+
+
+@pytest.mark.parametrize("adapter", ["sync", "async", "asyncpg"])
+async def test_native_storage_export_null_refusal(
+    native_connection: psycopg.Connection,
+    native_storage_uri: str,
+    cockroachdb_service: "CockroachDBService",
+    adapter: str,
+) -> None:
+    from sqlspec.exceptions import SQLSpecError
+
+    config = {"host": cockroachdb_service.host, "port": cockroachdb_service.port, "user": "root"}
+    connection: Any = native_connection
+    if adapter == "async":
+        connection = await psycopg.AsyncConnection.connect(
+            **config, dbname=cockroachdb_service.database, sslmode="disable", autocommit=True
+        )
+        driver: Any = CockroachPsycopgAsyncDriver(connection, driver_features={"enable_native_storage": True})
+    elif adapter == "asyncpg":
+        connection = await asyncpg.connect(**config, database=cockroachdb_service.database, ssl=False)
+        driver = CockroachAsyncpgDriver(connection, driver_features={"enable_native_storage": True})
+    else:
+        driver = CockroachPsycopgSyncDriver(connection, driver_features={"enable_native_storage": True})
+    try:
+        with pytest.raises(SQLSpecError, match="NULL value encountered"):
+            result = driver.select_to_storage("SELECT NULL::STRING AS label", native_storage_uri, format_hint="csv")
+            if adapter != "sync":
+                await result
+    finally:
+        if adapter != "sync":
+            await connection.close()

--- a/tests/integration/adapters/cockroach/test_native_storage.py
+++ b/tests/integration/adapters/cockroach/test_native_storage.py
@@ -33,15 +33,25 @@ async def test_native_storage_export_import_roundtrip(
         "enable_native_storage": True,
         "native_storage_csv_options": {"skip": 0, "nullas": "NULL", "nullif": "NULL"},
     }
-    config = {"host": cockroachdb_service.host, "port": cockroachdb_service.port, "user": "root"}
     connection: Any = native_connection
     if adapter == "async":
         connection = await psycopg.AsyncConnection.connect(
-            **config, dbname=cockroachdb_service.database, sslmode="disable", autocommit=True
+            host=cockroachdb_service.host,
+            port=cockroachdb_service.port,
+            user="root",
+            dbname=cockroachdb_service.database,
+            sslmode="disable",
+            autocommit=True,
         )
         driver: Any = CockroachPsycopgAsyncDriver(connection, driver_features=features)
     elif adapter == "asyncpg":
-        connection = await asyncpg.connect(**config, database=cockroachdb_service.database, ssl=False)
+        connection = await asyncpg.connect(
+            host=cockroachdb_service.host,
+            port=cockroachdb_service.port,
+            user="root",
+            database=cockroachdb_service.database,
+            ssl=False,
+        )
         driver = CockroachAsyncpgDriver(connection, driver_features=features)
     else:
         driver = CockroachPsycopgSyncDriver(connection, driver_features=features)
@@ -88,15 +98,25 @@ async def test_native_storage_export_null_refusal(
 ) -> None:
     from sqlspec.exceptions import SQLSpecError
 
-    config = {"host": cockroachdb_service.host, "port": cockroachdb_service.port, "user": "root"}
     connection: Any = native_connection
     if adapter == "async":
         connection = await psycopg.AsyncConnection.connect(
-            **config, dbname=cockroachdb_service.database, sslmode="disable", autocommit=True
+            host=cockroachdb_service.host,
+            port=cockroachdb_service.port,
+            user="root",
+            dbname=cockroachdb_service.database,
+            sslmode="disable",
+            autocommit=True,
         )
         driver: Any = CockroachPsycopgAsyncDriver(connection, driver_features={"enable_native_storage": True})
     elif adapter == "asyncpg":
-        connection = await asyncpg.connect(**config, database=cockroachdb_service.database, ssl=False)
+        connection = await asyncpg.connect(
+            host=cockroachdb_service.host,
+            port=cockroachdb_service.port,
+            user="root",
+            database=cockroachdb_service.database,
+            ssl=False,
+        )
         driver = CockroachAsyncpgDriver(connection, driver_features={"enable_native_storage": True})
     else:
         driver = CockroachPsycopgSyncDriver(connection, driver_features={"enable_native_storage": True})

--- a/tests/integration/adapters/cockroach/test_native_storage_benchmark.py
+++ b/tests/integration/adapters/cockroach/test_native_storage_benchmark.py
@@ -1,0 +1,40 @@
+"""Local paired native/inherited Parquet benchmark acceptance run."""
+
+import json
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit, urlunsplit
+
+import pytest
+from tools.scripts.bench_cockroach_storage import run_benchmark
+
+from tests.fixtures.rustfs import rustfs_fsspec_kwargs
+from tests.integration.adapters.cockroach.test_native_storage_capabilities import (
+    native_storage_uri as native_storage_uri,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from pytest_databases.docker.cockroachdb import CockroachDBService
+    from pytest_databases.docker.rustfs import RustfsService
+
+
+def test_native_storage_paired_benchmark(
+    cockroachdb_service: "CockroachDBService",
+    rustfs_service: "RustfsService",
+    native_storage_uri: str,
+    monkeypatch: pytest.MonkeyPatch,
+    record_property: "Callable[[str, object], None]",
+) -> None:
+    monkeypatch.setenv(
+        "SQLSPEC_COCKROACH_DSN",
+        f"host={cockroachdb_service.host} port={cockroachdb_service.port} dbname={cockroachdb_service.database} user=root sslmode=disable",
+    )
+    monkeypatch.setenv("SQLSPEC_COCKROACH_NATIVE_URI", native_storage_uri)
+    monkeypatch.setenv("SQLSPEC_COCKROACH_CLIENT_URI", urlunsplit(urlsplit(native_storage_uri)._replace(query="")))
+    monkeypatch.setenv("SQLSPEC_COCKROACH_STORAGE_OPTIONS", json.dumps(rustfs_fsspec_kwargs(rustfs_service)))
+    result = run_benchmark([100, 1000, 10000], warmup=1, iterations=3, poll_interval=0.02)
+    assert len(result["samples"]) == 18
+    assert len(result["summaries"]) == 12
+    assert all(item["samples"] == 3 for item in result["summaries"])
+    record_property("cockroach_native_benchmark", json.dumps(result))

--- a/tests/integration/adapters/cockroach/test_native_storage_capabilities.py
+++ b/tests/integration/adapters/cockroach/test_native_storage_capabilities.py
@@ -1,0 +1,285 @@
+"""Local server contracts required by CockroachDB native object storage."""
+
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Literal
+from urllib.parse import urlencode, urlsplit, urlunsplit
+from uuid import uuid4
+
+import asyncpg
+import psycopg
+import pytest
+from psycopg import sql
+
+from tests.fixtures.rustfs import rustfs_filesystem
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from pytest_databases.docker.cockroachdb import CockroachDBService
+    from pytest_databases.docker.rustfs import RustfsService
+
+
+@pytest.fixture
+def native_connection(cockroachdb_service: "CockroachDBService") -> Iterator[psycopg.Connection]:
+    with psycopg.connect(
+        host=cockroachdb_service.host,
+        port=cockroachdb_service.port,
+        dbname=cockroachdb_service.database,
+        user="root",
+        sslmode="disable",
+        autocommit=True,
+    ) as connection:
+        yield connection
+
+
+@pytest.fixture
+def native_storage_uri(rustfs_service: "RustfsService", rustfs_bucket_name: str) -> Iterator[str]:
+    rustfs_service.container.reload()
+    networks = rustfs_service.container.attrs["NetworkSettings"]["Networks"]
+    address = next(iter(networks.values()))["IPAddress"]
+    prefix = f"native-{uuid4().hex}"
+    query = urlencode({
+        "AWS_ACCESS_KEY_ID": rustfs_service.access_key,
+        "AWS_SECRET_ACCESS_KEY": rustfs_service.secret_key,
+        "AWS_ENDPOINT": f"http://{address}:9000",
+        "AWS_REGION": "us-east-1",
+        "AUTH": "specified",
+    })
+    try:
+        yield f"s3://{rustfs_bucket_name}/{prefix}?{query}"
+    finally:
+        filesystem = rustfs_filesystem(rustfs_service)
+        if filesystem.exists(f"{rustfs_bucket_name}/{prefix}"):
+            filesystem.rm(f"{rustfs_bucket_name}/{prefix}", recursive=True)
+
+
+def _file_uri(destination: str, filename: str) -> str:
+    parts = urlsplit(destination)
+    return urlunsplit(parts._replace(path=f"{parts.path}/{filename}"))
+
+
+def test_native_storage_connection_baseline(
+    native_connection: psycopg.Connection, record_property: "Callable[[str, object], None]"
+) -> None:
+    row = native_connection.execute("SELECT version()").fetchone()
+    assert row is not None
+    assert "CockroachDB" in row[0]
+    record_property("cockroach_version", row[0])
+
+
+@pytest.mark.parametrize("file_format", ["CSV", "PARQUET"])
+def test_native_storage_bound_values_roundtrip(
+    native_connection: psycopg.Connection, native_storage_uri: str, file_format: Literal["CSV", "PARQUET"]
+) -> None:
+    cursor = native_connection.execute(
+        sql.SQL("EXPORT INTO {} %s FROM (SELECT %s::INT8 AS id, %s::STRING AS label)").format(sql.SQL(file_format)),
+        (native_storage_uri, 7, "O'Reilly"),
+    )
+    assert cursor.description is not None
+    assert [column.name for column in cursor.description] == ["filename", "rows", "bytes"]
+    files = cursor.fetchall()
+    assert len(files) == 1
+    filename, row_count, byte_count = files[0]
+    assert row_count == 1
+    assert byte_count > 0
+    source = _file_uri(native_storage_uri, filename)
+    target = sql.Identifier(f"native_{uuid4().hex}")
+    native_connection.execute(sql.SQL("CREATE TABLE {} (id INT8 PRIMARY KEY, label STRING)").format(target))
+    try:
+        cursor = native_connection.execute(
+            sql.SQL("IMPORT INTO {} {} DATA (%s)").format(target, sql.SQL(file_format)), (source,)
+        )
+        assert cursor.description is not None
+        row = cursor.fetchone()
+        assert row is not None
+        result = dict(zip((column.name for column in cursor.description), row, strict=True))
+        assert result["status"] == "succeeded"
+        assert result["rows"] == 1
+        assert result["bytes"] > 0
+        assert native_connection.execute(sql.SQL("SELECT * FROM {}").format(target)).fetchall() == [(7, "O'Reilly")]
+    finally:
+        native_connection.execute(sql.SQL("DROP TABLE {}").format(target))
+
+
+def test_native_csv_requires_explicit_null_encoding(
+    native_connection: psycopg.Connection, native_storage_uri: str, record_property: "Callable[[str, object], None]"
+) -> None:
+    with pytest.raises(psycopg.InternalError, match="NULL value encountered during EXPORT") as caught:
+        native_connection.execute("EXPORT INTO CSV %s FROM SELECT NULL::STRING", (native_storage_uri,))
+    record_property("csv_null_error", str(caught.value))
+
+
+@pytest.mark.parametrize("marker", ["", "__SQLSPEC_NULL__"])
+def test_native_csv_marker_collides_with_literal_data(
+    native_connection: psycopg.Connection, native_storage_uri: str, marker: str
+) -> None:
+    files = native_connection.execute(
+        "EXPORT INTO CSV %s WITH nullas = %s FROM "
+        "(SELECT 1::INT8 AS id, NULL::STRING AS label UNION ALL SELECT 2, %s::STRING)",
+        (native_storage_uri, marker, marker),
+    ).fetchall()
+    target = sql.Identifier(f"native_{uuid4().hex}")
+    native_connection.execute(sql.SQL("CREATE TABLE {} (id INT8 PRIMARY KEY, label STRING)").format(target))
+    try:
+        native_connection.execute(
+            sql.SQL("IMPORT INTO {} CSV DATA (%s) WITH nullif = %s").format(target),
+            (_file_uri(native_storage_uri, files[0][0]), marker),
+        )
+        # An automatic marker would silently corrupt the second row.
+        assert native_connection.execute(sql.SQL("SELECT * FROM {} ORDER BY id").format(target)).fetchall() == [
+            (1, None),
+            (2, None),
+        ]
+    finally:
+        native_connection.execute(sql.SQL("DROP TABLE {}").format(target))
+
+
+def test_native_parquet_preserves_null_empty_and_marker_values(
+    native_connection: psycopg.Connection, native_storage_uri: str
+) -> None:
+    files = native_connection.execute(
+        "EXPORT INTO PARQUET %s FROM (SELECT 1::INT8 AS id, NULL::STRING AS label "
+        "UNION ALL SELECT 2, '' UNION ALL SELECT 3, %s::STRING)",
+        (native_storage_uri, r"\N"),
+    ).fetchall()
+    target = sql.Identifier(f"native_{uuid4().hex}")
+    native_connection.execute(sql.SQL("CREATE TABLE {} (id INT8 PRIMARY KEY, label STRING)").format(target))
+    try:
+        native_connection.execute(
+            sql.SQL("IMPORT INTO {} PARQUET DATA (%s)").format(target), (_file_uri(native_storage_uri, files[0][0]),)
+        )
+        assert native_connection.execute(sql.SQL("SELECT * FROM {} ORDER BY id").format(target)).fetchall() == [
+            (1, None),
+            (2, ""),
+            (3, r"\N"),
+        ]
+    finally:
+        native_connection.execute(sql.SQL("DROP TABLE {}").format(target))
+
+
+def test_native_csv_header_requires_explicit_skip(
+    native_connection: psycopg.Connection,
+    native_storage_uri: str,
+    rustfs_service: "RustfsService",
+    record_property: "Callable[[str, object], None]",
+) -> None:
+    parts = urlsplit(native_storage_uri)
+    rustfs_filesystem(rustfs_service).pipe(f"{parts.netloc}{parts.path}/header.csv", b"id,label\n7,seven\n8,eight\n")
+    source = _file_uri(native_storage_uri, "header.csv")
+    target = sql.Identifier(f"native_{uuid4().hex}")
+    native_connection.execute(sql.SQL("CREATE TABLE {} (id INT8 PRIMARY KEY, label STRING)").format(target))
+    try:
+        with pytest.raises(psycopg.Error, match="error parsing row 1") as caught:
+            native_connection.execute(sql.SQL("IMPORT INTO {} CSV DATA (%s)").format(target), (source,))
+        record_property("csv_header_error", str(caught.value))
+        native_connection.execute(sql.SQL("IMPORT INTO {} CSV DATA (%s) WITH skip = '1'").format(target), (source,))
+        assert native_connection.execute(sql.SQL("SELECT * FROM {} ORDER BY id").format(target)).fetchall() == [
+            (7, "seven"),
+            (8, "eight"),
+        ]
+    finally:
+        native_connection.execute(sql.SQL("DROP TABLE {}").format(target))
+
+
+@pytest.mark.parametrize("operation", ["EXPORT", "IMPORT"])
+def test_native_storage_rejects_explicit_transactions(
+    native_connection: psycopg.Connection,
+    native_storage_uri: str,
+    operation: str,
+    record_property: "Callable[[str, object], None]",
+) -> None:
+    target = sql.Identifier(f"native_{uuid4().hex}")
+    native_connection.execute(sql.SQL("CREATE TABLE {} (id INT8 PRIMARY KEY)").format(target))
+    statement = (
+        sql.SQL("EXPORT INTO CSV %s FROM SELECT 1")
+        if operation == "EXPORT"
+        else sql.SQL("IMPORT INTO {} CSV DATA (%s)").format(target)
+    )
+    try:
+        with (
+            pytest.raises(psycopg.Error, match="cannot be used inside a multi-statement transaction") as caught,
+            native_connection.transaction(),
+        ):
+            native_connection.execute(statement, (native_storage_uri,))
+        record_property(f"{operation.lower()}_transaction_error", str(caught.value))
+        assert native_connection.info.transaction_status == psycopg.pq.TransactionStatus.IDLE
+    finally:
+        native_connection.execute(sql.SQL("DROP TABLE {}").format(target))
+
+
+def test_native_csv_export_has_no_column_names_option(
+    native_connection: psycopg.Connection, native_storage_uri: str, record_property: "Callable[[str, object], None]"
+) -> None:
+    with pytest.raises(psycopg.Error, match='invalid option "column_names"') as caught:
+        native_connection.execute("EXPORT INTO CSV %s WITH column_names FROM SELECT 1 AS id", (native_storage_uri,))
+    record_property("csv_column_names_error", str(caught.value))
+
+
+def test_native_custom_endpoint_requires_external_io_privilege(
+    native_connection: psycopg.Connection, native_storage_uri: str, record_property: "Callable[[str, object], None]"
+) -> None:
+    role = sql.Identifier(f"native_role_{uuid4().hex}")
+    target = sql.Identifier(f"native_{uuid4().hex}")
+    files = native_connection.execute("EXPORT INTO CSV %s FROM SELECT 1 AS id", (native_storage_uri,)).fetchall()
+    source = _file_uri(native_storage_uri, files[0][0])
+    native_connection.execute(sql.SQL("CREATE ROLE {}").format(role))
+    native_connection.execute(sql.SQL("CREATE TABLE {} (id INT8 PRIMARY KEY)").format(target))
+    native_connection.execute(sql.SQL("GRANT ALL ON TABLE {} TO {}").format(target, role))
+    try:
+        native_connection.execute(sql.SQL("SET ROLE {}").format(role))
+        with pytest.raises(psycopg.errors.InsufficientPrivilege) as caught:
+            native_connection.execute("EXPORT INTO CSV %s FROM SELECT 1", (native_storage_uri,))
+        record_property("custom_endpoint_export_privilege_error", str(caught.value))
+        with pytest.raises(psycopg.errors.InsufficientPrivilege) as caught:
+            native_connection.execute(sql.SQL("IMPORT INTO {} CSV DATA (%s)").format(target), (source,))
+        record_property("custom_endpoint_import_privilege_error", str(caught.value))
+        native_connection.execute("RESET ROLE")
+        native_connection.execute(sql.SQL("GRANT SYSTEM EXTERNALIOIMPLICITACCESS TO {}").format(role))
+        native_connection.execute(sql.SQL("SET ROLE {}").format(role))
+        assert (
+            native_connection.execute("EXPORT INTO CSV %s FROM SELECT 1", (native_storage_uri,)).fetchall()[0][1] == 1
+        )
+        native_connection.execute(sql.SQL("IMPORT INTO {} CSV DATA (%s)").format(target), (source,))
+        assert native_connection.execute(sql.SQL("SELECT * FROM {}").format(target)).fetchall() == [(1,)]
+    finally:
+        native_connection.execute("RESET ROLE")
+        native_connection.execute(sql.SQL("DROP TABLE {}").format(target))
+        native_connection.execute(sql.SQL("REVOKE SYSTEM EXTERNALIOIMPLICITACCESS FROM {}").format(role))
+        native_connection.execute(sql.SQL("DROP ROLE {}").format(role))
+
+
+@pytest.mark.parametrize("client", ["asyncpg", "psycopg"])
+async def test_native_export_async_clients_bind_uri_and_query_values(
+    cockroachdb_service: "CockroachDBService", native_storage_uri: str, client: str
+) -> None:
+    if client == "asyncpg":
+        pg_connection = await asyncpg.connect(
+            host=cockroachdb_service.host,
+            port=cockroachdb_service.port,
+            database=cockroachdb_service.database,
+            user="root",
+            ssl=False,
+        )
+        try:
+            pg_rows = await pg_connection.fetch(
+                "EXPORT INTO PARQUET $1 FROM (SELECT $2::STRING AS label)", native_storage_uri, "O'Reilly"
+            )
+            assert len(pg_rows) == 1
+            assert pg_rows[0]["rows"] == 1
+        finally:
+            await pg_connection.close()
+    else:
+        async with await psycopg.AsyncConnection.connect(
+            host=cockroachdb_service.host,
+            port=cockroachdb_service.port,
+            dbname=cockroachdb_service.database,
+            user="root",
+            sslmode="disable",
+            autocommit=True,
+        ) as connection:
+            cursor = await connection.execute(
+                "EXPORT INTO PARQUET %s FROM (SELECT %s::STRING AS label)", (native_storage_uri, "O'Reilly")
+            )
+            rows = await cursor.fetchall()
+            assert len(rows) == 1
+            assert rows[0][1] == 1

--- a/tests/unit/adapters/test_cockroach_asyncpg/test_config.py
+++ b/tests/unit/adapters/test_cockroach_asyncpg/test_config.py
@@ -20,6 +20,37 @@ from sqlspec.adapters.cockroach_asyncpg import (
     CockroachAsyncpgRetryConfig,
 )
 from sqlspec.core import StatementConfig
+from sqlspec.exceptions import ImproperConfigurationError
+
+
+def test_cockroach_asyncpg_native_storage_defaults_off() -> None:
+    config = CockroachAsyncpgConfig()
+    assert config.driver_features["enable_native_storage"] is False
+
+
+def test_cockroach_asyncpg_native_storage_options_reach_driver() -> None:
+    options = {"nullas": "NULL", "nullif": "NULL", "skip": 0}
+    config = CockroachAsyncpgConfig(
+        driver_features={"enable_native_storage": True, "native_storage_csv_options": options}
+    )
+    driver = config.driver_type(connection=cast("Any", object()), driver_features=config.driver_features)
+    assert driver.driver_features["enable_native_storage"] is True
+    assert driver.driver_features["native_storage_csv_options"] == options
+
+
+@pytest.mark.parametrize(
+    "options",
+    [None, [], {"invalid": "fragment"}, {"nullas": 1}, {"nullif": None}, {"skip": -1}, {"skip": True}, {"skip": "1"}],
+)
+def test_cockroach_asyncpg_native_storage_rejects_invalid_csv_options(options: Any) -> None:
+    with pytest.raises(ImproperConfigurationError, match="native_storage_csv_options"):
+        CockroachAsyncpgConfig(driver_features={"native_storage_csv_options": options})
+
+
+@pytest.mark.parametrize("options", [{}, {"skip": 1}, {"nullas": ""}, {"nullif": ""}])
+def test_cockroach_asyncpg_native_storage_preserves_explicit_csv_options(options: dict[str, Any]) -> None:
+    config = CockroachAsyncpgConfig(driver_features={"native_storage_csv_options": options})
+    assert config.driver_features["native_storage_csv_options"] == options
 
 
 def test_cockroach_asyncpg_config_default_initialization() -> None:

--- a/tests/unit/adapters/test_cockroach_native_storage.py
+++ b/tests/unit/adapters/test_cockroach_native_storage.py
@@ -1,0 +1,316 @@
+"""Native Cockroach storage SQL and fallback contracts."""
+
+from importlib import import_module
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.parametrize("adapter", ["cockroach_asyncpg", "cockroach_psycopg"])
+def test_native_storage_commands_bind_values(adapter: str) -> None:
+    core = import_module("sqlspec.adapters." + adapter + ".core")
+    uri = "s3://bucket/O'Reilly?secret=do-not-inline"
+    sql, params = core.build_native_export("SELECT 7 AS id", [], uri, "csv", {"nullas": "'NULL'"})
+    assert uri not in sql and "'NULL'" not in sql
+    assert params == [uri, "'NULL'"]
+    assert "EXPORT INTO CSV" in sql and "nullas" in sql
+    sql, params = core.build_native_import('public."Odd Table"', uri, "csv", {"skip": 0, "nullif": "'NULL'"})
+    assert '"public"."Odd Table"' in sql
+    assert params == [uri, "0", "'NULL'"]
+    assert uri not in sql and "'NULL'" not in sql
+
+
+@pytest.mark.parametrize("adapter", ["cockroach_asyncpg", "cockroach_psycopg"])
+def test_native_storage_rejects_empty_table(adapter: str) -> None:
+    core = import_module("sqlspec.adapters." + adapter + ".core")
+    with pytest.raises(ValueError, match="Table"):
+        core.build_native_import("", "s3://bucket/file", "parquet", {})
+
+
+@pytest.mark.parametrize("adapter", ["cockroach_asyncpg", "cockroach_psycopg"])
+def test_native_storage_measured_metadata(adapter: str) -> None:
+    core = import_module("sqlspec.adapters." + adapter + ".core")
+    rows: list[dict[str, Any]] = [
+        {"filename": "a.parquet", "rows": 2, "bytes": 12},
+        {"filename": "b.parquet", "rows": 3, "bytes": 19},
+    ]
+    telemetry = core.native_export_telemetry(rows, "s3://bucket/prefix", "s3", "parquet")
+    assert telemetry["rows_processed"] == 5
+    assert telemetry["bytes_processed"] == 31
+    assert telemetry["extra"]["files"] == ["a.parquet", "b.parquet"]
+    imported = core.native_import_telemetry(
+        [{"job_id": 42, "status": "succeeded", "rows": 5, "bytes": 900}], "target", "s3", "parquet"
+    )
+    assert imported["rows_processed"] == 5
+    assert "bytes_processed" not in imported
+    assert imported["extra"]["job_id"] == 42
+
+
+@pytest.fixture(params=["asyncpg", "sync", "async"])
+def native_driver(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> Any:
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from sqlspec.adapters.cockroach_asyncpg import CockroachAsyncpgDriver
+    from sqlspec.adapters.cockroach_psycopg import CockroachPsycopgAsyncDriver, CockroachPsycopgSyncDriver
+    from sqlspec.storage.pipeline import ResolvedStorageTarget
+
+    cls = {"asyncpg": CockroachAsyncpgDriver, "sync": CockroachPsycopgSyncDriver, "async": CockroachPsycopgAsyncDriver}[
+        request.param
+    ]
+    connection = MagicMock()
+    connection.autocommit = True
+    connection.info.transaction_status = 0
+    connection.is_in_transaction.return_value = False
+    driver = cls(connection, driver_features={"enable_native_storage": True})
+    execute = MagicMock() if request.param == "sync" else AsyncMock()
+    monkeypatch.setattr(cls, "_execute_native_storage", execute)
+    pipeline = SimpleNamespace(
+        resolve_destination=MagicMock(return_value=ResolvedStorageTarget("s3://bucket/O'Reilly", "s3"))
+    )
+    monkeypatch.setattr(cls, "_storage_pipeline", lambda self: pipeline)
+    parent = cls.__bases__[0]
+    fallback = MagicMock(return_value="inherited") if request.param == "sync" else AsyncMock(return_value="inherited")
+    monkeypatch.setattr(parent, "select_to_storage", fallback)
+    monkeypatch.setattr(parent, "load_from_storage", fallback)
+    return SimpleNamespace(driver=driver, execute=execute, fallback=fallback, pipeline=pipeline, connection=connection)
+
+
+async def _result(value: Any) -> Any:
+    from inspect import isawaitable
+
+    return await value if isawaitable(value) else value
+
+
+async def test_native_driver_export_parameters_and_metadata(native_driver: Any) -> None:
+    native_driver.execute.return_value = [{"filename": "a.csv", "rows": 1, "bytes": 19}]
+    native_driver.driver.driver_features["native_storage_csv_options"] = {"nullas": "NULL"}
+    result = await _result(
+        native_driver.driver.select_to_storage(
+            "SELECT :value::STRING AS label",
+            "alias://remote/out",
+            {"value": "O'Reilly"},
+            format_hint="csv",
+            partitioner={"x": 1},
+            telemetry={"correlation_id": "original"},
+        )
+    )
+    sql, values = native_driver.execute.call_args.args
+    assert "O'Reilly" not in sql and "NULL" not in sql
+    assert sorted(values) == sorted(["O'Reilly", "s3://bucket/O'Reilly", "NULL"])
+    assert result.telemetry["extra"]["files"] == ["a.csv"]
+    assert result.telemetry["extra"]["partitioner"] == {"x": 1}
+    assert result.telemetry["extra"]["source"] == {"correlation_id": "original"}
+    native_driver.execute.assert_called_once()
+    native_driver.fallback.assert_not_called()
+
+
+@pytest.mark.parametrize("reason", ["disabled", "local", "format", "transaction", "nonselect"])
+async def test_native_export_fallback_before_sql(native_driver: Any, reason: str) -> None:
+    from sqlspec.storage.pipeline import ResolvedStorageTarget
+
+    if reason == "disabled":
+        native_driver.driver.driver_features["enable_native_storage"] = False
+    if reason == "local":
+        native_driver.pipeline.resolve_destination.return_value = ResolvedStorageTarget("file:///tmp/file", "file")
+    if reason == "transaction":
+        native_driver.connection.info.transaction_status = 2
+        native_driver.connection.is_in_transaction.return_value = True
+    query = "DELETE FROM test" if reason == "nonselect" else "SELECT 1"
+    result = await _result(
+        native_driver.driver.select_to_storage(
+            query, "alias://target/out", format_hint="json" if reason == "format" else "parquet"
+        )
+    )
+    assert result == "inherited"
+    native_driver.execute.assert_not_called()
+    native_driver.fallback.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "file_format,options", [("parquet", {}), ("csv", {"skip": 0}), ("csv", {"skip": 1, "nullif": "NULL"})]
+)
+async def test_native_driver_import_options(native_driver: Any, file_format: str, options: dict[str, Any]) -> None:
+    native_driver.driver.driver_features["native_storage_csv_options"] = options
+    native_driver.execute.return_value = [{"job_id": 22, "status": "succeeded", "rows": 2}]
+    result = await _result(
+        native_driver.driver.load_from_storage(
+            'public."Odd Table"', "alias://remote/file", file_format=file_format, partitioner={"p": 1}
+        )
+    )
+    sql, values = native_driver.execute.call_args.args
+    assert values == ["s3://bucket/O'Reilly", *[str(options[k]) for k in ("skip", "nullif") if k in options]]
+    assert '"public"."Odd Table"' in sql
+    assert result.telemetry["extra"]["job_id"] == 22
+    assert result.telemetry["extra"]["partitioner"] == {"p": 1}
+    native_driver.execute.assert_called_once()
+
+
+@pytest.mark.parametrize("reason", ["disabled", "local", "format", "transaction", "overwrite", "csv"])
+async def test_native_import_fallback_before_sql(native_driver: Any, reason: str) -> None:
+    from sqlspec.storage.pipeline import ResolvedStorageTarget
+
+    if reason == "disabled":
+        native_driver.driver.driver_features["enable_native_storage"] = False
+    if reason == "local":
+        native_driver.pipeline.resolve_destination.return_value = ResolvedStorageTarget("file:///tmp/file", "file")
+    if reason == "transaction":
+        native_driver.connection.info.transaction_status = 2
+        native_driver.connection.is_in_transaction.return_value = True
+    result = await _result(
+        native_driver.driver.load_from_storage(
+            "target",
+            "alias://source/file",
+            file_format={"format": "json", "csv": "csv"}.get(reason, "parquet"),
+            overwrite=reason == "overwrite",
+        )
+    )
+    assert result == "inherited"
+    native_driver.execute.assert_not_called()
+    native_driver.fallback.assert_called_once()
+
+
+@pytest.mark.parametrize("operation", ["export", "import"])
+@pytest.mark.parametrize("failure", ["execute", "result"])
+async def test_native_failures_never_replay(native_driver: Any, operation: str, failure: str) -> None:
+    if failure == "execute":
+        native_driver.execute.side_effect = RuntimeError("native failed")
+    else:
+        native_driver.execute.return_value = [{}]
+    with pytest.raises((RuntimeError, KeyError)):
+        value = (
+            native_driver.driver.select_to_storage("SELECT 1", "s3://bucket/out")
+            if operation == "export"
+            else native_driver.driver.load_from_storage("target", "s3://bucket/in", file_format="parquet")
+        )
+        await _result(value)
+    native_driver.execute.assert_called_once()
+    native_driver.fallback.assert_not_called()
+
+
+@pytest.mark.parametrize("adapter", ["cockroach_asyncpg", "cockroach_psycopg"])
+def test_native_storage_failed_job_metadata(adapter: str) -> None:
+    core = import_module("sqlspec.adapters." + adapter + ".core")
+    with pytest.raises(ValueError, match="did not succeed"):
+        core.native_import_telemetry([{"status": "failed"}], "target", "s3", "parquet")
+
+
+async def test_native_driver_invalid_table_before_sql(native_driver: Any) -> None:
+    with pytest.raises(ValueError, match="Table"):
+        await _result(native_driver.driver.load_from_storage("", "s3://bucket/in", file_format="parquet"))
+    native_driver.execute.assert_not_called()
+    native_driver.fallback.assert_not_called()
+
+
+@pytest.mark.parametrize("adapter", ["asyncpg", "sync", "async"])
+async def test_native_database_failure_mapped_once(adapter: str) -> None:
+    from unittest.mock import AsyncMock, MagicMock
+
+    import asyncpg
+    import psycopg
+
+    from sqlspec.adapters.cockroach_asyncpg import CockroachAsyncpgDriver
+    from sqlspec.adapters.cockroach_psycopg import CockroachPsycopgAsyncDriver, CockroachPsycopgSyncDriver
+    from sqlspec.exceptions import SQLSpecError
+
+    connection = MagicMock()
+    if adapter == "asyncpg":
+        connection.fetch = AsyncMock(side_effect=asyncpg.PostgresError("native refused"))
+        driver: Any = CockroachAsyncpgDriver(connection)
+        execute = connection.fetch
+    else:
+        cursor = MagicMock()
+        connection.cursor.return_value = cursor
+        if adapter == "async":
+            cursor.execute = AsyncMock(side_effect=psycopg.DatabaseError("native refused"))
+            cursor.close = AsyncMock()
+            driver = CockroachPsycopgAsyncDriver(connection)
+        else:
+            cursor.execute.side_effect = psycopg.DatabaseError("native refused")
+            driver = CockroachPsycopgSyncDriver(connection)
+        execute = cursor.execute
+    with pytest.raises(SQLSpecError):
+        await _result(driver._execute_native_storage("EXPORT INTO PARQUET placeholder FROM SELECT 1", ["uri"]))
+    execute.assert_called_once()
+
+
+async def test_native_export_after_compiled_cache_warmup(native_driver: Any) -> None:
+    from sqlspec.core import SQL
+
+    query = "SELECT :native_cached_value::INT8 AS value"
+    warm = SQL(query, {"native_cached_value": 8}, statement_config=native_driver.driver.statement_config)
+    native_driver.driver._compiled_sql(warm, warm.statement_config)
+    native_driver.execute.return_value = [{"filename": "cached.parquet", "rows": 1, "bytes": 12}]
+    result = await _result(native_driver.driver.select_to_storage(query, "s3://bucket/out", {"native_cached_value": 8}))
+    assert result.telemetry["rows_processed"] == 1
+    native_driver.execute.assert_called_once()
+    native_driver.fallback.assert_not_called()
+
+
+def test_native_psycopg_percent_literals_remain_literal() -> None:
+    from sqlspec.adapters.cockroach_psycopg.core import build_native_export, build_native_import
+
+    query, values = build_native_export("SELECT '100%'::STRING AS label", [], "s3://bucket/out", "parquet", {})
+    assert "'100%%'" in query
+    assert values == ["s3://bucket/out"]
+    query, values = build_native_import('"100% table"', "s3://bucket/in", "parquet", {})
+    assert '"100%% table"' in query
+    assert values == ["s3://bucket/in"]
+
+
+async def test_native_export_resolves_real_remote_and_local_aliases(
+    native_driver: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    from sqlspec.storage import StorageRegistry, SyncStoragePipeline
+
+    registry = StorageRegistry()
+    registry.register_alias("remote", "s3://bucket/base", backend="fsspec", key="test", secret="test")
+    registry.register_alias("local", str(tmp_path), backend="local")
+    pipeline = SyncStoragePipeline(registry=registry)
+    monkeypatch.setattr(type(native_driver.driver), "_storage_pipeline", lambda self: pipeline)
+    native_driver.execute.return_value = [{"filename": "out.parquet", "rows": 1, "bytes": 10}]
+    job = await _result(native_driver.driver.select_to_storage("SELECT 1", "alias://remote/prefix"))
+    assert job.telemetry["destination"] == "s3://bucket/base/prefix"
+    assert native_driver.execute.call_args.args[1] == ["s3://bucket/base/prefix"]
+    assert await _result(native_driver.driver.select_to_storage("SELECT 1", "alias://local/out.parquet")) == "inherited"
+    native_driver.execute.assert_called_once()
+    native_driver.fallback.assert_called_once()
+
+
+def test_native_benchmark_cli_omits_failure_credentials(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from unittest.mock import Mock
+
+    from tools.scripts import bench_cockroach_storage
+
+    monkeypatch.setattr("sys.argv", ["bench_cockroach_storage"])
+    monkeypatch.setattr(bench_cockroach_storage, "run_benchmark", Mock(side_effect=RuntimeError("secret-access-key")))
+    with pytest.raises(SystemExit) as exc:
+        bench_cockroach_storage.main()
+    assert exc.value.code == 1
+    output = capsys.readouterr()
+    assert "RuntimeError" in output.err
+    assert "secret-access-key" not in output.err
+
+
+@pytest.mark.parametrize("query", ["SELECT 1 -- trailing comment", "SELECT ';' AS value -- trailing comment"])
+async def test_native_export_preserves_comments_and_literal_delimiters(native_driver: Any, query: str) -> None:
+    native_driver.execute.return_value = [{"filename": "out.parquet", "rows": 1, "bytes": 10}]
+    await _result(native_driver.driver.select_to_storage(query, "s3://bucket/out"))
+    command = native_driver.execute.call_args.args[0]
+    assert command.endswith("\n)")
+    assert "-- trailing comment" in command
+    assert "; -- trailing" not in command
+
+
+async def test_native_export_raw_script_falls_back(native_driver: Any) -> None:
+    assert await _result(native_driver.driver.select_to_storage("SELECT 1; SELECT 2", "s3://bucket/out")) == "inherited"
+    native_driver.execute.assert_not_called()
+
+
+@pytest.mark.parametrize("adapter", ["cockroach_asyncpg", "cockroach_psycopg"])
+def test_native_export_delimiter_normalization(adapter: str) -> None:
+    core = import_module("sqlspec.adapters." + adapter + ".core")
+    assert core.normalize_native_export_query("SELECT ';' AS value; -- tail") == "SELECT ';' AS value -- tail"
+    assert core.normalize_native_export_query("SELECT 1; SELECT 2") is None

--- a/tests/unit/adapters/test_cockroach_psycopg/test_config.py
+++ b/tests/unit/adapters/test_cockroach_psycopg/test_config.py
@@ -8,7 +8,7 @@ Tests cover:
 - Connection config normalization
 """
 
-from typing import Any
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -23,6 +23,75 @@ from sqlspec.adapters.cockroach_psycopg import (
 )
 from sqlspec.adapters.cockroach_psycopg.config import default_statement_config
 from sqlspec.exceptions import ImproperConfigurationError
+
+
+@pytest.mark.parametrize("config_type", [CockroachPsycopgSyncConfig, CockroachPsycopgAsyncConfig])
+def test_cockroach_psycopg_native_storage_defaults_off(
+    config_type: type[CockroachPsycopgSyncConfig] | type[CockroachPsycopgAsyncConfig],
+) -> None:
+    assert config_type().driver_features["enable_native_storage"] is False
+
+
+@pytest.mark.parametrize("config_type", [CockroachPsycopgSyncConfig, CockroachPsycopgAsyncConfig])
+def test_cockroach_psycopg_native_storage_options_reach_driver(
+    config_type: type[CockroachPsycopgSyncConfig] | type[CockroachPsycopgAsyncConfig],
+) -> None:
+    options = {"nullas": "NULL", "nullif": "NULL", "skip": 0}
+    config = config_type(
+        connection_config={"autocommit": True},
+        driver_features={"enable_native_storage": True, "native_storage_csv_options": options},
+    )
+    driver = config.driver_type(connection=cast("Any", object()), driver_features=config.driver_features)
+    assert driver.driver_features["enable_native_storage"] is True
+    assert driver.driver_features["native_storage_csv_options"] == options
+
+
+@pytest.mark.parametrize("config_type", [CockroachPsycopgSyncConfig, CockroachPsycopgAsyncConfig])
+@pytest.mark.parametrize(
+    "connection_config", [{}, {"autocommit": False}, {"autocommit": False, "kwargs": {"autocommit": True}}]
+)
+def test_cockroach_psycopg_native_storage_requires_autocommit(
+    config_type: type[CockroachPsycopgSyncConfig] | type[CockroachPsycopgAsyncConfig], connection_config: dict[str, Any]
+) -> None:
+    with pytest.raises(ImproperConfigurationError, match="autocommit=True"):
+        config_type(connection_config=connection_config, driver_features={"enable_native_storage": True})
+
+
+@pytest.mark.parametrize("config_type", [CockroachPsycopgSyncConfig, CockroachPsycopgAsyncConfig])
+@pytest.mark.parametrize(
+    "connection_config",
+    [
+        {"kwargs": {"autocommit": True}},
+        {"extra": {"autocommit": True}},
+        {"autocommit": True, "kwargs": {"autocommit": False}},
+    ],
+)
+def test_cockroach_psycopg_native_storage_honors_effective_autocommit(
+    config_type: type[CockroachPsycopgSyncConfig] | type[CockroachPsycopgAsyncConfig], connection_config: dict[str, Any]
+) -> None:
+    config = config_type(connection_config=connection_config, driver_features={"enable_native_storage": True})
+    assert config.driver_features["enable_native_storage"] is True
+
+
+@pytest.mark.parametrize("config_type", [CockroachPsycopgSyncConfig, CockroachPsycopgAsyncConfig])
+@pytest.mark.parametrize(
+    "options",
+    [None, [], {"invalid": "fragment"}, {"nullas": 1}, {"nullif": None}, {"skip": -1}, {"skip": True}, {"skip": "1"}],
+)
+def test_cockroach_psycopg_native_storage_rejects_invalid_csv_options(
+    config_type: type[CockroachPsycopgSyncConfig] | type[CockroachPsycopgAsyncConfig], options: Any
+) -> None:
+    with pytest.raises(ImproperConfigurationError, match="native_storage_csv_options"):
+        config_type(driver_features={"native_storage_csv_options": options})
+
+
+@pytest.mark.parametrize("config_type", [CockroachPsycopgSyncConfig, CockroachPsycopgAsyncConfig])
+@pytest.mark.parametrize("options", [{}, {"skip": 1}, {"nullas": ""}, {"nullif": ""}])
+def test_cockroach_psycopg_native_storage_preserves_explicit_csv_options(
+    config_type: type[CockroachPsycopgSyncConfig] | type[CockroachPsycopgAsyncConfig], options: dict[str, Any]
+) -> None:
+    config = config_type(driver_features={"native_storage_csv_options": options})
+    assert config.driver_features["native_storage_csv_options"] == options
 
 
 class _SyncPoolSpy:

--- a/tools/scripts/bench_cockroach_storage.py
+++ b/tools/scripts/bench_cockroach_storage.py
@@ -1,0 +1,207 @@
+"""Compare native and inherited Cockroach Parquet storage on local services.
+
+Configure SQLSPEC_COCKROACH_DSN, SQLSPEC_COCKROACH_NATIVE_URI (server-accessible
+credentials/endpoint), SQLSPEC_COCKROACH_CLIENT_URI (same bucket/prefix), and
+SQLSPEC_COCKROACH_STORAGE_OPTIONS (JSON fsspec credentials/endpoint). Secrets are
+never printed. Each run owns a random prefix and tables, removed on completion.
+"""
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import threading
+import time
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+from uuid import uuid4
+
+import psycopg
+from psycopg import sql
+
+from sqlspec.adapters.cockroach_psycopg import CockroachPsycopgSyncConfig, CockroachPsycopgSyncDriver
+from sqlspec.storage import StorageRegistry, SyncStoragePipeline
+
+
+def _append_uri(uri: str, suffix: str) -> str:
+    parts = urlsplit(uri)
+    return urlunsplit(parts._replace(path=parts.path.rstrip("/") + "/" + suffix))
+
+
+def _monitor(
+    dsn: str, table: str, stop: threading.Event, ready: threading.Event, interval: float, samples: list[dict[str, Any]]
+) -> None:
+    with psycopg.connect(dsn, autocommit=True) as connection:
+        connection.execute("SET statement_timeout = '250ms'")
+        ready.set()
+        while not stop.is_set():
+            started = time.perf_counter()
+            try:
+                connection.execute(sql.SQL("SELECT 1 FROM {} LIMIT 1").format(sql.Identifier(table)))
+            except psycopg.Error as exc:
+                samples.append({"at": started, "duration_s": time.perf_counter() - started, "sqlstate": exc.sqlstate})
+            stop.wait(interval)
+
+
+def run_benchmark(sizes: list[int], warmup: int, iterations: int, poll_interval: float) -> dict[str, Any]:
+    """Run paired export/import samples; report polling uncertainty separately."""
+    dsn = os.environ["SQLSPEC_COCKROACH_DSN"]
+    native_base = os.environ["SQLSPEC_COCKROACH_NATIVE_URI"]
+    client_base = os.environ["SQLSPEC_COCKROACH_CLIENT_URI"]
+    options = json.loads(os.environ.get("SQLSPEC_COCKROACH_STORAGE_OPTIONS", "{}"))
+    registry = StorageRegistry()
+
+    class BenchmarkPipeline(SyncStoragePipeline):
+        __slots__ = ()
+
+        def __init__(self) -> None:
+            super().__init__(registry=registry)
+
+    class BenchmarkDriver(CockroachPsycopgSyncDriver):
+        __slots__ = ()
+        storage_pipeline_factory = BenchmarkPipeline
+
+        def select_to_arrow(self, *args: Any, **kwargs: Any) -> Any:
+            if self.driver_features["enable_native_storage"]:
+                msg = "Native benchmark unexpectedly selected client-side export"
+                raise RuntimeError(msg)
+            return super().select_to_arrow(*args, **kwargs)
+
+    prefix = "sqlspec_bench_" + uuid4().hex
+    alias = prefix
+    registry.register_alias(alias, _append_uri(client_base, prefix), backend="fsspec", **options)
+    backend = registry.get(alias)
+    results: list[dict[str, Any]] = []
+    try:
+        with psycopg.connect(dsn, autocommit=True) as connection:
+            version = connection.execute("SELECT version()").fetchone()
+            for size in sizes:
+                for native in (False, True):
+                    config = CockroachPsycopgSyncConfig(
+                        connection_config={"autocommit": True}, driver_features={"enable_native_storage": native}
+                    )
+                    driver = BenchmarkDriver(
+                        connection, statement_config=config.statement_config, driver_features=config.driver_features
+                    )
+                    for iteration in range(-warmup, iterations):
+                        sample_name = uuid4().hex
+                        destination = (
+                            _append_uri(native_base, prefix + "/" + sample_name)
+                            if native
+                            else "alias://" + alias + "/" + sample_name + ".parquet"
+                        )
+                        query = "SELECT i::INT8 AS id, repeat('x', 64)::STRING AS label FROM generate_series(1, :rows) AS t(i)"
+                        if native and not driver._native_storage_ready():
+                            msg = (
+                                "Native benchmark connection not ready: autocommit="
+                                + str(connection.autocommit)
+                                + ", status="
+                                + str(connection.info.transaction_status)
+                            )
+                            raise RuntimeError(msg)
+                        started = time.perf_counter()
+                        exported = driver.select_to_storage(query, destination, {"rows": size}, format_hint="parquet")
+                        export_s = time.perf_counter() - started
+                        if exported.telemetry["rows_processed"] != size:
+                            msg = "Export row count mismatch"
+                            raise RuntimeError(msg)
+                        sources = (
+                            [_append_uri(destination, str(name)) for name in exported.telemetry["extra"]["files"]]
+                            if native
+                            else [destination]
+                        )
+                        table = prefix + "_" + sample_name
+                        connection.execute(
+                            sql.SQL("CREATE TABLE {} (id INT8 PRIMARY KEY, label STRING)").format(sql.Identifier(table))
+                        )
+                        stop, ready = threading.Event(), threading.Event()
+                        unavailable: list[dict[str, Any]] = []
+                        monitor = threading.Thread(
+                            target=_monitor, args=(dsn, table, stop, ready, poll_interval, unavailable), daemon=True
+                        )
+                        monitor.start()
+                        try:
+                            if not ready.wait(10):
+                                msg = "Offline monitor failed to connect"
+                                raise RuntimeError(msg)
+                            started = time.perf_counter()
+                            imported_rows = 0
+                            for source in sources:
+                                imported_rows += driver.load_from_storage(
+                                    table, source, file_format="parquet"
+                                ).telemetry["rows_processed"]
+                            import_s = time.perf_counter() - started
+                            if imported_rows != size or connection.execute(
+                                sql.SQL("SELECT count(*) FROM {}").format(sql.Identifier(table))
+                            ).fetchone() != (size,):
+                                msg = "Import row count mismatch"
+                                raise RuntimeError(msg)
+                        finally:
+                            stop.set()
+                            monitor.join(5)
+                            connection.execute(sql.SQL("DROP TABLE {}").format(sql.Identifier(table)))
+                        if iteration >= 0:
+                            span = (
+                                unavailable[-1]["at"] - unavailable[0]["at"] + unavailable[-1]["duration_s"]
+                                if unavailable
+                                else 0.0
+                            )
+                            results.append({
+                                "rows": size,
+                                "native": native,
+                                "iteration": iteration,
+                                "export_s": export_s,
+                                "import_s": import_s,
+                                "unavailable_samples": len(unavailable),
+                                "observed_unavailable_span_s": span,
+                                "unavailable_sqlstates": sorted({str(item["sqlstate"]) for item in unavailable}),
+                            })
+        summaries = []
+        for size in sizes:
+            for native in (False, True):
+                group = [item for item in results if item["rows"] == size and item["native"] == native]
+                for operation in ("export", "import"):
+                    values = [item[operation + "_s"] for item in group]
+                    summaries.append({
+                        "scenario": operation,
+                        "rows": size,
+                        "native": native,
+                        "samples": len(values),
+                        "median_s": statistics.median(values),
+                        "min_s": min(values),
+                        "max_s": max(values),
+                    })
+        return {
+            "server_version": version[0] if version else None,
+            "poll_interval_s": poll_interval,
+            "probe_timeout_s": 0.25,
+            "offline_measurement": "Observed failed-probe span only; polling and query latency bound resolution. Zero samples does not prove zero offline time.",
+            "samples": results,
+            "summaries": summaries,
+        }
+    finally:
+        if backend.list_objects_sync():
+            backend.delete_sync("", recursive=True)
+        registry.clear()
+
+
+def main() -> None:
+    """Run the explicitly configured local benchmark."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rows", nargs="+", type=int, default=[100, 1000, 10000])
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--iterations", type=int, default=3)
+    parser.add_argument("--poll-interval", type=float, default=0.02)
+    args = parser.parse_args()
+    if min(args.rows) <= 0 or args.warmup < 0 or args.iterations <= 0 or args.poll_interval <= 0:
+        parser.error("rows, iterations and poll interval must be positive; warmup must be nonnegative")
+    try:
+        result = run_benchmark(args.rows, args.warmup, args.iterations, args.poll_interval)
+    except Exception as exc:
+        parser.exit(1, "Benchmark failed (credentials omitted): " + type(exc).__name__ + "\n")
+    sys.stdout.write(json.dumps(result, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds an opt-in mode that lets CockroachDB move object-store data itself, using `EXPORT INTO` and `IMPORT INTO`, instead of streaming every row through the client. It is off by default, and the trade-offs are real enough that you should measure your own workload before enabling it.

- **Opt in per connection** with `enable_native_storage`. When it is off — the default — nothing changes.
- **Exports write a prefix, not a file.** The server generates one or more files below the destination you give, and their names come back in the result's `extra["files"]`.
- **Imports take the table offline** for the duration and invalidate foreign keys, which is CockroachDB's behavior for `IMPORT INTO`, not something added here.
- **Caller transactions are never touched.** A connection already inside an explicit transaction uses the previous path, chosen before any statement runs, so nothing is implicitly committed.
- **Falls back for anything unsupported:** local paths, HTTP, formats other than CSV and Parquet, and overwrite imports.
- **CSV conventions are explicit.** `native_storage_csv_options` accepts only `nullas`, `nullif` and `skip`, validated at configuration time; native CSV import requires you to state the header row count rather than guessing it.

## How you use it

```python
config = CockroachPsycopgSyncConfig(
    pool_config={"conninfo": ..., "autocommit": True},
    driver_features={"enable_native_storage": True},
)
result = driver.select_to_storage("SELECT * FROM events", "s3://bucket/exports/")
result.telemetry["extra"]["files"]  # the generated file names
```

Psycopg connections must be configured with `autocommit=True`, since CockroachDB refuses these statements inside a transaction. Exporting gives you a prefix, so import an actual returned file rather than the prefix itself. The server needs its own access to the object store.

## Performance

This is the part worth reading before enabling it. Against a local cluster and a co-located S3-compatible store, native was **slower than the existing client path at every size measured** (median ms):

| rows | client export | native export | client import | native import |
|---|---|---|---|---|
| 100 | 5.34 | 12.78 | 8.61 | 107.03 |
| 1,000 | 6.59 | 13.55 | 18.92 | 112.92 |
| 10,000 | 16.62 | 23.18 | 76.41 | 129.86 |

Native job startup dominates at these sizes, and native imports took the table offline for 21–63 ms while client imports never did. A co-located client is the least favourable case for handing work to the server, and these samples say nothing about large or distributed workloads — but they do mean this is not a drop-in speedup, which is why it defaults to off and ships with the benchmark used to produce the table.

CockroachDB Cloud, GCS and Azure are not verified; only a local cluster with an S3-compatible store was exercised.
