### PR TITLE
feat: export uuid helpers and Litestar correlation middleware

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -66,6 +66,7 @@ Unreleased
   ``sqlspec.utils.serializers``, and ``sqlspec.utils.correlation`` modules and
   the ``to_schema``, ``to_value_type``, and ``transform_dict_keys`` functions
   from ``sqlspec.utils.schema`` as supported APIs.
+  (`#758 <https://github.com/litestar-org/sqlspec/issues/758>`_)
 
 * Storage pipelines expose ``resolve_destination()``, returning a
   ``ResolvedStorageTarget(uri, protocol)`` without opening a database session.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -62,9 +62,10 @@ Unreleased
 * ``uuid4``, ``uuid6``, ``uuid7``, and ``nanoid`` can be imported from the
   top-level ``sqlspec`` package. ``sqlspec.extensions.litestar`` exports
   ``CorrelationMiddleware`` and ``TRACE_CONTEXT_FALLBACK_HEADERS``. The
-  :doc:`/reference/utils` reference now covers ``sqlspec.utils.text``,
-  ``sqlspec.utils.serializers``, ``sqlspec.utils.schema``, and
-  ``sqlspec.utils.correlation`` as supported modules.
+  :doc:`/reference/utils` reference now covers the ``sqlspec.utils.text``,
+  ``sqlspec.utils.serializers``, and ``sqlspec.utils.correlation`` modules and
+  the ``to_schema``, ``to_value_type``, and ``transform_dict_keys`` functions
+  from ``sqlspec.utils.schema`` as supported APIs.
 
 * Storage pipelines expose ``resolve_destination()``, returning a
   ``ResolvedStorageTarget(uri, protocol)`` without opening a database session.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -59,6 +59,13 @@ Unreleased
   ``begin_transaction()`` to keep several calls in one transaction. Existing
   code that passes a driver still works. See :doc:`/recipes/service_layer`.
 
+* ``uuid4``, ``uuid6``, ``uuid7``, and ``nanoid`` can be imported from the
+  top-level ``sqlspec`` package. ``sqlspec.extensions.litestar`` exports
+  ``CorrelationMiddleware`` and ``TRACE_CONTEXT_FALLBACK_HEADERS``. The
+  :doc:`/reference/utils` reference now covers ``sqlspec.utils.text``,
+  ``sqlspec.utils.serializers``, ``sqlspec.utils.schema``, and
+  ``sqlspec.utils.correlation`` as supported modules.
+
 * Storage pipelines expose ``resolve_destination()``, returning a
   ``ResolvedStorageTarget(uri, protocol)`` without opening a database session.
   Direct remote URIs retain their address, alias paths resolve relative to the

--- a/docs/reference/extensions/litestar.rst
+++ b/docs/reference/extensions/litestar.rst
@@ -40,11 +40,10 @@ yourself only when you build the middleware stack without the plugin.
 
 .. py:data:: sqlspec.extensions.litestar.TRACE_CONTEXT_FALLBACK_HEADERS
 
-   Trace-context headers the plugin checks after ``correlation_header`` and
-   ``correlation_headers`` while ``auto_trace_headers`` is enabled, which is the
-   default. In order: ``x-request-id``, ``x-correlation-id``, ``traceparent``,
-   ``x-cloud-trace-context``, ``grpc-trace-bin``, ``x-amzn-trace-id``,
-   ``x-b3-traceid``, and ``x-client-trace-id``.
+   Ordered trace-context header names that the plugin checks after
+   ``correlation_header`` and ``correlation_headers`` while
+   ``auto_trace_headers`` is enabled, which is the default. Import the constant
+   to inspect the names or pass them to ``CorrelationMiddleware``.
 
    :type: tuple[str, ...]
 

--- a/docs/reference/extensions/litestar.rst
+++ b/docs/reference/extensions/litestar.rst
@@ -19,6 +19,35 @@ Configuration
    :members:
    :show-inheritance:
 
+Correlation Middleware
+======================
+
+``SQLSpecPlugin`` installs ``CorrelationMiddleware`` while
+``enable_correlation_middleware`` is enabled, which is the default. Add it
+yourself only when you build the middleware stack without the plugin.
+
+.. code-block:: python
+
+   from litestar.middleware import DefineMiddleware
+
+   from sqlspec.extensions.litestar import TRACE_CONTEXT_FALLBACK_HEADERS, CorrelationMiddleware
+
+   middleware = [DefineMiddleware(CorrelationMiddleware, headers=TRACE_CONTEXT_FALLBACK_HEADERS)]
+
+.. autoclass:: sqlspec.extensions.litestar.CorrelationMiddleware
+   :members:
+   :show-inheritance:
+
+.. py:data:: sqlspec.extensions.litestar.TRACE_CONTEXT_FALLBACK_HEADERS
+
+   Trace-context headers the plugin checks after ``correlation_header`` and
+   ``correlation_headers`` while ``auto_trace_headers`` is enabled, which is the
+   default. In order: ``x-request-id``, ``x-correlation-id``, ``traceparent``,
+   ``x-cloud-trace-context``, ``grpc-trace-bin``, ``x-amzn-trace-id``,
+   ``x-b3-traceid``, and ``x-client-trace-id``.
+
+   :type: tuple[str, ...]
+
 Channels Backend
 ================
 

--- a/docs/reference/utils.rst
+++ b/docs/reference/utils.rst
@@ -3,9 +3,10 @@ Utility Functions
 =================
 
 SQLSpec exposes small, reusable helpers for runtime type narrowing, configuration,
-identifier generation, optional dependency loading, sync/async interoperation,
-deprecation, and fixture files. These modules are supported public APIs; import
-helpers from their defining ``sqlspec.utils`` module.
+identifier generation, text and identifier formatting, serialization, schema
+conversion, correlation tracking, optional dependency loading, sync/async
+interoperation, deprecation, and fixture files. These modules are supported
+public APIs; import helpers from their defining ``sqlspec.utils`` module.
 
 Type Guards
 ===========
@@ -26,6 +27,33 @@ UUIDs and Compact Identifiers
 =============================
 
 .. automodule:: sqlspec.utils.uuids
+   :members:
+
+The most common generators, ``uuid4``, ``uuid6``, ``uuid7``, and ``nanoid``, are
+also importable from the top-level ``sqlspec`` package.
+
+Text and Identifiers
+====================
+
+.. automodule:: sqlspec.utils.text
+   :members:
+
+Serialization
+=============
+
+.. automodule:: sqlspec.utils.serializers
+   :members:
+
+Schema Conversion
+=================
+
+.. automodule:: sqlspec.utils.schema
+   :members: to_schema, to_value_type, transform_dict_keys
+
+Correlation Tracking
+====================
+
+.. automodule:: sqlspec.utils.correlation
    :members:
 
 Module and Optional Dependency Loading

--- a/docs/reference/utils.rst
+++ b/docs/reference/utils.rst
@@ -44,6 +44,11 @@ Serialization
 .. automodule:: sqlspec.utils.serializers
    :members:
 
+.. py:data:: DEFAULT_TYPE_ENCODERS
+
+   Default mapping of Python types to JSON encoder functions; ``type_encoders``
+   passed to a serializer are merged over it.
+
 Schema Conversion
 =================
 

--- a/docs/reference/utils.rst
+++ b/docs/reference/utils.rst
@@ -5,8 +5,9 @@ Utility Functions
 SQLSpec exposes small, reusable helpers for runtime type narrowing, configuration,
 identifier generation, text and identifier formatting, serialization, schema
 conversion, correlation tracking, optional dependency loading, sync/async
-interoperation, deprecation, and fixture files. These modules are supported
-public APIs; import helpers from their defining ``sqlspec.utils`` module.
+interoperation, deprecation, and fixture files. The modules and members
+documented on this page are supported public APIs; import helpers from their
+defining ``sqlspec.utils`` module.
 
 Type Guards
 ===========

--- a/sqlspec/__init__.py
+++ b/sqlspec/__init__.py
@@ -182,6 +182,14 @@ def __getattr__(name: str) -> "Any":
     if name == "dialects":
         return importlib.import_module("sqlspec.dialects")
     if name in _LAZY_UUID_NAMES:
-        return getattr(importlib.import_module("sqlspec.utils.uuids"), name)
+        value = getattr(importlib.import_module("sqlspec.utils.uuids"), name)
+        globals()[name] = value
+        return value
     msg = f"module {__name__!r} has no attribute {name!r}"
     raise AttributeError(msg)
+
+
+def __dir__() -> "list[str]":
+    """Expose the public surface for autocomplete and ``dir()``."""
+
+    return sorted(set(globals()) | set(__all__))

--- a/sqlspec/__init__.py
+++ b/sqlspec/__init__.py
@@ -82,10 +82,10 @@ from sqlspec.observability import (
 )
 from sqlspec.typing import ConnectionT, PoolT, SchemaT, StatementParameters, SupportedSchemaModel
 from sqlspec.utils.logging import suppress_erroneous_sqlglot_log_messages
+from sqlspec.utils.uuids import nanoid, uuid4, uuid6, uuid7
 
 if TYPE_CHECKING:
     from sqlspec import dialects
-    from sqlspec.utils.uuids import nanoid, uuid4, uuid6, uuid7
 
 __all__ = (
     "SQL",
@@ -171,25 +171,13 @@ __all__ = (
     "uuid7",
 )
 
-_LAZY_UUID_NAMES = frozenset(("nanoid", "uuid4", "uuid6", "uuid7"))
-
 suppress_erroneous_sqlglot_log_messages()
 
 
 def __getattr__(name: str) -> "Any":
-    import importlib
-
     if name == "dialects":
+        import importlib
+
         return importlib.import_module("sqlspec.dialects")
-    if name in _LAZY_UUID_NAMES:
-        value = getattr(importlib.import_module("sqlspec.utils.uuids"), name)
-        globals()[name] = value
-        return value
     msg = f"module {__name__!r} has no attribute {name!r}"
     raise AttributeError(msg)
-
-
-def __dir__() -> "list[str]":
-    """Expose the public surface for autocomplete and ``dir()``."""
-
-    return sorted(set(globals()) | set(__all__))

--- a/sqlspec/__init__.py
+++ b/sqlspec/__init__.py
@@ -85,6 +85,7 @@ from sqlspec.utils.logging import suppress_erroneous_sqlglot_log_messages
 
 if TYPE_CHECKING:
     from sqlspec import dialects
+    from sqlspec.utils.uuids import nanoid, uuid4, uuid6, uuid7
 
 __all__ = (
     "SQL",
@@ -159,20 +160,28 @@ __all__ = (
     "loader",
     "matches_param_type",
     "migrations",
+    "nanoid",
     "register_param_type",
     "resolve_param_type",
     "sql",
     "typing",
     "utils",
+    "uuid4",
+    "uuid6",
+    "uuid7",
 )
+
+_LAZY_UUID_NAMES = frozenset(("nanoid", "uuid4", "uuid6", "uuid7"))
 
 suppress_erroneous_sqlglot_log_messages()
 
 
 def __getattr__(name: str) -> "Any":
-    if name == "dialects":
-        import importlib
+    import importlib
 
+    if name == "dialects":
         return importlib.import_module("sqlspec.dialects")
+    if name in _LAZY_UUID_NAMES:
+        return getattr(importlib.import_module("sqlspec.utils.uuids"), name)
     msg = f"module {__name__!r} has no attribute {name!r}"
     raise AttributeError(msg)

--- a/sqlspec/extensions/litestar/__init__.py
+++ b/sqlspec/extensions/litestar/__init__.py
@@ -7,7 +7,9 @@ from sqlspec.extensions.litestar.plugin import (
     DEFAULT_CONNECTION_KEY,
     DEFAULT_POOL_KEY,
     DEFAULT_SESSION_KEY,
+    TRACE_CONTEXT_FALLBACK_HEADERS,
     CommitMode,
+    CorrelationMiddleware,
     SQLSpecPlugin,
 )
 from sqlspec.extensions.litestar.store import BaseSQLSpecStore
@@ -18,8 +20,10 @@ __all__ = (
     "DEFAULT_CONNECTION_KEY",
     "DEFAULT_POOL_KEY",
     "DEFAULT_SESSION_KEY",
+    "TRACE_CONTEXT_FALLBACK_HEADERS",
     "BaseSQLSpecStore",
     "CommitMode",
+    "CorrelationMiddleware",
     "LitestarConfig",
     "SQLSpecAsyncService",
     "SQLSpecChannelsBackend",

--- a/sqlspec/extensions/litestar/plugin.py
+++ b/sqlspec/extensions/litestar/plugin.py
@@ -115,6 +115,20 @@ def not_found_error_handler(_request: "Request[Any, Any, Any]", exc: NotFoundErr
 
 
 class CorrelationMiddleware:
+    """ASGI middleware that binds a correlation ID to each HTTP request.
+
+    The first non-empty value among ``headers``, checked in order, becomes the
+    correlation ID; when none is present a new ID is generated. The ID is set on
+    :class:`~sqlspec.utils.correlation.CorrelationContext` and in the request scope
+    for the duration of the request, then the previous ID is restored. Non-HTTP
+    scopes, and instances created with an empty ``headers`` tuple, pass through
+    unchanged.
+
+    Args:
+        app: The downstream ASGI application.
+        headers: Lower-case request header names to check, in priority order.
+    """
+
     __slots__ = ("_app", "_extractor", "_headers")
 
     def __init__(self, app: "ASGIApp", *, headers: tuple[str, ...]) -> None:

--- a/sqlspec/extensions/litestar/plugin.py
+++ b/sqlspec/extensions/litestar/plugin.py
@@ -118,7 +118,9 @@ class CorrelationMiddleware:
     """ASGI middleware that binds a correlation ID to each HTTP request.
 
     The first non-empty value among ``headers``, checked in order, becomes the
-    correlation ID; when none is present a new ID is generated. The ID is set on
+    correlation ID after surrounding whitespace is trimmed and the value is
+    truncated to 128 characters; when no header has a value, or the trimmed
+    value is empty, a new ID is generated. The ID is set on
     :class:`~sqlspec.utils.correlation.CorrelationContext` and in the request scope
     for the duration of the request, then the previous ID is restored. Non-HTTP
     scopes, and instances created with an empty ``headers`` tuple, pass through
@@ -126,7 +128,7 @@ class CorrelationMiddleware:
 
     Args:
         app: The downstream ASGI application.
-        headers: Lower-case request header names to check, in priority order.
+        headers: Request header names to check, in priority order.
     """
 
     __slots__ = ("_app", "_extractor", "_headers")

--- a/sqlspec/utils/correlation.py
+++ b/sqlspec/utils/correlation.py
@@ -104,13 +104,13 @@ def correlation_context(correlation_id: "str | None" = None) -> "Generator[str, 
         The active correlation ID
 
     Example:
-        ```python
-        with correlation_context() as correlation_id:
-            logger.info(
-                "Processing request",
-                extra={"correlation_id": correlation_id},
-            )
-        ```
+        .. code-block:: python
+
+            with correlation_context() as correlation_id:
+                logger.info(
+                    "Processing request",
+                    extra={"correlation_id": correlation_id},
+                )
     """
     with CorrelationContext.context(correlation_id) as cid:
         yield cid

--- a/sqlspec/utils/schema.py
+++ b/sqlspec/utils/schema.py
@@ -915,13 +915,14 @@ def to_value_type(value: Any, value_type: "type[ValueT]") -> "ValueT":
     Args:
         value: The value to convert.
         value_type: The target Python type. Supported types include:
-        - Primitives: int, float, str, bool
-        - Temporal: datetime, date, time
-        - Numeric: Decimal
-        - Identifiers: UUID, Path
-        - Collections: dict, list (for JSON/JSONB columns)
-        - Schema types: Pydantic models, dataclasses, msgspec Structs,
-            attrs classes, TypedDict (for JSONB columns)
+
+            - Primitives: int, float, str, bool
+            - Temporal: datetime, date, time
+            - Numeric: Decimal
+            - Identifiers: UUID, Path
+            - Collections: dict, list (for JSON/JSONB columns)
+            - Schema types: Pydantic models, dataclasses, msgspec Structs,
+              attrs classes, TypedDict (for JSONB columns)
 
     Returns:
         The converted value of the specified type.

--- a/sqlspec/utils/text.py
+++ b/sqlspec/utils/text.py
@@ -237,7 +237,7 @@ def quote_backtick_identifier(identifier: str) -> str:
     """Quote a SQL identifier with backtick escaping (MySQL family).
 
     Wraps the value in backticks and escapes any embedded backtick by
-    doubling it (`` ` `` -> `` `` ``). Used by MySQL-family adapters
+    doubling it, so each backtick becomes two. Used by MySQL-family adapters
     (asyncmy, aiomysql, mysqlconnector, pymysql) where the backtick is
     the dialect's identifier delimiter.
 

--- a/sqlspec/utils/type_guards.py
+++ b/sqlspec/utils/type_guards.py
@@ -510,7 +510,7 @@ def is_iterable_parameters(parameters: Any) -> "TypeGuard[Sequence[Any]]":
 
 
 def has_with_method(obj: Any) -> "TypeGuard[WithMethodProtocol]":
-    """Check if an object has a callable 'with_' method.
+    """Check if an object has a callable ``with_`` method.
 
     This is a more specific check than hasattr for SQLGlot expressions.
 
@@ -518,7 +518,7 @@ def has_with_method(obj: Any) -> "TypeGuard[WithMethodProtocol]":
         obj: The object to check
 
     Returns:
-        True if the object has a callable with_ method, False otherwise
+        True if the object has a callable ``with_`` method, False otherwise
     """
     return isinstance(obj, WithMethodProtocol)
 

--- a/sqlspec/utils/uuids.py
+++ b/sqlspec/utils/uuids.py
@@ -220,7 +220,7 @@ def nanoid() -> str:
 
     Nano IDs are URL-safe, compact 21-character identifiers suitable
     for use as primary keys or short identifiers. The default alphabet
-    uses A-Za-z0-9_- characters.
+    uses ``A-Za-z0-9_-`` characters.
 
     Returns:
         A 21-character Nano ID string, or 32-character UUID hex if

--- a/tests/unit/test_public_exports.py
+++ b/tests/unit/test_public_exports.py
@@ -1,5 +1,9 @@
 """Tests for names promoted to the public package surfaces."""
 
+from typing import NoReturn
+
+import pytest
+
 import sqlspec
 from sqlspec.utils import serializers, uuids
 
@@ -13,6 +17,28 @@ def test_top_level_uuid_exports() -> None:
     assert uuid7 is uuids.uuid7
     assert nanoid is uuids.nanoid
     assert {"uuid4", "uuid6", "uuid7", "nanoid"}.issubset(sqlspec.__all__)
+
+
+@pytest.mark.parametrize("name", ("nanoid", "uuid4", "uuid6", "uuid7"))
+def test_top_level_uuid_exports_are_cached_after_first_access(monkeypatch: pytest.MonkeyPatch, name: str) -> None:
+    """The first lookup stores the helper on the module so later lookups skip ``__getattr__``."""
+    monkeypatch.delitem(vars(sqlspec), name, raising=False)
+
+    first = getattr(sqlspec, name)
+
+    assert first is getattr(uuids, name)
+    assert vars(sqlspec)[name] is first
+
+    def fail_lookup(attr: str) -> NoReturn:
+        raise AssertionError(attr)
+
+    monkeypatch.setattr(sqlspec, "__getattr__", fail_lookup)
+    assert getattr(sqlspec, name) is first
+
+
+def test_top_level_dir_lists_public_exports() -> None:
+    """``dir(sqlspec)`` includes every name in ``sqlspec.__all__``."""
+    assert set(sqlspec.__all__) <= set(dir(sqlspec))
 
 
 def test_litestar_correlation_exports() -> None:

--- a/tests/unit/test_public_exports.py
+++ b/tests/unit/test_public_exports.py
@@ -1,0 +1,37 @@
+"""Tests for names promoted to the public package surfaces."""
+
+import sqlspec
+from sqlspec.utils import serializers, uuids
+
+
+def test_top_level_uuid_exports() -> None:
+    """The top-level package re-exports the identifier generators from ``sqlspec.utils.uuids``."""
+    from sqlspec import nanoid, uuid4, uuid6, uuid7
+
+    assert uuid4 is uuids.uuid4
+    assert uuid6 is uuids.uuid6
+    assert uuid7 is uuids.uuid7
+    assert nanoid is uuids.nanoid
+    assert {"uuid4", "uuid6", "uuid7", "nanoid"}.issubset(sqlspec.__all__)
+
+
+def test_litestar_correlation_exports() -> None:
+    """The Litestar package exports the correlation middleware and trace header defaults."""
+    from sqlspec.extensions import litestar
+    from sqlspec.extensions.litestar import TRACE_CONTEXT_FALLBACK_HEADERS, CorrelationMiddleware, plugin
+
+    assert CorrelationMiddleware is plugin.CorrelationMiddleware
+    assert TRACE_CONTEXT_FALLBACK_HEADERS is plugin.TRACE_CONTEXT_FALLBACK_HEADERS
+    assert {"CorrelationMiddleware", "TRACE_CONTEXT_FALLBACK_HEADERS"}.issubset(litestar.__all__)
+
+
+def test_top_level_exports_resolve() -> None:
+    """Every name in ``sqlspec.__all__`` resolves, including lazily loaded names."""
+    for name in sqlspec.__all__:
+        getattr(sqlspec, name)
+
+
+def test_serializer_exports_resolve() -> None:
+    """Every name in ``sqlspec.utils.serializers.__all__`` resolves."""
+    for name in serializers.__all__:
+        getattr(serializers, name)

--- a/tests/unit/test_public_exports.py
+++ b/tests/unit/test_public_exports.py
@@ -1,63 +1,18 @@
 """Tests for names promoted to the public package surfaces."""
 
-from typing import NoReturn
-
-import pytest
-
 import sqlspec
-from sqlspec.utils import serializers, uuids
+from sqlspec.utils import uuids
 
 
 def test_top_level_uuid_exports() -> None:
     """The top-level package re-exports the identifier generators from ``sqlspec.utils.uuids``."""
-    from sqlspec import nanoid, uuid4, uuid6, uuid7
-
-    assert uuid4 is uuids.uuid4
-    assert uuid6 is uuids.uuid6
-    assert uuid7 is uuids.uuid7
-    assert nanoid is uuids.nanoid
-    assert {"uuid4", "uuid6", "uuid7", "nanoid"}.issubset(sqlspec.__all__)
-
-
-@pytest.mark.parametrize("name", ("nanoid", "uuid4", "uuid6", "uuid7"))
-def test_top_level_uuid_exports_are_cached_after_first_access(monkeypatch: pytest.MonkeyPatch, name: str) -> None:
-    """The first lookup stores the helper on the module so later lookups skip ``__getattr__``."""
-    monkeypatch.delitem(vars(sqlspec), name, raising=False)
-
-    first = getattr(sqlspec, name)
-
-    assert first is getattr(uuids, name)
-    assert vars(sqlspec)[name] is first
-
-    def fail_lookup(attr: str) -> NoReturn:
-        raise AssertionError(attr)
-
-    monkeypatch.setattr(sqlspec, "__getattr__", fail_lookup)
-    assert getattr(sqlspec, name) is first
-
-
-def test_top_level_dir_lists_public_exports() -> None:
-    """``dir(sqlspec)`` includes every name in ``sqlspec.__all__``."""
-    assert set(sqlspec.__all__) <= set(dir(sqlspec))
-
-
-def test_litestar_correlation_exports() -> None:
-    """The Litestar package exports the correlation middleware and trace header defaults."""
-    from sqlspec.extensions import litestar
-    from sqlspec.extensions.litestar import TRACE_CONTEXT_FALLBACK_HEADERS, CorrelationMiddleware, plugin
-
-    assert CorrelationMiddleware is plugin.CorrelationMiddleware
-    assert TRACE_CONTEXT_FALLBACK_HEADERS is plugin.TRACE_CONTEXT_FALLBACK_HEADERS
-    assert {"CorrelationMiddleware", "TRACE_CONTEXT_FALLBACK_HEADERS"}.issubset(litestar.__all__)
+    assert sqlspec.uuid4 is uuids.uuid4
+    assert sqlspec.uuid6 is uuids.uuid6
+    assert sqlspec.uuid7 is uuids.uuid7
+    assert sqlspec.nanoid is uuids.nanoid
 
 
 def test_top_level_exports_resolve() -> None:
     """Every name in ``sqlspec.__all__`` resolves, including lazily loaded names."""
     for name in sqlspec.__all__:
         getattr(sqlspec, name)
-
-
-def test_serializer_exports_resolve() -> None:
-    """Every name in ``sqlspec.utils.serializers.__all__`` resolves."""
-    for name in serializers.__all__:
-        getattr(serializers, name)


### PR DESCRIPTION
Helpers that applications already use are now importable from their public packages and covered in the reference docs, so nobody has to reach into internal module paths.

- **Top-level uuid helpers:** `uuid4`, `uuid6`, `uuid7`, and `nanoid` import directly from `sqlspec`. Import time is unchanged, since `import sqlspec` already loads that module.
- **Litestar correlation exports:** `CorrelationMiddleware` and `TRACE_CONTEXT_FALLBACK_HEADERS` import from `sqlspec.extensions.litestar`.
- **Utility reference:** the utilities page now documents `sqlspec.utils.text`, `sqlspec.utils.serializers`, `sqlspec.utils.correlation`, and the schema conversion functions.
- **Docstring rendering fixes:** a few existing docstrings in the newly documented modules (and two neighbors on the same page) rendered broken markup; they're fixed without behavior changes. `CorrelationMiddleware` gains a class docstring.

## How you use it

```python
from sqlspec import uuid7
from sqlspec.extensions.litestar import CorrelationMiddleware, TRACE_CONTEXT_FALLBACK_HEADERS
```

Closes #758
