### PR TITLE
refactor: enforce kwargs parameter passing and audit documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.16.5"
+    rev: "v0.16.6"
     hooks:
       - id: ruff-check
         args: ["--fix"]
@@ -43,7 +43,7 @@ repos:
         exclude: "test*|tools"
         args: ["--use-tuple"]
   - repo: https://github.com/ariebovenberg/slotscheck
-    rev: v0.20.1
+    rev: v0.21.0b1
     hooks:
       - id: slotscheck
         exclude: "docs|.github"

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,12 +1,11 @@
-Contribution guide
+Contribution Guide
 ==================
 
 Setting up the environment
 --------------------------
 
-1. Run ``make install-uv`` to install `uv <https://docs.astral.sh/uv/>`_ if not already installed
-1. Run ``make install`` to install all dependencies
-
+1. Run ``make install-uv`` to install `uv <https://docs.astral.sh/uv/>`_ if not already installed.
+2. Run ``make install`` to create the virtual environment and install all development dependencies.
 
 Code contributions
 ------------------
@@ -14,36 +13,50 @@ Code contributions
 Workflow
 ++++++++
 
-1. `Fork <https://github.com/litestar-org/sqlspec/fork>`_ the `sqlspec repository <https://github.com/litestar-org/sqlspec>`_
-2. Clone your fork locally with git
-3. `Set up the environment <#setting-up-the-environment>`_
-4. Make your changes
-5. Run ``make lint`` to run linters and formatters. This step is optional and will be executed
-   automatically by git before you make a commit, but you may want to run it manually in order to apply fixes
-6. Commit your changes to git
-7. Push the changes to your fork
-8. Open a `pull request <https://docs.github.com/en/pull-requests>`_. Give the pull request a descriptive title
-   indicating what it changes. If it has a corresponding open issue, the issue number should be included in the title as
-   well. For example a pull request that fixes issue ``bug: Increased stack size making it impossible to find needle #100``
-   could be titled ``fix(#100): Make needles easier to find by applying fire to haystack``
+1. `Fork <https://github.com/litestar-org/sqlspec/fork>`_ the `sqlspec repository <https://github.com/litestar-org/sqlspec>`_.
+2. Clone your fork locally with git.
+3. `Set up the environment <#setting-up-the-environment>`_.
+4. Create a dedicated feature or bugfix branch.
+5. Make your code changes and write tests.
+6. Run ``make lint`` to run code formatters, Prek hooks, type checkers, slotscheck, and workflow audits. Always run this before committing; project setup intentionally does not install Git hook shims.
+7. Commit your changes following the `Conventional Commit format <https://www.conventionalcommits.org>`_ (e.g. ``fix(#100): resolve connection pooling leak`` or ``feat: add database adapter feature``).
+8. Push the changes to your fork.
+9. Open a `pull request <https://docs.github.com/en/pull-requests>`_. Give the pull request a descriptive title indicating what it changes. Include the corresponding issue number if applicable (e.g., ``fix(#100): ...``).
 
 .. tip:: Pull requests and commits all need to follow the
-    `Conventional Commit format <https://www.conventionalcommits.org>`_
+    `Conventional Commit format <https://www.conventionalcommits.org>`_.
 
 Guidelines for writing code
-----------------------------
+---------------------------
 
-- All code should be fully `typed <https://peps.python.org/pep-0484/>`_. This is enforced via
-  `mypy <https://mypy.readthedocs.io/en/stable/>`_.
-- All code should be tested. This is enforced via `pytest <https://docs.pytest.org/en/stable/>`_.
-- All code should be properly formatted. This is enforced via `Ruff <https://docs.astral.sh/ruff/>`_.
-- Package modules must not import ``__future__.annotations``. Prek checks this with an AST-based local hook.
-- ``make lint`` applies Ruff fixes and formatting, runs every Prek hook, checks types and slots, and audits workflows with zizmor.
-- Prek runs only through the explicit lint command; project setup does not install Git hook shims.
-- Dependency resolution uses a seven-day cooldown by default, with Litestar ecosystem packages exempt so coordinated releases remain testable.
+- **Python Version & Typing**:
+  - Python 3.10+ baseline.
+  - All code must be fully typed (enforced via `mypy <https://mypy.readthedocs.io/en/stable/>`_ and `pyright <https://microsoft.github.io/pyright/>`_). Avoid ``Any`` whenever possible.
+  - Use PEP 585 built-in collection types (``dict``, ``list``, ``tuple``, ``set``) rather than their ``typing`` module equivalents.
+  - Use PEP 604 union types (``T | None``), never ``Optional[T]`` or ``Union[T, None]``.
+  - Package modules must **not** import ``from __future__ import annotations``. Prek checks this using an AST-based local hook.
+
+- **Comments & Documentation**:
+  - **Never use in-line comments in Python code**. If code requires explanation, document the rationale in the class or function docstring.
+  - Use Google-style docstrings for public classes and functions with structured ``Args:``, ``Returns:``, and ``Raises:`` blocks.
+  - Explain *why* something is done in a specific way, not merely *what* the code does.
+
+- **Naming Conventions**:
+  - Functions, methods, and variables: ``snake_case``.
+  - Classes, exceptions, and protocols: ``PascalCase``.
+  - Constants and module-level singletons: ``SCREAMING_SNAKE_CASE``.
+
+- **SQL Safety**:
+  - SQL queries must **always** use parameterized placeholders (``:param`` or ``?``).
+  - Never use f-strings, string concatenation, or ``%``/``.format()`` formatting to construct SQL statements with dynamic inputs.
+
+- **Linting & Code Quality**:
+  - Formatting and linting are handled via Ruff and Prek.
+  - ``make lint`` applies Ruff fixes and formatting, runs every Prek hook, checks types and slots, and audits workflows with zizmor.
+  - Dependency resolution uses a seven-day cooldown by default, with Litestar ecosystem packages exempt so coordinated releases remain testable.
 
 Logging
-++++++++
++++++++
 
 - Logger names must follow the ``sqlspec.<module>`` hierarchy.
 - Always obtain loggers via ``sqlspec.utils.logging.get_logger`` to ensure filters are attached.
@@ -52,11 +65,19 @@ Logging
 Writing and running tests
 +++++++++++++++++++++++++
 
-Put behavior shared by adapters in the contract suite. Keep vendor-only cases
-in that adapter's test folder. Use unit tests for code that does not need a
-database. The `test placement guide
-<https://github.com/litestar-org/sqlspec/blob/main/tests/README.md>`_ explains
-where tests and fixtures belong. It also lists the checks to run.
+- **Test Style**: Use pytest function-based tests (``test_*`` or ``async def test_*``). Do not use test classes.
+- **Test Placement**:
+  - Put behavior shared by adapters in the contract suite (`tests/integration/adapters/<database>/test_shared.py`).
+  - Keep vendor-only cases in that adapter's test folder (`tests/integration/adapters/<database>/<driver>/`).
+  - Use unit tests (`tests/unit/`) for code that does not need a database (parsing, config normalization, parameter formatting).
+  - Review the `test placement guide <https://github.com/litestar-org/sqlspec/blob/main/tests/README.md>`_ for detailed fixture conventions.
+- **Integration Resources**:
+  - Integration tests use ``pytest-databases`` fixtures.
+  - Run database containers locally before running integration tests if testing locally (e.g. via ``make infra-up``).
+- **Coverage Requirements**:
+  - The repository-wide coverage floor is temporarily 76%.
+  - Every new commit must keep changed-code coverage at or above **90%**.
+  - Detect and eliminate N+1 queries for result mapping and list operations.
 
 Run the smallest relevant test file first, then run the repository gates:
 
@@ -66,9 +87,6 @@ Run the smallest relevant test file first, then run the repository gates:
    make type-check
    make test
    make coverage
-
-The repository-wide coverage floor is temporarily 76%. Every new commit must
-keep its changed code at or above 90% coverage.
 
 Mypyc and performance gates
 +++++++++++++++++++++++++++
@@ -85,9 +103,9 @@ before opening a pull request:
    make install-compiled && make test
    uv run python tools/scripts/mypyc_inventory.py
 
-``make install-compiled`` compiles the full mypyc include set (so it catches
-compile errors in any compiled module), and the test suite automatically skips
-the cases that cannot run against a compiled build.
+``make install-compiled`` compiles the full mypyc include set (catching compile
+errors in any compiled module), and the test suite automatically skips cases
+that cannot run against a compiled build.
 
 For pull requests that change build hooks, wheel workflows, or compiled import
 boundaries, also run:
@@ -124,15 +142,18 @@ CI gate ownership:
 Project documentation
 ---------------------
 
-The documentation is located in the ``/docs`` directory and is `ReST <https://docutils.sourceforge.io/rst.html>`_ and
-`Sphinx <https://www.sphinx-doc.org/en/master/>`_. If you're unfamiliar with any of those,
-`ReStructuredText primer <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_ and
-`Sphinx quickstart <https://www.sphinx-doc.org/en/master/usage/quickstart.html>`_ are recommended reads.
+The documentation is located in the ``/docs`` directory and is written in
+`ReST <https://docutils.sourceforge.io/rst.html>`_ and built with
+`Sphinx <https://www.sphinx-doc.org/en/master/>`_. If you're unfamiliar with either,
+the `ReStructuredText primer <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html>`_
+and `Sphinx quickstart <https://www.sphinx-doc.org/en/master/usage/quickstart.html>`_ are
+recommended reads.
 
 Running the docs locally
 ++++++++++++++++++++++++
 
-You can serve the documentation with ``make docs-serve``, or build them with ``make docs``.
+You can serve the documentation locally with live reloading via ``make docs-serve``, or
+build the static HTML output via ``make docs``.
 
 CLI demo recordings
 +++++++++++++++++++
@@ -174,16 +195,18 @@ This will process every ``.tape`` file in ``docs/_tapes/`` and write GIF output 
 
    make docs-all
 
-Creating a new release
-----------------------
+Release process
+---------------
 
-1. Increment the version in `pyproject.toml <https://github.com/litestar-org/sqlspec/blob/main/pyproject.toml>`_.
-    .. note:: The version should follow `semantic versioning <https://semver.org/>`_ and `PEP 440 <https://peps.python.org/pep-0440/>`_.
-2. `Draft a new release <https://github.com/litestar-org/sqlspec/releases/new>`_ on GitHub
+Releases follow `Semantic Versioning <https://semver.org/>`_ and `PEP 440 <https://peps.python.org/pep-0440/>`_.
+Release preparation is automated via the repository `Makefile`:
 
-   * Use ``vMAJOR.MINOR.PATCH`` (e.g. ``v1.2.3``) as both the tag and release title
-   * Fill in the release description. You can use the "Generate release notes" function to get a draft for this
-3. Commit your changes and push to ``main``
-4. Publish the release
-5. Go to `Actions <https://github.com/litestar-org/sqlspec/actions>`_ and approve the release workflow
-6. Check that the workflow runs successfully
+.. code-block:: console
+
+   # Stable releases (patch, minor, major)
+   make release bump=patch
+
+   # Pre-releases
+   make pre-release version=0.63.0-alpha.1
+
+See the full :doc:`releases` guide for detailed information on versioning schemes, pre-release cadences, deprecation policies, and the automated CI publishing pipeline.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ SQLSpec is a SQL execution layer for Python. You write the SQL -- as strings, th
 ## Quick Start
 
 ```bash
+uv add sqlspec
+# or
 pip install sqlspec
 ```
 
@@ -43,7 +45,7 @@ db = spec.add_config(SqliteConfig(connection_config={"database": ":memory:"}))
 
 with spec.provide_session(db) as session:
     greeting = session.select_one("SELECT 'Hello, SQLSpec!' AS message", schema_type=Greeting)
-    print(greeting.message)  # Output: Hello, SQLSpec!
+    print(greeting.message)
 ```
 
 Write SQL, define a schema, get typed objects back. The [getting started guide](https://sqlspec.dev/getting_started/) covers adapter installation and the query builder.
@@ -64,7 +66,7 @@ Write SQL, define a schema, get typed objects back. The [getting started guide](
 
 - [Getting Started](https://sqlspec.dev/getting_started/) -- installation, adapter selection, first steps
 - [Usage Guides](https://sqlspec.dev/usage/) -- adapters, configuration, SQL file loader, and more
-- [Examples Gallery](https://sqlspec.dev/examples/) -- working code for common patterns
+- [Recipes](https://sqlspec.dev/recipes/) -- production patterns (DI, service layers, multi-tenancy)
 - [API Reference](https://sqlspec.dev/reference/) -- full API docs
 - [CLI Reference](https://sqlspec.dev/usage/cli.html) -- migration and management commands
 

--- a/docs/PYPI_README.md
+++ b/docs/PYPI_README.md
@@ -23,6 +23,8 @@ SQLSpec is a SQL execution layer for Python. You write the SQL -- as strings, th
 ## Quick Start
 
 ```bash
+uv add sqlspec
+# or
 pip install sqlspec
 ```
 
@@ -43,7 +45,7 @@ db = spec.add_config(SqliteConfig(connection_config={"database": ":memory:"}))
 
 with spec.provide_session(db) as session:
     greeting = session.select_one("SELECT 'Hello, SQLSpec!' AS message", schema_type=Greeting)
-    print(greeting.message)  # Output: Hello, SQLSpec!
+    print(greeting.message)
 ```
 
 Write SQL, define a schema, get typed objects back. The [getting started guide](https://sqlspec.dev/getting_started/) covers adapter installation and the query builder.
@@ -64,7 +66,7 @@ Write SQL, define a schema, get typed objects back. The [getting started guide](
 
 - [Getting Started](https://sqlspec.dev/getting_started/) -- installation, adapter selection, first steps
 - [Usage Guides](https://sqlspec.dev/usage/) -- adapters, configuration, SQL file loader, and more
-- [Examples Gallery](https://sqlspec.dev/examples/) -- working code for common patterns
+- [Recipes](https://sqlspec.dev/recipes/) -- production patterns (DI, service layers, multi-tenancy)
 - [API Reference](https://sqlspec.dev/reference/) -- full API docs
 - [CLI Reference](https://sqlspec.dev/usage/cli.html) -- migration and management commands
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,142 +9,12 @@ important operational fixes.
 Recent Updates
 ==============
 
-Unreleased
-----------
-
-**Fixed:**
-
-* Optimized ``INSERT`` builds keep ``ON CONFLICT ... DO UPDATE`` and
-  ``ON DUPLICATE KEY UPDATE`` assignments in written order. An assignment such as
-  ``do_update(name=exp.column("name", table="excluded"))`` previously rendered as
-  ``SET excluded.name = name``, which databases reject. Conflict targets and
-  ``SET`` columns are quoted like the rest of the statement, so reserved words
-  such as ``order`` and ``group`` work as conflict and update columns.
-
-* Executing a ``SQL`` object that already carries named parameters with more
-  named parameters, as keyword arguments or a single mapping, now binds both
-  sets. Previously the statement's own parameters were dropped, so
-  ``session.select(SQL("... :a ... :b", a=1), b=2)`` failed with a parameter
-  count mismatch. A value passed at execute time replaces a bound value of the
-  same name. ``execute_many()`` is unchanged.
-  (`#762 <https://github.com/litestar-org/sqlspec/issues/762>`_)
-* DuckDB secrets declared in ``driver_features["secrets"]`` are created only when
-  missing, so a second connection to a shared database, such as the default shared
-  in-memory database, or a process restart with a stored persistent secret no longer
-  fails with ``secret already exists``, and concurrent connection setup no longer races.
-  Declared values are not applied to an existing secret unless ``replace=True`` is set,
-  for example after rotating credentials. An existing secret is compared on its type,
-  provider and the declared settings DuckDB does not redact, such as ``scope``,
-  ``key_id`` or ``endpoint``; settings the declaration omits are kept as stored. A
-  difference raises for ``required=True`` secrets and logs a warning otherwise.
-  (`#754 <https://github.com/litestar-org/sqlspec/issues/754>`_)
-* The ``litestar`` extra now requires ``litestar>=2.23.0``. The Litestar
-  extension imports ``NamedDependency`` and ``SkipValidation``, which are not
-  available in 2.22, so installs resolved to 2.22 failed on import.
-* ``PymssqlDriver.begin()`` no longer issues ``BEGIN TRANSACTION`` on a connection
-  with autocommit disabled, where pymssql already holds an open transaction. The
-  extra nesting level kept ``commit()`` from making the work durable. On an
-  autocommit connection, ``commit()`` and ``rollback()`` now end the transaction
-  that ``begin()`` opened with T-SQL, because pymssql ignores those calls under
-  autocommit.
-* The psqlpy driver tracks transactions opened with ``begin()`` itself. It
-  previously read psqlpy's coroutine-returning ``in_transaction()`` as always true,
-  so statement stacks never opened their own transaction.
-* DuckDB, BigQuery, Spanner, and ADBC connections to DuckDB, BigQuery, or
-  Snowflake raise ``NotImplementedError`` from the savepoint methods instead of
-  sending ``SAVEPOINT`` statements those databases reject. Oracle's
-  ``release_savepoint()`` only validates the name, because Oracle has no
-  ``RELEASE SAVEPOINT`` statement.
-
-* The Litestar plugin registers its correlation and SQLCommenter middleware at the
-  outermost position of the middleware stack instead of the innermost one. Requests
-  rejected by application middleware such as authentication or session handling now carry
-  a correlation ID in logs and error hooks, and application middleware keeps its original
-  relative order. (`#729 <https://github.com/litestar-org/sqlspec/issues/729>`_)
-* The Litestar plugin no longer adds a second ``CorrelationMiddleware`` when the
-  application's middleware already includes it or a subclass, and warns when that
-  leaves configured correlation header settings unapplied.
-  (`#760 <https://github.com/litestar-org/sqlspec/issues/760>`_)
-* Litestar routes raising ``NotFoundError`` no longer return 500 when they have no
-  middleware, run ``after_exception`` hooks twice, or drop headers added by
-  application middleware from the 404 response.
-  (`#760 <https://github.com/litestar-org/sqlspec/issues/760>`_)
-* A migration whose ``up()`` returns an empty list is now recorded in the
-  tracking table instead of being reported as applied and then staying pending
-  forever (`#748 <https://github.com/litestar-org/sqlspec/issues/748>`_). An
-  empty list is the supported no-op for conditional migrations; omitting
-  ``down()`` still marks a migration irreversible.
-
-* ``Select.group_by()`` accepts the ``sql.rollup()``, ``sql.cube()``, and
-  ``sql.grouping_sets()`` factory expressions directly. The factory helpers and
-  the ``group_by_rollup()``, ``group_by_cube()``, and
-  ``group_by_grouping_sets()`` methods now build the same expressions, and each
-  grouping set must be a tuple or list of columns; a bare string raises
-  ``SQLBuilderError`` instead of producing incorrect SQL.
-
-* MySQL adapters accept either ``local_infile=True`` or
-  ``allow_local_infile=True`` to enable eligible native bulk loads. A separate
-  bulk-load opt-in is no longer required; set
-  ``enable_local_infile_bulk_load=False`` to retain ``executemany``.
-
-* ``sqlspec.extensions.litestar.LitestarConfig`` now exposes the complete plugin
-  configuration, including ``session_table=True``, through the same type as
-  ``sqlspec.config.LitestarConfig``.
-
-* ``PymssqlConfig`` and ``MssqlPythonConfig`` construct again when SQLSpec is
-  installed from a compiled wheel. Both raised
-  ``TypeError: interpreted classes cannot inherit from compiled`` while setting
-  up their migration tracker.
-  (`#747 <https://github.com/litestar-org/sqlspec/issues/747>`_)
-
-**Removed:**
-
-* Removed the undocumented ``sqlspec.exceptions.wrap_exceptions`` helper,
-  superseded by the typed per-adapter exception handlers.
+v0.63.0 - Transactions, table fixtures, SQL fragments, storage, and kwargs parameter binding
+---------------------------------------------------------------------------------------------------
 
 **Added:**
 
-* Data dictionary column metadata reports more about each column.
-  ``get_columns`` returns ``is_primary`` on DuckDB, MySQL, and CockroachDB (SQLite
-  and PostgreSQL already did), ``identity_generation`` (``a`` for ``GENERATED
-  ALWAYS``, ``d`` for ``GENERATED BY DEFAULT``) and ``sequence_name`` for the
-  sequence owned by a serial or identity column on PostgreSQL and CockroachDB,
-  ``column_type``, ``column_key``, and ``extra`` for a single MySQL table, and
-  ``is_generated`` on DuckDB. On PostgreSQL and CockroachDB,
-  ``get_columns(table=...)`` without a schema now finds the table through the
-  session search path instead of assuming ``public``.
-
-* ``sqlspec.utils.fixtures`` loads and exports table data with
-  ``load_table_fixtures_sync``/``load_table_fixtures_async`` and
-  ``export_table_fixtures_sync``/``export_table_fixtures_async``. Each table uses
-  one ``<table>.json`` or ``<table>.jsonl`` file, optionally gzipped. Loading
-  supports a table subset, an explicit load order, batched inserts, upserts on
-  conflict key columns (PostgreSQL-family, SQLite, DuckDB, and MySQL), conversion
-  of JSON values to the target column types read from the data dictionary, and, on
-  PostgreSQL, resetting serial and identity sequences past the loaded ids. Table and
-  column names are matched exactly. Generated columns are skipped on export and
-  load where column metadata is read (PostgreSQL family, MySQL, DuckDB, SQLite). The
-  loader does not commit. Exporting orders rows by primary key (or by every column),
-  writes files atomically, and replaces the table's other fixture files in the
-  directory.
-  See :doc:`/usage/testing`.
-  (`#766 <https://github.com/litestar-org/sqlspec/issues/766>`_)
-* SQL files can share SQL through ``-- fragment:`` sections spliced in with
-  ``/* include: name */``, and mark ``/* slot: name */`` fill points that
-  ``spec.get_sql(name, **slots)`` fills with a string, a sqlglot expression, or a
-  ``SQL`` object. These comment shapes are now reserved in ``.sql`` files; see
-  :ref:`sql-fragments-and-slots` for the syntax and compatibility notes.
-  (`#763 <https://github.com/litestar-org/sqlspec/issues/763>`_)
-* ``SQLSpecChannelsBackend`` can check a payload against the PostgreSQL
-  ``NOTIFY`` limit before publishing. ``measure(data)`` returns the encoded
-  ``notify`` envelope size, ``fits(data)`` reports whether it is within ``notify_budget``,
-  and ``notify_budget`` is ``None`` for backends without a payload limit.
-  ``metrics_snapshot()`` returns all observability metrics for the event
-  channel's database configuration together with the backend instance's output
-  queue depth and dropped message count. ``AsyncEventChannel`` and
-  ``SyncEventChannel`` also expose ``backend_name`` and ``metrics_snapshot()``.
-  (`#756 <https://github.com/litestar-org/sqlspec/issues/756>`_)
-* Sync and async drivers provide ``transaction()``, a context manager that begins a
+* Sync and async drivers provide :meth:`~sqlspec.driver.SyncDriverAdapterBase.transaction`, a context manager that begins a
   transaction, commits when the block succeeds, and rolls back and re-raises when
   it fails; a failed commit is followed by a rollback attempt. A block entered while
   the connection already has an open transaction joins it and ends it on exit. A
@@ -153,57 +23,177 @@ Unreleased
   ``begin_transaction()`` blocks the same way: an inner block runs in a savepoint
   on the same session, so a failure such as a unique violation undoes only the
   inner work and the outer block can still commit. Adapters without savepoint
-  support raise ``ImproperConfigurationError`` when a block is nested.
-  Services also expose ``config``, the configuration they were built from, or
-  ``None`` when built from a session. See :doc:`/reference/driver` and
-  :doc:`/recipes/service_layer`.
+  support (DuckDB, BigQuery, Spanner, and ADBC to DuckDB/BigQuery/Snowflake) raise
+  ``ImproperConfigurationError`` when a block is nested. Services also expose public
+  ``service.config``, the configuration they were built from (or ``None`` when built from a session),
+  enabling construction of collaborating services without accessing private attributes.
+  See :doc:`/reference/driver` and :doc:`/recipes/service_layer`.
+  (`#765 <https://github.com/litestar-org/sqlspec/issues/765>`_)
 
-* Services can now open a short session for each query. Pass ``config=`` and,
-  if needed, ``loader=``. Use ``session=`` to borrow a driver or
-  ``begin_transaction()`` to keep several calls in one transaction. Existing
-  code that passes a driver still works. See :doc:`/recipes/service_layer`.
+* Table data fixtures in :mod:`sqlspec.utils.fixtures` load and export table datasets with
+  ``load_table_fixtures_sync`` / ``load_table_fixtures_async`` and
+  ``export_table_fixtures_sync`` / ``export_table_fixtures_async``. Each table uses
+  a single ``<table>.json`` or ``<table>.jsonl`` file (with optional gzip compression). Loading
+  supports table subsets, explicit dependency ordering, batched inserts, upserts on
+  ``conflict_keys`` (``ON CONFLICT ... DO UPDATE`` on PostgreSQL-family, SQLite, and DuckDB;
+  ``ON DUPLICATE KEY UPDATE`` on MySQL), automatic type coercion against live data dictionary
+  metadata, and PostgreSQL identity/serial sequence resynchronization (``resync_sequences=True``).
+  Generated columns are excluded from export and omitted on load. Table and column identifiers
+  are quoted for exact-case and reserved-word compatibility.
+  See :doc:`/usage/testing`.
+  (`#766 <https://github.com/litestar-org/sqlspec/issues/766>`_)
 
-* ``uuid4``, ``uuid6``, ``uuid7``, and ``nanoid`` can be imported from the
-  top-level ``sqlspec`` package. ``sqlspec.extensions.litestar`` exports
-  ``CorrelationMiddleware`` and ``TRACE_CONTEXT_FALLBACK_HEADERS``. The
-  :doc:`/reference/utils` reference now covers the ``sqlspec.utils.text``,
-  ``sqlspec.utils.serializers``, and ``sqlspec.utils.correlation`` modules and
-  the ``to_schema``, ``to_value_type``, and ``transform_dict_keys`` functions
-  from ``sqlspec.utils.schema`` as supported APIs.
+* SQL file loader supports reusable SQL sections via ``-- fragment: name`` directives spliced
+  with ``/* include: name */``, and dynamic fill points via ``/* slot: name */`` comments.
+  Slots accept default fallbacks via ``-- slot: name = default`` and can be populated at load time
+  via ``loader.get_sql(name, **slots)`` or ``spec.get_sql(name, **slots)`` using strings,
+  sqlglot expressions, or ``SQL`` instances with parameter merging.
+  See :ref:`sql-fragments-and-slots`.
+  (`#763 <https://github.com/litestar-org/sqlspec/issues/763>`_)
+
+* DuckDB transfers object-store data natively without materializing Python Arrow tables.
+  ``load_from_storage`` issues ``INSERT INTO ... SELECT * FROM read_parquet(...)`` for remote Parquet,
+  and ``select_to_storage`` issues ``COPY (...) TO ...`` for Parquet and CSV. Requests incompatible
+  with native engine execution fall back transparently to Arrow streaming.
+  (`#752 <https://github.com/litestar-org/sqlspec/pull/752>`_)
+
+* CockroachDB adapters (asyncpg and psycopg) introduce opt-in native storage transfers via
+  ``enable_native_storage=True`` in driver features. ``select_to_storage`` executes server-side
+  ``EXPORT INTO``, returning generated destination filenames in telemetry, and ``load_from_storage``
+  executes server-side ``IMPORT INTO`` for remote Parquet and CSV files with configurable
+  ``native_storage_csv_options`` (``nullas``, ``nullif``, ``skip``).
+  (`#753 <https://github.com/litestar-org/sqlspec/pull/753>`_)
+
+* BigQuery adapter supports direct query exports to cloud object storage.
+  (`#746 <https://github.com/litestar-org/sqlspec/pull/746>`_)
+
+* Data dictionary column metadata provides expanded introspection attributes:
+  ``is_primary`` on DuckDB, MySQL, and CockroachDB; ``identity_generation`` and
+  ``sequence_name`` on PostgreSQL and CockroachDB; ``column_type``, ``column_key``, and
+  ``extra`` on MySQL; and ``is_generated`` on DuckDB. On PostgreSQL and CockroachDB,
+  ``get_columns(table=...)`` without an explicit schema resolves tables through the session
+  ``search_path`` instead of defaulting to ``public``.
+
+* ``SQLSpecChannelsBackend`` provides preflight payload budget validation and Prometheus metrics
+  for PostgreSQL ``NOTIFY`` envelopes. ``measure(data)`` returns the UTF-8 encoded envelope size,
+  ``fits(data)`` verifies compliance against ``notify_budget`` (derived from ``MAX_NOTIFY_BYTES``),
+  and ``metrics_snapshot()`` aggregates channel database metrics with queue depth and dropped message
+  counts. ``AsyncEventChannel`` and ``SyncEventChannel`` also expose ``backend_name`` and
+  ``metrics_snapshot()``.
+  (`#756 <https://github.com/litestar-org/sqlspec/issues/756>`_)
+
+* Litestar plugin registers a default exception handler for :class:`~sqlspec.exceptions.IntegrityError`
+  and subclasses (e.g. unique constraint violations), returning an HTTP 409 Conflict response with generic
+  detail ``"Conflict"`` to prevent internal schema text from leaking. In autocommit mode, this error status
+  automatically triggers a request transaction rollback.
+  (`#760 <https://github.com/litestar-org/sqlspec/issues/760>`_)
+
+* Litestar extension introduces the ``manage_lifespan`` configuration option, governing whether the plugin
+  initializes and disposes driver connection pools during application startup and shutdown. Defaults to the
+  inverse of ``disable_di``, allowing external dependency injection containers to reuse SQLSpec pool lifecycles.
+  (`#760 <https://github.com/litestar-org/sqlspec/issues/760>`_)
+
+* Top-level ``sqlspec`` package exports identifier generators ``uuid4``, ``uuid6``, ``uuid7``, and
+  ``nanoid``. :mod:`sqlspec.extensions.litestar` exports ``CorrelationMiddleware`` and
+  ``TRACE_CONTEXT_FALLBACK_HEADERS``. Reference documentation now includes supported public APIs in
+  ``sqlspec.utils.text``, ``sqlspec.utils.serializers``, ``sqlspec.utils.correlation``, and
+  ``sqlspec.utils.schema``.
   (`#758 <https://github.com/litestar-org/sqlspec/issues/758>`_)
 
-* Storage pipelines expose ``resolve_destination()``, returning a
-  ``ResolvedStorageTarget(uri, protocol)`` without opening a database session.
-  Direct remote URIs retain their address, alias paths resolve relative to the
-  configured backend, and local paths become absolute. Backend options come
-  only from the method's explicit ``storage_options`` argument, not pipeline
-  writer defaults.
+* Service layer allows constructing instances directly from database configurations via
+  ``service = Service(config=config)``, opening short-lived sessions per query.
+  (`#745 <https://github.com/litestar-org/sqlspec/pull/745>`_)
 
-* The Litestar plugin returns HTTP 409 with the generic detail ``Conflict`` when a
-  route raises ``IntegrityError`` or a subclass. Existing handlers for
-  ``IntegrityError``, its base classes, or status 500 still receive the exception,
-  and a handler for status 409 or ``HTTPException`` renders the response.
+* Storage pipelines provide :meth:`resolve_destination`, returning a ``ResolvedStorageTarget(uri, protocol)``
+  without requiring an active database session.
+
+**Changed:**
+
+* Driver execution methods (:meth:`~sqlspec.driver.SyncDriverAdapterBase.execute`,
+  :meth:`~sqlspec.driver.SyncDriverAdapterBase.select`, etc.) enforce keyword argument parameter passing
+  (``execute(sql, a=1, b=2)`` or ``execute(sql, **params)``). Passing positional dictionary literals
+  is prohibited across documentation, examples, and internal extensions to take advantage of the driver
+  fast-path parameter dispatch.
+
+* The Litestar extension now requires ``litestar>=2.23.0``.
+
+* Litestar plugin registers correlation and SQLCommenter middleware at the outermost position of the
+  middleware stack, ensuring requests rejected by upstream authentication or guard handlers retain
+  correlation headers in logs and error responses.
+
+* Litestar plugin automatically deduplicates ``CorrelationMiddleware`` when already configured in the
+  application middleware stack, logging diagnostics if configured header settings differ.
+
+* Unified ``sqlspec.extensions.litestar.LitestarConfig`` with ``sqlspec.config.LitestarConfig`` for
+  consistent typing and schema export.
+
+**Fixed:**
+
+* Query builder keeps ``ON CONFLICT ... DO UPDATE`` and ``ON DUPLICATE KEY UPDATE`` assignments in written
+  order. Assignments such as ``do_update(name=exp.column("name", table="excluded"))`` no longer render
+  reversed. Conflict targets and update columns are quoted, allowing reserved words (e.g. ``order``, ``group``)
+  to be used as column names.
+
+* Executing a ``SQL`` object that already carries bound named parameters with additional keyword arguments
+  merges both sets, with execute-time arguments overriding matching names. Previously, pre-bound parameters
+  were dropped.
+  (`#762 <https://github.com/litestar-org/sqlspec/issues/762>`_)
+
+* DuckDB secrets declared in ``driver_features["secrets"]`` issue ``CREATE [PERSISTENT] SECRET IF NOT EXISTS``
+  by default. Existing secrets matching type, provider, and unredacted settings are reused, avoiding connection
+  setup race conditions on shared in-memory databases. Setting ``replace=True`` issues ``CREATE OR REPLACE``
+  for credential rotation.
+  (`#754 <https://github.com/litestar-org/sqlspec/issues/754>`_)
+
+* ``PymssqlDriver.begin()`` no longer issues duplicate ``BEGIN TRANSACTION`` on connections with autocommit
+  disabled, ensuring transaction work commits durably. On autocommit connections, ``commit()`` and ``rollback()``
+  correctly finalize T-SQL transactions.
+
+* The psqlpy driver correctly tracks transaction state initiated with ``begin()``, avoiding false positives
+  from coroutine-returning transaction inspections.
+
+* Adapters without savepoint support (DuckDB, BigQuery, Spanner, Snowflake) raise ``ImproperConfigurationError``
+  when attempting nested transaction blocks instead of sending unsupported DDL. Oracle skips unsupported
+  ``RELEASE SAVEPOINT`` statements.
+
+* Litestar routes raising ``NotFoundError`` preserve headers added by route middleware and avoid duplicate
+  ``after_exception`` hook invocations.
   (`#760 <https://github.com/litestar-org/sqlspec/issues/760>`_)
 
-* The Litestar extension setting ``manage_lifespan`` controls whether the plugin
-  creates and closes each config's pool with the application. It defaults to the
-  inverse of ``disable_di``, so existing applications are unchanged. Set
-  ``disable_di=True`` and ``manage_lifespan=True`` to use another dependency
-  injection container while the plugin still manages the pool. See
-  :doc:`/usage/frameworks/litestar/dependency_injection`.
-  (`#760 <https://github.com/litestar-org/sqlspec/issues/760>`_)
+* Migration tracker records empty ``up()`` statement executions in the schema tracking table, preventing
+  no-op migrations from remaining in pending state indefinitely.
+  (`#748 <https://github.com/litestar-org/sqlspec/issues/748>`_)
 
-**Breaking changes:**
+* Migration squashing accepts all documented version range identifier formats.
+  (`#743 <https://github.com/litestar-org/sqlspec/pull/743>`_)
 
-* Removed the unimplemented driver methods ``stage_artifact()``,
-  ``flush_staging_artifacts()``, and ``get_storage_job()``, and the exported
-  ``StorageLoadRequest`` and ``StagedArtifact`` types. Retain the
-  ``StorageBridgeJob`` returned by a storage operation instead of looking it up.
-* Removed pipeline ``allocate_staging_artifacts()`` and
-  ``cleanup_staging_artifacts()``, the ``requires_staging_for_load`` and
-  ``staging_protocols`` capability settings, and the unused
-  ``storage_bridge.partitions_created`` diagnostic counter. Working storage
-  import, export, and per-operation partition telemetry remain available.
+* Compiled wheel installations for ``PymssqlConfig`` and ``MssqlPythonConfig`` permit interpreted tracker
+  subclasses under mypyc without raising inheritance TypeErrors.
+  (`#747 <https://github.com/litestar-org/sqlspec/issues/747>`_)
+
+* Query builder ``Select.group_by()`` accepts ``sql.rollup()``, ``sql.cube()``, and ``sql.grouping_sets()``
+  factory expressions directly. Grouping set inputs must be tuples or lists of columns; bare strings raise
+  ``SQLBuilderError``.
+
+* MySQL bulk loading accepts ``local_infile=True`` or ``allow_local_infile=True`` without requiring an
+  isolated bulk-load feature flag.
+
+* Storage obstore backend corrects glob matching, prefix listing, and ensures resolved paths remain strictly
+  contained within the backend root directory.
+  (`#736 <https://github.com/litestar-org/sqlspec/pull/736>`_, `#737 <https://github.com/litestar-org/sqlspec/pull/737>`_)
+
+* Resolved Sphinx autodoc forward reference errors during documentation builds for ``ExecutionResult``
+  NamedTuple type hints.
+
+**Removed:**
+
+* Retracted experimental storage staging methods (:meth:`stage_artifact`, :meth:`flush_staging_artifacts`,
+  :meth:`get_storage_job`, :meth:`allocate_staging_artifacts`, :meth:`cleanup_staging_artifacts`) and related
+  staging capability options in favor of direct storage pipeline execution.
+  (`#740 <https://github.com/litestar-org/sqlspec/pull/740>`_)
+
+* Removed undocumented ``sqlspec.exceptions.wrap_exceptions`` helper, superseded by typed per-adapter exception
+  handlers.
 
 v0.62.2 - Litestar config lookup diagnostics
 ---------------------------------------------

--- a/docs/contributing/creating_adapters.rst
+++ b/docs/contributing/creating_adapters.rst
@@ -1,31 +1,222 @@
-==================
+=================
 Creating Adapters
-==================
+=================
 
-This guide outlines the minimum structure for a SQLSpec adapter and links to the
-example adapter skeleton.
+This guide explains how to build and contribute a database adapter for SQLSpec. SQLSpec provides a type-safe SQL query execution and result-mapping layer designed for minimal abstraction without ORM semantics. Adapters connect SQLSpec's core statement processing pipeline—including SQLGlot AST transformation, dialect conversions, and parameter extraction—to a concrete database driver.
 
-Example
-=======
+Overview
+========
+
+An adapter in SQLSpec bridges two layers:
+
+1. **The SQLSpec Pipeline**: Transforms user queries, optimizes AST representations, normalizes parameters, and maps results to dictionaries, tuples, dataclasses, msgspec Structs, Pydantic models, or Arrow tables.
+2. **The Database Driver**: Manages physical connections, cursor lifecycles, statement execution, and transaction boundaries.
+
+Adapters are modular and live under ``sqlspec/adapters/<adapter_name>/``.
+
+Sync vs. Async Architecture
+===========================
+
+SQLSpec supports both synchronous and asynchronous database drivers through dedicated base classes:
+
+- **Synchronous Adapters**:
+  - Configuration subclasses :class:`~sqlspec.config.SyncDatabaseConfig`.
+  - Driver subclasses :class:`~sqlspec.driver.SyncDriverAdapterBase`.
+  - Data dictionary subclasses :class:`~sqlspec.driver.SyncDataDictionaryBase`.
+  - Exception handler subclasses :class:`~sqlspec.driver.BaseSyncExceptionHandler`.
+- **Asynchronous Adapters**:
+  - Configuration subclasses :class:`~sqlspec.config.AsyncDatabaseConfig`.
+  - Driver subclasses :class:`~sqlspec.driver.AsyncDriverAdapterBase`.
+  - Data dictionary subclasses :class:`~sqlspec.driver.AsyncDataDictionaryBase`.
+  - Exception handler subclasses :class:`~sqlspec.driver.BaseAsyncExceptionHandler`.
+
+Both modes expose the same high-level query operations (:meth:`execute`, :meth:`select`, :meth:`select_value`, :meth:`select_to_arrow`, :meth:`select_stream`, :meth:`execute_many`), with asynchronous operations defined as awaitable coroutines and async context managers.
+
+Adapter Module Layout
+=====================
+
+Every database adapter is organized into a standardized directory structure:
+
+.. code-block:: text
+
+   sqlspec/adapters/<name>/
+   ├── __init__.py           # Re-exports the public adapter interface
+   ├── _typing.py            # Local type aliases for connection and cursor types
+   ├── config.py             # Typed configuration, connection params, and driver features
+   ├── core.py               # Statement config, apply_driver_features, exception mapping
+   ├── driver.py             # Driver adapter implementation and exception handling
+   ├── pool.py               # Connection pool implementation or driver pool wrapper
+   ├── data_dictionary.py    # Database schema introspection (tables, columns, indexes, FKs)
+   └── type_converter.py     # Optional database-specific type conversion and serialization
+
+Module Responsibilities
+-----------------------
+
+``config.py``
++++++++++++++
+
+Defines the adapter configuration and connection parameters:
+
+- Subclasses :class:`~sqlspec.config.SyncDatabaseConfig` or :class:`~sqlspec.config.AsyncDatabaseConfig`.
+- Declares a ``<Name>ConnectionParams`` :class:`~typing.TypedDict` for driver-specific connection arguments.
+- Declares a ``<Name>DriverFeatures`` :class:`~typing.TypedDict` for optional feature flags.
+- Implements ``provide_connection()``, ``provide_pool()``, and ``provide_session()``.
+
+``core.py``
++++++++++++
+
+Houses compiled and core helpers for statement execution:
+
+- ``default_statement_config``: Configures the SQLGlot dialect, parameter style (``named``, ``qmark``, ``numeric``, or ``pyformat``), and type coercions.
+- ``apply_driver_features(statement_config, driver_features)``: Merges feature defaults and applies parameter serializer customizations, returning a ``tuple[StatementConfig, dict[str, Any]]``.
+- ``create_mapped_exception(error, *, logger=None)``: Translates native database driver exceptions into the unified :mod:`sqlspec.exceptions` hierarchy.
+
+``driver.py``
++++++++++++++
+
+Implements the driver adapter by subclassing :class:`~sqlspec.driver.SyncDriverAdapterBase` or :class:`~sqlspec.driver.AsyncDriverAdapterBase`. The driver must implement:
+
+- :meth:`dispatch_execute`: Executes a single SQL statement with parameters and returns an :class:`~sqlspec.driver.ExecutionResult`.
+- :meth:`dispatch_execute_many`: Executes a statement across multiple parameter batches.
+- :meth:`dispatch_execute_script`: Executes raw SQL scripts or DDL.
+- :meth:`begin`, :meth:`commit`, :meth:`rollback`: Manages transaction boundaries.
+- :meth:`with_cursor`: Context manager yielding a cursor for database operations.
+- :meth:`handle_database_exceptions`: Context manager wrapping operations in the adapter's exception handler.
+- :meth:`_connection_in_transaction`: Inspects whether the active connection is inside a transaction.
+- :attr:`data_dictionary`: Returns the data dictionary instance for schema introspection.
+
+``data_dictionary.py``
+++++++++++++++++++++++
+
+Provides schema introspection capabilities by subclassing :class:`~sqlspec.driver.SyncDataDictionaryBase` or :class:`~sqlspec.driver.AsyncDataDictionaryBase`:
+
+- :meth:`get_tables`: Retrieves table metadata for a given schema.
+- :meth:`get_columns`: Retrieves column metadata for a table or schema.
+- :meth:`get_indexes`: Retrieves index metadata.
+- :meth:`get_foreign_keys`: Retrieves foreign key relationships.
+- :meth:`get_version`: Queries database version information.
+- :meth:`get_feature_flag`: Checks feature availability on the target database engine.
+
+``pool.py``
++++++++++++
+
+Manages connection pooling, wrapping either the driver's native connection pool or implementing SQLSpec's connection pool protocols.
+
+``__init__.py``
++++++++++++++++
+
+Re-exports the public API of the adapter, including configuration classes, connection parameters, driver classes, and the default statement configuration.
+
+The Driver Features Pattern
+===========================
+
+SQLSpec standardizes adapter capabilities through driver feature dictionaries. Features allow callers to toggle adapter behaviors such as custom type adapters, JSON serialization, UUID conversion, or native bulk-loading optimizations:
+
+.. code-block:: python
+
+   from typing import Any, TypedDict
+   from typing_extensions import NotRequired
+
+
+   class ExampleDriverFeatures(TypedDict):
+       enable_custom_adapters: NotRequired[bool]
+       enable_uuid_conversion: NotRequired[bool]
+       json_serializer: NotRequired[Any]
+       json_deserializer: NotRequired[Any]
+
+In ``core.py``, the :func:`apply_driver_features` helper normalizes these options and returns an updated statement configuration:
+
+.. code-block:: python
+
+   def apply_driver_features(
+       statement_config: StatementConfig,
+       driver_features: Mapping[str, Any] | None,
+   ) -> tuple[StatementConfig, dict[str, Any]]:
+       features = dict(driver_features) if driver_features else {}
+       features.setdefault("enable_custom_adapters", False)
+       features.setdefault("enable_uuid_conversion", True)
+
+       # Update statement_config with any custom serializers or settings
+       return statement_config, features
+
+Exception Mapping
+=================
+
+Adapters must never leak raw driver exceptions to application callers. Every database exception is mapped to a subclass of :class:`~sqlspec.exceptions.SQLSpecError` via :func:`create_mapped_exception`:
+
+.. code-block:: python
+
+   from sqlspec.exceptions import (
+       CheckViolationError,
+       DatabaseConnectionError,
+       DataError,
+       DeadlockError,
+       ForeignKeyViolationError,
+       IntegrityError,
+       NotNullViolationError,
+       OperationalError,
+       SQLParsingError,
+       SQLSpecError,
+       UniqueViolationError,
+   )
+
+
+   def create_mapped_exception(
+       error: Exception,
+       *,
+       logger: Any = None,
+   ) -> SQLSpecError:
+       """Map driver-specific exception to a SQLSpec exception."""
+       # Inspect driver error codes or error hierarchy and return the matching SQLSpecError
+       return OperationalError(str(error))
+
+Adapter Skeleton
+================
+
+Below is a minimal synchronous driver implementation illustrating the required dispatch and transaction methods:
 
 .. literalinclude:: /examples/contributing/new_adapter.py
    :language: python
-   :caption: ``adapter skeleton``
+   :caption: Adapter Driver Skeleton
    :start-after: # start-example
    :end-before: # end-example
-   :dedent: 4
-   :no-upgrade:
 
-Adapter Checklist
-=================
+Testing Guidelines
+==================
 
-- ``config.py`` with a typed config class.
-- ``driver.py`` implementing sync or async driver APIs.
-- Optional ``type_converter.py`` and ``_types.py`` for DB-specific types.
-- ``__init__.py`` exports the public surface.
+All adapter contributions must include comprehensive test coverage following the repository's test placement structure:
+
+1. **Unit Tests** (``tests/unit/adapters/<adapter>/``):
+   - Test configuration instantiation, parameter normalization, statement compilation, and feature flag merging.
+   - Unit tests must run without requiring live database services.
+2. **Contract Tests** (``tests/integration/adapters/<family>/test_shared.py``):
+   - Reusable test contracts verify multi-driver behavioral parity across database families (e.g. SQLite, PostgreSQL, MySQL, Oracle, MSSQL).
+3. **Integration Tests** (``tests/integration/adapters/<family>/<driver>/``):
+   - Live database tests using ``pytest-databases`` fixtures.
+   - Test connection pooling, transactional commit and rollback, savepoints, batch execution, and Arrow table streaming.
+
+Quality Verification
+--------------------
+
+Before opening a pull request for a new adapter, ensure all quality gates pass locally:
+
+.. code-block:: console
+
+   # Run linters, formatters, Prek hooks, and slotscheck
+   make lint
+
+   # Run static type checking (mypy + pyright)
+   make type-check
+
+   # Run tests
+   make test
+
+   # Verify test coverage (changed code must maintain >= 90% coverage)
+   make coverage
 
 See Also
 ========
 
-- :doc:`/reference/driver` for required driver methods.
-- :doc:`/reference/adapters` for config naming conventions.
+- :doc:`/reference/driver` for the complete driver protocol and base class references.
+- :doc:`/reference/adapters` for existing adapter configuration reference.
+- :doc:`/contribution-guide` for repository setup, commit standards, and PR workflows.

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -2,29 +2,41 @@
 Developers
 ==========
 
-Thank you for your interest in contributing to SQLSpec! This section provides guidance for developers who want to extend SQLSpec, create new adapters, or contribute to the project.
+Welcome to the SQLSpec developer documentation! SQLSpec is a type-safe SQL query mapper and connectivity layer designed for high performance with minimal abstraction. Whether you are building new database adapters, enhancing the query builder, fixing a bug, or improving documentation, this section provides the essential resources to get started.
 
 .. grid:: 1 1 2 2
     :padding: 0
     :gutter: 2
 
-    .. grid-item-card:: :octicon:`database` Creating Adapters
-      :link: creating_adapters
-      :link-type: doc
-
-      Comprehensive guide to building new database adapters for SQLSpec.
-
     .. grid-item-card:: :octicon:`git-pull-request` Contribution Guide
       :link: ../contribution-guide
       :link-type: doc
 
-      General contribution guidelines, code standards, and PR workflow.
+      Environment setup with ``uv``, development workflow, coding standards (PEP 604, typing, docstrings), and repository quality gates.
+
+    .. grid-item-card:: :octicon:`database` Creating Adapters
+      :link: creating_adapters
+      :link-type: doc
+
+      Architecture guide for authoring new synchronous and asynchronous database adapters, driver base classes, statement configs, and feature flags.
+
+    .. grid-item-card:: :octicon:`tag` Releases & Versioning
+      :link: ../releases
+      :link-type: doc
+
+      Release lifecycle, Semantic Versioning standards, pre-release cadences, LTS deprecation policies, and the automated CI publishing pipeline.
+
+    .. grid-item-card:: :octicon:`history` Changelog
+      :link: ../changelog
+      :link-type: doc
+
+      Comprehensive version-by-version change log covering features, bug fixes, breaking changes, and migration notes across all releases.
 
 .. toctree::
     :maxdepth: 2
     :hidden:
 
-    creating_adapters
-    ../changelog
     ../contribution-guide
+    creating_adapters
     ../releases
+    ../changelog

--- a/docs/contribution-guide.rst
+++ b/docs/contribution-guide.rst
@@ -1,3 +1,1 @@
-:orphan:
-
 .. include:: ../CONTRIBUTING.rst

--- a/docs/examples/contributing/new_adapter.py
+++ b/docs/examples/contributing/new_adapter.py
@@ -1,35 +1,108 @@
 from __future__ import annotations
 
-from typing import Any, NoReturn
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
 
-__all__ = ("test_new_adapter",)
+from sqlspec.driver import SyncDriverAdapterBase
+from sqlspec.driver._exception_handler import BaseSyncExceptionHandler
+
+if TYPE_CHECKING:
+    from sqlspec.core import SQL
+    from sqlspec.driver import ExecutionResult, SyncDataDictionaryBase
+
+__all__ = ("ExampleDriver", "ExampleExceptionHandler", "test_new_adapter")
+
+
+# start-example
+class ExampleExceptionHandler(BaseSyncExceptionHandler):
+    """Adapter-specific exception handler wrapping database errors."""
+
+
+class ExampleDriver(SyncDriverAdapterBase):
+    """Example synchronous database driver adapter."""
+
+    @property
+    def data_dictionary(self) -> SyncDataDictionaryBase:
+        """Return the data dictionary instance for schema inspection.
+
+        Returns:
+            Data dictionary instance.
+        """
+        raise NotImplementedError
+
+    def dispatch_execute(self, cursor: Any, statement: SQL) -> ExecutionResult:
+        """Execute a single statement and return execution metadata.
+
+        Args:
+            cursor: Database cursor.
+            statement: SQL statement to execute.
+
+        Returns:
+            Execution result metadata.
+        """
+        raise NotImplementedError
+
+    def dispatch_execute_many(self, cursor: Any, statement: SQL) -> ExecutionResult:
+        """Execute a statement with multiple parameter sets.
+
+        Args:
+            cursor: Database cursor.
+            statement: SQL statement with batched parameters.
+
+        Returns:
+            Execution result metadata.
+        """
+        raise NotImplementedError
+
+    def begin(self) -> None:
+        """Begin a transaction on the current connection."""
+        raise NotImplementedError
+
+    def commit(self) -> None:
+        """Commit the current transaction."""
+        raise NotImplementedError
+
+    def rollback(self) -> None:
+        """Roll back the current transaction."""
+        raise NotImplementedError
+
+    @contextmanager
+    def with_cursor(self, connection: Any) -> Generator[Any, None, None]:
+        """Acquire and yield a cursor from the connection.
+
+        Args:
+            connection: Active database connection.
+
+        Yields:
+            Database cursor.
+        """
+        cursor = connection.cursor()
+        try:
+            yield cursor
+        finally:
+            cursor.close()
+
+    def handle_database_exceptions(self) -> ExampleExceptionHandler:
+        """Provide the exception handler context manager.
+
+        Returns:
+            Exception handler instance.
+        """
+        return ExampleExceptionHandler()
+
+    def _connection_in_transaction(self) -> bool:
+        """Check whether the active connection is in an open transaction.
+
+        Returns:
+            True if in a transaction, False otherwise.
+        """
+        return False
+
+
+# end-example
 
 
 def test_new_adapter() -> None:
-    # start-example
-    from sqlspec.driver import SyncDriverAdapterBase
-    from sqlspec.exceptions import SQLSpecError
-
-    class ExampleDriver(SyncDriverAdapterBase):
-        def begin(self) -> None:
-            raise NotImplementedError
-
-        def commit(self) -> None:
-            raise NotImplementedError
-
-        def rollback(self) -> None:
-            raise NotImplementedError
-
-        def with_cursor(self, connection: Any) -> NoReturn:
-            raise NotImplementedError
-
-        def handle_database_exceptions(self) -> NoReturn:
-            msg = "Replace with adapter-specific handler"
-            raise SQLSpecError(msg)
-
-        def _connection_in_transaction(self) -> bool:
-            return False
-
-    # end-example
-
+    """Validate that the example driver skeleton defines required methods."""
     assert ExampleDriver._connection_in_transaction is not None

--- a/docs/examples/drivers/asyncpg_connection.py
+++ b/docs/examples/drivers/asyncpg_connection.py
@@ -11,8 +11,7 @@ def test_asyncpg_connection() -> None:
     from sqlspec.adapters.asyncpg import AsyncpgConfig
 
     config = AsyncpgConfig(
-        connection_config={"dsn": "postgresql://user:pass@localhost:5432/app"},
-        pool_config={"min_size": 1, "max_size": 5},
+        connection_config={"dsn": "postgresql://user:pass@localhost:5432/app", "min_size": 1, "max_size": 5}
     )
     # end-example
 

--- a/docs/examples/drivers/service_config.py
+++ b/docs/examples/drivers/service_config.py
@@ -19,7 +19,7 @@ def test_sync_service_config(tmp_path: Path) -> None:
     try:
         with service.begin_transaction() as session:
             session.execute("CREATE TABLE users (name TEXT)")
-            session.execute("INSERT INTO users VALUES (:name)", {"name": "Ada"})
+            session.execute("INSERT INTO users VALUES (:name)", name="Ada")
 
         # Each bare helper acquires and releases its own session.
         assert service.get_one(users) == {"name": "Ada"}
@@ -33,13 +33,13 @@ def test_sync_service_config(tmp_path: Path) -> None:
 
         # Both helpers see the same uncommitted transaction.
         with service.begin_transaction() as session:
-            session.execute("INSERT INTO users VALUES (:name)", {"name": "Grace"})
+            session.execute("INSERT INTO users VALUES (:name)", name="Grace")
             assert service.exists(sql.select("name").from_("users").where_eq("name", "Grace"))
             assert service.paginate(users).total == 2
 
         try:
             with service.begin_transaction() as session:
-                session.execute("INSERT INTO users VALUES (:name)", {"name": "Rolled back"})
+                session.execute("INSERT INTO users VALUES (:name)", name="Rolled back")
                 msg = "Cancel this change"
                 raise ValueError(msg)  # noqa: TRY301 - Demonstrate an application error rolling back the block.
         except ValueError:
@@ -65,7 +65,7 @@ async def test_async_service_config(tmp_path: Path) -> None:
     try:
         async with service.begin_transaction() as session:
             await session.execute("CREATE TABLE users (name TEXT)")
-            await session.execute("INSERT INTO users VALUES (:name)", {"name": "Ada"})
+            await session.execute("INSERT INTO users VALUES (:name)", name="Ada")
 
         assert await service.get_one(users) == {"name": "Ada"}
         assert await service.exists(users)
@@ -76,13 +76,13 @@ async def test_async_service_config(tmp_path: Path) -> None:
             assert await service.get_one(users, session=session) == {"name": "Ada"}
 
         async with service.begin_transaction() as session:
-            await session.execute("INSERT INTO users VALUES (:name)", {"name": "Grace"})
+            await session.execute("INSERT INTO users VALUES (:name)", name="Grace")
             assert await service.exists(sql.select("name").from_("users").where_eq("name", "Grace"))
             assert (await service.paginate(users)).total == 2
 
         try:
             async with service.begin_transaction() as session:
-                await session.execute("INSERT INTO users VALUES (:name)", {"name": "Rolled back"})
+                await session.execute("INSERT INTO users VALUES (:name)", name="Rolled back")
                 msg = "Cancel this change"
                 raise ValueError(msg)  # noqa: TRY301 - Demonstrate an application error rolling back the block.
         except ValueError:

--- a/docs/examples/extensions/litestar/dependency_keys.py
+++ b/docs/examples/extensions/litestar/dependency_keys.py
@@ -10,20 +10,25 @@ def test_litestar_dependency_keys() -> None:
     # start-example
     from sqlspec import SQLSpec
     from sqlspec.adapters.sqlite import SqliteConfig
+    from sqlspec.extensions.litestar import SQLSpecPlugin
 
     sqlspec = SQLSpec()
     sqlspec.add_config(
         SqliteConfig(
-            connection_config={"database": ":memory:"}, extension_config={"litestar": {"session_key": "analytics"}}
-        ),
-        name="analytics",
+            bind_key="analytics",
+            connection_config={"database": ":memory:"},
+            extension_config={"litestar": {"session_key": "analytics"}},
+        )
     )
     sqlspec.add_config(
         SqliteConfig(
-            connection_config={"database": ":memory:"}, extension_config={"litestar": {"session_key": "primary"}}
-        ),
-        name="primary",
+            bind_key="primary",
+            connection_config={"database": ":memory:"},
+            extension_config={"litestar": {"session_key": "primary"}},
+        )
     )
+    plugin = SQLSpecPlugin(sqlspec=sqlspec)
     # end-example
 
-    assert set(sqlspec.configs.keys()) == {"analytics", "primary"}
+    assert plugin.get_config("analytics").bind_key == "analytics"
+    assert plugin.get_config("primary").bind_key == "primary"

--- a/docs/examples/frameworks/litestar/commit_modes.py
+++ b/docs/examples/frameworks/litestar/commit_modes.py
@@ -10,21 +10,20 @@ def test_litestar_commit_modes() -> None:
     # start-example
     from sqlspec import SQLSpec
     from sqlspec.adapters.sqlite import SqliteConfig
-    from sqlspec.extensions.litestar import CommitMode, SQLSpecPlugin
+    from sqlspec.extensions.litestar import SQLSpecPlugin
 
     sqlspec = SQLSpec()
     sqlspec.add_config(
         SqliteConfig(
-            connection_config={"database": ":memory:"},
-            extension_config={"litestar": {"commit_mode": CommitMode.autocommit}},
+            connection_config={"database": ":memory:"}, extension_config={"litestar": {"commit_mode": "autocommit"}}
         )
     )
     sqlspec.add_config(
         SqliteConfig(
+            bind_key="manual",
             connection_config={"database": ":memory:"},
-            extension_config={"litestar": {"commit_mode": CommitMode.manual}},
-        ),
-        name="manual",
+            extension_config={"litestar": {"commit_mode": "manual"}},
+        )
     )
 
     plugin = SQLSpecPlugin(sqlspec=sqlspec)

--- a/docs/examples/quickstart/basic_connection.py
+++ b/docs/examples/quickstart/basic_connection.py
@@ -1,18 +1,13 @@
-from __future__ import annotations
-
-from pathlib import Path
-
 __all__ = ("test_basic_connection",)
 
 
-def test_basic_connection(tmp_path: Path) -> None:
+def test_basic_connection() -> None:
     # start-example
     from sqlspec import SQLSpec
     from sqlspec.adapters.sqlite import SqliteConfig
 
-    db_path = tmp_path / "sqlspec.db"
     spec = SQLSpec()
-    config = spec.add_config(SqliteConfig(connection_config={"database": str(db_path)}))
+    config = spec.add_config(SqliteConfig(connection_config={"database": ":memory:"}))
 
     with spec.provide_session(config) as session:
         session.execute("create table if not exists notes (id integer primary key, body text)")

--- a/docs/examples/quickstart/configuration.py
+++ b/docs/examples/quickstart/configuration.py
@@ -1,22 +1,17 @@
-from __future__ import annotations
-
-from pathlib import Path
-
 __all__ = ("test_configuration",)
 
 
-def test_configuration(tmp_path: Path) -> None:
+def test_configuration() -> None:
     # start-example
     from sqlspec import SQLSpec
     from sqlspec.adapters.sqlite import SqliteConfig
     from sqlspec.core import StatementConfig
 
-    db_path = tmp_path / "app.db"
     statement_config = StatementConfig(enable_validation=False)
 
     spec = SQLSpec()
     primary = spec.add_config(
-        SqliteConfig(connection_config={"database": str(db_path)}, statement_config=statement_config)
+        SqliteConfig(connection_config={"database": ":memory:"}, statement_config=statement_config)
     )
 
     with spec.provide_session(primary) as session:

--- a/docs/examples/quickstart/first_query.py
+++ b/docs/examples/quickstart/first_query.py
@@ -1,18 +1,13 @@
-from __future__ import annotations
-
-from pathlib import Path
-
 __all__ = ("test_first_query",)
 
 
-def test_first_query(tmp_path: Path) -> None:
+def test_first_query() -> None:
     # start-example
     from sqlspec import SQLSpec
     from sqlspec.adapters.sqlite import SqliteConfig
 
-    db_path = tmp_path / "queries.db"
     spec = SQLSpec()
-    config = spec.add_config(SqliteConfig(connection_config={"database": str(db_path)}))
+    config = spec.add_config(SqliteConfig(connection_config={"database": ":memory:"}))
 
     with spec.provide_session(config) as session:
         session.execute("create table if not exists users (id integer primary key, name text)")

--- a/docs/examples/reference/builder_api.py
+++ b/docs/examples/reference/builder_api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 __all__ = ("test_builder_api",)
 
 
@@ -10,4 +8,4 @@ def test_builder_api() -> None:
     query = sql.select("id", "name").from_("users").where_eq("status", "active").limit(10).offset(0)
     # end-example
 
-    assert "select" in query.sql.lower()
+    assert "select" in query.to_sql().lower()

--- a/docs/extensions/adk/api.rst
+++ b/docs/extensions/adk/api.rst
@@ -13,13 +13,13 @@ Services
    :show-inheritance:
    :no-index:
 
-.. autoclass:: sqlspec.extensions.adk.memory.SQLSpecMemoryService
+.. autoclass:: SQLSpecMemoryService
    :members:
    :undoc-members:
    :show-inheritance:
    :no-index:
 
-.. autoclass:: sqlspec.extensions.adk.memory.SQLSpecSyncMemoryService
+.. autoclass:: SQLSpecSyncMemoryService
    :members:
    :undoc-members:
    :show-inheritance:
@@ -76,6 +76,15 @@ Artifact Stores
    :show-inheritance:
    :no-index:
 
+Session Listing & Ordering
+==========================
+
+.. autodata:: SessionOrderBy
+   :no-index:
+
+.. autofunction:: normalize_session_list_options
+   :no-index:
+
 Retention Helpers
 =================
 
@@ -94,16 +103,31 @@ arguments and produces the same report.
 .. autofunction:: prune_sessions
    :no-index:
 
+.. autofunction:: prune_sessions_sync
+   :no-index:
+
 .. autofunction:: prune_events
+   :no-index:
+
+.. autofunction:: prune_events_sync
    :no-index:
 
 .. autofunction:: prune_memory
    :no-index:
 
+.. autofunction:: prune_memory_sync
+   :no-index:
+
 .. autofunction:: prune_user_state
    :no-index:
 
+.. autofunction:: prune_user_state_sync
+   :no-index:
+
 .. autofunction:: prune_artifacts
+   :no-index:
+
+.. autofunction:: prune_artifacts_sync
    :no-index:
 
 Pruning Artifacts
@@ -186,10 +210,18 @@ Configuration
    :show-inheritance:
    :no-index:
 
-Converters
-==========
+Session Converters
+==================
 
 .. automodule:: sqlspec.extensions.adk.converters
+   :members:
+   :undoc-members:
+   :no-index:
+
+Memory Converters
+=================
+
+.. automodule:: sqlspec.extensions.adk.memory.converters
    :members:
    :undoc-members:
    :no-index:

--- a/docs/extensions/adk/quickstart.rst
+++ b/docs/extensions/adk/quickstart.rst
@@ -34,10 +34,10 @@ When a user returns, the agent can resume from where it left off.
        },
    )
 
-   store = AsyncpgADKStore(config)
-   await store.ensure_tables()
+   session_store = AsyncpgADKStore(config)
+   await session_store.ensure_tables()
 
-   session_service = SQLSpecSessionService(store)
+   session_service = SQLSpecSessionService(session_store)
 
    # Create a session with scoped state
    session = await session_service.create_session(
@@ -111,7 +111,7 @@ Memory Service
 ==============
 
 The memory service retains context that the agent can reference later. This
-enables long-term memory across sessions with full-text search.
+enables long-term memory across sessions with full-text search and pgvector semantic recall.
 
 .. code-block:: python
 
@@ -123,9 +123,29 @@ enables long-term memory across sessions with full-text search.
 
    memory_service = SQLSpecMemoryService(memory_store)
 
+   # Ingest a completed session into searchable memory
+   await memory_service.add_session_to_memory(session)
+
+   # Text search over memory entries
+   results = await memory_service.search_memory(
+       app_name="my_agent",
+       user_id="user_123",
+       query="database migration preferences",
+   )
+
+   # Semantic vector recall (using pgvector)
+   query_embedding = [0.021, -0.045, 0.112, ...]  # 768-dimensional vector
+   vector_results = await memory_service.search_memory(
+       app_name="my_agent",
+       user_id="user_123",
+       query="database migration preferences",
+       embedding=query_embedding,
+   )
+
 Enable full-text search by setting ``memory_use_fts: True`` in the ADK config.
-This creates database-native FTS indexes (tsvector, FTS5, InnoDB FT) for
-efficient memory retrieval.
+For pgvector semantic recall, configure ``vector_index_type`` (e.g. ``"hnsw"``)
+and ``vector_dimensions`` (e.g. ``768``) under ``extension_config["adk"]``.
+See :ref:`pgvector-recall` for advanced hybrid search and RRF configurations.
 
 Artifact Service
 ================

--- a/docs/extensions/adk/schema.rst
+++ b/docs/extensions/adk/schema.rst
@@ -272,19 +272,108 @@ Default name: ``adk_memory``
    * - ``user_id``
      - ``VARCHAR`` / ``TEXT``
      - User identifier.
-   * - ``content_text``
-     - ``TEXT``
-     - Searchable text content (used by FTS).
+   * - ``scope``
+     - ``VARCHAR`` / ``TEXT``
+     - Scope visibility: ``'user'`` (default) or ``'app'``.
+   * - ``event_id``
+     - ``VARCHAR`` / ``TEXT``
+     - Unique event identifier for deduplication on ingest.
+   * - ``author``
+     - ``VARCHAR`` / ``TEXT``
+     - Author or role of the originating event (e.g. ``user``, ``model``).
+   * - ``timestamp``
+     - ``TIMESTAMP`` / ``TIMESTAMPTZ``
+     - Event timestamp.
+   * - ``embedding``
+     - ``VECTOR`` (or dialect array)
+     - Vector embedding of size ``vector_dimensions`` for semantic recall.
    * - ``content_json``
      - ``JSONB`` / ``JSON`` / ``TEXT``
-     - Structured content.
+     - Full structured ADK Content object.
+   * - ``content_text``
+     - ``TEXT``
+     - Plain text extracted from content parts (used by FTS/BM25).
+   * - ``metadata_json``
+     - ``JSONB`` / ``JSON`` / ``TEXT`` (nullable)
+     - Custom or entry-level metadata dictionary.
    * - ``inserted_at``
-     - ``TIMESTAMP``
-     - When the entry was created.
+     - ``TIMESTAMP`` / ``TIMESTAMPTZ``
+     - When the entry was inserted (UTC).
 
-When ``memory_use_fts`` is enabled in the ADK config, backends create
-full-text search indexes on ``content_text`` using the database's native
-FTS engine (tsvector, FTS5, InnoDB FT, etc.).
+An optional ``owner_id`` column can be added via ``owner_id_column`` in the ADK
+config for multi-tenant isolation.
+
+.. _pgvector-recall:
+
+pgvector Recall and Search Strategies
+=====================================
+
+When querying memories via :meth:`~sqlspec.extensions.adk.SQLSpecMemoryService.search_memory`,
+SQLSpec supports multiple retrieval modes depending on adapter capabilities and configuration:
+
+1. **Semantic Vector Search (pgvector)**
+   When an ``embedding`` vector is passed, PostgreSQL uses the pgvector cosine distance
+   operator (``embedding <=> :query_vector::vector``) to rank entries by semantic similarity:
+
+   .. code-block:: sql
+
+      SELECT * FROM adk_memory
+      WHERE app_name = $1 AND ((scope = 'user' AND user_id = $2) OR scope = 'app')
+        AND embedding IS NOT NULL
+      ORDER BY embedding <=> $3::float8[]::vector ASC, timestamp DESC
+      LIMIT $4
+
+   Vector indexes are configured via ``vector_index_type``:
+   - ``"hnsw"`` (default): Hierarchical Navigable Small World graphs with ``vector_cosine_ops``.
+   - ``"ivfflat"``: Inverted file index with vector cosine distance.
+   - ``"scann"``: AlloyDB/ScaNN tree quantization index (tuned via ``scann_num_leaves`` and ``scann_quantizer``).
+
+2. **Full-Text Search (FTS)**
+   When ``memory_use_fts`` is ``True``, backends create native full-text indexes (GIN on
+   ``to_tsvector('english', content_text)`` on PostgreSQL, FTS5 on SQLite, InnoDB FT on MySQL,
+   Oracle Text on Oracle, or ``TOKENIZE_FULLTEXT`` on Spanner). Queries execute using native
+   stemmed text matching.
+
+3. **Hybrid Search with Reciprocal Rank Fusion (RRF)**
+   When both a text ``query`` and a vector ``embedding`` are provided and ``enable_bm25=True``
+   (using PostgreSQL 17/18 with ``pg_textsearch`` or AlloyDB), SQLSpec executes a hybrid query
+   fusing dense vector search and sparse BM25 text rank using Reciprocal Rank Fusion:
+
+   .. code-block:: sql
+
+      WITH vector_matches AS (
+          SELECT id, RANK() OVER (ORDER BY embedding <=> $3::float8[]::vector) AS rank_vec
+          FROM adk_memory
+          WHERE ... AND embedding IS NOT NULL
+          LIMIT $5
+      ),
+      text_matches AS (
+          SELECT id, RANK() OVER (ORDER BY content_text <@> $4) AS rank_txt
+          FROM adk_memory
+          WHERE ...
+          LIMIT $5
+      )
+      SELECT m.*, (COALESCE(1.0 / (60 + v.rank_vec), 0.0) + COALESCE(1.0 / (60 + t.rank_txt), 0.0)) AS rrf_score
+      FROM adk_memory m
+      LEFT JOIN vector_matches v ON m.id = v.id
+      LEFT JOIN text_matches t ON m.id = t.id
+      WHERE v.id IS NOT NULL OR t.id IS NOT NULL
+      ORDER BY rrf_score DESC, m.timestamp DESC
+      LIMIT $6
+
+4. **Simple Fallback**
+   When FTS and vector search are not configured, queries fall back to case-insensitive
+   substring matching (``content_text ILIKE %query%``).
+
+Indexes Created on Memory Table
+-------------------------------
+
+- ``idx_{table}_app_scope_user_time``: composite index on ``(app_name, scope, user_id, timestamp DESC)``
+- ``idx_{table}_scope``: composite index on ``(app_name, scope)``
+- ``idx_{table}_session``: index on ``(session_id)``
+- ``idx_{table}_fts``: GIN index on ``to_tsvector('english', content_text)`` (when ``memory_use_fts=True``)
+- ``idx_{table}_bm25``: BM25 index on ``content_text`` (when ``enable_bm25=True``)
+- ``idx_{table}_{index_type}``: HNSW, IVFFlat, or ScaNN vector index on ``embedding``
 
 .. _artifact-schema:
 
@@ -333,10 +422,10 @@ Default name: ``adk_artifact``
 
 The composite key is ``(app_name, user_id, session_id, filename, version)``.
 
-Table Name Configuration
-========================
+Table and Extension Configuration
+=================================
 
-All table names are configurable:
+All table names and extension settings are configured through ``extension_config["adk"]``:
 
 .. code-block:: python
 
@@ -344,13 +433,31 @@ All table names are configurable:
        connection_config={"dsn": "postgresql://..."},
        extension_config={
            "adk": {
-               "session_table": "my_sessions",        # default: "adk_session"
-               "events_table": "my_events",            # default: "adk_event"
-               "app_state_table": "my_app_state",      # default: "adk_app_state"
-               "user_state_table": "my_user_state",    # default: "adk_user_state"
-               "metadata_table": "my_metadata",        # default: "adk_internal_metadata"
-               "memory_table": "my_memory",            # default: "adk_memory"
-               "artifact_table": "my_artifacts",       # artifact metadata stores
+               # Table name overrides
+               "session_table": "adk_session",
+               "events_table": "adk_event",
+               "app_state_table": "adk_app_state",
+               "user_state_table": "adk_user_state",
+               "metadata_table": "adk_internal_metadata",
+               "memory_table": "adk_memory",
+               "artifact_table": "adk_artifact",
+               # Multi-tenant isolation
+               "owner_id_column": "tenant_id INTEGER NOT NULL",
+               # Memory search & pgvector configuration
+               "memory_use_fts": True,
+               "memory_max_results": 20,
+               "vector_index_type": "hnsw",  # 'hnsw', 'ivfflat', or 'scann'
+               "vector_dimensions": 768,      # embedding dimension
+               "enable_bm25": False,          # requires pg_textsearch
+               "scann_num_leaves": 100,
+               "scann_quantizer": "SQ8",
+               # Artifact storage
+               "artifact_storage_uri": "s3://my-bucket/adk-artifacts",
+               # Schema lifecycle
+               "manage_schema": True,
+               "create_schema": True,
+               "enable_sessions": True,
+               "enable_memory": True,
            }
        },
    )

--- a/docs/extensions/index.rst
+++ b/docs/extensions/index.rst
@@ -1,8 +1,9 @@
 ===========
 Extensions
-==========
+===========
 
-SQLSpec extensions add service-specific helpers that build on the core usage guides.
+SQLSpec extensions add framework integrations, event systems, AI agent persistence,
+and observability helpers that build on the core usage guides.
 
 .. grid:: 1 1 2 2
    :gutter: 2
@@ -13,6 +14,24 @@ SQLSpec extensions add service-specific helpers that build on the core usage gui
       :link-type: doc
 
       Persist ADK memory, sessions, and events with SQLSpec backends.
+
+   .. grid-item-card:: Events & Channels
+      :link: /reference/extensions/events
+      :link-type: doc
+
+      Pub/sub channels, durable table queues, and native LISTEN/NOTIFY or Oracle AQ transports.
+
+   .. grid-item-card:: Observability Extensions
+      :link: /usage/observability
+      :link-type: doc
+
+      OpenTelemetry tracing spans, Prometheus metrics, and cloud logging formatters.
+
+   .. grid-item-card:: Framework Integrations
+      :link: /usage/framework_integrations
+      :link-type: doc
+
+      Integrations for Litestar, FastAPI, Flask, Sanic, and Starlette.
 
 .. toctree::
    :hidden:

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -197,6 +197,10 @@ Package groups
 Multiple extras
 ---------------
 
+Combine multiple extras in a comma-separated list to install everything your stack
+requires. For example, to configure async PostgreSQL with high-performance ``msgspec``
+mapping and Litestar framework integration:
+
 .. tab-set::
 
    .. tab-item:: uv

--- a/docs/getting_started/introduction.rst
+++ b/docs/getting_started/introduction.rst
@@ -8,7 +8,7 @@ Introduction
 
    .. grid-item-card::
 
-      **SQLSpec is a SQL first data access layer.**
+      **SQLSpec is a SQL-first data access layer.**
       It keeps you close to SQL while adding type-safe results, consistent driver APIs, and optional
       tooling for query construction and observability.
 
@@ -62,5 +62,12 @@ Good fit when
 
 - You prefer writing SQL and want predictable behavior.
 - You need consistent APIs across multiple databases.
-- You care about performance, type safety, and data‑engineering workflows.
+- You care about performance, type safety, and data-engineering workflows.
 - You want optional tools rather than a full ORM stack.
+
+Next steps
+----------
+
+- Head to :doc:`installation` to install SQLSpec and database driver dependencies.
+- Follow the :doc:`quickstart` guide to connect and execute your first query.
+

--- a/docs/getting_started/introduction.rst
+++ b/docs/getting_started/introduction.rst
@@ -70,4 +70,3 @@ Next steps
 
 - Head to :doc:`installation` to install SQLSpec and database driver dependencies.
 - Follow the :doc:`quickstart` guide to connect and execute your first query.
-

--- a/docs/getting_started/quickstart.rst
+++ b/docs/getting_started/quickstart.rst
@@ -12,6 +12,10 @@ purpose so you can copy them into a scratch file and experiment.
 Step 1: Connect
 ---------------
 
+Create a ``SQLSpec`` registry, register an adapter configuration (using SQLite in-memory
+for this walkthrough), and open a session with ``provide_session()``. Sessions manage
+connection lifecycle and cleanup automatically:
+
 .. literalinclude:: /examples/quickstart/basic_connection.py
    :language: python
    :caption: ``connect to sqlite``
@@ -23,6 +27,10 @@ Step 1: Connect
 Step 2: Run Your First Query
 ----------------------------
 
+Execute statements with parameter placeholders (``?`` for SQLite or ``:param`` for named parameters).
+SQLSpec binds parameters safely to prevent SQL injection and returns structured results accessible
+via ``.one()``, ``.all()``, or ``.scalar()``:
+
 .. literalinclude:: /examples/quickstart/first_query.py
    :language: python
    :caption: ``first query``
@@ -33,6 +41,9 @@ Step 2: Run Your First Query
 
 Step 3: Tweak Configuration
 ---------------------------
+
+Fine-tune statement execution behavior with ``StatementConfig``. For example, you can
+disable AST validation for vendor-specific extensions or customize dialect handling:
 
 .. literalinclude:: /examples/quickstart/configuration.py
    :language: python
@@ -49,4 +60,5 @@ Next Steps
 - :doc:`../usage/query_builder` if you want the fluent SQL builder.
 - :doc:`../usage/sql_files` to load named SQL queries from files.
 - :doc:`../usage/framework_integrations` to plug into Litestar, FastAPI, Flask, or Starlette.
+- :doc:`../recipes/index` for production patterns like DI containers and service layers.
 - :doc:`/usage/index` for deeper configuration and driver guidance.

--- a/docs/playground.rst
+++ b/docs/playground.rst
@@ -1,6 +1,6 @@
-==============
+===============
 Live Playground
-==============
+===============
 
 Try SQLSpec directly in your browser. The playground runs a sandboxed Python runtime
 using WebAssembly and an in-memory SQLite database.

--- a/docs/recipes/dishka.rst
+++ b/docs/recipes/dishka.rst
@@ -6,73 +6,86 @@ Dishka Dependency Injection
 
    This recipe requires `dishka <https://github.com/reagento/dishka>`_.
 
-Dishka is a dependency injection framework used in several sqlspec production projects.
-This recipe shows how to wire sqlspec configs and drivers into Dishka's scope system.
+Dishka is an inversion-of-control container used to manage scoped dependencies in Python
+applications. This recipe demonstrates how to register SQLSpec configs and drivers into
+Dishka's scope system.
 
 Setup
 =====
 
-The core pattern: database configs live at ``APP`` scope (created once), while drivers
-are ``REQUEST``-scoped (one per HTTP request or CLI invocation).
+The core pattern: database configs live at ``APP`` scope (created once for the application),
+while drivers are ``REQUEST``-scoped (one per HTTP request or task execution).
 
 .. code-block:: python
 
-   from dishka import Provider, Scope, provide
    from collections.abc import AsyncIterator
+   from dishka import Provider, Scope, provide
 
    from sqlspec import SQLSpec
-   from sqlspec.adapters.asyncpg import AsyncpgConfig
-
-
-   db_manager = SQLSpec()
-   db = db_manager.add_config(
-       AsyncpgConfig(pool_config={"dsn": "postgresql://localhost/mydb"})
-   )
+   from sqlspec.adapters.asyncpg import AsyncpgConfig, AsyncpgDriver
 
 
    class DatabaseProvider(Provider):
+       @provide(scope=Scope.APP)
+       def provide_sqlspec(self) -> tuple[SQLSpec, AsyncpgConfig]:
+           sqlspec = SQLSpec()
+           config = sqlspec.add_config(
+               AsyncpgConfig(
+                   connection_config={"dsn": "postgresql://localhost/mydb"},
+                   extension_config={"fastapi": {"disable_di": True}},
+               )
+           )
+           return sqlspec, config
+
        @provide(scope=Scope.REQUEST)
-       async def provide_driver(self) -> AsyncIterator:
-           async with db_manager.provide_session(db) as driver:
+       async def provide_driver(
+           self, app_deps: tuple[SQLSpec, AsyncpgConfig]
+       ) -> AsyncIterator[AsyncpgDriver]:
+           sqlspec, config = app_deps
+           async with sqlspec.provide_session(config) as driver:
                yield driver
 
 Container Factories
 ===================
 
-Different entry points (web server, CLI, worker) share the same providers but
-create separate containers:
+Different application entry points (web server, CLI, background worker) share the same
+providers:
 
 .. code-block:: python
 
    from dishka import make_async_container
+   from sqlspec.adapters.asyncpg import AsyncpgDriver
 
-   # Litestar app
    container = make_async_container(DatabaseProvider())
 
-   # CLI tool
-   async with make_async_container(DatabaseProvider()) as container:
-       driver = await container.get(AsyncDriverAdapterBase)
+   # Inside a request or task scope
+   async with container() as request_container:
+       driver = await request_container.get(AsyncpgDriver)
+       result = await driver.select("SELECT 1 as status")
 
 Service Integration
 ===================
 
-Inject drivers into service classes via Dishka:
+Inject drivers into domain services via Dishka's ``FromDishka`` marker:
 
 .. code-block:: python
 
+   from typing import Any
    from dishka import FromDishka
+   from sqlspec.adapters.asyncpg import AsyncpgDriver
+
 
    class UserService:
-       def __init__(self, driver: FromDishka[AsyncDriverAdapterBase]) -> None:
+       def __init__(self, driver: FromDishka[AsyncpgDriver]) -> None:
            self.driver = driver
 
-       async def get_user(self, user_id: str):
-           return await self.driver.select_one(
+       async def get_user(self, user_id: str) -> dict[str, Any] | None:
+           return await self.driver.select_one_or_none(
                "SELECT * FROM users WHERE id = :id",
-               id=user_id,
+               {"id": user_id},
            )
 
 .. seealso::
 
    - `Dishka documentation <https://dishka.readthedocs.io/>`_
-   - :doc:`/usage/framework_integrations` for built-in framework support
+   - :doc:`/usage/framework_integrations` for built-in framework integrations

--- a/docs/recipes/service_layer.rst
+++ b/docs/recipes/service_layer.rst
@@ -40,13 +40,15 @@ does not resolve named SQL for you.
    * - ``exists(statement, *parameters, session=None)``
      - Returns ``True`` when the query matches at least one row.
    * - ``begin_transaction()``
-     - Holds one session across helpers, commits on success, and rolls back on error.
+     - Holds one session across helpers, commits on success, and rolls back on error. Nested blocks run in savepoints.
    * - ``provide_session(session=None)``
      - Yields a session for explicit reuse. Acquired sessions are released on exit.
    * - ``begin(session=None)`` / ``commit(session=None)`` / ``rollback(session=None)``
      - Control an available session; they never acquire a disposable session.
    * - ``session`` / ``driver``
      - The caller's session or the active transaction's driver.
+   * - ``config``
+     - The database configuration the service was built from, or ``None`` for session-built services.
 
 Subclass whichever matches your driver and add your own query methods:
 
@@ -146,10 +148,10 @@ may hit a unique constraint run without aborting the surrounding transaction:
     async with service.begin_transaction() as session:
         try:
             async with service.begin_transaction():
-                await session.execute("INSERT INTO users (email) VALUES ($1)", email)
+                await session.execute("INSERT INTO users (email) VALUES (:email)", email=email)
         except UniqueViolationError:
             pass
-        user = await service.get_one("SELECT id, email FROM users WHERE email = $1", email)
+        user = await service.get_one("SELECT id, email FROM users WHERE email = :email", email=email)
 
 The outer block commits everything that was not rolled back; if the outer block
 raises, work from inner blocks that succeeded is rolled back with it. Nesting works
@@ -160,7 +162,8 @@ after an earlier statement, the block joins that transaction instead of calling
 ``begin()``, and exiting the block commits or rolls back all of it, including the
 earlier work. If the outer commit fails, the block
 attempts a rollback before raising the commit error. Adapters without savepoint
-support raise ``ImproperConfigurationError`` when a nested block is entered.
+support (DuckDB, BigQuery, Spanner, and ADBC connections to DuckDB, BigQuery,
+or Snowflake) raise ``ImproperConfigurationError`` when a nested block is entered.
 
 A nested block must run in the task or thread that entered the outer block. Entering
 ``begin_transaction()`` from another task or thread while the outer block is active

--- a/docs/recipes/service_layer.rst
+++ b/docs/recipes/service_layer.rst
@@ -194,16 +194,13 @@ inside ``begin_transaction()`` or through an explicitly provided session.
 
       .. code-block:: python
 
-         from typing import TYPE_CHECKING
+         from uuid import UUID
 
          from pydantic import BaseModel
          from sqlspec import sql
          from sqlspec.adapters.asyncpg import AsyncpgDriver
          from sqlspec.core.filters import OffsetPagination, StatementFilter
          from sqlspec.service import SQLSpecAsyncService
-
-         if TYPE_CHECKING:
-             from uuid import UUID
 
 
          class User(BaseModel):
@@ -221,7 +218,7 @@ inside ``begin_transaction()`` or through an explicitly provided session.
                      schema_type=User,
                  )
 
-             async def get_user(self, user_id: "UUID") -> User:
+             async def get_user(self, user_id: UUID) -> User:
                  return await self.get_one(
                      sql.select("id", "email", "name").from_("users").where_eq("id", user_id),
                      schema_type=User,
@@ -238,16 +235,13 @@ inside ``begin_transaction()`` or through an explicitly provided session.
 
       .. code-block:: python
 
-         from typing import TYPE_CHECKING
+         from uuid import UUID
 
          from pydantic import BaseModel
          from sqlspec import sql
          from sqlspec.adapters.sqlite import SqliteDriver
          from sqlspec.core.filters import OffsetPagination, StatementFilter
          from sqlspec.service import SQLSpecSyncService
-
-         if TYPE_CHECKING:
-             from uuid import UUID
 
 
          class User(BaseModel):
@@ -265,7 +259,7 @@ inside ``begin_transaction()`` or through an explicitly provided session.
                      schema_type=User,
                  )
 
-             def get_user(self, user_id: "UUID") -> User:
+             def get_user(self, user_id: UUID) -> User:
                  return self.get_one(
                      sql.select("id", "email", "name").from_("users").where_eq("id", user_id),
                      schema_type=User,

--- a/docs/reference/adapters/adbc.rst
+++ b/docs/reference/adapters/adbc.rst
@@ -242,12 +242,19 @@ Configuration
    :members:
    :show-inheritance:
 
+Connection Parameters
+=====================
+
+.. autoclass:: sqlspec.adapters.adbc.AdbcConnectionParams
+   :members:
+   :show-inheritance:
+
 Driver Features
 ===============
 
-.. autoclass:: sqlspec.adapters.adbc.config.AdbcDriverFeatures
+.. autoclass:: sqlspec.adapters.adbc.AdbcDriverFeatures
    :members:
-   :no-index:
+   :show-inheritance:
 
 Driver
 ======

--- a/docs/reference/adapters/aiomysql.rst
+++ b/docs/reference/adapters/aiomysql.rst
@@ -11,13 +11,6 @@ Configuration
    :members:
    :show-inheritance:
 
-Driver
-======
-
-.. autoclass:: sqlspec.adapters.aiomysql.AiomysqlDriver
-   :members:
-   :show-inheritance:
-
 Connection Parameters
 =====================
 
@@ -36,6 +29,13 @@ Driver Features
 ===============
 
 .. autoclass:: sqlspec.adapters.aiomysql.AiomysqlDriverFeatures
+   :members:
+   :show-inheritance:
+
+Driver
+======
+
+.. autoclass:: sqlspec.adapters.aiomysql.AiomysqlDriver
    :members:
    :show-inheritance:
 

--- a/docs/reference/adapters/aiosqlite.rst
+++ b/docs/reference/adapters/aiosqlite.rst
@@ -12,6 +12,42 @@ Configuration
    :members:
    :show-inheritance:
 
+Connection Parameters
+=====================
+
+.. autoclass:: sqlspec.adapters.aiosqlite.AiosqliteConnectionParams
+   :members:
+   :show-inheritance:
+
+Pool Parameters
+===============
+
+.. autoclass:: sqlspec.adapters.aiosqlite.AiosqlitePoolParams
+   :members:
+   :show-inheritance:
+
+Driver Features
+===============
+
+.. autoclass:: sqlspec.adapters.aiosqlite.AiosqliteDriverFeatures
+   :members:
+   :show-inheritance:
+
+User-Defined Functions and Extensions
+=====================================
+
+.. autoclass:: sqlspec.adapters.aiosqlite.AiosqliteFunctionConfig
+   :members:
+   :show-inheritance:
+
+.. autoclass:: sqlspec.adapters.aiosqlite.AiosqliteCollationConfig
+   :members:
+   :show-inheritance:
+
+.. autoclass:: sqlspec.adapters.aiosqlite.AiosqliteAggregateConfig
+   :members:
+   :show-inheritance:
+
 Driver
 ======
 
@@ -22,7 +58,7 @@ Driver
 Connection Pool
 ===============
 
-.. autoclass:: sqlspec.adapters.aiosqlite.pool.AiosqliteConnectionPool
+.. autoclass:: sqlspec.adapters.aiosqlite.AiosqliteConnectionPool
    :members:
    :show-inheritance:
 

--- a/docs/reference/adapters/arrow_odbc.rst
+++ b/docs/reference/adapters/arrow_odbc.rst
@@ -24,9 +24,15 @@ Configuration
    :members:
    :show-inheritance:
 
+Connection Parameters
+=====================
+
 .. autoclass:: sqlspec.adapters.arrow_odbc.ArrowOdbcConnectionParams
    :members:
    :show-inheritance:
+
+Driver Features
+===============
 
 .. autoclass:: sqlspec.adapters.arrow_odbc.ArrowOdbcDriverFeatures
    :members:

--- a/docs/reference/adapters/asyncmy.rst
+++ b/docs/reference/adapters/asyncmy.rst
@@ -2,12 +2,39 @@
 asyncmy
 =======
 
-Async MySQL driver.
+Async MySQL adapter using `asyncmy <https://github.com/long2ice/asyncmy>`_, an
+asyncio-native MySQL driver written in Cython. Provides asynchronous execution,
+connection pooling, and PyMySQL-compatible wire protocol handling.
 
 Configuration
 =============
 
 .. autoclass:: sqlspec.adapters.asyncmy.AsyncmyConfig
+   :members:
+   :show-inheritance:
+
+Connection Parameters
+=====================
+
+.. autoclass:: sqlspec.adapters.asyncmy.AsyncmyConnectionParams
+   :members:
+   :show-inheritance:
+
+.. autoclass:: sqlspec.adapters.asyncmy.AsyncmySSLParams
+   :members:
+   :show-inheritance:
+
+Pool Parameters
+===============
+
+.. autoclass:: sqlspec.adapters.asyncmy.AsyncmyPoolParams
+   :members:
+   :show-inheritance:
+
+Driver Features
+===============
+
+.. autoclass:: sqlspec.adapters.asyncmy.AsyncmyDriverFeatures
    :members:
    :show-inheritance:
 

--- a/docs/reference/adapters/asyncpg.rst
+++ b/docs/reference/adapters/asyncpg.rst
@@ -12,6 +12,27 @@ Configuration
    :members:
    :show-inheritance:
 
+Connection Parameters
+=====================
+
+.. autoclass:: sqlspec.adapters.asyncpg.AsyncpgConnectionConfig
+   :members:
+   :show-inheritance:
+
+Pool Parameters
+===============
+
+.. autoclass:: sqlspec.adapters.asyncpg.AsyncpgPoolConfig
+   :members:
+   :show-inheritance:
+
+Driver Features
+===============
+
+.. autoclass:: sqlspec.adapters.asyncpg.AsyncpgDriverFeatures
+   :members:
+   :show-inheritance:
+
 JSON and JSONB Codecs
 =====================
 
@@ -21,14 +42,6 @@ This lets regular statement execution and ``load_from_arrow()`` pass Python
 preserving asyncpg's binary COPY protocol expectations for ``jsonb`` payloads.
 Set ``driver_features={"enable_json_codecs": False}`` when an application needs
 to manage asyncpg JSON codecs manually.
-
-.. autoclass:: sqlspec.adapters.asyncpg.config.AsyncpgPoolConfig
-   :members:
-   :show-inheritance:
-
-.. autoclass:: sqlspec.adapters.asyncpg.config.AsyncpgConnectionConfig
-   :members:
-   :show-inheritance:
 
 Driver
 ======

--- a/docs/reference/adapters/bigquery.rst
+++ b/docs/reference/adapters/bigquery.rst
@@ -144,6 +144,20 @@ Configuration
    :members:
    :show-inheritance:
 
+Connection Parameters
+=====================
+
+.. autoclass:: sqlspec.adapters.bigquery.BigQueryConnectionParams
+   :members:
+   :show-inheritance:
+
+Driver Features
+===============
+
+.. autoclass:: sqlspec.adapters.bigquery.BigQueryDriverFeatures
+   :members:
+   :show-inheritance:
+
 Driver
 ======
 

--- a/docs/reference/adapters/cockroach_asyncpg.rst
+++ b/docs/reference/adapters/cockroach_asyncpg.rst
@@ -87,7 +87,8 @@ inherited client-side path.
             exported = await driver.select_to_storage(
                 "SELECT :id::INT8 AS id, :label::STRING AS label",
                 destination,
-                {"id": 7, "label": "O'Reilly"},
+                id=7,
+                label="O'Reilly",
                 format_hint="csv",
             )
             prefix = urlsplit(exported.telemetry["destination"])

--- a/docs/reference/adapters/cockroach_asyncpg.rst
+++ b/docs/reference/adapters/cockroach_asyncpg.rst
@@ -11,14 +11,24 @@ Configuration
    :members:
    :show-inheritance:
 
+Connection Parameters
+=====================
+
+.. autoclass:: sqlspec.adapters.cockroach_asyncpg.CockroachAsyncpgConnectionConfig
+   :members:
+   :show-inheritance:
+
+Pool Parameters
+===============
+
 .. autoclass:: sqlspec.adapters.cockroach_asyncpg.CockroachAsyncpgPoolConfig
    :members:
    :show-inheritance:
 
-Driver
-======
+Driver Features
+===============
 
-.. autoclass:: sqlspec.adapters.cockroach_asyncpg.CockroachAsyncpgDriver
+.. autoclass:: sqlspec.adapters.cockroach_asyncpg.CockroachAsyncpgDriverFeatures
    :members:
    :show-inheritance:
 
@@ -26,6 +36,13 @@ Retry Configuration
 ===================
 
 .. autoclass:: sqlspec.adapters.cockroach_asyncpg.CockroachAsyncpgRetryConfig
+   :members:
+   :show-inheritance:
+
+Driver
+======
+
+.. autoclass:: sqlspec.adapters.cockroach_asyncpg.CockroachAsyncpgDriver
    :members:
    :show-inheritance:
 

--- a/docs/reference/adapters/cockroach_psycopg.rst
+++ b/docs/reference/adapters/cockroach_psycopg.rst
@@ -19,6 +19,27 @@ Async Configuration
    :members:
    :show-inheritance:
 
+Connection Parameters
+=====================
+
+.. autoclass:: sqlspec.adapters.cockroach_psycopg.CockroachPsycopgConnectionConfig
+   :members:
+   :show-inheritance:
+
+Pool Parameters
+===============
+
+.. autoclass:: sqlspec.adapters.cockroach_psycopg.CockroachPsycopgPoolConfig
+   :members:
+   :show-inheritance:
+
+Driver Features
+===============
+
+.. autoclass:: sqlspec.adapters.cockroach_psycopg.CockroachPsycopgDriverFeatures
+   :members:
+   :show-inheritance:
+
 Sync Driver
 ===========
 

--- a/docs/reference/adapters/cockroach_psycopg.rst
+++ b/docs/reference/adapters/cockroach_psycopg.rst
@@ -138,7 +138,8 @@ filenames; preserve URI query parameters when constructing import sources.
             exported = driver.select_to_storage(
                 "SELECT :id::INT8 AS id, :label::STRING AS label",
                 destination,
-                {"id": 7, "label": "O'Reilly"},
+                id=7,
+                label="O'Reilly",
                 format_hint="parquet",
             )
             prefix = urlsplit(exported.telemetry["destination"])

--- a/docs/reference/adapters/duckdb.rst
+++ b/docs/reference/adapters/duckdb.rst
@@ -194,11 +194,35 @@ Configuration
    :members:
    :show-inheritance:
 
-.. autoclass:: sqlspec.adapters.duckdb.config.DuckDBExtensionConfig
+Connection Parameters
+=====================
+
+.. autoclass:: sqlspec.adapters.duckdb.DuckDBConnectionParams
    :members:
    :show-inheritance:
 
-.. autoclass:: sqlspec.adapters.duckdb.config.DuckDBSecretConfig
+Pool Parameters
+===============
+
+.. autoclass:: sqlspec.adapters.duckdb.DuckDBPoolParams
+   :members:
+   :show-inheritance:
+
+Driver Features
+===============
+
+.. autoclass:: sqlspec.adapters.duckdb.DuckDBDriverFeatures
+   :members:
+   :show-inheritance:
+
+Extensions and Secrets
+======================
+
+.. autoclass:: sqlspec.adapters.duckdb.DuckDBExtensionConfig
+   :members:
+   :show-inheritance:
+
+.. autoclass:: sqlspec.adapters.duckdb.DuckDBSecretConfig
    :members:
    :show-inheritance:
 

--- a/docs/reference/adapters/index.rst
+++ b/docs/reference/adapters/index.rst
@@ -113,7 +113,7 @@ exports a typed config class and a driver implementation.
       :link: mssql_python
       :link-type: doc
 
-      Sync + Async SQL Server via Microsoft's official mssql-python driver.
+      Sync SQL Server via Microsoft's official mssql-python driver.
 
    .. grid-item-card:: pymssql
       :link: pymssql
@@ -237,7 +237,7 @@ Feature Comparison
      -
    * - mssql_python
      - Yes
-     - Yes
+     -
      - Yes
      -
      -

--- a/docs/reference/adapters/mssql_python.rst
+++ b/docs/reference/adapters/mssql_python.rst
@@ -15,13 +15,22 @@ Configuration
    :members:
    :show-inheritance:
 
+Connection Parameters
+=====================
+
 .. autoclass:: sqlspec.adapters.mssql_python.MssqlPythonConnectionParams
    :members:
    :show-inheritance:
 
+Pool Parameters
+===============
+
 .. autoclass:: sqlspec.adapters.mssql_python.MssqlPythonPoolParams
    :members:
    :show-inheritance:
+
+Driver Features
+===============
 
 .. autoclass:: sqlspec.adapters.mssql_python.MssqlPythonDriverFeatures
    :members:

--- a/docs/reference/adapters/mysqlconnector.rst
+++ b/docs/reference/adapters/mysqlconnector.rst
@@ -18,6 +18,39 @@ Async Configuration
    :members:
    :show-inheritance:
 
+Connection Parameters
+=====================
+
+.. autoclass:: sqlspec.adapters.mysqlconnector.MysqlConnectorSyncConnectionParams
+   :members:
+   :show-inheritance:
+
+.. autoclass:: sqlspec.adapters.mysqlconnector.MysqlConnectorAsyncConnectionParams
+   :members:
+   :show-inheritance:
+
+.. autoclass:: sqlspec.adapters.mysqlconnector.MysqlConnectorCursorParams
+   :members:
+   :show-inheritance:
+
+.. autoclass:: sqlspec.adapters.mysqlconnector.MysqlConnectorFailoverTarget
+   :members:
+   :show-inheritance:
+
+Pool Parameters
+===============
+
+.. autoclass:: sqlspec.adapters.mysqlconnector.MysqlConnectorPoolParams
+   :members:
+   :show-inheritance:
+
+Driver Features
+===============
+
+.. autoclass:: sqlspec.adapters.mysqlconnector.MysqlConnectorDriverFeatures
+   :members:
+   :show-inheritance:
+
 Sync Driver
 ===========
 

--- a/docs/reference/adapters/oracledb.rst
+++ b/docs/reference/adapters/oracledb.rst
@@ -211,7 +211,9 @@ rewrite it into ``MERGE``. For a single row, select the named bind values from
 
     await session.execute(
         merge_widget,
-        {"sku": "W-100", "name": "Widget", "quantity": 3},
+        sku="W-100",
+        name="Widget",
+        quantity=3,
     )
 
 Do not add ``RETURNING`` to this ``MERGE``. When the caller needs an ID
@@ -220,7 +222,7 @@ transaction is committed::
 
     widget_id = await session.select_value(
         "SELECT id FROM widget WHERE sku = :sku",
-        {"sku": "W-100"},
+        sku="W-100",
     )
 
 Keeping the ``MERGE`` and follow-up ``SELECT`` in one SQLSpec session preserves
@@ -281,6 +283,27 @@ Async Configuration
 ===================
 
 .. autoclass:: sqlspec.adapters.oracledb.OracleAsyncConfig
+   :members:
+   :show-inheritance:
+
+Connection Parameters
+=====================
+
+.. autoclass:: sqlspec.adapters.oracledb.OracleConnectionParams
+   :members:
+   :show-inheritance:
+
+Pool Parameters
+===============
+
+.. autoclass:: sqlspec.adapters.oracledb.OraclePoolParams
+   :members:
+   :show-inheritance:
+
+Driver Features
+===============
+
+.. autoclass:: sqlspec.adapters.oracledb.OracleDriverFeatures
    :members:
    :show-inheritance:
 

--- a/docs/reference/adapters/psqlpy.rst
+++ b/docs/reference/adapters/psqlpy.rst
@@ -12,7 +12,24 @@ Configuration
    :members:
    :show-inheritance:
 
-.. autoclass:: sqlspec.adapters.psqlpy.config.PsqlpyConnectionParams
+Connection Parameters
+=====================
+
+.. autoclass:: sqlspec.adapters.psqlpy.PsqlpyConnectionParams
+   :members:
+   :show-inheritance:
+
+Pool Parameters
+===============
+
+.. autoclass:: sqlspec.adapters.psqlpy.PsqlpyPoolParams
+   :members:
+   :show-inheritance:
+
+Driver Features
+===============
+
+.. autoclass:: sqlspec.adapters.psqlpy.PsqlpyDriverFeatures
    :members:
    :show-inheritance:
 

--- a/docs/reference/adapters/psycopg.rst
+++ b/docs/reference/adapters/psycopg.rst
@@ -40,14 +40,24 @@ Async Configuration
    :members:
    :show-inheritance:
 
-Shared Configuration
-====================
+Connection Parameters
+=====================
 
-.. autoclass:: sqlspec.adapters.psycopg.config.PsycopgConnectionParams
+.. autoclass:: sqlspec.adapters.psycopg.PsycopgConnectionParams
    :members:
    :show-inheritance:
 
-.. autoclass:: sqlspec.adapters.psycopg.config.PsycopgPoolParams
+Pool Parameters
+===============
+
+.. autoclass:: sqlspec.adapters.psycopg.PsycopgPoolParams
+   :members:
+   :show-inheritance:
+
+Driver Features
+===============
+
+.. autoclass:: sqlspec.adapters.psycopg.PsycopgDriverFeatures
    :members:
    :show-inheritance:
 

--- a/docs/reference/adapters/pymssql.rst
+++ b/docs/reference/adapters/pymssql.rst
@@ -17,14 +17,21 @@ Configuration
 Connection Parameters
 =====================
 
-.. autoclass:: sqlspec.adapters.pymssql.config.PymssqlConnectionParams
+.. autoclass:: sqlspec.adapters.pymssql.PymssqlConnectionParams
+   :members:
+   :show-inheritance:
+
+Pool Parameters
+===============
+
+.. autoclass:: sqlspec.adapters.pymssql.PymssqlPoolParams
    :members:
    :show-inheritance:
 
 Driver Features
 ===============
 
-.. autoclass:: sqlspec.adapters.pymssql.config.PymssqlDriverFeatures
+.. autoclass:: sqlspec.adapters.pymssql.PymssqlDriverFeatures
    :members:
    :show-inheritance:
 

--- a/docs/reference/adapters/pymysql.rst
+++ b/docs/reference/adapters/pymysql.rst
@@ -47,6 +47,38 @@ Driver
    :members:
    :show-inheritance:
 
+Connection Parameters
+=====================
+
+.. autoclass:: sqlspec.adapters.pymysql.PyMysqlConnectionParams
+   :members:
+   :show-inheritance:
+
+.. autoclass:: sqlspec.adapters.pymysql.config.PyMysqlSslParams
+   :members:
+   :show-inheritance:
+
+Pool Parameters
+===============
+
+.. autoclass:: sqlspec.adapters.pymysql.PyMysqlPoolParams
+   :members:
+   :show-inheritance:
+
+Driver Features
+===============
+
+.. autoclass:: sqlspec.adapters.pymysql.PyMysqlDriverFeatures
+   :members:
+   :show-inheritance:
+
+Connection Pool
+===============
+
+.. autoclass:: sqlspec.adapters.pymysql.pool.PyMysqlConnectionPool
+   :members:
+   :show-inheritance:
+
 Data Dictionary
 ===============
 

--- a/docs/reference/adapters/spanner.rst
+++ b/docs/reference/adapters/spanner.rst
@@ -75,6 +75,27 @@ Configuration
    :members:
    :show-inheritance:
 
+Connection Parameters
+=====================
+
+.. autoclass:: sqlspec.adapters.spanner.SpannerConnectionParams
+   :members:
+   :show-inheritance:
+
+Pool Parameters
+===============
+
+.. autoclass:: sqlspec.adapters.spanner.SpannerPoolParams
+   :members:
+   :show-inheritance:
+
+Driver Features
+===============
+
+.. autoclass:: sqlspec.adapters.spanner.SpannerDriverFeatures
+   :members:
+   :show-inheritance:
+
 Custom Dialects
 ================
 

--- a/docs/reference/adapters/sqlite.rst
+++ b/docs/reference/adapters/sqlite.rst
@@ -12,6 +12,35 @@ Configuration
    :members:
    :show-inheritance:
 
+Connection Parameters
+=====================
+
+.. autoclass:: sqlspec.adapters.sqlite.SqliteConnectionParams
+   :members:
+   :show-inheritance:
+
+Driver Features
+===============
+
+.. autoclass:: sqlspec.adapters.sqlite.SqliteDriverFeatures
+   :members:
+   :show-inheritance:
+
+User-Defined Functions and Extensions
+=====================================
+
+.. autoclass:: sqlspec.adapters.sqlite.SqliteFunctionConfig
+   :members:
+   :show-inheritance:
+
+.. autoclass:: sqlspec.adapters.sqlite.SqliteCollationConfig
+   :members:
+   :show-inheritance:
+
+.. autoclass:: sqlspec.adapters.sqlite.SqliteAggregateConfig
+   :members:
+   :show-inheritance:
+
 Driver
 ======
 

--- a/docs/reference/base.rst
+++ b/docs/reference/base.rst
@@ -21,17 +21,20 @@ Example
 Core Responsibilities
 =====================
 
-- Register database configurations.
-- Provide sync and async session context managers.
-- Manage connection pool startup and shutdown.
-- Track configs by bind key for multi-database setups.
+- Register and manage database configuration handles.
+- Provide sync and async connection and session context managers.
+- Manage connection pool startup, tracking, and shutdown.
+- Track database configurations by instance identity for multi-database setups.
+- Manage named SQL queries and parameter declarations through an integrated :class:`~sqlspec.loader.SQLFileLoader`.
+- Publish and subscribe to events across sync and async event channels.
 
-Session Management
-==================
+Connection and Session Management
+=================================
 
-- ``provide_session`` yields a session bound to a specific config.
-- Sync and async sessions share the same registry API.
-- Close pools explicitly with ``close_all_pools`` when needed.
+- ``provide_session`` and ``get_session`` yield or return driver adapter instances bound to a specific config.
+- ``provide_connection`` and ``get_connection`` provide raw database connections.
+- Sync and async operations share consistent registry APIs.
+- Pool lifecycle helpers (``get_pool``, ``close_pool``, ``close_all_pools``) handle resource cleanup.
 
 API Reference
 =============

--- a/docs/reference/builder/expressions.rst
+++ b/docs/reference/builder/expressions.rst
@@ -72,14 +72,14 @@ Base Classes
 Parsing Utilities
 =================
 
-.. autofunction:: sqlspec.builder.extract_expression
+.. autofunction:: extract_expression
 
-.. autofunction:: sqlspec.builder.parse_column_expression
+.. autofunction:: parse_column_expression
 
-.. autofunction:: sqlspec.builder.parse_condition_expression
+.. autofunction:: parse_condition_expression
 
-.. autofunction:: sqlspec.builder.parse_order_expression
+.. autofunction:: parse_order_expression
 
-.. autofunction:: sqlspec.builder.parse_table_expression
+.. autofunction:: parse_table_expression
 
-.. autofunction:: sqlspec.builder.to_expression
+.. autofunction:: to_expression

--- a/docs/reference/builder/factory.rst
+++ b/docs/reference/builder/factory.rst
@@ -18,7 +18,7 @@ SQLFactory
 Convenience Instance
 ====================
 
-.. py:data:: sqlspec.builder.sql
+.. py:data:: sql
    :type: SQLFactory
 
    Pre-configured ``SQLFactory`` instance for convenient query building.

--- a/docs/reference/builder/queries.rst
+++ b/docs/reference/builder/queries.rst
@@ -92,6 +92,18 @@ Insert
    :members:
    :show-inheritance:
 
+.. autoclass:: InsertIntoClauseMixin
+   :members:
+   :show-inheritance:
+
+.. autoclass:: InsertValuesMixin
+   :members:
+   :show-inheritance:
+
+.. autoclass:: InsertFromSelectMixin
+   :members:
+   :show-inheritance:
+
 Update
 ======
 
@@ -99,10 +111,26 @@ Update
    :members:
    :show-inheritance:
 
+.. autoclass:: UpdateTableClauseMixin
+   :members:
+   :show-inheritance:
+
+.. autoclass:: UpdateSetClauseMixin
+   :members:
+   :show-inheritance:
+
+.. autoclass:: UpdateFromClauseMixin
+   :members:
+   :show-inheritance:
+
 Delete
 ======
 
 .. autoclass:: Delete
+   :members:
+   :show-inheritance:
+
+.. autoclass:: DeleteFromClauseMixin
    :members:
    :show-inheritance:
 
@@ -117,6 +145,10 @@ Explain
 =======
 
 .. autoclass:: Explain
+   :members:
+   :show-inheritance:
+
+.. autoclass:: ExplainMixin
    :members:
    :show-inheritance:
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -124,4 +124,3 @@ Type Variables
 .. autodata:: ConfigT
 
 .. autodata:: DriverT
-

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -80,3 +80,48 @@ Extension Configuration Types
 .. autoclass:: ADKConfig
    :members:
    :show-inheritance:
+
+Framework Configuration Types
+=============================
+
+.. autoclass:: LitestarConfig
+   :members:
+   :show-inheritance:
+
+.. autoclass:: FastAPIConfig
+   :members:
+   :show-inheritance:
+
+.. autoclass:: StarletteConfig
+   :members:
+   :show-inheritance:
+
+.. autoclass:: SanicConfig
+   :members:
+   :show-inheritance:
+
+.. autoclass:: FlaskConfig
+   :members:
+   :show-inheritance:
+
+Extension Configuration Map
+===========================
+
+.. autodata:: ExtensionConfigs
+
+Validation Utilities
+====================
+
+.. autofunction:: validate_migration_config_keys
+
+Type Variables
+==============
+
+.. autodata:: SyncConfigT
+
+.. autodata:: AsyncConfigT
+
+.. autodata:: ConfigT
+
+.. autodata:: DriverT
+

--- a/docs/reference/core/cache.rst
+++ b/docs/reference/core/cache.rst
@@ -74,4 +74,6 @@ Module-Level Functions
 
 .. autofunction:: create_cache_key
 
-.. autofunction:: canonicalize_filters
+.. autofunction:: get_cache_instances
+
+.. autofunction:: get_pipeline_metrics

--- a/docs/reference/core/filters.rst
+++ b/docs/reference/core/filters.rst
@@ -8,15 +8,34 @@ via :func:`apply_filter`.
 
 .. currentmodule:: sqlspec.core.filters
 
-apply_filter
-============
+Filter Functions
+================
 
 .. autofunction:: apply_filter
+
+.. autofunction:: canonicalize_filters
+
+.. autofunction:: find_filter
 
 Base
 ====
 
 .. autoclass:: StatementFilter
+   :members:
+   :show-inheritance:
+
+.. autoclass:: PaginationFilter
+   :members:
+   :show-inheritance:
+
+Value and Choice Filters
+========================
+
+.. autoclass:: BooleanFilter
+   :members:
+   :show-inheritance:
+
+.. autoclass:: ChoicesFilter
    :members:
    :show-inheritance:
 
@@ -35,6 +54,10 @@ Date Filters
 
 Collection Filters
 ==================
+
+.. autoclass:: InAnyFilter
+   :members:
+   :show-inheritance:
 
 .. autoclass:: InCollectionFilter
    :members:
@@ -100,3 +123,7 @@ Type Aliases
 .. data:: FilterTypes
 
    Union type of all filter classes.
+
+.. data:: FilterTypeT
+
+   Type variable bound to :class:`StatementFilter`.

--- a/docs/reference/core/parameters.rst
+++ b/docs/reference/core/parameters.rst
@@ -10,51 +10,81 @@ Supports QMARK (``?``), NAMED (``:name``), NUMERIC (``$1``), and FORMAT (``%s``)
 ParameterProcessor
 ==================
 
-.. autoclass:: sqlspec.core.parameters._processor.ParameterProcessor
+.. autoclass:: ParameterProcessor
    :members:
    :show-inheritance:
 
 ParameterConverter
 ==================
 
-.. autoclass:: sqlspec.core.parameters._converter.ParameterConverter
+.. autoclass:: ParameterConverter
    :members:
    :show-inheritance:
 
 ParameterValidator
 ==================
 
-.. autoclass:: sqlspec.core.parameters._validator.ParameterValidator
+.. autoclass:: ParameterValidator
    :members:
    :show-inheritance:
 
-Types
-=====
+Types and Profiles
+==================
 
-.. autoclass:: sqlspec.core.parameters._types.ParameterStyle
+.. autoclass:: ParameterStyle
    :members:
    :show-inheritance:
 
-.. autoclass:: sqlspec.core.parameters._types.ParameterStyleConfig
+.. autoclass:: ParameterStyleConfig
    :members:
    :show-inheritance:
 
-.. autoclass:: sqlspec.core.parameters._types.TypedParameter
+.. autoclass:: TypedParameter
    :members:
    :show-inheritance:
 
-.. autoclass:: sqlspec.core.parameters._types.ParameterInfo
+.. autoclass:: ParameterInfo
    :members:
    :show-inheritance:
 
-.. autoclass:: sqlspec.core.parameters._types.DriverParameterProfile
+.. autoclass:: DriverParameterProfile
    :members:
    :show-inheritance:
 
-.. autoclass:: sqlspec.core.parameters._types.ParameterProfile
+.. autoclass:: ParameterProfile
    :members:
    :show-inheritance:
 
-.. autoclass:: sqlspec.core.parameters._types.ParameterProcessingResult
+.. autoclass:: ParameterProcessingResult
    :members:
    :show-inheritance:
+
+.. autoclass:: ParameterDeclaration
+   :members:
+   :show-inheritance:
+
+Profile Management
+==================
+
+.. autofunction:: get_driver_profile
+
+.. autofunction:: register_driver_profile
+
+.. autofunction:: build_statement_config_from_profile
+
+Parameter Helpers
+=================
+
+.. autofunction:: validate_parameter_alignment
+
+.. autofunction:: normalize_parameter_key
+
+.. autofunction:: is_iterable_parameters
+
+.. autofunction:: wrap_with_type
+
+.. autofunction:: register_param_type
+
+.. autofunction:: resolve_param_type
+
+.. autofunction:: matches_param_type

--- a/docs/reference/core/query-modifiers.rst
+++ b/docs/reference/core/query-modifiers.rst
@@ -10,9 +10,10 @@ and building condition expressions programmatically.
 ConditionFactory
 ================
 
-.. autoclass:: ConditionFactory
-   :members:
-   :show-inheritance:
+.. data:: ConditionFactory
+
+   Callable type alias: ``Callable[[exp.Expr, exp.Placeholder], exp.Expr]``.
+   Used for constructing condition expressions from a column and placeholder.
 
 Statement Modifiers
 ===================
@@ -26,6 +27,8 @@ Statement Modifiers
 .. autofunction:: apply_offset
 
 .. autofunction:: apply_select_only
+
+.. autofunction:: apply_column_pruning
 
 .. autofunction:: safe_modify_with_cte
 

--- a/docs/reference/core/results.rst
+++ b/docs/reference/core/results.rst
@@ -11,7 +11,7 @@ result wrappers, providing helpers like ``all()``, ``one()``, ``scalar()``,
 StatementResult
 ===============
 
-.. autoclass:: sqlspec.core.result._base.StatementResult
+.. autoclass:: StatementResult
    :members:
    :show-inheritance:
 
@@ -32,14 +32,14 @@ ArrowResult
 DMLResult
 =========
 
-.. autoclass:: sqlspec.core.result._base.DMLResult
+.. autoclass:: DMLResult
    :members:
    :show-inheritance:
 
 EmptyResult
 ===========
 
-.. autoclass:: sqlspec.core.result._base.EmptyResult
+.. autoclass:: EmptyResult
    :members:
    :show-inheritance:
 
@@ -53,8 +53,10 @@ StackResult
 Factory Functions
 =================
 
-.. autofunction:: sqlspec.core.result.create_sql_result
+.. autofunction:: create_sql_result
 
-.. autofunction:: sqlspec.core.result.create_arrow_result
+.. autofunction:: create_arrow_result
 
-.. autofunction:: sqlspec.core.result.build_arrow_result_from_table
+.. autofunction:: build_arrow_result_from_table
+
+.. autofunction:: build_arrow_result_from_reader

--- a/docs/reference/core/statement.rst
+++ b/docs/reference/core/statement.rst
@@ -13,6 +13,10 @@ SQL
    :members:
    :show-inheritance:
 
+.. data:: Statement
+
+   Alias for :class:`SQL`.
+
 StatementConfig
 ===============
 
@@ -50,6 +54,10 @@ Compiler
 .. autoclass:: OperationProfile
    :members:
    :show-inheritance:
+
+.. data:: OperationType
+
+   Literal type for operation classifications (``SELECT``, ``INSERT``, ``UPDATE``, ``DELETE``, ``COPY``, ``COPY_FROM``, ``COPY_TO``, ``EXECUTE``, ``SCRIPT``, ``DDL``, ``PRAGMA``, ``MERGE``, ``COMMAND``).
 
 .. autofunction:: is_copy_operation
 

--- a/docs/reference/dialects.rst
+++ b/docs/reference/dialects.rst
@@ -22,7 +22,7 @@ PostgreSQL Extensions
 PGVector
 --------
 
-.. autoclass:: sqlspec.dialects.postgres.pgvector.PGVector
+.. autoclass:: sqlspec.dialects.postgres.PGVector
    :members:
    :show-inheritance:
    :no-index:
@@ -50,7 +50,7 @@ Adds support for pgvector distance operators:
 ParadeDB
 --------
 
-.. autoclass:: sqlspec.dialects.postgres.paradedb.ParadeDB
+.. autoclass:: sqlspec.dialects.postgres.ParadeDB
    :members:
    :show-inheritance:
    :no-index:
@@ -63,19 +63,22 @@ Extends PGVector with ParadeDB pg_search operators:
    * - Operator
      - Description
    * - ``@@@``
-     - BM25 full-text search
+     - BM25 full-text search / complex query expressions
    * - ``&&&``
-     - Boolean AND search
+     - Conjunction match (all tokenized terms must match)
    * - ``|||``
-     - Boolean OR search
+     - Disjunction match (any tokenized term matches)
    * - ``===``
-     - Exact term match
+     - Exact term match (no tokenization of right-hand side)
    * - ``###``
-     - Score/rank retrieval
+     - Exact phrase match (token order and position enforced)
    * - ``##``
-     - Snippet/highlight retrieval
+     - Proximity match in any order (``'a' ## n ## 'b'``)
    * - ``##>``
-     - Snippet/highlight with options
+     - Ordered proximity match (left term must appear first)
+
+Scoring and snippets in ParadeDB are standard SQL functions (``pdb.score()``,
+``pdb.snippet()``), so they require no custom operator syntax.
 
 Spanner
 =======
@@ -94,8 +97,4 @@ Expression Types
 ================
 
 .. autofunction:: sqlspec.builder.VectorDistance
-   :no-index:
-
-.. autoclass:: sqlspec.dialects.postgres.paradedb.SearchOperator
-   :members:
    :no-index:

--- a/docs/reference/driver.rst
+++ b/docs/reference/driver.rst
@@ -18,6 +18,7 @@ Example
    :dedent: 4
    :no-upgrade:
 
+<<<<<<< HEAD
 Transaction Blocks
 ==================
 
@@ -90,23 +91,78 @@ block, using the syntax your database supports:
         await session.execute_script("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
         await session.execute("UPDATE accounts SET balance = balance - ? WHERE id = ?", 10, 1)
 
-Base Driver Classes
-===================
+Driver Adapter Protocol and Base Classes
+========================================
 
-Synchronous Driver
-------------------
+SQLSpec does not define standalone ``DriverProtocol``, ``AsyncDriverProtocol``, or
+``SessionProtocol`` classes. Instead, database drivers and sessions are instances
+of :class:`SyncDriverAdapterBase` or :class:`AsyncDriverAdapterBase`. The type alias
+:data:`DriverAdapterProtocol` unifies synchronous and asynchronous driver adapters
+for generic annotations.
+
+.. autodata:: DriverAdapterProtocol
+
+Synchronous Driver Adapter
+--------------------------
 
 .. autoclass:: SyncDriverAdapterBase
    :members:
    :undoc-members:
    :show-inheritance:
 
-Asynchronous Driver
--------------------
+Asynchronous Driver Adapter
+---------------------------
 
 .. autoclass:: AsyncDriverAdapterBase
    :members:
    :undoc-members:
+   :show-inheritance:
+
+Connection Context and Session Factories
+========================================
+
+Context managers that manage pool connection and session lifecycles for driver adapters.
+
+.. autoclass:: SyncPoolConnectionContext
+   :members:
+   :show-inheritance:
+
+.. autoclass:: AsyncPoolConnectionContext
+   :members:
+   :show-inheritance:
+
+.. autoclass:: SyncPoolSessionFactory
+   :members:
+   :show-inheritance:
+
+.. autoclass:: AsyncPoolSessionFactory
+   :members:
+   :show-inheritance:
+
+Row Streaming and Execution Results
+===================================
+
+.. autoclass:: SyncRowStream
+   :members:
+   :show-inheritance:
+
+.. autoclass:: AsyncRowStream
+   :members:
+   :show-inheritance:
+
+.. autoclass:: ExecutionResult
+   :members:
+   :show-inheritance:
+
+Exception Handlers
+==================
+
+.. autoclass:: BaseSyncExceptionHandler
+   :members:
+   :show-inheritance:
+
+.. autoclass:: BaseAsyncExceptionHandler
+   :members:
    :show-inheritance:
 
 Data Dictionary

--- a/docs/reference/driver.rst
+++ b/docs/reference/driver.rst
@@ -18,7 +18,6 @@ Example
    :dedent: 4
    :no-upgrade:
 
-<<<<<<< HEAD
 Transaction Blocks
 ==================
 
@@ -38,15 +37,15 @@ commits or rolls back that whole transaction, including work done before the blo
 
     async with config.provide_session() as session:
         async with session.transaction():
-            await session.execute("INSERT INTO users (name) VALUES (?)", "Ada")
-            await session.execute("INSERT INTO audit (action) VALUES (?)", "user-created")
+            await session.execute("INSERT INTO users (name) VALUES (:name)", name="Ada")
+            await session.execute("INSERT INTO audit (action) VALUES (:action)", action="user-created")
 
 .. code-block:: python
 
     with config.provide_session() as session:
         with session.transaction():
-            session.execute("INSERT INTO users (name) VALUES (?)", "Ada")
-            session.execute("INSERT INTO audit (action) VALUES (?)", "user-created")
+            session.execute("INSERT INTO users (name) VALUES (:name)", name="Ada")
+            session.execute("INSERT INTO audit (action) VALUES (:action)", action="user-created")
 
 Nested blocks
 -------------
@@ -63,10 +62,10 @@ enclosing block stays open and decides whether the work is committed. A service
     from sqlspec.exceptions import UniqueViolationError
 
     with session.transaction():
-        session.execute("INSERT INTO users (name) VALUES (?)", "Ada")
+        session.execute("INSERT INTO users (name) VALUES (:name)", name="Ada")
         try:
             with session.transaction():
-                session.execute("INSERT INTO users (name) VALUES (?)", "Ada")
+                session.execute("INSERT INTO users (name) VALUES (:name)", name="Ada")
         except UniqueViolationError:
             pass
 
@@ -89,7 +88,11 @@ block, using the syntax your database supports:
 
     async with session.transaction():
         await session.execute_script("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
-        await session.execute("UPDATE accounts SET balance = balance - ? WHERE id = ?", 10, 1)
+        await session.execute(
+            "UPDATE accounts SET balance = balance - :amount WHERE id = :id",
+            amount=10,
+            id=1,
+        )
 
 Driver Adapter Protocol and Base Classes
 ========================================

--- a/docs/reference/exceptions.rst
+++ b/docs/reference/exceptions.rst
@@ -263,4 +263,3 @@ Constants
 .. autodata:: SQLSTATE_EXCEPTION_MAP
 
 .. autodata:: STACK_SQL_PREVIEW_LIMIT
-

--- a/docs/reference/exceptions.rst
+++ b/docs/reference/exceptions.rst
@@ -166,6 +166,10 @@ Storage
    :members:
    :show-inheritance:
 
+.. autoclass:: StoragePathTraversalError
+   :members:
+   :show-inheritance:
+
 SQL Files
 =========
 
@@ -239,6 +243,7 @@ Inheritance Tree
    +-- StackExecutionError
    +-- StorageOperationFailedError
    |   +-- FileNotFoundInStorageError
+   |   +-- StoragePathTraversalError
    +-- StorageCapabilityError
    +-- SQLFileNotFoundError
    |   +-- SQLStatementNotFoundError
@@ -251,3 +256,11 @@ SQLSTATE Mapping
 ================
 
 .. autofunction:: map_sqlstate_to_exception
+
+Constants
+=========
+
+.. autodata:: SQLSTATE_EXCEPTION_MAP
+
+.. autodata:: STACK_SQL_PREVIEW_LIMIT
+

--- a/docs/reference/extensions/adk.rst
+++ b/docs/reference/extensions/adk.rst
@@ -89,3 +89,51 @@ Configuration
 .. autoclass:: sqlspec.extensions.adk.ADKConfig
    :members:
    :show-inheritance:
+
+Session Listing & Ordering
+==========================
+
+.. autodata:: sqlspec.extensions.adk.SessionOrderBy
+
+.. autofunction:: sqlspec.extensions.adk.normalize_session_list_options
+
+Retention Helpers
+=================
+
+.. autoclass:: sqlspec.extensions.adk.PruneReport
+   :members:
+   :show-inheritance:
+
+.. autofunction:: sqlspec.extensions.adk.prune_sessions
+
+.. autofunction:: sqlspec.extensions.adk.prune_sessions_sync
+
+.. autofunction:: sqlspec.extensions.adk.prune_events
+
+.. autofunction:: sqlspec.extensions.adk.prune_events_sync
+
+.. autofunction:: sqlspec.extensions.adk.prune_memory
+
+.. autofunction:: sqlspec.extensions.adk.prune_memory_sync
+
+.. autofunction:: sqlspec.extensions.adk.prune_user_state
+
+.. autofunction:: sqlspec.extensions.adk.prune_user_state_sync
+
+.. autofunction:: sqlspec.extensions.adk.prune_artifacts
+
+.. autofunction:: sqlspec.extensions.adk.prune_artifacts_sync
+
+Session Converters
+==================
+
+.. automodule:: sqlspec.extensions.adk.converters
+   :members:
+   :undoc-members:
+
+Memory Converters
+=================
+
+.. automodule:: sqlspec.extensions.adk.memory.converters
+   :members:
+   :undoc-members:

--- a/docs/reference/extensions/events.rst
+++ b/docs/reference/extensions/events.rst
@@ -414,6 +414,10 @@ Utility Functions
 
 .. autofunction:: sqlspec.extensions.events.load_native_backend
 
+.. autofunction:: sqlspec.extensions.events.get_runtime_hints
+
+.. autofunction:: sqlspec.extensions.events.resolve_adapter_name
+
 .. autofunction:: sqlspec.extensions.events.resolve_poll_interval
 
 .. autofunction:: sqlspec.extensions.events.resolve_event_poll_interval
@@ -421,3 +425,11 @@ Utility Functions
 .. autofunction:: sqlspec.extensions.events.normalize_event_channel_name
 
 .. autofunction:: sqlspec.extensions.events.normalize_queue_table_name
+
+Configuration
+=============
+
+.. autoclass:: sqlspec.config.EventsConfig
+   :members:
+   :show-inheritance:
+   :no-index:

--- a/docs/reference/extensions/index.rst
+++ b/docs/reference/extensions/index.rst
@@ -49,6 +49,18 @@ and services such as Litestar, FastAPI, Flask, Sanic, Starlette, and Google ADK.
 
       Pub/sub event channels with database-backed queues.
 
+   .. grid-item-card:: OpenTelemetry
+      :link: otel
+      :link-type: doc
+
+      Distributed tracing spans for database statements and operations.
+
+   .. grid-item-card:: Prometheus
+      :link: prometheus
+      :link-type: doc
+
+      Execution metrics, query counters, and latency histograms.
+
 .. toctree::
    :hidden:
 
@@ -59,3 +71,5 @@ and services such as Litestar, FastAPI, Flask, Sanic, Starlette, and Google ADK.
    starlette
    adk
    events
+   otel
+   prometheus

--- a/docs/reference/extensions/litestar.rst
+++ b/docs/reference/extensions/litestar.rst
@@ -26,6 +26,11 @@ Correlation Middleware
 ``enable_correlation_middleware`` is enabled, which is the default. Add it
 yourself only when you build the middleware stack without the plugin.
 
+When the application's middleware stack already contains ``CorrelationMiddleware``
+or a subclass, ``SQLSpecPlugin`` automatically skips adding a duplicate instance.
+It logs at ``DEBUG`` when the existing middleware honors the configured headers,
+or logs a ``WARNING`` when configured correlation headers would remain unapplied.
+
 .. code-block:: python
 
    from litestar.middleware import DefineMiddleware
@@ -46,6 +51,26 @@ yourself only when you build the middleware stack without the plugin.
    to inspect the names or pass them to ``CorrelationMiddleware``.
 
    :type: tuple[str, ...]
+
+Error Handling
+==============
+
+``SQLSpecPlugin`` automatically registers default exception handlers on Litestar's
+application configuration for database errors:
+
+* :class:`~sqlspec.exceptions.NotFoundError`: translated to HTTP 404, with the error message as detail.
+* :class:`~sqlspec.exceptions.IntegrityError` (and subclasses such as :class:`~sqlspec.exceptions.UniqueViolationError`): translated to HTTP 409 Conflict with the generic detail ``"Conflict"``, preventing internal database constraint or schema text from leaking to clients.
+
+The plugin renders these responses within the route's middleware stack, keeping headers
+added by application middleware and running ``after_exception`` hooks once. Handlers
+explicitly registered on the application or router for :class:`~sqlspec.exceptions.IntegrityError`
+or its subclasses take precedence; handlers for broader exceptions (such as
+:class:`~sqlspec.exceptions.SQLSpecError`, :class:`Exception`, or status 500) receive the original
+exception, while handlers for status 409 or :class:`litestar.exceptions.HTTPException` render the HTTP response.
+
+.. autofunction:: sqlspec.extensions.litestar.plugin.not_found_error_handler
+
+.. autofunction:: sqlspec.extensions.litestar.plugin.integrity_error_handler
 
 Channels Backend
 ================

--- a/docs/reference/extensions/litestar.rst
+++ b/docs/reference/extensions/litestar.rst
@@ -115,6 +115,8 @@ an endpoint must accept only raw configured values. Alias values are normalized
 before ``OrderByFilter`` is created, and unknown aliases cannot bypass the
 ``sort_field`` allowlist.
 
+.. autofunction:: sqlspec.extensions.litestar.providers.create_filter_dependencies
+
 .. autoclass:: sqlspec.extensions.litestar.providers.DependencyDefaults
    :members:
    :show-inheritance:

--- a/docs/reference/extensions/otel.rst
+++ b/docs/reference/extensions/otel.rst
@@ -1,0 +1,11 @@
+==============
+OpenTelemetry
+==============
+
+OpenTelemetry tracing extension for SQLSpec. Provides helpers for enabling
+OpenTelemetry spans across database statement executions and connection lifecycles.
+
+Helpers
+=======
+
+.. autofunction:: sqlspec.extensions.otel.enable_tracing

--- a/docs/reference/extensions/prometheus.rst
+++ b/docs/reference/extensions/prometheus.rst
@@ -1,0 +1,19 @@
+==========
+Prometheus
+==========
+
+Prometheus metrics extension for SQLSpec. Provides a statement observer and
+configuration helpers that record SQL execution counts, duration histograms,
+and row count histograms.
+
+Observer
+========
+
+.. autoclass:: sqlspec.extensions.prometheus.PrometheusStatementObserver
+   :members:
+   :show-inheritance:
+
+Helpers
+=======
+
+.. autofunction:: sqlspec.extensions.prometheus.enable_metrics

--- a/docs/reference/extensions/starlette.rst
+++ b/docs/reference/extensions/starlette.rst
@@ -27,6 +27,10 @@ Middleware
    :members:
    :show-inheritance:
 
+.. autoclass:: sqlspec.extensions.starlette.middleware.SQLCommenterMiddleware
+   :members:
+   :show-inheritance:
+
 State
 =====
 

--- a/docs/reference/loader.rst
+++ b/docs/reference/loader.rst
@@ -48,6 +48,13 @@ with ``/* include: name */``, and mark fill points with ``/* slot: name */``. Se
    :members:
    :show-inheritance:
 
+SQLFileCacheEntry
+=================
+
+.. autoclass:: SQLFileCacheEntry
+   :members:
+   :show-inheritance:
+
 Declared Parameters
 ===================
 
@@ -58,6 +65,7 @@ for the grammar and validation behavior.
 .. autoclass:: sqlspec.ParameterDeclaration
    :members:
    :show-inheritance:
+   :no-index:
 
 .. autofunction:: sqlspec.register_param_type
 

--- a/docs/reference/migrations.rst
+++ b/docs/reference/migrations.rst
@@ -71,6 +71,10 @@ Loaders
    :members:
    :show-inheritance:
 
+.. autoclass:: sqlspec.migrations.MigrationLoadError
+   :members:
+   :show-inheritance:
+
 .. autofunction:: sqlspec.migrations.loaders.get_migration_loader
 
 Squashing
@@ -131,6 +135,12 @@ Templates
 .. autoclass:: sqlspec.migrations.templates.PythonTemplateDefinition
    :members:
    :show-inheritance:
+
+.. autoclass:: sqlspec.migrations.templates.TemplateValidationError
+   :members:
+   :show-inheritance:
+
+.. autofunction:: sqlspec.migrations.templates.build_template_settings
 
 Utilities
 =========

--- a/docs/reference/observability.rst
+++ b/docs/reference/observability.rst
@@ -101,12 +101,13 @@ Cloud Log Formatters
    :members:
    :show-inheritance:
 
-Prometheus
+Extensions
 ==========
 
-.. autoclass:: sqlspec.extensions.prometheus.PrometheusStatementObserver
-   :members:
-   :show-inheritance:
+See the extension reference pages for distributed tracing and metrics:
+
+- :doc:`extensions/prometheus` for Prometheus metrics and observer helpers.
+- :doc:`extensions/otel` for OpenTelemetry span generation and tracing helpers.
 
 Helper Functions
 ================
@@ -116,3 +117,4 @@ Helper Functions
 .. autofunction:: sqlspec.observability.get_trace_context
 
 .. autofunction:: sqlspec.observability.resolve_db_system
+

--- a/docs/reference/observability.rst
+++ b/docs/reference/observability.rst
@@ -117,4 +117,3 @@ Helper Functions
 .. autofunction:: sqlspec.observability.get_trace_context
 
 .. autofunction:: sqlspec.observability.resolve_db_system
-

--- a/docs/reference/service.rst
+++ b/docs/reference/service.rst
@@ -18,7 +18,8 @@ concurrency rules.
 inside a savepoint on the outer block's session and never acquires a second
 session. It releases the savepoint when it succeeds and rolls back to the
 savepoint when it raises, then re-raises, so only the inner work is undone and the
-outer block can continue and commit. An adapter without savepoint support raises
+outer block can continue and commit. Adapters without savepoint support (DuckDB,
+BigQuery, Spanner, and ADBC connections to DuckDB, BigQuery, or Snowflake) raise
 ``ImproperConfigurationError`` when a nested block is entered.
 
 The five web-framework extensions — ``litestar``, ``fastapi``, ``flask``,

--- a/docs/reference/storage.rst
+++ b/docs/reference/storage.rst
@@ -79,8 +79,14 @@ Registry
    :members:
    :show-inheritance:
 
-Configuration Types
-===================
+.. autodata:: sqlspec.storage.storage_registry
+
+Configuration and Type Aliases
+==============================
+
+.. autodata:: sqlspec.storage.StorageDestination
+
+.. autodata:: sqlspec.storage.StorageFormat
 
 .. autoclass:: sqlspec.storage.StorageCapabilities
    :members:

--- a/docs/reference/typing.rst
+++ b/docs/reference/typing.rst
@@ -60,9 +60,63 @@ Protocols
 
 .. currentmodule:: sqlspec.typing
 
+SQLSpec defines focused protocols for reading dictionary-like rows, inspecting
+dataclasses, and interfacing with Apache Arrow record batch readers and schemas.
+
+.. note::
+   SQLSpec does not define standalone ``DriverProtocol``, ``AsyncDriverProtocol``,
+   or ``SessionProtocol`` protocols. Driver instances are implementations of
+   :class:`~sqlspec.driver.SyncDriverAdapterBase` or
+   :class:`~sqlspec.driver.AsyncDriverAdapterBase`, typed with
+   :data:`~sqlspec.driver.DriverAdapterProtocol`. Database configurations conform
+   to :class:`~sqlspec.config.DatabaseConfigProtocol`. Runtime statement protocols
+   reside in :mod:`sqlspec.protocols`.
+
 .. autoclass:: DictLike
    :members:
    :show-inheritance:
+
+.. autoclass:: DataclassProtocol
+   :members:
+   :show-inheritance:
+
+.. autoclass:: ArrowRecordBatchReaderProtocol
+   :members:
+   :show-inheritance:
+
+.. autoclass:: ArrowSchemaProtocol
+   :members:
+   :show-inheritance:
+
+Type Variables
+==============
+
+.. autodata:: ConnectionT
+
+.. autodata:: PoolT
+
+.. autodata:: SchemaT
+
+Type Aliases
+============
+
+.. autodata:: SupportedSchemaModel
+
+.. autodata:: StatementParameters
+
+.. autodata:: ArrowReturnFormat
+
+Sentinels
+=========
+
+.. autodata:: Empty
+
+.. autodata:: UNSET
+
+Helper Functions
+================
+
+.. autofunction:: get_type_adapter
 
 Feature Flags
 =============

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,78 +1,89 @@
-:orphan:
-
-======================
+================
 SQLSpec Releases
-======================
+================
+
+SQLSpec follows structured release cadences, transparent versioning policies, and automated build pipelines to ensure reliability across all supported database drivers and compiled extensions.
 
 Version Numbering
 -----------------
 
-This library follows the `Semantic Versioning standard <https://semver.org/>`_, using the ``<major>.<minor>.<patch>``
-schema:
+SQLSpec strictly adheres to `Semantic Versioning (SemVer 2.0.0) <https://semver.org/>`_ and `PEP 440 <https://peps.python.org/pep-0440/>`_ using the ``<major>.<minor>.<patch>`` scheme:
 
-**Major**
-    Backwards incompatible changes have been made
+**Major (X.0.0)**
+    Introduces backwards-incompatible API changes or major architectural redesigns. Breaking changes are announced in advance with deprecation warnings in prior minor releases whenever feasible.
 
-**Minor**
-    Functionality was added in a backwards compatible manner
+**Minor (0.Y.0 or X.Y.0)**
+    Adds new functionality, adapters, query builder capabilities, or optimizations in a backwards-compatible manner.
 
-**Patch**
-    Bugfixes were applied in a backwards compatible manner
+**Patch (0.Y.Z or X.Y.Z)**
+    Includes backwards-compatible bug fixes, driver compatibility corrections, performance enhancements, and documentation revisions.
 
 Pre-release Versions
-++++++++++++++++++++
+--------------------
 
-Before a new major release, we will make ``alpha``, ``beta``, and release candidate (``rc``) releases, numbered as
-``<major>.<minor>.<patch><release_type><number>``. For example, ``2.0.0alpha1``, ``2.0.0beta1``, ``2.0.0rc1``.
+Prior to a new major or significant minor release, SQLSpec publishes preview releases using the format ``<major>.<minor>.<patch>-<stage>.<number>``:
 
-- ``alpha``
-    Early developer preview. Features may not be complete and breaking changes can occur.
+- **Alpha (``alpha.N``)**: Early developer preview for testing new features, public API changes, and experimental adapter implementations. APIs may evolve before stabilization.
+- **Beta (``beta.N``)**: Feature-complete preview. Core APIs are frozen; testing focuses on edge cases, multi-database contract conformance, and integration stability.
+- **Release Candidate (``rc.N``)**: Final validation build under a complete feature freeze. Only critical regression fixes are accepted before the official release.
 
-- ``beta``
-    More stable preview release. Feature complete, no major breaking changes expected.
+Long-term Support (LTS) & Maintenance
+-------------------------------------
 
-- ``rc``
-    Release candidate. Feature freeze, only bugfixes until final release.
-    Suitable for testing migration to the upcoming major release.
+Major releases are supported according to our project maintenance lifecycle:
 
-Long-term Support Releases (LTS)
---------------------------------
+Supported Versions
+++++++++++++++++++
 
-Major releases are designated as LTS releases for the life of that major release series.
-These releases will receive bugfixes for a guaranteed period of time as defined in
-`Supported Versions <#supported-versions>`_.
+At any given time, the Litestar organization actively maintains:
+
+- The current major release series (e.g., ``1.x``).
+- The previous major release series (for critical security and regression fixes).
+- Any designated LTS releases.
+
+Bug fixes are applied directly to the active development branch and backported to supported release branches based on severity and impact.
 
 Deprecation Policy
 ------------------
 
-When a feature is going to be removed, a deprecation warning will be added in a **minor** release.
-The feature will continue to work for all releases in that major series, and will be removed in the next major release.
+When an existing API, parameter, or driver feature is scheduled for retirement:
 
-For example, if a deprecation warning is added in ``1.1``, the feature will work throughout all ``1.x`` releases,
-and be removed in ``2.0``.
+1. A deprecation notice and runtime warning (such as ``DeprecationWarning``) is introduced in a **minor** release.
+2. The deprecated feature remains functional throughout the remainder of that major release series.
+3. The feature is completely removed in the subsequent **major** release.
 
-Supported Versions
-------------------
+Release Workflow & Automation
+-----------------------------
 
-At any time, the Litestar organization will actively support:
+SQLSpec automates release versioning and package distribution using repository tooling and GitHub Actions.
 
-- The current major release series
-- The previous major release series
-- Any other designated LTS releases (Special cases)
+Local Release Preparation
++++++++++++++++++++++++++
 
-For example, if the current release is ``2.0``, we will actively support ``2.x`` and ``1.x``.
-When ``3.0`` is released, we will drop support for ``1.x``.
+Maintainers prepare releases via dedicated `Makefile` targets that coordinate clean builds, documentation validation, version increments, and lockfile updates:
 
-Bugfixes will be applied to the current major release, and selectively backported to older
-supported versions based on severity and feasibility.
+.. code-block:: console
 
-Release Process
----------------
+   # Prepare a stable patch release (or bump=minor, bump=major)
+   make release bump=patch
 
-Each major release cycle consists of a few phases:
+   # Prepare a pre-release
+   make pre-release version=0.63.0-alpha.1
 
-#. **Planning**: Define roadmap, spec out major features. Work should begin on implementation.
-#. **Development**: Active development on planned features. Ends with an alpha release and branch of ``A.B.x``
-   branch from `main`.
-#. **Bugfixes**: Only bugfixes, no new features. Progressively release beta, release candidates.
-   Feature freeze at RC. Become more selective with backports to avoid regressions.
+These targets use `bump-my-version` to update the canonical version in `pyproject.toml`, rebuild the distribution artifacts, update lockfiles, and generate git tags.
+
+CI/CD Publishing Pipeline
++++++++++++++++++++++++++
+
+When a release tag (``v*``) is pushed to the repository, ``.github/workflows/publish.yml`` automatically executes:
+
+1. **Standard Distributions**: Builds standard source distribution (``sdist``) and pure Python wheel packages.
+2. **Compiled Mypyc Wheels**: Compiles high-performance C-extensions via `hatch-mypyc` across a matrix of operating systems (Linux, macOS, Windows) and Python versions (3.10 through 3.14).
+3. **Profile-Guided Optimization (PGO)**: Compiles Linux and macOS binary wheels using execution profile data to optimize critical statement translation and dispatch paths.
+4. **Smoke Testing**: Validates binary wheel imports across supported architectures before publishing to `PyPI <https://pypi.org/project/sqlspec/>`_.
+
+See Also
+--------
+
+- :doc:`changelog` for release notes, detailed change lists, and migration instructions.
+- :doc:`contribution-guide` for development workflow, testing, and contribution standards.

--- a/docs/usage/bulk_ingest.rst
+++ b/docs/usage/bulk_ingest.rst
@@ -83,6 +83,12 @@ Capability matrix
      - Binary ``COPY`` with ``INSERT`` fallback
      - Atomic
      - Always on
+   * - cockroach (asyncpg / psycopg)
+     - ``COPY`` streaming for records/Arrow; ``load_from_storage`` appends
+       remote CSV/Parquet through ``IMPORT INTO``
+     - Server-managed (``IMPORT INTO`` takes table offline and invalidates FKs)
+     - Opt-in via ``enable_native_storage=True``; autocommit required on psycopg;
+       transactions and overwrite retain client Arrow path
    * - adbc
      - ``adbc_ingest`` (append/replace)
      - Driver-dependent; ``adbc_ingest`` is always attempted and unsupported drivers raise
@@ -165,6 +171,15 @@ Some fast paths are opt-in because they read local files or change semantics:
   high-throughput, independently committed ``insert_or_update`` groups instead
   of a single in-transaction flush. The upsert semantics keep each group
   idempotent on replay.
+- **CockroachDB native storage** (``enable_native_storage``) routes
+  ``load_from_storage`` through server-side ``IMPORT INTO`` for remote CSV and
+  Parquet. CockroachDB takes the target table offline during the import and
+  invalidates foreign keys, which must be revalidated afterward. Psycopg
+  connections require ``connection_config={"autocommit": True}`` because
+  CockroachDB rejects import statements inside user transactions. Native CSV
+  import requires explicit ``native_storage_csv_options={"skip": <count>}``
+  (e.g., ``skip=0`` for headerless files or ``skip=1`` for single-header files)
+  rather than guessing headers.
 
 Examples
 --------

--- a/docs/usage/bulk_ingest.rst
+++ b/docs/usage/bulk_ingest.rst
@@ -12,9 +12,9 @@ The API
 Three methods cover the common shapes. They share return type
 ``StorageBridgeJob`` (its ``telemetry`` dict reports ``rows_processed``):
 
-- ``load_from_arrow(table, source, *, overwrite=False)`` -- load an Arrow table
-  (or anything coercible to one) using the adapter's native ingest path.
-- ``load_from_storage(table, source, *, file_format, overwrite=False)`` -- load
+- ``load_from_arrow(table, source, *, partitioner=None, overwrite=False)`` -- load an Arrow table,
+  RecordBatch, RecordBatchReader, or an ``ArrowResult`` directly using the adapter's native ingest path.
+- ``load_from_storage(table, source, *, file_format, partitioner=None, overwrite=False)`` -- load
   a staged artifact (a local path or cloud URI) into a table.
 - ``load_from_records(table, records, *, columns=None, overwrite=False)`` --
   load in-memory rows. ``records`` may be mappings (columns derived from the
@@ -22,6 +22,8 @@ Three methods cover the common shapes. They share return type
   normalize records through their native Arrow ingest path. AsyncPG sends
   validated record tuples directly to binary ``COPY``; callers that pass an
   actual Arrow input still use ``load_from_arrow`` unchanged.
+
+In synchronous drivers:
 
 .. code-block:: python
 
@@ -31,8 +33,32 @@ Three methods cover the common shapes. They share return type
     # positional records -- columns required
     driver.load_from_records("orders", [(3, 1.0), (4, 2.0)], columns=["id", "total"])
 
+    # load staged local Parquet or CSV file
+    driver.load_from_storage("orders", "data/staging_orders.parquet", file_format="parquet")
+
+In asynchronous drivers, all three methods are coroutines:
+
+.. code-block:: python
+
+    # Ingest in-memory records
+    await async_driver.load_from_records("orders", [{"id": 1, "total": 9.99}])
+
+    # Load from cloud storage (S3 / GCS / Azure)
+    await async_driver.load_from_storage(
+        "orders",
+        "s3://my-bucket/staging/orders.parquet",
+        file_format="parquet",
+        overwrite=True,
+    )
+
+    # Direct zero-copy ingest from an ArrowResult or pyarrow.Table
+    arrow_result = await source_driver.select_to_arrow("SELECT * FROM raw_orders", native_only=True)
+    job = await target_driver.load_from_arrow("orders", arrow_result)
+    print(f"Loaded {job.telemetry['rows_processed']} rows")
+
 Empty input, mismatched mapping keys, or a positional/column width mismatch
 raise :class:`~sqlspec.exceptions.ImproperConfigurationError`.
+
 
 Capability matrix
 -----------------

--- a/docs/usage/cli.rst
+++ b/docs/usage/cli.rst
@@ -1,45 +1,155 @@
 Command Line Interface
 ======================
 
-SQLSpec includes a CLI for managing migrations and inspecting configuration. Use it
-when you want a fast, explicit workflow without additional tooling.
+SQLSpec includes a CLI for managing migrations, inspecting configurations, and maintaining
+extensions. Use it for standalone workflows or integrate it into web framework CLIs.
 
-Every command needs a configuration reference. Pass it with ``--config``, set
+Every standalone command needs a configuration reference. Pass it with ``--config``, set
 ``SQLSPEC_CONFIG``, or record it in ``[tool.sqlspec]`` -- see
-:ref:`pointing-the-cli-at-your-configuration` for the details.
+:ref:`pointing-the-cli-at-your-configuration` for details.
 
 Core Commands
 -------------
 
 .. code-block:: console
 
+   # Inspect resolved database configurations and migration status
    sqlspec --config database:database_config show-config
+
+   # Initialize migration directory structure
    sqlspec --config database:database_config init --no-prompt
-   sqlspec --config database:database_config create-migration -m "add users" --no-prompt
+
+   # Create a new migration revision (SQL or Python)
+   sqlspec --config database:database_config create-migration -m "add users table" --no-prompt
+
+   # Apply pending migrations up to head (or a specific revision)
    sqlspec --config database:database_config upgrade --no-prompt
+
+   # Revert migrations down by one step (or to a target revision)
    sqlspec --config database:database_config downgrade --no-prompt
+
+   # Check the current applied revision in the database
    sqlspec --config database:database_config show-current-revision
 
-Common Options
---------------
+   # Stamp the tracking table with a revision without executing DDL
+   sqlspec --config database:database_config stamp 0005
 
-- ``--bind-key`` targets a specific database configuration.
-- ``--no-prompt`` skips confirmation prompts.
-- ``--format`` selects SQL vs Python migration files.
-- ``--validate-config`` reports each configuration and whether it is async-capable.
-- ``--use-logger`` emits migration output via structured logger.
-- ``--no-echo`` disables console output for migration commands.
-- ``--summary`` emits a single summary log entry when logger output is enabled.
+   # Reconcile timestamp-based migrations into sequential format
+   sqlspec --config database:database_config fix --dry-run
 
-Tips
-----
+   # Squash multiple sequential migrations into a single consolidated file
+   sqlspec --config database:database_config squash 1:7 -m "squash initial migrations"
 
-- ``show-config`` verifies the CLI resolved the configuration you expected
-  before you run anything that touches the database.
-- Run ``sqlspec --help`` to see global options.
-- Run ``sqlspec upgrade --help`` to see command-specific migration options.
+Command Reference
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 36 40
+
+   * - Command
+     - Arguments
+     - Description
+   * - ``show-config``
+     - (none)
+     - Display all discovered database configurations, paths, and migration statuses.
+   * - ``init``
+     - ``[DIRECTORY]``
+     - Initialize a migrations directory. Defaults to the configured ``script_location``.
+   * - ``create-migration``
+     - (none)
+     - Generate a new migration file. Alias: ``make-migration``.
+   * - ``upgrade``
+     - ``[REVISION]``
+     - Upgrade database to target revision (default: ``head``).
+   * - ``downgrade``
+     - ``[REVISION]``
+     - Downgrade database by steps or to target revision (default: ``-1``).
+   * - ``show-current-revision``
+     - (none)
+     - Query and print current migration revision from the database tracker table.
+   * - ``stamp``
+     - ``REVISION``
+     - Record a revision in the tracking table without executing SQL statements.
+   * - ``fix``
+     - (none)
+     - Convert legacy timestamp migrations to sequential ``0001_...`` naming.
+   * - ``squash``
+     - ``VERSION_RANGE``
+     - Collapse sequential migrations (e.g. ``1:5`` or ``1..5``) into one file.
+   * - ``adk memory cleanup``
+     - ``--days N``
+     - Delete ADK session memory records older than *N* days.
+   * - ``adk memory verify``
+     - (none)
+     - Verify ADK session memory tables exist and are reachable.
+
+Command Options
+---------------
+
+Global & Execution Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``--config <path>``: Dotted path to config object or factory callable (env: ``SQLSPEC_CONFIG``). Comma-separated paths support multi-database setups.
+- ``--validate-config``: Report each configuration and whether it is async-capable before running.
+- ``--bind-key <key>``: Target a specific configuration by its bind key.
+- ``--include <key>`` / ``--exclude <key>``: Filter targeted configurations for multi-database operations (can be repeated).
+- ``--dry-run``: Show what would be applied without modifying database state or files.
+- ``--no-prompt``: Bypass interactive confirmation prompts (ideal for CI/CD).
+- ``--verbose``: Enable detailed output (supported on ``show-current-revision``).
+
+Migration Output & Format Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``--format`` / ``--file-type [sql|py]``: Migration file format for ``create-migration`` (default: per template profile).
+- ``--use-logger``: Emit migration output through standard Python structured logging instead of rich console output.
+- ``--no-echo``: Silence console output during execution.
+- ``--summary``: Emit a single aggregated summary log record when logger output is enabled.
+- ``--no-auto-sync``: Disable automatic checksum reconciliation when migrations have been renamed during ``upgrade``.
+- ``--output-format [sql|py]``: Output format for squashed migrations in ``squash`` (default: ``sql``).
+- ``--allow-gaps``: Allow gaps in the version sequence during ``squash``.
+
+Multi-Database CLI Operations
+-----------------------------
+
+When managing applications with multiple databases (e.g., primary and analytics replica),
+pass multiple configurations separated by commas:
+
+.. code-block:: console
+
+   sqlspec --config app.db:primary_config,app.db:analytics_config show-config
+
+Target all databases simultaneously or scope commands using ``--include``, ``--exclude``,
+or ``--bind-key``:
+
+.. code-block:: console
+
+   # Upgrade all configured databases
+   sqlspec --config app.db:get_configs upgrade --no-prompt
+
+   # Upgrade only the primary database
+   sqlspec --config app.db:get_configs upgrade --bind-key primary --no-prompt
+
+   # Exclude specific databases
+   sqlspec --config app.db:get_configs upgrade --exclude analytics --no-prompt
+
+Framework Integration (Litestar)
+--------------------------------
+
+When using the Litestar extension (``SQLSpecPlugin``), all migration commands are
+automatically exposed under Litestar's CLI group:
+
+.. code-block:: console
+
+   litestar db show-config
+   litestar db init
+   litestar db create-migration -m "add orders"
+   litestar db upgrade
+   litestar db downgrade
+   litestar db show-current-revision
 
 Related Guides
 --------------
 
-- :doc:`migrations` for migration workflow details.
+- :doc:`migrations` for complete migration configuration, templates, and Python migration APIs.
+- :doc:`frameworks/litestar/index` for Litestar integration details.

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -19,9 +19,12 @@ Core Configuration
 Pooling and Connections
 -----------------------
 
-- Sync adapters expose ``provide_session()`` and ``provide_connection()`` context managers.
-- Async adapters expose async context managers with the same method names.
-- Drivers with pooling support provide ``create_pool()`` and ``get_pool()`` helpers.
+- Sync database configs expose ``provide_session()`` and ``provide_connection()`` context managers.
+- Async database configs expose async context managers with the same method names.
+- ``provide_session()`` yields a driver adapter instance ready for executing queries and managing transactions.
+- ``provide_connection()`` yields the raw, underlying database connection from the driver.
+- Configs supporting connection pooling implement ``create_pool()`` and ``provide_pool()``.
+- On a ``SQLSpec`` registry instance, call ``spec.get_pool(config)`` to obtain the managed connection pool.
 
 Extension Settings
 ------------------
@@ -54,6 +57,7 @@ Key points:
 Related Guides
 --------------
 
-- :doc:`drivers_and_querying` for driver-specific connection settings.
+- :doc:`drivers_and_querying` for driver-specific connection settings and execution patterns.
 - :doc:`framework_integrations` for framework extension configuration.
-- :doc:`../reference/adapters` for adapter-specific configuration reference.
+- :doc:`/reference/adapters/index` for adapter-specific configuration reference.
+- :doc:`/reference/config` for core configuration classes and options.

--- a/docs/usage/data_dictionary.rst
+++ b/docs/usage/data_dictionary.rst
@@ -217,17 +217,26 @@ lookups return a ``DDLResult`` directly:
 Use ``get_schema_ddl()`` when you need a collection of DDL items. That method
 returns a ``MetadataResult`` whose items are ``DDLResult`` instances.
 
-Sort DDL by typed dependencies before replay. Dependency-capable adapters should
-return enough edge metadata for callers to order objects before exporting or
+Sort DDL by typed dependencies before replay. Dependency-capable adapters return
+typed dependency edge metadata so callers can order objects before exporting or
 replaying them:
 
 .. code-block:: python
 
+   from sqlspec.data_dictionary import dependency_edges_from_metadata, sort_ddl_results, sort_dependencies
+
+   # Order a collection of DDLResult objects directly:
+   schema_ddl = db.data_dictionary.get_schema_ddl(db, schema="public")
+   if schema_ddl.capability.support == "supported":
+       ordered_ddl = sort_ddl_results(schema_ddl.items, order="create")
+
+   # Or sort specific object identities using extracted edges:
    dependencies = db.data_dictionary.get_dependencies(db, schema="public")
    ddl = db.data_dictionary.get_ddl(db, "orders", schema="public")
-
    if dependencies.capability.support == "supported":
-       ordered_items = order_for_replay((ddl,), dependencies.items)
+       edges = dependency_edges_from_metadata(dependencies.items)
+       sort_result = sort_dependencies([ddl.identity], edges, order="create")
+       ordered_identities = sort_result.ordered
 
 System And Performance Metadata
 ===============================
@@ -292,3 +301,10 @@ inspection metadata unless the target workflow explicitly accepts those limits.
 
 SQLSpec's bundled dialect query packs are maintained SQLSpec query packs based
 on public catalog behavior.
+
+Related Guides
+==============
+
+- :doc:`drivers_and_querying` for driver sessions and query execution.
+- :doc:`/reference/adapters/index` for adapter-specific data dictionary support.
+- :doc:`/reference/driver` for the ``SyncDataDictionaryBase`` and ``AsyncDataDictionaryBase`` interface.

--- a/docs/usage/data_flow.rst
+++ b/docs/usage/data_flow.rst
@@ -1,19 +1,62 @@
+=========
 Data Flow
 =========
 
-SQLSpec processes SQL statements through a consistent pipeline: statement parsing,
-parameter normalization, driver execution, and result transformation. This guide keeps
-things short and points you to deeper examples when you need them.
+SQLSpec processes database interactions through a four-stage pipeline: statement
+authoring, compilation and normalization, driver execution, and result
+transformation. This architecture decouples how queries are written from how
+databases execute them and how applications consume results.
 
 Pipeline Overview
 -----------------
 
 .. mermaid::
 
-   flowchart LR
-     A[SQL / QueryBuilder] --> B[StatementConfig]
-     B --> C[Driver Adapter]
-     C --> D[Result Objects]
+   flowchart TD
+     A[Stage 1: Statement Input<br/>Raw SQL, SQL Object, Builder, or SQL Files] --> B[Stage 2: Compilation & Normalization<br/>StatementConfig, Placeholders, AST Cache, Declared Params]
+     B --> C[Stage 3: Session & Driver Execution<br/>Sync / Async Driver Adapter, Connection Pool, Transactions]
+     C --> D[Stage 4: Result Transformation<br/>SQLResult, Schema Mapping, Chunked Streams, Arrow Zero-Copy]
+
+Stage 1: Statement Input
+------------------------
+
+SQLSpec accepts queries in multiple forms to match the needs of your application:
+
+- **Raw SQL strings**: Plain SQL with named (``:name``) or positional (``?``) placeholders.
+- **SQL objects**: Instances of :class:`~sqlspec.core.statement.SQL` with support for immutable ``.where()`` condition chaining, ``.select_only()``, and ``.paginate()``.
+- **QueryBuilder**: The fluent AST builder (``sql.select()``, ``sql.insert()``, ``sql.update()``, ``sql.delete()``) with compile-time dialect targeting.
+- **SQL Files**: External ``.sql`` files loaded into the registry via ``spec.load_sql_files()`` and retrieved by name with ``spec.get_sql()``.
+
+Stage 2: Compilation & Normalization
+-------------------------------------
+
+Before reaching the database, queries pass through the core pipeline:
+
+- **Parameter style conversion**: Placeholders (``:param``, ``?``, ``$n``) are automatically mapped to the dialect-native style required by the target driver.
+- **Declared parameter validation**: Queries loaded from SQL files with ``-- param:`` directives have parameter presence and Python types verified before driver dispatch.
+- **Compiled statement caching**: Parameterized queries and AST structures are cached by fingerprint to bypass repeated SQL parsing overhead on hot paths.
+- **Dialect translation**: SQLGlot-powered AST transformers can convert expressions between SQL dialects when cross-database portability is needed.
+
+Stage 3: Session & Driver Execution
+-----------------------------------
+
+Database operations occur within a managed session:
+
+- **Session provisioning**: Calling ``spec.provide_session(config)`` yields a synchronous (``SyncDriverAdapterBase``) or asynchronous (``AsyncDriverAdapterBase``) driver adapter.
+- **Connection management**: The session acquires a physical connection from the config's pool (``provide_pool()`` / ``create_pool()``) and releases it upon exit.
+- **Transaction control**: Sessions manage transaction boundaries via ``session.begin()``, ``session.commit()``, ``session.rollback()``, savepoints, or the ``service.begin_transaction()`` context manager.
+- **Exception mapping**: Low-level database errors (DBAPI exceptions, driver errors) are translated into unified SQLSpec exceptions (:exc:`~sqlspec.exceptions.SQLSpecError`, :exc:`~sqlspec.exceptions.IntegrityError`, :exc:`~sqlspec.exceptions.OperationalError`).
+
+Stage 4: Result Transformation
+------------------------------
+
+Drivers provide flexible consumption patterns for query results:
+
+- **Structured SQLResult**: Low-level ``session.execute()`` returns a :class:`~sqlspec.core.result.SQLResult` with ``.all()``, ``.one()``, ``.one_or_none()``, ``.scalar()``, ``.scalar_or_none()``, and DML stats (``.rows_affected``, ``.last_inserted_id``).
+- **Direct query helpers**: ``session.select()``, ``session.select_one()``, ``session.select_value()``, and ``session.select_with_total()`` return processed rows directly.
+- **Schema mapping**: Passing ``schema_type=Model`` automatically maps result rows into dataclasses, msgspec Structs, Pydantic models, attrs classes, or TypedDict instances.
+- **Memory-bounded streaming**: ``session.select_stream(chunk_size=N)`` streams large result sets in bounded chunks using the driver's native cursor streaming primitive.
+- **Arrow integration**: ``session.select_to_arrow()`` yields Apache Arrow Tables, RecordBatches, or RecordBatchReaders for zero-copy analytical processing.
 
 Minimal Execution Example
 -------------------------
@@ -26,8 +69,10 @@ Minimal Execution Example
    :dedent: 4
    :no-upgrade:
 
-Next Steps
-----------
+Related Guides
+--------------
 
-- :doc:`drivers_and_querying` for driver-specific behaviors.
-- :doc:`query_builder` for the fluent SQL builder pipeline.
+- :doc:`configuration` for configuring adapters, pools, and multiple databases.
+- :doc:`drivers_and_querying` for driver execution APIs, streaming, and transactions.
+- :doc:`query_builder` for the fluent query builder API.
+- :doc:`sql_files` for organizing SQL files and parameter declarations.

--- a/docs/usage/drivers_and_querying.rst
+++ b/docs/usage/drivers_and_querying.rst
@@ -28,6 +28,59 @@ Core Execution Pattern
 Transactions
 ------------
 
+SQLSpec drivers provide a ``transaction()`` context manager that commits on
+successful block exit and rolls back when an exception is raised. If the connection
+already has an open transaction, the block joins it instead of starting a new one.
+
+.. tab-set::
+
+   .. tab-item:: Async
+
+      .. code-block:: python
+
+         async with config.provide_session() as session:
+             async with session.transaction():
+                 await session.execute("INSERT INTO users (name) VALUES (:name)", name="Ada")
+                 await session.execute("INSERT INTO audit (action) VALUES (:action)", action="user-created")
+
+   .. tab-item:: Sync
+
+      .. code-block:: python
+
+         with config.provide_session() as session:
+             with session.transaction():
+                 session.execute("INSERT INTO users (name) VALUES (:name)", name="Ada")
+                 session.execute("INSERT INTO audit (action) VALUES (:action)", action="user-created")
+
+Nested Transactions and Savepoints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Nested ``transaction()`` blocks run inside a savepoint on the enclosing
+transaction. If the inner block raises, only its work is rolled back, allowing
+the outer transaction to catch the error, continue, and commit:
+
+.. code-block:: python
+
+    from sqlspec.exceptions import UniqueViolationError
+
+    with session.transaction():
+        session.execute("INSERT INTO users (name) VALUES (:name)", name="Ada")
+        try:
+            with session.transaction():
+                session.execute("INSERT INTO users (name) VALUES (:name)", name="Ada")
+        except UniqueViolationError:
+            pass
+
+Adapters without savepoint support (DuckDB, BigQuery, Spanner, and ADBC connections
+to DuckDB, BigQuery, or Snowflake) raise ``ImproperConfigurationError`` when a
+nested block is entered.
+
+Manual Transaction Control
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For fine-grained lifecycle control, you can call ``begin()``, ``commit()``, and
+``rollback()`` directly on the driver:
+
 .. literalinclude:: /examples/drivers/transaction_handling.py
    :language: python
    :caption: ``manual transaction``

--- a/docs/usage/drivers_and_querying.rst
+++ b/docs/usage/drivers_and_querying.rst
@@ -8,10 +8,11 @@ Supported Drivers (High Level)
 ------------------------------
 
 - **PostgreSQL**: asyncpg, psycopg (sync/async), psqlpy, ADBC
+- **CockroachDB**: cockroach-asyncpg, cockroach-psycopg
 - **SQLite**: sqlite3, aiosqlite, ADBC
-- **MySQL**: asyncmy, mysql-connector, pymysql
+- **MySQL & MariaDB**: aiomysql, asyncmy, mysql-connector, pymysql
 - **SQL Server**: mssql-python, pymssql, arrow-odbc
-- **Analytics / Cloud**: DuckDB, BigQuery, Spanner, Oracle, ADBC
+- **Analytics & Cloud**: DuckDB, BigQuery, Spanner, Oracle, ADBC, arrow-odbc
 
 Core Execution Pattern
 ----------------------
@@ -49,8 +50,12 @@ Parameter Binding
 Schema Mapping
 --------------
 
-Use the ``schema_type`` parameter on ``select()``, ``select_one()``, and
-``select_one_or_none()`` to map result rows to dataclass instances automatically.
+Use the ``schema_type`` parameter on ``select()``, ``select_one()``,
+``select_one_or_none()``, and ``select_stream()`` to map result rows directly to
+dataclasses, msgspec Structs, Pydantic models, attrs classes, or TypedDict
+shapes. When working with raw ``SQLResult`` objects from ``execute()``, pass
+``schema_type`` to ``result.all()``, ``result.one()``, ``result.one_or_none()``,
+or ``result.get_data()``.
 
 .. literalinclude:: /examples/querying/schema_mapping.py
    :language: python
@@ -63,9 +68,10 @@ Use the ``schema_type`` parameter on ``select()``, ``select_one()``, and
 Scalar Values and Pagination
 -----------------------------
 
-``select_value`` returns a single scalar from a one-row, one-column result.
-``select_value_or_none`` returns ``None`` when no rows match.
-``select_with_total`` returns both the data page and the total count for pagination.
+- ``select_value()`` returns a single scalar from a one-row, one-column result (with optional type conversion via ``value_type``).
+- ``select_value_or_none()`` returns ``None`` when no rows match.
+- ``select_with_total()`` returns a ``(data_rows, total_count)`` tuple for pagination.
+- Drivers also provide ``fetch()``, ``fetch_one()``, ``fetch_one_or_none()``, ``fetch_value()``, ``fetch_value_or_none()``, ``fetch_with_total()``, and ``fetch_stream()`` aliases matching asyncpg conventions.
 
 .. literalinclude:: /examples/querying/batch_operations.py
    :language: python
@@ -162,5 +168,6 @@ Driver Configuration Examples
 Related References
 ------------------
 
-- :doc:`../reference/adapters` for full adapter configuration reference.
-- :doc:`/reference/adapters` for adapter capabilities and connection profiles.
+- :doc:`/reference/adapters/index` for full adapter configuration, feature matrix, and connection profiles.
+- :doc:`/reference/driver` for the driver interface and query execution API.
+- :doc:`/reference/core/statement` for the ``SQL`` statement model and modifiers.

--- a/docs/usage/etl.rst
+++ b/docs/usage/etl.rst
@@ -24,25 +24,64 @@ Arrow-Based Bulk Transfer
 
 For large datasets, use ``select_to_arrow()`` to get results as Apache Arrow
 tables. This avoids per-row Python object overhead and enables zero-copy
-transfers between databases that support native Arrow (ADBC, DuckDB, BigQuery).
+transfers between databases that support native Arrow (ADBC, DuckDB, BigQuery,
+Arrow ODBC, mssql-python, and Oracle).
+
+Passing ``native_only=True`` ensures that the query executes through the driver's
+fast, zero-copy C/C++ columnar path. If the adapter does not support native Arrow,
+it raises :class:`~sqlspec.exceptions.ImproperConfigurationError` rather than
+silently falling back to row-by-row dict conversion.
 
 .. code-block:: python
 
-    # Extract as Arrow table
+    # Extract as Arrow table using zero-copy native path
     arrow_result = await source_session.select_to_arrow(
         "SELECT * FROM large_table WHERE updated > :since",
-        since=last_sync,
+        {"since": last_sync},
+        native_only=True,
     )
 
-    # Arrow table can be converted to pandas, polars, or written to Parquet
-    df = arrow_result.to_pandas()
+    # Convert to Polars or Pandas DataFrames
+    df_polars = arrow_result.to_polars()
+    df_pandas = arrow_result.to_pandas()
 
-    # Or use native Arrow paths for zero-copy with DuckDB/ADBC
+    # Direct export to cloud storage (Parquet / Arrow IPC)
+    await arrow_result.write_to_storage_async("s3://my-bucket/exports/table.parquet")
+
+Direct Zero-Copy Cross-Database Transfer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Because ``load_from_arrow()`` accepts an ``ArrowResult`` directly, you can stream
+data between heterogeneous databases without any intermediate Python objects:
+
+.. code-block:: python
+
+    # 1. Zero-copy extract from PostgreSQL via ADBC
+    arrow_result = await postgres_session.select_to_arrow(
+        "SELECT id, event_type, payload, created_at FROM events WHERE processed = false",
+        native_only=True,
+    )
+
+    # 2. Direct zero-copy load into DuckDB analytical staging table
+    job = duckdb_session.load_from_arrow("staging_events", arrow_result)
+    print(f"Transferred {job.telemetry['rows_processed']} rows")
+
+Streaming Large Result Sets
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To stream datasets that exceed available RAM, use ``return_format="reader"`` to
+obtain a ``pyarrow.RecordBatchReader``:
+
+.. code-block:: python
+
     arrow_result = await session.select_to_arrow(
         "SELECT * FROM events",
-        return_format="table",    # "table", "batch", "batches", or "reader"
-        batch_size=10000,         # rows per batch
+        return_format="reader",   # Streams RecordBatch objects
+        batch_size=10000,         # Rows per batch
     )
+    reader = arrow_result.get_data()
+    for batch in reader:
+        process_batch(batch)
 
 Supported ``return_format`` values:
 
@@ -55,6 +94,7 @@ Supported ``return_format`` values:
 
    :doc:`bulk_ingest` for the inbound side -- loading Arrow tables, staged
    files, and in-memory records into a table via native driver primitives.
+
 
 DuckDB as Staging Layer
 -----------------------

--- a/docs/usage/filtering.rst
+++ b/docs/usage/filtering.rst
@@ -90,9 +90,11 @@ Using filters in a Litestar handler:
 
 .. code-block:: python
 
-    from litestar import Litestar, get
+    from litestar import get
+    from sqlspec import sql
+    from sqlspec.adapters.asyncpg import AsyncpgDriver
     from sqlspec.core import FilterTypes
-    from sqlspec.extensions.litestar.providers import FilterConfig, create_filter_dependencies
+    from sqlspec.extensions.litestar.providers import create_filter_dependencies
 
     user_filter_deps = create_filter_dependencies({
         "pagination_type": "limit_offset",
@@ -161,21 +163,30 @@ base classes ``SQLSpecAsyncService`` and ``SQLSpecSyncService`` in ``sqlspec.ser
 
 .. code-block:: python
 
+    from dataclasses import dataclass
+    from sqlspec import sql
+    from sqlspec.adapters.asyncpg import AsyncpgDriver
+    from sqlspec.core import OffsetPagination, StatementFilter
     from sqlspec.service import SQLSpecAsyncService
-    from sqlspec.core.filters import LimitOffsetFilter
 
-    class UserService(SQLSpecAsyncService):
+    @dataclass
+    class User:
+        id: int
+        name: str
+
+    class UserService(SQLSpecAsyncService[AsyncpgDriver]):
         async def list_users(self, filters: list[StatementFilter]) -> OffsetPagination[User]:
             query = sql.select("*").from_("users")
             return await self.paginate(query, *filters, schema_type=User)
 
-    async def some_handler(db_session: AsyncDriver, filters: list[StatementFilter]):
+    async def some_handler(db_session: AsyncpgDriver, filters: list[StatementFilter]) -> OffsetPagination[User]:
         service = UserService(db_session)
-        page = await service.list_users(filters)
-        return page  # Returns OffsetPagination container
+        return await service.list_users(filters)
 
 Related Guides
 --------------
 
 - :doc:`drivers_and_querying` for ``select_with_total`` and query methods.
 - :doc:`query_builder` for building queries with ``.where()`` clauses.
+- :doc:`/recipes/service_layer` for building robust application service layers.
+- :doc:`/reference/core/filters` for the core filter classes and parameters API.

--- a/docs/usage/frameworks/fastapi.rst
+++ b/docs/usage/frameworks/fastapi.rst
@@ -41,7 +41,7 @@ Basic Setup
 ===========
 
 Create a SQLSpec instance, register your database config, and attach the plugin to your
-FastAPI app. The plugin provides a ``provide_session`` dependency that yields a session
+FastAPI app. The plugin provides ``provide_session`` dependencies that yield a session
 for each request. Configure FastAPI-specific options under ``extension_config["fastapi"]``.
 
 .. literalinclude:: /examples/frameworks/fastapi/basic_setup.py
@@ -52,30 +52,96 @@ for each request. Configure FastAPI-specific options under ``extension_config["f
    :dedent: 4
    :no-upgrade:
 
-Key Concepts
-============
+Transaction Modes
+=================
 
-**Dependency Injection**
-   Use ``Depends(db_ext.provide_session())`` to inject a session into your route handlers.
-   The session is scoped to the request and automatically cleaned up afterward.
+FastAPI uses Starlette-compatible transaction middleware configured via ``extension_config["fastapi"]``:
 
-**Session Lifecycle**
-   Sessions are created at the start of each request and closed when the request completes.
-   For long-running operations, consider using background tasks with their own session.
+``manual`` (default)
+   SQLSpec manages the connection lifecycle and closes connections at the end of the
+   request, leaving transaction commit and rollback decisions to your handler logic.
 
-**Multiple Databases**
-   Register multiple configs with different names and create separate dependencies for each:
+``autocommit``
+   SQLSpec automatically commits transactions for 2xx responses and rolls back on 4xx/5xx
+   responses or unhandled exceptions.
 
-   .. code-block:: python
+``autocommit_include_redirect``
+   Extends autocommit to also commit on redirect responses (2xx and 3xx).
 
-      sqlspec.add_config(primary_config, name="primary")
-      sqlspec.add_config(analytics_config, name="analytics")
+.. code-block:: python
 
-      primary_dep = db_ext.provide_session("primary")
-      analytics_dep = db_ext.provide_session("analytics")
+   from sqlspec.adapters.aiosqlite import AiosqliteConfig
+
+   config = AiosqliteConfig(
+       connection_config={"database": "app.db"},
+       extension_config={
+           "fastapi": {
+               "commit_mode": "autocommit",
+               "extra_rollback_statuses": {409},
+               "session_key": "db",
+           }
+       },
+   )
+
+Multiple Databases
+==================
+
+Configure each database with unique ``session_key``, ``connection_key``, and ``pool_key``
+values under ``extension_config["fastapi"]``. Inject distinct sessions by passing the
+key to ``provide_session()``:
+
+.. literalinclude:: /examples/frameworks/fastapi/multi_database.py
+   :language: python
+   :caption: ``fastapi multi database``
+   :start-after: # start-example
+   :end-before: # end-example
+   :dedent: 4
+   :no-upgrade:
+
+Dependency Injection Helpers
+============================
+
+The ``SQLSpecPlugin`` provides several dependency factories for FastAPI routes:
+
+- ``db_ext.provide_session(key=None)``: Injects a driver session (sync or async depending on config).
+- ``db_ext.provide_async_session(key=None)``: Type-narrowed dependency returning ``AsyncDriverAdapterBase``.
+- ``db_ext.provide_sync_session(key=None)``: Type-narrowed dependency returning ``SyncDriverAdapterBase``.
+- ``db_ext.provide_connection(key=None)``: Injects the raw database connection.
+
+Filter Dependencies
+===================
+
+SQLSpec provides ``provide_filters`` to parse HTTP query parameters into typed
+``StatementFilter`` objects (pagination, sorting, search, before/after):
+
+.. code-block:: python
+
+   from typing import Annotated
+   from fastapi import Depends, FastAPI
+   from sqlspec.core.filters import FilterTypes
+   from sqlspec.extensions.fastapi import provide_filters
+
+   app = FastAPI()
+
+   filter_dep = provide_filters(
+       {
+           "pagination_type": "limit_offset",
+           "pagination_size": 20,
+           "sort_field": ["name", "created_at"],
+           "search": "name,email",
+       }
+   )
+
+   @app.get("/items")
+   async def list_items(
+       filters: Annotated[list[FilterTypes], Depends(filter_dep)],
+   ) -> dict[str, str]:
+       return {"status": "ok"}
 
 Related Guides
 ==============
 
 - :doc:`/usage/configuration` for detailed config options.
+- :doc:`/usage/filtering` for available filter types.
 - :doc:`/reference/adapters` for adapter-specific settings.
+- :doc:`starlette` for underlying ASGI middleware details.

--- a/docs/usage/frameworks/flask.rst
+++ b/docs/usage/frameworks/flask.rst
@@ -4,7 +4,7 @@ Flask
 
 SQLSpec provides a Flask extension that manages database connections within the Flask
 request lifecycle. The extension registers connection pool setup and teardown with
-Flask's application context hooks.
+Flask's application context hooks, supporting both synchronous and asynchronous adapters.
 
 Installation
 ============
@@ -51,28 +51,59 @@ Flask app. Use ``plugin.get_session()`` inside request handlers to obtain a sess
    :dedent: 4
    :no-upgrade:
 
-Key Concepts
-============
+Transaction Modes
+=================
 
-**Request-Scoped Sessions**
-   Sessions obtained via ``get_session()`` are bound to the current request context.
-   They are automatically closed when the request finishes.
+Configure the commit mode under ``extension_config["flask"]``:
 
-**Application Factory Pattern**
-   When using the factory pattern, initialize the plugin in your ``create_app`` function:
+``manual`` (default)
+   SQLSpec manages connection lifecycle within the request context. Your route handler
+   commits or rolls back explicitly.
 
-   .. code-block:: python
+``autocommit``
+   SQLSpec automatically commits transactions for 2xx responses and rolls back for 4xx/5xx
+   responses or unhandled exceptions.
 
-      def create_app():
-          app = Flask(__name__)
-          sqlspec = SQLSpec()
-          sqlspec.add_config(SqliteConfig(...))
-          plugin = SQLSpecPlugin(sqlspec, app)
-          return app
+``autocommit_include_redirect``
+   Extends autocommit to also commit on redirect responses (2xx and 3xx).
 
-**Sync Execution**
-   Flask operates synchronously by default. Use sync adapters like ``SqliteConfig`` or
-   ``PsycopgSyncConfig`` for straightforward integration.
+.. code-block:: python
+
+   from sqlspec.adapters.sqlite import SqliteConfig
+
+   config = SqliteConfig(
+       connection_config={"database": "app.db"},
+       extension_config={
+           "flask": {
+               "commit_mode": "autocommit",
+               "extra_rollback_statuses": {409},
+               "session_key": "db",
+           }
+       },
+   )
+
+Multiple Databases
+==================
+
+For multiple databases, assign unique ``session_key``, ``connection_key``, and ``pool_key``
+settings under ``extension_config["flask"]``. Retrieve sessions by passing the key to
+``plugin.get_session()``:
+
+.. literalinclude:: /examples/frameworks/flask/multi_database.py
+   :language: python
+   :caption: ``flask multi database``
+   :start-after: # start-example
+   :end-before: # end-example
+   :dedent: 4
+   :no-upgrade:
+
+Async Adapter Support
+=====================
+
+While Flask operates synchronously by default, SQLSpec provides seamless support for
+asynchronous database adapters (such as ``AsyncpgConfig`` or ``AiosqliteConfig``) via
+an internal AnyIO portal runner. In async configurations, ``get_session()`` handles the
+event loop bridge transparently.
 
 Related Guides
 ==============

--- a/docs/usage/frameworks/litestar/api.rst
+++ b/docs/usage/frameworks/litestar/api.rst
@@ -13,12 +13,37 @@ Plugin
    :show-inheritance:
    :no-index:
 
+Configuration
+=============
+
+.. autoclass:: LitestarConfig
+   :members:
+   :undoc-members:
+   :no-index:
+
 Session Stores
 ==============
+
+.. autoclass:: BaseSQLSpecStore
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :no-index:
 
 .. currentmodule:: sqlspec.adapters.aiosqlite.litestar
 
 .. autoclass:: AiosqliteStore
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :no-index:
+
+Channels Backend
+================
+
+.. currentmodule:: sqlspec.extensions.litestar
+
+.. autoclass:: SQLSpecChannelsBackend
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/usage/frameworks/litestar/api.rst
+++ b/docs/usage/frameworks/litestar/api.rst
@@ -21,6 +21,27 @@ Configuration
    :undoc-members:
    :no-index:
 
+Correlation Middleware
+======================
+
+.. autoclass:: CorrelationMiddleware
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :no-index:
+
+.. py:data:: TRACE_CONTEXT_FALLBACK_HEADERS
+   :no-index:
+
+Exception Handlers
+==================
+
+.. autofunction:: sqlspec.extensions.litestar.plugin.not_found_error_handler
+   :no-index:
+
+.. autofunction:: sqlspec.extensions.litestar.plugin.integrity_error_handler
+   :no-index:
+
 Session Stores
 ==============
 

--- a/docs/usage/frameworks/litestar/dependency_injection.rst
+++ b/docs/usage/frameworks/litestar/dependency_injection.rst
@@ -86,13 +86,15 @@ sync DuckDB for ETL operations:
        )
    )
 
+   from typing import Any
+
    @get("/report")
-   async def report(db: AsyncpgDriver, etl_db: DuckDBDriver) -> dict:
+   async def report(db: AsyncpgDriver, etl_db: DuckDBDriver) -> dict[str, Any]:
        # Async query to primary PostgreSQL
        users = await db.select("SELECT * FROM users")
        # Sync query to DuckDB ETL database
        metrics = etl_db.select("SELECT * FROM analytics")
-       return {"users": users.all(), "metrics": metrics.all()}
+       return {"users": users, "metrics": metrics}
 
    app = Litestar(
        route_handlers=[report],
@@ -270,7 +272,7 @@ This pattern enables querying PostgreSQL tables directly from DuckDB SQL:
 .. code-block:: python
 
    @get("/sync-users")
-   def sync_users(etl_db: DuckDBDriver) -> dict:
+   def sync_users(etl_db: DuckDBDriver) -> dict[str, int]:
        # Query PostgreSQL via DuckDB's postgres extension
        result = etl_db.execute(
            "INSERT INTO local_users SELECT * FROM pg.users RETURNING *"

--- a/docs/usage/frameworks/litestar/installation.rst
+++ b/docs/usage/frameworks/litestar/installation.rst
@@ -121,9 +121,9 @@ Install SQLSpec with the Litestar extra and a database adapter.
 Requirements
 ------------
 
-- **Python 3.9+**
+- **Python 3.10+**
 - **Litestar 2.0+**
-- A compatible async database adapter
+- A compatible database adapter (async recommended for web request concurrency)
 
 Next Steps
 ----------

--- a/docs/usage/frameworks/litestar/installation.rst
+++ b/docs/usage/frameworks/litestar/installation.rst
@@ -122,7 +122,7 @@ Requirements
 ------------
 
 - **Python 3.10+**
-- **Litestar 2.0+**
+- **Litestar 2.23+**
 - A compatible database adapter (async recommended for web request concurrency)
 
 Next Steps

--- a/docs/usage/frameworks/litestar/session_stores.rst
+++ b/docs/usage/frameworks/litestar/session_stores.rst
@@ -28,11 +28,19 @@ Pass a SQLSpec store to Litestar's ``SessionMiddleware``:
 Available Stores
 ----------------
 
-SQLSpec provides stores for async adapters:
+SQLSpec provides store backends for both async and sync database adapters, all inheriting
+from :class:`~sqlspec.extensions.litestar.store.BaseSQLSpecStore`:
 
-- ``AsyncpgStore`` - PostgreSQL via asyncpg
-- ``AiosqliteStore`` - SQLite via aiosqlite
-- ``ArrowOdbcStore`` - SQL Server via arrow-odbc and Microsoft ODBC Driver 18
+- **SQLite**: ``sqlspec.adapters.aiosqlite.litestar.AiosqliteStore`` (async) and ``sqlspec.adapters.sqlite.litestar.SQLiteStore`` (sync)
+- **PostgreSQL**: ``sqlspec.adapters.asyncpg.litestar.AsyncpgStore`` (asyncpg), ``sqlspec.adapters.psycopg.litestar.PsycopgAsyncStore`` (psycopg async), and ``sqlspec.adapters.psycopg.litestar.PsycopgSyncStore`` (psycopg sync)
+- **MySQL**: ``sqlspec.adapters.pymysql.litestar.PyMysqlStore``
+- **DuckDB**: ``sqlspec.adapters.duckdb.litestar.DuckdbStore``
+- **SQL Server / ODBC**: ``sqlspec.adapters.arrow_odbc.litestar.ArrowOdbcStore``, ``sqlspec.adapters.pymssql.litestar.PymssqlStore``, and ``sqlspec.adapters.mssql_python.litestar.MssqlPythonStore``
+- **CockroachDB**: ``sqlspec.adapters.cockroach_asyncpg.litestar.CockroachAsyncpgStore``
+- **BigQuery**: ``sqlspec.adapters.bigquery.litestar.BigQueryStore``
+- **Spanner**: ``sqlspec.adapters.spanner.litestar.SpannerSyncStore``
+- **Oracle**: ``sqlspec.adapters.oracledb.litestar.OracleAsyncStore`` and ``sqlspec.adapters.oracledb.litestar.OracleSyncStore``
+- **Arrow / ADBC**: ``sqlspec.adapters.adbc.litestar.ADBCStore``
 
 Each store can create its session table. It can also add new columns from its
 own DDL. Set this behavior under ``extension_config["litestar"]``:

--- a/docs/usage/frameworks/litestar/transactions.rst
+++ b/docs/usage/frameworks/litestar/transactions.rst
@@ -99,3 +99,15 @@ SQLSpec drivers provide explicit savepoint management within active transactions
        await db_session.release_savepoint("sp1")
    except Exception:
        await db_session.rollback_to_savepoint("sp1")
+
+Error Handling and 409 Conflict
+-------------------------------
+
+When a database operation raises :class:`~sqlspec.exceptions.IntegrityError` (such as a unique
+constraint or foreign key violation), ``SQLSpecPlugin`` automatically translates it to an
+HTTP 409 Conflict response with generic detail ``"Conflict"``. In ``autocommit`` mode,
+this error status triggers an automatic rollback of the request transaction.
+
+Custom handlers registered on the application or router for :class:`~sqlspec.exceptions.IntegrityError`
+take precedence, while broader handlers (e.g. for :class:`~sqlspec.exceptions.SQLSpecError` or status 500)
+receive the original exception.

--- a/docs/usage/frameworks/litestar/transactions.rst
+++ b/docs/usage/frameworks/litestar/transactions.rst
@@ -56,7 +56,9 @@ You can customize which HTTP statuses trigger commits or rollbacks using
 Manual Transactions in Handlers
 -------------------------------
 
-In ``manual`` mode, handlers control transaction boundaries directly on the injected driver:
+In ``manual`` mode, handlers control transaction boundaries directly on the injected driver.
+The recommended approach is to wrap operations in ``async with db_session.transaction():``,
+which commits on exit and rolls back on exception:
 
 .. code-block:: python
 
@@ -73,23 +75,45 @@ In ``manual`` mode, handlers control transaction boundaries directly on the inje
 
    @post("/transfer")
    async def transfer(db_session: AsyncpgDriver, data: TransferRequest) -> dict[str, str]:
-       await db_session.execute(
-           "UPDATE accounts SET balance = balance - :amount WHERE id = :from_id",
-           amount=data.amount,
-           from_id=data.from_account,
-       )
-       await db_session.execute(
-           "UPDATE accounts SET balance = balance + :amount WHERE id = :to_id",
-           amount=data.amount,
-           to_id=data.to_account,
-       )
-       await db_session.commit()
+       async with db_session.transaction():
+           await db_session.execute(
+               "UPDATE accounts SET balance = balance - :amount WHERE id = :from_id",
+               amount=data.amount,
+               from_id=data.from_account,
+           )
+           await db_session.execute(
+               "UPDATE accounts SET balance = balance + :amount WHERE id = :to_id",
+               amount=data.amount,
+               to_id=data.to_account,
+           )
        return {"status": "transferred"}
 
-Savepoints
-----------
+You can also call ``await db_session.begin()``, ``await db_session.commit()``, and
+``await db_session.rollback()`` directly for manual control.
 
-SQLSpec drivers provide explicit savepoint management within active transactions:
+Savepoints and Nested Transactions
+----------------------------------
+
+Nested ``transaction()`` blocks automatically run in savepoints: an inner block rolls
+back only its own work if it fails, allowing the outer transaction to continue:
+
+.. code-block:: python
+
+   from sqlspec.exceptions import UniqueViolationError
+
+   async with db_session.transaction():
+       await db_session.execute("INSERT INTO audit_log (event) VALUES (:event)", event="attempt")
+       try:
+           async with db_session.transaction():
+               await db_session.execute("INSERT INTO users (email) VALUES (:email)", email=data.email)
+       except UniqueViolationError:
+           pass
+
+Adapters without savepoint support (DuckDB, BigQuery, Spanner, and ADBC connections to
+DuckDB, BigQuery, or Snowflake) raise ``ImproperConfigurationError`` when a nested block
+is entered.
+
+Drivers also provide explicit low-level savepoint methods:
 
 .. code-block:: python
 

--- a/docs/usage/frameworks/litestar/transactions.rst
+++ b/docs/usage/frameworks/litestar/transactions.rst
@@ -2,19 +2,27 @@
 Transactions
 =============
 
-The SQLSpec plugin supports two transaction modes: **autocommit** and **manual commit**.
-Choose the mode that fits your application's error handling and rollback requirements.
+The SQLSpec plugin supports three transaction commit modes: ``manual``,
+``autocommit``, and ``autocommit_include_redirect``.
 
 Commit Modes
 ------------
 
-**Autocommit (default)**
-   Each statement commits automatically. Use this for read-heavy workloads or when
-   you don't need atomic multi-statement operations.
+``manual`` (default)
+   SQLSpec manages connection lifecycle and cleanup at response completion, but leaves
+   transaction control to your application logic. Use this when handlers need explicit
+   commits or multi-step error recovery.
 
-**Manual Commit**
-   You control when to commit or rollback. Use this for write operations that must
-   succeed or fail together.
+``autocommit``
+   SQLSpec automatically commits transactions for successful HTTP responses (status
+   codes 200–299) and issues a rollback for client or server errors (status codes 400+)
+   or unhandled exceptions.
+
+``autocommit_include_redirect``
+   Extends ``autocommit`` behavior to also commit transactions when the response is a
+   redirect (status codes 200–399).
+
+Configure the commit mode under ``extension_config["litestar"]``:
 
 .. literalinclude:: /examples/frameworks/litestar/commit_modes.py
    :language: python
@@ -24,31 +32,70 @@ Commit Modes
    :dedent: 4
    :no-upgrade:
 
-Rollback on Error
------------------
+Custom Status Codes
+-------------------
 
-In manual mode, uncaught exceptions trigger an automatic rollback before the response
-is sent. This keeps your database consistent when handlers fail.
+You can customize which HTTP statuses trigger commits or rollbacks using
+``extra_commit_statuses`` and ``extra_rollback_statuses``:
 
 .. code-block:: python
 
+   from sqlspec.adapters.asyncpg import AsyncpgConfig
+
+   config = AsyncpgConfig(
+       connection_config={"dsn": "postgresql://localhost/app"},
+       extension_config={
+           "litestar": {
+               "commit_mode": "autocommit",
+               "extra_rollback_statuses": {409},
+               "extra_commit_statuses": {207},
+           }
+       },
+   )
+
+Manual Transactions in Handlers
+-------------------------------
+
+In ``manual`` mode, handlers control transaction boundaries directly on the injected driver:
+
+.. code-block:: python
+
+   from litestar import post
+   from pydantic import BaseModel
+   from sqlspec.adapters.asyncpg import AsyncpgDriver
+
+
+   class TransferRequest(BaseModel):
+       from_account: int
+       to_account: int
+       amount: int
+
+
    @post("/transfer")
-   async def transfer(db: AsyncSession, data: TransferRequest) -> dict:
-       await db.execute(
+   async def transfer(db_session: AsyncpgDriver, data: TransferRequest) -> dict[str, str]:
+       await db_session.execute(
            "UPDATE accounts SET balance = balance - :amount WHERE id = :from_id",
            amount=data.amount,
            from_id=data.from_account,
        )
-       await db.execute(
+       await db_session.execute(
            "UPDATE accounts SET balance = balance + :amount WHERE id = :to_id",
            amount=data.amount,
            to_id=data.to_account,
        )
-       await db.commit()  # Both updates succeed or both rollback
+       await db_session.commit()
        return {"status": "transferred"}
 
-Nested Transactions
--------------------
+Savepoints
+----------
 
-Use savepoints for nested transaction scopes. SQLSpec translates ``begin_nested()``
-to savepoints on databases that support them.
+SQLSpec drivers provide explicit savepoint management within active transactions:
+
+.. code-block:: python
+
+   await db_session.create_savepoint("sp1")
+   try:
+       await db_session.execute("INSERT INTO audit_log (event) VALUES (:event)", event="processed")
+       await db_session.release_savepoint("sp1")
+   except Exception:
+       await db_session.rollback_to_savepoint("sp1")

--- a/docs/usage/frameworks/starlette.rst
+++ b/docs/usage/frameworks/starlette.rst
@@ -4,7 +4,7 @@ Starlette
 
 SQLSpec provides a Starlette extension that hooks database sessions into the ASGI
 lifecycle. The extension uses Starlette's lifespan context to manage connection pools
-and provides middleware for request-scoped sessions.
+and provides middleware for request-scoped sessions and transactions.
 
 Installation
 ============
@@ -40,8 +40,9 @@ Install SQLSpec with the Starlette extra:
 Basic Setup
 ===========
 
-Create a SQLSpec instance, register your database config, and attach the plugin to your
-Starlette app. The plugin adds middleware that makes sessions available during each request.
+Create a SQLSpec instance, register your database config, and attach ``SQLSpecPlugin``
+to your Starlette app. The plugin adds lifespan handlers to manage pools and middleware
+for request sessions.
 
 .. literalinclude:: /examples/frameworks/starlette/basic_setup.py
    :language: python
@@ -51,24 +52,70 @@ Starlette app. The plugin adds middleware that makes sessions available during e
    :dedent: 4
    :no-upgrade:
 
-Key Concepts
-============
+Transaction Modes
+=================
 
-**Lifespan Management**
-   The plugin registers startup and shutdown handlers to initialize and close connection
-   pools. Pools are created when the application starts and released when it stops.
+Configure the commit mode under ``extension_config["starlette"]``:
 
-**Async Sessions**
-   Starlette is async-first. Use async adapters like ``AiosqliteConfig``, ``AsyncpgConfig``,
-   or ``PsycopgAsyncConfig`` for optimal performance.
+``manual`` (default)
+   SQLSpec manages the connection lifecycle and closes connections before completing
+   the request, leaving commits and rollbacks to your route handlers.
 
-**Request State**
-   Sessions are stored in ``request.state`` and can be accessed in route handlers or
-   middleware that runs after the SQLSpec middleware.
+``autocommit``
+   SQLSpec commits transactions for successful 2xx responses and rolls back on 4xx/5xx
+   responses or unhandled exceptions.
+
+``autocommit_include_redirect``
+   Extends autocommit to commit transactions on redirect responses (2xx and 3xx).
+
+.. code-block:: python
+
+   from sqlspec.adapters.aiosqlite import AiosqliteConfig
+
+   config = AiosqliteConfig(
+       connection_config={"database": "app.db"},
+       extension_config={
+           "starlette": {
+               "commit_mode": "autocommit",
+               "extra_rollback_statuses": {409},
+               "session_key": "db",
+           }
+       },
+   )
+
+Multiple Databases
+==================
+
+For multiple databases, configure each config with unique ``session_key``,
+``connection_key``, and ``pool_key`` settings. Retrieve sessions by key:
+
+.. literalinclude:: /examples/frameworks/starlette/multi_database.py
+   :language: python
+   :caption: ``starlette multi database``
+   :start-after: # start-example
+   :end-before: # end-example
+   :dedent: 4
+   :no-upgrade:
+
+Request and App Access
+======================
+
+The plugin provides methods to access sessions, connections, and pools:
+
+- ``db_plugin.get_session(request, key=None)``: Returns the request-scoped driver session.
+- ``db_plugin.get_connection(request, key=None)``: Returns the underlying database connection.
+- ``db_plugin.get_pool(app, key=None)``: Returns the application connection pool from ``app.state``.
+
+disable_di
+==========
+
+Set ``disable_di=True`` when an external dependency injection framework (such as Dishka)
+manages request-scoped connections. SQLSpec still initializes and cleans up pools via
+Starlette lifespan, but omits request-scoped session middleware.
 
 Related Guides
 ==============
 
 - :doc:`/usage/configuration` for detailed config options.
 - :doc:`/reference/adapters` for adapter-specific settings.
-- :doc:`fastapi` shares the same underlying integration patterns.
+- :doc:`fastapi` extends this Starlette foundation with FastAPI dependency injection.

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -90,6 +90,12 @@ Choose a topic
 
       Move data between databases with Arrow-based bulk transfer.
 
+   .. grid-item-card:: Bulk Ingest
+      :link: bulk_ingest
+      :link-type: doc
+
+      High-volume data writes using native database bulk loaders.
+
    .. grid-item-card:: Performance Tuning
       :link: performance
       :link-type: doc

--- a/docs/usage/migrations.rst
+++ b/docs/usage/migrations.rst
@@ -106,11 +106,22 @@ Migrations can also be driven in process:
 
 .. code-block:: python
 
+    # Apply all pending migrations (head)
     config.migrate_up()
+
+    # Apply up to a specific revision
     config.migrate_up(revision="003")
+
+    # Dry-run migration execution
     config.migrate_up(dry_run=True)
 
-For async configurations, ``migrate_up()`` returns an awaitable:
+    # Revert the last migration step
+    config.migrate_down()
+
+    # Revert back to a specific revision (or "base" for all)
+    config.migrate_down(revision="base")
+
+For async configurations, ``migrate_up()`` and ``migrate_down()`` return awaitables:
 
 .. code-block:: python
 
@@ -122,6 +133,7 @@ For async configurations, ``migrate_up()`` returns an awaitable:
     )
 
     await config.migrate_up()
+    await config.migrate_down(revision="-1")
 
 Common keys
 ~~~~~~~~~~~
@@ -398,13 +410,107 @@ finds nothing to do:
             return []
         return ["ALTER TABLE orders ADD COLUMN audited_at TIMESTAMP"]
 
-The same holds for ``down()``: an empty list reverses nothing and removes the
-tracking record. Omitting ``down()`` entirely is different -- it marks the
-migration irreversible, and a downgrade skips it with a warning rather than
-removing its record.
+Programmatic Migration Runner
+-----------------------------
+
+In addition to ``config.migrate_up()``, SQLSpec provides lower-level migration command
+interfaces via ``create_migration_commands(config)`` or ``config.get_migration_commands()``:
+
+.. code-block:: python
+
+    from sqlspec.migrations.commands import create_migration_commands
+
+    commands = create_migration_commands(config)
+
+    # Sync configs: direct execution
+    commands.init("migrations", package=True)
+    commands.revision("add products table", file_type="sql")
+    commands.upgrade(revision="head")
+    current_rev = commands.current(verbose=True)
+    commands.stamp("0003")
+
+For async configurations, `create_migration_commands` returns an `AsyncMigrationCommands`
+instance where operations like `init()`, `upgrade()`, and `downgrade()` are awaitable.
+
+Squashing Migrations
+--------------------
+
+Over time, long migration histories can slow down fresh database provisioning and test
+initialization. SQLSpec can squash a contiguous range of sequential migrations into a
+single consolidated migration file:
+
+.. code-block:: console
+
+    # Squash revisions 0001 through 0007 into a single migration
+    sqlspec squash 1:7 -m "squash initial schema" --dry-run
+    sqlspec squash 1:7 -m "squash initial schema" --yes
+
+In Python:
+
+.. code-block:: python
+
+    commands.squash(
+        start_version="0001",
+        end_version="0007",
+        description="squash initial schema",
+        output_format="sql",  # or "py"
+        dry_run=False,
+    )
+
+The squashed migration combines the SQL statements, updates tracker records, and safely
+removes the intermediate files. Use ``--allow-gaps`` if migrations contain gaps in their
+version numbers.
+
+Fixing Timestamp Migrations
+---------------------------
+
+If your project began with timestamp-based migration names (e.g.,
+``20240101120000_create_users.sql``), use the ``fix`` command to convert them to
+deterministic sequential format (``0001_create_users.sql``):
+
+.. code-block:: console
+
+    sqlspec fix --dry-run
+    sqlspec fix --yes
+
+This updates both the filenames on disk and the corresponding applied records in the
+database tracking table.
+
+Additive Schema Management
+--------------------------
+
+For microservices or applications requiring additive schema verification at startup without
+running full migration files, SQLSpec includes ``ensure_schema_sync`` and
+``ensure_schema_async``:
+
+.. code-block:: python
+
+    from sqlspec.migrations.schema import SchemaTarget, ensure_schema_sync
+    from sqlspec.builder import sql
+
+    # Define target table using SQLSpec builder
+    users_target = SchemaTarget(
+        table_name="users",
+        create_table=(
+            sql.create_table("users")
+            .column("id", "INTEGER", primary_key=True)
+            .column("email", "VARCHAR(255)", not_null=True, unique=True)
+            .column("created_at", "TIMESTAMP", default="CURRENT_TIMESTAMP")
+        ),
+    )
+
+    with config.provide_session() as driver:
+        result = ensure_schema_sync(
+            driver,
+            [users_target],
+            manage_schema=True,  # Discovers existing schema and creates missing tables/columns
+            create_schema=True,
+        )
+        print(f"Created tables: {result.created_tables}, Added columns: {result.added_columns}")
 
 Output and Logging
 ------------------
+
 
 Control output with ``migration_config`` keys or their CLI equivalents:
 

--- a/docs/usage/observability.rst
+++ b/docs/usage/observability.rst
@@ -8,8 +8,8 @@ track request correlations, and gather metrics on query duration and rows affect
 Instrumentation
 ---------------
 
-To enable observability features, you typically wrap or extend your base configuration.
-SQLSpec provides helper functions in `sqlspec.extensions` to make this easier.
+To enable observability features, you can attach an :class:`~sqlspec.observability.ObservabilityConfig`
+to your database configuration or SQLSpec instance, or declare settings via ``extension_config``.
 
 Custom Statement Observers
 --------------------------
@@ -42,61 +42,151 @@ every SQL execution. Custom observers conform to the public
 OpenTelemetry Tracing
 ---------------------
 
-SQLSpec can automatically generate OpenTelemetry spans for every SQL query. This is useful
-for distributed tracing and performance bottlenecks analysis.
+SQLSpec can automatically generate OpenTelemetry spans for every SQL query and migration command.
+This enables end-to-end distributed tracing across microservices and storage operations.
 
-To enable tracing, use the ``enable_tracing`` helper:
+To enable tracing programmatically, use the ``enable_tracing`` helper:
 
 .. code-block:: python
 
     from sqlspec.extensions.otel import enable_tracing
-    from sqlspec.config import ObservabilityConfig
+    from sqlspec.observability import ObservabilityConfig
 
     # Create a configuration with tracing enabled
     observability = enable_tracing(
         base_config=ObservabilityConfig(),
-        resource_attributes={"service.name": "my-service"}
+        resource_attributes={"service.name": "my-service"},
+        enable_spans=True,
     )
 
-    # Use this config when initializing SQLSpec or your session
-    # ...
+    # Attach to database configuration
+    config = AsyncpgConfig(
+        connection_config={"dsn": "postgresql://localhost/app"},
+        observability_config=observability,
+    )
 
-This will create spans with attributes like:
-- ``db.system`` (e.g., "postgresql", "sqlite")
+Alternatively, configure OpenTelemetry declaratively via ``extension_config``:
+
+.. code-block:: python
+
+    config = AsyncpgConfig(
+        connection_config={"dsn": "postgresql://localhost/app"},
+        extension_config={
+            "otel": {
+                "enabled": True,
+                "resource_attributes": {"service.name": "my-service"},
+                "enable_spans": True,
+            }
+        },
+    )
+
+Generated spans include standard semantic attributes:
+- ``db.system`` (e.g., "postgresql", "sqlite", "duckdb")
 - ``db.statement`` (the sanitized SQL query)
-- ``db.operation`` (e.g., "SELECT", "INSERT")
+- ``db.operation`` (e.g., "SELECT", "INSERT", "UPDATE")
+- Migration command spans under ``command.upgrade``, ``command.downgrade``, etc.
 
 Prometheus Metrics
 ------------------
 
-You can expose Prometheus metrics for your database interactions, such as query counts
-and execution time histograms.
+Expose Prometheus metrics for queries, execution duration histograms, and affected row counts.
 
-To enable metrics, use the ``enable_metrics`` helper:
+To enable metrics programmatically, use the ``enable_metrics`` helper:
 
 .. code-block:: python
 
     from sqlspec.extensions.prometheus import enable_metrics
-    from sqlspec.config import ObservabilityConfig
+    from sqlspec.observability import ObservabilityConfig
 
     # Enable Prometheus metrics
     observability = enable_metrics(
         base_config=ObservabilityConfig(),
-        namespace="myapp_sql",  # Prefix for metrics
-        label_names=("db_system", "operation")
+        namespace="myapp_sql",       # Metric prefix (default: 'sqlspec')
+        subsystem="driver",          # Metric subsystem (default: 'driver')
+        label_names=("db_system", "operation"),
     )
 
-    # Use this config...
+Or declaratively via ``extension_config``:
 
-Metrics exposed:
-- ``myapp_sql_query_total``: Counter of executed queries.
-- ``myapp_sql_query_duration_seconds``: Histogram of execution duration.
-- ``myapp_sql_query_rows``: Histogram of rows affected.
+.. code-block:: python
+
+    config = AsyncpgConfig(
+        connection_config={"dsn": "postgresql://localhost/app"},
+        extension_config={
+            "prometheus": {
+                "enabled": True,
+                "namespace": "myapp_sql",
+                "subsystem": "driver",
+                "label_names": ("db_system", "operation"),
+            }
+        },
+    )
+
+Exposed metrics:
+- ``{namespace}_{subsystem}_query_total``: Counter of executed queries.
+- ``{namespace}_{subsystem}_query_duration_seconds``: Histogram of execution duration.
+- ``{namespace}_{subsystem}_query_rows``: Histogram of rows affected.
+
+Pass ``subsystem=""`` if you wish to omit the subsystem prefix (e.g., ``myapp_sql_query_total``).
 
 OpenTelemetry tracing is span-based and does not register a statement observer.
 Use ``statement_observers`` for callback-style integrations such as metrics,
 audit sinks, or custom log emission; use ``TelemetryConfig`` or
 ``enable_tracing()`` for OpenTelemetry spans.
+
+Lifecycle Hooks
+---------------
+
+Lifecycle hooks allow applications to intercept connection pool events, session lifecycles,
+and statement execution phases:
+
+.. code-block:: python
+
+    from sqlspec.observability import ObservabilityConfig
+
+    def on_connection_created(connection: object) -> None:
+        print(f"New connection established: {connection}")
+
+    def on_query_start(sql: str, params: dict) -> None:
+        print(f"Starting execution: {sql}")
+
+    def on_query_error(error: Exception, sql: str, params: dict) -> None:
+        print(f"Query error occurred: {error} in {sql}")
+
+    observability = ObservabilityConfig(
+        lifecycle={
+            "on_connection_create": [on_connection_created],
+            "on_query_start": [on_query_start],
+            "on_error": [on_query_error],
+        }
+    )
+
+Supported lifecycle hooks include:
+
+- ``on_connection_create`` / ``on_connection_destroy``: Connection lifecycle events.
+- ``on_pool_create`` / ``on_pool_destroying`` / ``on_pool_destroy``: Pool lifecycle events.
+- ``on_session_start`` / ``on_session_end``: Session boundary events.
+- ``on_query_start``: Invoked before statement execution with ``(sql, params)``.
+- ``on_query_complete``: Invoked after successful statement execution with ``(sql, params, result)``.
+- ``on_error``: Invoked on execution failure with ``(exception, sql, params)``.
+
+Data Redaction
+--------------
+
+Sensitive parameter and literal masking can be configured via :class:`~sqlspec.observability.RedactionConfig`:
+
+.. code-block:: python
+
+    from sqlspec.observability import ObservabilityConfig, RedactionConfig
+
+    observability = ObservabilityConfig(
+        redaction=RedactionConfig(
+            mask_parameters=True,
+            mask_literals=True,
+            parameter_allow_list=("user_id", "status"),
+        )
+    )
+
 
 SQLCommenter
 ------------

--- a/docs/usage/performance.rst
+++ b/docs/usage/performance.rst
@@ -43,6 +43,32 @@ The checked-in baseline snapshots themselves are interpreted/uncompiled only
 (``metadata.mypyc_compiled`` is ``false``); they are not compiled-performance
 references.
 
+To benchmark custom driver scenarios directly:
+
+.. code-block:: bash
+
+   # Run a targeted benchmark scenario
+   uv run python tools/scripts/bench.py --driver asyncpg --library sqlspec --scenario read_heavy --iterations 5
+
+   # Run the performance regression gate with custom row counts
+   uv run python tools/scripts/bench_gate.py --rows 5000 --iterations 5
+
+Compiled Execution (MyPyC)
+==========================
+
+For production deployments, SQLSpec supports native compilation via MyPyC for
+significant CPU overhead reduction across statement compilation, parameter processing,
+and result mapping:
+
+.. code-block:: bash
+
+   # Build editable compiled install
+   make install-compiled
+
+   # Build distribution wheel with compiled C-extensions
+   make build-performance
+
+
 Async bridge executor limits
 ============================
 

--- a/docs/usage/query_builder.rst
+++ b/docs/usage/query_builder.rst
@@ -92,5 +92,6 @@ Query Modifiers
 Related Guides
 --------------
 
-- :doc:`drivers_and_querying` for execution behavior.
-- :doc:`../reference/builder` for the full builder API.
+- :doc:`drivers_and_querying` for execution behavior and transaction management.
+- :doc:`filtering` for filter types, order by, and pagination helpers.
+- :doc:`/reference/builder/index` for the full query builder, DDL, and expression API reference.

--- a/docs/usage/sql_files.rst
+++ b/docs/usage/sql_files.rst
@@ -301,3 +301,10 @@ How Query Names Work
 - Add ``-- dialect: postgres`` on the first line of a block to bind SQL to a dialect.
 - Declare parameters with ``-- param: <name> <type>[?] [description]`` (see `Declared Parameters`_).
 - Directory structures become namespaces when you load directories (``reports/daily.sql`` -> ``reports.<query>``).
+
+Related Guides
+--------------
+
+- :doc:`drivers_and_querying` for query execution and transaction patterns.
+- :doc:`query_builder` for programmatic SQL construction and chaining.
+- :doc:`/reference/loader` for the ``SQLFileLoader`` reference documentation.

--- a/docs/usage/testing.rst
+++ b/docs/usage/testing.rst
@@ -1,16 +1,17 @@
 Testing
 =======
 
-SQLSpec provides tools for both unit and integration testing of database code.
+SQLSpec provides comprehensive support for both fast in-memory unit tests and containerized
+integration testing against real database engines.
 
-Pytest Fixture Tips
--------------------
+Unit Testing with SQLite
+------------------------
 
-- Use ``tmp_path`` (pytest built-in) for SQLite file databases
-- Use ``:memory:`` for fast in-memory tests
-- Create factory functions for reusable test setup
-- Use ``execute_many`` for bulk fixture data
-- Use ``select_value`` for assertion checks on counts
+For fast unit tests without external service dependencies, SQLite in-memory (``:memory:``)
+or temporary file databases via pytest's ``tmp_path`` fixture are recommended.
+
+Fast In-Memory Fixture
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
 
@@ -19,28 +20,169 @@ Pytest Fixture Tips
     from sqlspec.adapters.sqlite import SqliteConfig
 
     @pytest.fixture
-    def db(tmp_path):
+    def db_session():
+        spec = SQLSpec()
+        config = spec.add_config(
+            SqliteConfig(connection_config={"database": ":memory:"})
+        )
+        with spec.provide_session(config) as session:
+            session.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)")
+            yield session
+        config.close_pool()
+
+Temporary File Fixture
+~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``tmp_path`` when testing multi-connection scenarios, migrations, or file-backed storage:
+
+.. code-block:: python
+
+    from pathlib import Path
+    import pytest
+    from sqlspec import SQLSpec
+    from sqlspec.adapters.sqlite import SqliteConfig
+
+    @pytest.fixture
+    def db_config(tmp_path: Path) -> SqliteConfig:
         spec = SQLSpec()
         config = spec.add_config(
             SqliteConfig(connection_config={"database": str(tmp_path / "test.db")})
         )
         with spec.provide_session(config) as session:
-            session.execute("create table users (id integer primary key, name text)")
+            session.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+            session.execute_many(
+                "INSERT INTO users (name) VALUES (?)",
+                [("Alice",), ("Bob",)],
+            )
+        yield config
+        config.close_pool()
+
+    def test_get_users(db_config: SqliteConfig) -> None:
+        with db_config.provide_session() as session:
+            count = session.select_value("SELECT COUNT(*) FROM users")
+            assert count == 2
+
+Integration Testing with ``pytest-databases``
+---------------------------------------------
+
+For integration testing against production-grade database systems, SQLSpec integrates
+directly with `pytest-databases <https://github.com/litestar-org/pytest-databases>`_.
+``pytest-databases`` provisions and manages Docker containers for database engines and
+handles database isolation across parallel ``pytest-xdist`` workers.
+
+Supported Database Services
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``pytest-databases`` provides managed Docker fixtures for:
+
+- ``PostgresService`` (PostgreSQL, pgvector, ParadeDB)
+- ``MySQLService`` (MySQL, MariaDB)
+- ``OracleService`` (Oracle Free / Express)
+- ``MSSQLService`` (Microsoft SQL Server)
+- ``BigQueryService`` (Google Cloud BigQuery emulator)
+- ``SpannerService`` (Google Cloud Spanner emulator)
+- ``CockroachDBService`` (CockroachDB)
+- ``RustfsService`` (S3 / cloud blob storage emulator)
+
+PostgreSQL Integration Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Install ``pytest-databases`` with PostgreSQL support:
+
+.. code-block:: console
+
+    uv add --dev "pytest-databases[postgres]"
+
+Configure your pytest fixtures using the provided service fixture:
+
+.. code-block:: python
+
+    from collections.abc import AsyncGenerator
+    import pytest
+    from pytest_databases.docker.postgres import PostgresService
+    from sqlspec.adapters.asyncpg import AsyncpgConfig, AsyncpgDriver
+
+    @pytest.fixture
+    def asyncpg_config(postgres_service: PostgresService) -> AsyncpgConfig:
+        """Create an AsyncpgConfig connected to the containerized test database."""
+        return AsyncpgConfig(
+            connection_config={
+                "host": postgres_service.host,
+                "port": postgres_service.port,
+                "user": postgres_service.user,
+                "password": postgres_service.password,
+                "database": postgres_service.database,
+            }
+        )
+
+    @pytest.fixture
+    async def db_session(asyncpg_config: AsyncpgConfig) -> AsyncGenerator[AsyncpgDriver, None]:
+        """Provide an active session with automatic pool teardown."""
+        async with asyncpg_config.provide_session() as session:
+            await session.execute(
+                "CREATE TABLE IF NOT EXISTS items (id SERIAL PRIMARY KEY, title TEXT NOT NULL)"
+            )
             yield session
+        await asyncpg_config.close_pool()
 
-Integration Test Patterns
--------------------------
+    async def test_insert_and_fetch_item(db_session: AsyncpgDriver) -> None:
+        result = await db_session.execute(
+            "INSERT INTO items (title) VALUES (:title) RETURNING id",
+            title="Widget",
+        )
+        item_id = result.last_inserted_id
+        assert item_id is not None
 
-For integration tests against real databases, use the standard ``SQLSpec`` +
-adapter config pattern with temporary databases.
+        item = await db_session.select_one("SELECT title FROM items WHERE id = :id", id=item_id)
+        assert item["title"] == "Widget"
 
-.. literalinclude:: /examples/patterns/integration_testing.py
-   :language: python
-   :caption: ``integration test fixtures``
-   :start-after: # start-example
-   :end-before: # end-example
-   :dedent: 4
-   :no-upgrade:
+Running Migrations in Test Fixtures
+-----------------------------------
+
+When testing against real databases, use ``migrate_up()`` to initialize the schema before tests:
+
+.. code-block:: python
+
+    @pytest.fixture
+    async def migrated_config(postgres_service: PostgresService) -> AsyncGenerator[AsyncpgConfig, None]:
+        config = AsyncpgConfig(
+            connection_config={
+                "host": postgres_service.host,
+                "port": postgres_service.port,
+                "user": postgres_service.user,
+                "password": postgres_service.password,
+                "database": postgres_service.database,
+            },
+            migration_config={
+                "script_location": "migrations/postgres",
+            },
+        )
+        # Apply all migrations up to head
+        await config.migrate_up()
+
+        yield config
+
+        # Teardown connection pool
+        await config.close_pool()
+
+Parallel Testing with ``pytest-xdist``
+--------------------------------------
+
+``pytest-databases`` automatically allocates unique database names or schemas per xdist
+worker process, preventing tests from colliding when running in parallel:
+
+.. code-block:: console
+
+    # Run tests in parallel across CPU cores
+    uv run pytest -n auto
+
+Testing Best Practices
+----------------------
+
+1. **Always clean up connection pools**: Call ``config.close_pool()`` or ``await config.close_pool()`` in fixture teardown to prevent hanging database connections.
+2. **Use function-based tests**: Write asynchronous tests using ``async def test_...`` without wrapping them in test classes.
+3. **Assert with ``select_value``**: For aggregate queries like counts, use ``session.select_value("SELECT COUNT(*)...")`` to retrieve scalar values directly.
+4. **Bulk test seeding**: Seed test datasets efficiently with ``session.execute_many()`` or native ``driver.load_from_records()``.
 
 Table Fixtures
 --------------
@@ -171,5 +313,7 @@ arguments with an async driver.
 Related Guides
 --------------
 
-- :doc:`configuration` for adapter configuration options.
-- :doc:`drivers_and_querying` for the full query API.
+- :doc:`configuration` for full adapter configuration options.
+- :doc:`drivers_and_querying` for querying and transaction APIs.
+- :doc:`migrations` for migration execution and schema tracking.
+- :doc:`bulk_ingest` for high-volume data loading in tests.

--- a/docs/usage/testing.rst
+++ b/docs/usage/testing.rst
@@ -216,10 +216,39 @@ memory, so these helpers suit fixture-sized data rather than bulk transfers.
         )
         session.commit()
 
-        export_table_fixtures_sync(session, fixtures, ["users", "posts"], compress=True)
+        export_table_fixtures_sync(session, fixtures, tables=["users", "posts"], compress=True)
 
-``load_table_fixtures_async`` and ``export_table_fixtures_async`` take the same
-arguments with an async driver.
+``load_table_fixtures_async`` and ``export_table_fixtures_async`` provide identical
+functionality for asynchronous drivers:
+
+.. code-block:: python
+
+    from pathlib import Path
+    import pytest
+    from sqlspec.adapters.asyncpg import AsyncpgDriver
+    from sqlspec.utils.fixtures import export_table_fixtures_async, load_table_fixtures_async
+
+    fixtures = Path("tests/fixtures/tables")
+
+    @pytest.fixture
+    async def seeded_session(db_session: AsyncpgDriver) -> AsyncpgDriver:
+        await load_table_fixtures_async(
+            db_session,
+            fixtures,
+            table_order=["users", "posts"],
+            conflict_keys={"users": ["id"]},
+            resync_sequences=True,
+        )
+        await db_session.commit()
+        return db_session
+
+    async def test_export_fixtures(db_session: AsyncpgDriver) -> None:
+        await export_table_fixtures_async(
+            db_session,
+            fixtures,
+            tables=["users", "posts"],
+            compress=True,
+        )
 
 - **Which tables load:** every table fixture file in the directory, or only the
   names passed as ``tables``. Files whose names are not table identifiers are
@@ -317,3 +346,4 @@ Related Guides
 - :doc:`drivers_and_querying` for querying and transaction APIs.
 - :doc:`migrations` for migration execution and schema tracking.
 - :doc:`bulk_ingest` for high-volume data loading in tests.
+- :doc:`/reference/utils` for fixture utility function signatures and API reference.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ maintainers = [{ name = "Litestar Developers", email = "hello@litestar.dev" }]
 name = "sqlspec"
 readme = "README.md"
 requires-python = ">=3.10, <4.0"
-version = "0.62.2"
+version = "0.63.0"
 
 [project.urls]
 Discord = "https://discord.gg/litestar"
@@ -330,7 +330,7 @@ opt_level = "3"   # Maximum optimization (0-3)
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.62.2"
+current_version = "0.63.0"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to v{new_version}"

--- a/sqlspec/adapters/adbc/config.py
+++ b/sqlspec/adapters/adbc/config.py
@@ -81,20 +81,20 @@ class AdbcDriverFeatures(TypedDict):
     Attributes:
         json_serializer: JSON serialization function to use.
             Callable that takes Any and returns str (JSON string).
-        Default: sqlspec.utils.serializers.to_json
+            Default: sqlspec.utils.serializers.to_json
         enable_cast_detection: Enable cast-aware parameter processing.
             When True, detects SQL casts and applies appropriate
             serialization. Currently used for PostgreSQL JSONB handling.
-        Default: True
+            Default: True
         enable_strict_type_coercion: Enforce strict type coercion rules.
             When True, raises errors for unsupported type conversions.
             When False, attempts best-effort conversion.
-        Default: False
+            Default: False
         strict_type_coercion: Alias for enable_strict_type_coercion.
         enable_arrow_extension_types: Enable PyArrow extension type support.
             When True, preserves Arrow extension type metadata when reading data.
             When False, falls back to storage types.
-        Default: True
+            Default: True
         arrow_extension_types: Alias for enable_arrow_extension_types.
         enable_pgvector: Enable automatic pgvector extension detection.
             When True and the resolved dialect is PostgreSQL, queries ``pg_extension``
@@ -111,7 +111,7 @@ class AdbcDriverFeatures(TypedDict):
         on_connection_create: Callback executed when a connection is created.
             Receives the raw ADBC connection for low-level driver configuration.
         events_backend: Event channel backend selection.
-        Only option: "poll_queue" (durable table-backed queue with lease-based retries and acknowledgements).
+            Only option: "poll_queue" (durable table-backed queue with lease-based retries and acknowledgements).
             ADBC does not have native pub/sub, so poll_queue is the only backend.
             Defaults to "poll_queue".
     """

--- a/sqlspec/adapters/bigquery/litestar/store.py
+++ b/sqlspec/adapters/bigquery/litestar/store.py
@@ -201,7 +201,7 @@ class BigQueryStore(BaseSQLSpecStore["BigQueryConfig"]):
         """
 
         with self._config.provide_session() as driver:
-            result = driver.select_one(sql, {"session_id": key})
+            result = driver.select_one(sql, session_id=key)
 
             if result is None:
                 return None
@@ -218,7 +218,7 @@ class BigQueryStore(BaseSQLSpecStore["BigQueryConfig"]):
                     SET expires_at = @expires_at
                     WHERE session_id = @session_id
                     """
-                    driver.execute(update_sql, {"expires_at": new_expires_at_ts, "session_id": key})
+                    driver.execute(update_sql, expires_at=new_expires_at_ts, session_id=key)
 
             return bytes(data) if data is not None else None
 
@@ -240,14 +240,14 @@ class BigQueryStore(BaseSQLSpecStore["BigQueryConfig"]):
         """
 
         with self._config.provide_session() as driver:
-            driver.execute(sql, {"session_id": key, "data": data, "expires_at": expires_at_ts})
+            driver.execute(sql, session_id=key, data=data, expires_at=expires_at_ts)
 
     def _delete(self, key: str) -> None:
         """Synchronous implementation of delete."""
         sql = f"DELETE FROM {self._table_name} WHERE session_id = @session_id"
 
         with self._config.provide_session() as driver:
-            driver.execute(sql, {"session_id": key})
+            driver.execute(sql, session_id=key)
 
     def _delete_all(self) -> None:
         """Synchronous implementation of delete_all."""
@@ -267,7 +267,7 @@ class BigQueryStore(BaseSQLSpecStore["BigQueryConfig"]):
         """
 
         with self._config.provide_session() as driver:
-            result = driver.select_one(sql, {"session_id": key})
+            result = driver.select_one(sql, session_id=key)
             return result is not None
 
     def _expires_in(self, key: str) -> "int | None":
@@ -278,7 +278,7 @@ class BigQueryStore(BaseSQLSpecStore["BigQueryConfig"]):
         """
 
         with self._config.provide_session() as driver:
-            result = driver.select_one(sql, {"session_id": key})
+            result = driver.select_one(sql, session_id=key)
 
             if result is None:
                 return None

--- a/sqlspec/adapters/mysqlconnector/_typing.py
+++ b/sqlspec/adapters/mysqlconnector/_typing.py
@@ -12,12 +12,8 @@ import mysql.connector as _mysql_connector
 from mysql.connector import MySQLConnection as _MysqlConnectorSyncConnection
 from mysql.connector import aio as _mysql_connector_aio
 from mysql.connector import pooling as _mysql_connector_pooling
-from mysql.connector.aio import (
-    MySQLConnection as _MysqlConnectorAsyncConnection,  # pyright: ignore[reportMissingImports]
-)
-from mysql.connector.aio.cursor import (
-    MySQLCursor as _MysqlConnectorAsyncRawCursor,  # pyright: ignore[reportMissingImports]
-)
+from mysql.connector.aio import MySQLConnection as _MysqlConnectorAsyncConnection  # pyright: ignore[reportMissingImports]
+from mysql.connector.aio.cursor import MySQLCursor as _MysqlConnectorAsyncRawCursor  # pyright: ignore[reportMissingImports]
 from mysql.connector.constants import FieldType as _MysqlConnectorFieldType
 from mysql.connector.cursor import MySQLCursor as _MysqlConnectorSyncRawCursor
 

--- a/sqlspec/adapters/oracledb/type_converter.py
+++ b/sqlspec/adapters/oracledb/type_converter.py
@@ -54,9 +54,7 @@ class OracleOutputConverter:
             return value
 
         if isinstance(value, array.array):
-            from sqlspec.adapters.oracledb._vector_handlers import (  # pyright: ignore[reportPrivateUsage]
-                numpy_converter_out,
-            )
+            from sqlspec.adapters.oracledb._vector_handlers import numpy_converter_out  # pyright: ignore[reportPrivateUsage]
 
             return numpy_converter_out(value)
 
@@ -81,9 +79,7 @@ class OracleOutputConverter:
         import numpy as np
 
         if isinstance(value, np.ndarray):
-            from sqlspec.adapters.oracledb._vector_handlers import (  # pyright: ignore[reportPrivateUsage]
-                numpy_converter_in,
-            )
+            from sqlspec.adapters.oracledb._vector_handlers import numpy_converter_in  # pyright: ignore[reportPrivateUsage]
 
             return numpy_converter_in(value)
 

--- a/sqlspec/data_dictionary/_types.py
+++ b/sqlspec/data_dictionary/_types.py
@@ -1191,7 +1191,28 @@ class TableDetails(ObjectMetadata):
 
 
 class ColumnMetadata(TypedDict, total=False):
-    """Metadata for a database column."""
+    """Metadata for a database column.
+
+    Attributes:
+        schema_name: Schema containing the table.
+        table_name: Table name.
+        column_name: Name of the column.
+        data_type: Dialect or canonical data type name.
+        is_nullable: Whether the column allows null values.
+        column_default: Default value expression or sequence default.
+        ordinal_position: 1-based column position in the table.
+        max_length: Maximum character or byte length.
+        numeric_precision: Numeric precision.
+        numeric_scale: Numeric scale.
+        is_primary: Whether the column is part of the primary key.
+        is_unique: Whether the column has a unique constraint.
+        extra: Dialect-specific extra column attributes.
+        column_type: Full column type specification (e.g. on MySQL).
+        column_key: Index key designation (e.g. MySQL ``PRI``, ``UNI``, ``MUL``).
+        identity_generation: Identity column generation type (``a`` for ALWAYS, ``d`` for BY DEFAULT).
+        sequence_name: Name of the sequence owned by a serial or identity column.
+        is_generated: Whether the column is a generated/computed column.
+    """
 
     schema_name: str
     table_name: str

--- a/sqlspec/driver/_async.py
+++ b/sqlspec/driver/_async.py
@@ -544,7 +544,7 @@ class AsyncDriverAdapterBase(CommonDriverAttributesMixin):
 
                 async with session.transaction():
                     await session.execute(
-                        "INSERT INTO items (id) VALUES (?)", 1
+                        "INSERT INTO items (id) VALUES (:id)", id=1
                     )
 
         Returns:

--- a/sqlspec/driver/_common.py
+++ b/sqlspec/driver/_common.py
@@ -32,6 +32,7 @@ from sqlspec.core._pool import get_processed_state_pool, get_sql_pool
 from sqlspec.core.filters import find_filter as _find_filter_impl
 from sqlspec.core.metrics import StackExecutionMetrics
 from sqlspec.core.parameters import ParameterProcessor, structural_fingerprint, value_fingerprint
+from sqlspec.core.result._base import RowFormat
 from sqlspec.core.statement import ProcessedState
 from sqlspec.data_dictionary import (
     ForeignKeyMetadata,
@@ -84,7 +85,6 @@ if TYPE_CHECKING:
 
     from sqlspec.core import ArrowResult, FilterTypeT, StatementFilter
     from sqlspec.core.parameters._types import ConvertedParameters
-    from sqlspec.core.result._base import RowFormat
     from sqlspec.core.stack import StatementStack
     from sqlspec.data_dictionary._types import DialectConfig
     from sqlspec.storage import (
@@ -179,17 +179,17 @@ class ExecutionResult(NamedTuple):
     cursor_result: Any
     rowcount_override: int | None
     special_data: Any
-    selected_data: "list[Any] | None"
-    column_names: "list[str] | None"
+    selected_data: list[Any] | None
+    column_names: list[str] | None
     data_row_count: int | None
     statement_count: int | None
     successful_statements: int | None
     is_script_result: bool
     is_select_result: bool
     is_many_result: bool
-    row_format: "RowFormat" = "dict"
+    row_format: RowFormat = "dict"
     last_inserted_id: int | str | None = None
-    column_types: "dict[str, str] | None" = None
+    column_types: dict[str, str] | None = None
 
 
 def describe_stack_statement(statement: "StatementProtocol | str") -> str:

--- a/sqlspec/driver/_sync.py
+++ b/sqlspec/driver/_sync.py
@@ -563,7 +563,9 @@ class SyncDriverAdapterBase(CommonDriverAttributesMixin):
             .. code-block:: python
 
                 with session.transaction():
-                    session.execute("INSERT INTO items (id) VALUES (?)", 1)
+                    session.execute(
+                        "INSERT INTO items (id) VALUES (:id)", id=1
+                    )
 
         Returns:
             A context manager yielding this driver.

--- a/sqlspec/service.py
+++ b/sqlspec/service.py
@@ -412,6 +412,8 @@ class SQLSpecAsyncService(Generic[AsyncDriverT]):
     def begin_transaction(self) -> "_AsyncBeginTransactionContext[AsyncDriverT]":
         """Context manager that commits on success and rolls back on error.
 
+        Nested blocks run in a savepoint on the outer session.
+
         Returns:
             The underlying driver session bound to the active transaction.
         """
@@ -692,6 +694,8 @@ class SQLSpecSyncService(Generic[SyncDriverT]):
 
     def begin_transaction(self) -> "_SyncBeginTransactionContext[SyncDriverT]":
         """Context manager that commits on success and rolls back on error.
+
+        Nested blocks run in a savepoint on the outer session.
 
         Returns:
             The underlying driver session bound to the active transaction.

--- a/tests/integration/adapters/_shared/behaviors.py
+++ b/tests/integration/adapters/_shared/behaviors.py
@@ -3920,7 +3920,7 @@ def _bigquery_param_codecs(driver: object, case: DriverCase) -> None:
     sync_driver = cast("SyncContractDriver", driver)
 
     with pytest.raises(SQLSpecError, match="Cannot determine BigQuery ARRAY type"):
-        sync_driver.execute("SELECT ARRAY_LENGTH(@values)", {"values": []})
+        sync_driver.execute("SELECT ARRAY_LENGTH(@values)", values=[])
 
 
 register_sync_extra_assertion("param_codecs:bigquery", PARAM_CODECS_SCOPE, _bigquery_param_codecs)

--- a/tests/integration/adapters/oracle/oracledb/test_json_storage_modes.py
+++ b/tests/integration/adapters/oracle/oracledb/test_json_storage_modes.py
@@ -42,7 +42,7 @@ async def test_native_json_round_trip_matrix(oracle_async_session: "OracleAsyncD
     try:
         for row_id, payload in enumerate(payloads, start=1):
             await oracle_async_session.execute(
-                f"INSERT INTO {table_name} (id, payload) VALUES (:id, :payload)", {"id": row_id, "payload": payload}
+                f"INSERT INTO {table_name} (id, payload) VALUES (:id, :payload)", id=row_id, payload=payload
             )
 
         rows = await oracle_async_session.select(f"SELECT id, payload FROM {table_name} ORDER BY id")
@@ -69,7 +69,7 @@ async def test_blob_is_json_round_trip_on_oracle_18c(oracle_18c_async_session: "
 
     try:
         await oracle_18c_async_session.execute(
-            f"INSERT INTO {table_name} (id, payload) VALUES (:id, :payload)", {"id": 1, "payload": direct_payload}
+            f"INSERT INTO {table_name} (id, payload) VALUES (:id, :payload)", id=1, payload=direct_payload
         )
         await oracle_18c_async_session.execute_many(
             f"INSERT INTO {table_name} (id, payload) VALUES (:id, :payload)",
@@ -97,11 +97,10 @@ async def test_clob_is_json_round_trip_on_oracle_18c(oracle_18c_async_session: "
 
     try:
         await oracle_18c_async_session.execute(
-            f"INSERT INTO {table_name} (id, payload) VALUES (:id, :payload)",
-            {"id": 1, "payload": OracleClob(to_json(payload))},
+            f"INSERT INTO {table_name} (id, payload) VALUES (:id, :payload)", id=1, payload=OracleClob(to_json(payload))
         )
 
-        row = await oracle_18c_async_session.select_one(f"SELECT payload FROM {table_name} WHERE id = :id", {"id": 1})
+        row = await oracle_18c_async_session.select_one(f"SELECT payload FROM {table_name} WHERE id = :id", id=1)
 
         assert row["payload"] == payload
         assert isinstance(row["payload"]["number"], float)

--- a/tests/integration/adapters/oracle/oracledb/test_smart_lob_coercion.py
+++ b/tests/integration/adapters/oracle/oracledb/test_smart_lob_coercion.py
@@ -55,11 +55,10 @@ async def test_oracle_clob_wrapper_round_trip(oracle_async_session: "OracleAsync
     )
     await oracle_async_session.execute_script("CREATE TABLE smart_lob_clob (id NUMBER PRIMARY KEY, content CLOB)")
     await oracle_async_session.execute(
-        "INSERT INTO smart_lob_clob (id, content) VALUES (:id, :content)",
-        {"id": 1, "content": OracleClob(_LARGE_CLOB_TEXT)},
+        "INSERT INTO smart_lob_clob (id, content) VALUES (:id, :content)", id=1, content=OracleClob(_LARGE_CLOB_TEXT)
     )
 
-    result = await oracle_async_session.execute("SELECT content FROM smart_lob_clob WHERE id = :id", {"id": 1})
+    result = await oracle_async_session.execute("SELECT content FROM smart_lob_clob WHERE id = :id", id=1)
     rows = result.get_data() if hasattr(result, "get_data") else result.data
     fetched = rows[0]
     value = fetched["content"] if isinstance(fetched, dict) else fetched[0]
@@ -74,10 +73,10 @@ async def test_oracle_blob_wrapper_round_trip(oracle_async_session: "OracleAsync
     )
     await oracle_async_session.execute_script("CREATE TABLE smart_lob_blob (id NUMBER PRIMARY KEY, data BLOB)")
     await oracle_async_session.execute(
-        "INSERT INTO smart_lob_blob (id, data) VALUES (:id, :data)", {"id": 1, "data": OracleBlob(_LARGE_BLOB_BYTES)}
+        "INSERT INTO smart_lob_blob (id, data) VALUES (:id, :data)", id=1, data=OracleBlob(_LARGE_BLOB_BYTES)
     )
 
-    result = await oracle_async_session.execute("SELECT data FROM smart_lob_blob WHERE id = :id", {"id": 1})
+    result = await oracle_async_session.execute("SELECT data FROM smart_lob_blob WHERE id = :id", id=1)
     rows = result.get_data() if hasattr(result, "get_data") else result.data
     fetched = rows[0]
     value = fetched["data"] if isinstance(fetched, dict) else fetched[0]
@@ -96,11 +95,10 @@ async def test_oracle_json_wrapper_native_round_trip(oracle_async_session: "Orac
     )
     await oracle_async_session.execute_script("CREATE TABLE smart_lob_json (id NUMBER PRIMARY KEY, payload JSON)")
     await oracle_async_session.execute(
-        "INSERT INTO smart_lob_json (id, payload) VALUES (:id, :payload)",
-        {"id": 1, "payload": OracleJson(_LARGE_JSON_PAYLOAD)},
+        "INSERT INTO smart_lob_json (id, payload) VALUES (:id, :payload)", id=1, payload=OracleJson(_LARGE_JSON_PAYLOAD)
     )
 
-    result = await oracle_async_session.execute("SELECT payload FROM smart_lob_json WHERE id = :id", {"id": 1})
+    result = await oracle_async_session.execute("SELECT payload FROM smart_lob_json WHERE id = :id", id=1)
     rows = result.get_data() if hasattr(result, "get_data") else result.data
     fetched = rows[0]
     payload = fetched["payload"] if isinstance(fetched, dict) else fetched[0]
@@ -133,10 +131,10 @@ async def test_threshold_override_keeps_string_as_varchar2(
             )
             payload = "y" * 5000
             await session.execute(
-                "INSERT INTO smart_lob_extended (id, content) VALUES (:id, :content)", {"id": 1, "content": payload}
+                "INSERT INTO smart_lob_extended (id, content) VALUES (:id, :content)", id=1, content=payload
             )
 
-            result = await session.execute("SELECT content FROM smart_lob_extended WHERE id = :id", {"id": 1})
+            result = await session.execute("SELECT content FROM smart_lob_extended WHERE id = :id", id=1)
             rows = result.get_data() if hasattr(result, "get_data") else result.data
             fetched = rows[0]
             value = fetched["content"] if isinstance(fetched, dict) else fetched[0]
@@ -167,12 +165,11 @@ async def test_json_bytes_payload_no_manual_createlob_needed(oracle_async_sessio
     assert isinstance(serialized, bytes)
 
     await oracle_async_session.execute(
-        "INSERT INTO smart_lob_json_bytes (id, payload) VALUES (:id, :payload)",
-        {"id": 1, "payload": OracleJson(payload)},
+        "INSERT INTO smart_lob_json_bytes (id, payload) VALUES (:id, :payload)", id=1, payload=OracleJson(payload)
     )
     del serialized
 
-    result = await oracle_async_session.execute("SELECT payload FROM smart_lob_json_bytes WHERE id = :id", {"id": 1})
+    result = await oracle_async_session.execute("SELECT payload FROM smart_lob_json_bytes WHERE id = :id", id=1)
     rows = result.get_data() if hasattr(result, "get_data") else result.data
     fetched = rows[0]
     value = fetched["payload"] if isinstance(fetched, dict) else fetched[0]
@@ -189,10 +186,11 @@ def test_oracle_clob_wrapper_round_trip_sync(oracle_sync_session: "OracleSyncDri
     oracle_sync_session.execute_script("CREATE TABLE smart_lob_clob_sync (id NUMBER PRIMARY KEY, content CLOB)")
     oracle_sync_session.execute(
         "INSERT INTO smart_lob_clob_sync (id, content) VALUES (:id, :content)",
-        {"id": 1, "content": OracleClob(_LARGE_CLOB_TEXT)},
+        id=1,
+        content=OracleClob(_LARGE_CLOB_TEXT),
     )
 
-    result = oracle_sync_session.execute("SELECT content FROM smart_lob_clob_sync WHERE id = :id", {"id": 1})
+    result = oracle_sync_session.execute("SELECT content FROM smart_lob_clob_sync WHERE id = :id", id=1)
     rows = result.get_data() if hasattr(result, "get_data") else result.data
     fetched = rows[0]
     value = fetched["content"] if isinstance(fetched, dict) else fetched[0]
@@ -207,11 +205,10 @@ def test_oracle_blob_wrapper_round_trip_sync(oracle_sync_session: "OracleSyncDri
     )
     oracle_sync_session.execute_script("CREATE TABLE smart_lob_blob_sync (id NUMBER PRIMARY KEY, data BLOB)")
     oracle_sync_session.execute(
-        "INSERT INTO smart_lob_blob_sync (id, data) VALUES (:id, :data)",
-        {"id": 1, "data": OracleBlob(_LARGE_BLOB_BYTES)},
+        "INSERT INTO smart_lob_blob_sync (id, data) VALUES (:id, :data)", id=1, data=OracleBlob(_LARGE_BLOB_BYTES)
     )
 
-    result = oracle_sync_session.execute("SELECT data FROM smart_lob_blob_sync WHERE id = :id", {"id": 1})
+    result = oracle_sync_session.execute("SELECT data FROM smart_lob_blob_sync WHERE id = :id", id=1)
     rows = result.get_data() if hasattr(result, "get_data") else result.data
     fetched = rows[0]
     value = fetched["data"] if isinstance(fetched, dict) else fetched[0]

--- a/tests/integration/adapters/spanner/spanner/test_batch_write_api.py
+++ b/tests/integration/adapters/spanner/spanner/test_batch_write_api.py
@@ -54,5 +54,5 @@ def test_batch_write_ingest(spanner_batch_write_config: SpannerSyncConfig, test_
         assert job.telemetry["rows_processed"] == 8
 
     with spanner_batch_write_config.provide_session() as session:
-        rows = session.select(f"SELECT id FROM {test_users_table} WHERE id IN UNNEST(@ids)", {"ids": user_ids})
+        rows = session.select(f"SELECT id FROM {test_users_table} WHERE id IN UNNEST(@ids)", ids=user_ids)
         assert len(rows) == 8

--- a/tests/integration/adapters/spanner/spanner/test_crud_operations.py
+++ b/tests/integration/adapters/spanner/spanner/test_crud_operations.py
@@ -29,7 +29,7 @@ def test_select_string(spanner_session: SpannerSyncDriver) -> None:
 
 def test_select_with_parameters(spanner_session: SpannerSyncDriver) -> None:
     """Test SELECT with parameterized query."""
-    result = spanner_session.select_value("SELECT @value", {"value": 42})
+    result = spanner_session.select_value("SELECT @value", value=42)
     assert result == 42
 
 
@@ -40,20 +40,23 @@ def test_insert_through_session(spanner_config: SpannerSyncConfig, test_users_ta
     with spanner_config.provide_write_session() as session:
         result = session.execute(
             f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-            {"id": user_id, "name": "Test User", "email": "test@example.com", "age": 30},
+            id=user_id,
+            name="Test User",
+            email="test@example.com",
+            age=30,
         )
         assert isinstance(result, SQLResult)
         assert result.rows_affected == 1
 
     with spanner_config.provide_session() as session:
-        row = session.select_one(f"SELECT id, name, email, age FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        row = session.select_one(f"SELECT id, name, email, age FROM {test_users_table} WHERE id = @id", id=user_id)
         assert row is not None
         assert row["name"] == "Test User"
         assert row["email"] == "test@example.com"
         assert row["age"] == 30
 
     with spanner_config.provide_write_session() as session:
-        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=user_id)
 
 
 def test_update_through_session(spanner_config: SpannerSyncConfig, test_users_table: str) -> None:
@@ -63,25 +66,30 @@ def test_update_through_session(spanner_config: SpannerSyncConfig, test_users_ta
     with spanner_config.provide_write_session() as session:
         session.execute(
             f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-            {"id": user_id, "name": "Original Name", "email": "original@example.com", "age": 25},
+            id=user_id,
+            name="Original Name",
+            email="original@example.com",
+            age=25,
         )
 
     with spanner_config.provide_write_session() as session:
         result = session.execute(
             f"UPDATE {test_users_table} SET name = @name, age = @age WHERE id = @id",
-            {"id": user_id, "name": "Updated Name", "age": 35},
+            id=user_id,
+            name="Updated Name",
+            age=35,
         )
         assert isinstance(result, SQLResult)
         assert result.rows_affected == 1
 
     with spanner_config.provide_session() as session:
-        row = session.select_one(f"SELECT name, age FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        row = session.select_one(f"SELECT name, age FROM {test_users_table} WHERE id = @id", id=user_id)
         assert row is not None
         assert row["name"] == "Updated Name"
         assert row["age"] == 35
 
     with spanner_config.provide_write_session() as session:
-        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=user_id)
 
 
 def test_delete_through_session(spanner_config: SpannerSyncConfig, test_users_table: str) -> None:
@@ -91,20 +99,23 @@ def test_delete_through_session(spanner_config: SpannerSyncConfig, test_users_ta
     with spanner_config.provide_write_session() as session:
         session.execute(
             f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-            {"id": user_id, "name": "To Delete", "email": "delete@example.com", "age": 40},
+            id=user_id,
+            name="To Delete",
+            email="delete@example.com",
+            age=40,
         )
 
     with spanner_config.provide_session() as session:
-        row = session.select_one_or_none(f"SELECT id FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        row = session.select_one_or_none(f"SELECT id FROM {test_users_table} WHERE id = @id", id=user_id)
         assert row is not None
 
     with spanner_config.provide_write_session() as session:
-        result = session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        result = session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=user_id)
         assert isinstance(result, SQLResult)
         assert result.rows_affected == 1
 
     with spanner_config.provide_session() as session:
-        row = session.select_one_or_none(f"SELECT id FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        row = session.select_one_or_none(f"SELECT id FROM {test_users_table} WHERE id = @id", id=user_id)
         assert row is None
 
 
@@ -115,32 +126,35 @@ def test_full_crud_cycle(spanner_config: SpannerSyncConfig, test_users_table: st
     with spanner_config.provide_write_session() as session:
         insert_result = session.execute(
             f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-            {"id": user_id, "name": "CRUD Test", "email": "crud@example.com", "age": 30},
+            id=user_id,
+            name="CRUD Test",
+            email="crud@example.com",
+            age=30,
         )
         assert insert_result.rows_affected == 1
 
     with spanner_config.provide_session() as session:
-        row = session.select_one(f"SELECT id, name, email, age FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        row = session.select_one(f"SELECT id, name, email, age FROM {test_users_table} WHERE id = @id", id=user_id)
         assert row["name"] == "CRUD Test"
         assert row["email"] == "crud@example.com"
         assert row["age"] == 30
 
     with spanner_config.provide_write_session() as session:
         update_result = session.execute(
-            f"UPDATE {test_users_table} SET name = @name WHERE id = @id", {"id": user_id, "name": "Updated CRUD"}
+            f"UPDATE {test_users_table} SET name = @name WHERE id = @id", id=user_id, name="Updated CRUD"
         )
         assert update_result.rows_affected == 1
 
     with spanner_config.provide_session() as session:
-        row = session.select_one(f"SELECT name FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        row = session.select_one(f"SELECT name FROM {test_users_table} WHERE id = @id", id=user_id)
         assert row["name"] == "Updated CRUD"
 
     with spanner_config.provide_write_session() as session:
-        delete_result = session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        delete_result = session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=user_id)
         assert delete_result.rows_affected == 1
 
     with spanner_config.provide_session() as session:
-        row = session.select_one_or_none(f"SELECT id FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        row = session.select_one_or_none(f"SELECT id FROM {test_users_table} WHERE id = @id", id=user_id)
         assert row is None
 
 
@@ -152,13 +166,16 @@ def test_select_multiple_rows(spanner_config: SpannerSyncConfig, test_users_tabl
         for i, uid in enumerate(user_ids):
             result = session.execute(
                 f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-                {"id": uid, "name": f"User {i}", "email": f"user{i}@example.com", "age": 20 + i},
+                id=uid,
+                name=f"User {i}",
+                email=f"user{i}@example.com",
+                age=20 + i,
             )
             assert result.rows_affected == 1
 
     with spanner_config.provide_session() as session:
         results = session.select(
-            f"SELECT id, name FROM {test_users_table} WHERE age >= @min_age ORDER BY age", {"min_age": 20}
+            f"SELECT id, name FROM {test_users_table} WHERE age >= @min_age ORDER BY age", min_age=20
         )
         assert len(results) >= 3
         names = [r["name"] for r in results if r["name"].startswith("User ")]
@@ -168,7 +185,7 @@ def test_select_multiple_rows(spanner_config: SpannerSyncConfig, test_users_tabl
 
     with spanner_config.provide_write_session() as session:
         for uid in user_ids:
-            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": uid})
+            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=uid)
 
 
 def test_result_metadata(spanner_config: SpannerSyncConfig, test_users_table: str) -> None:
@@ -178,7 +195,10 @@ def test_result_metadata(spanner_config: SpannerSyncConfig, test_users_table: st
     with spanner_config.provide_write_session() as session:
         result = session.execute(
             f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-            {"id": user_id, "name": "Metadata Test", "email": "meta@example.com", "age": 28},
+            id=user_id,
+            name="Metadata Test",
+            email="meta@example.com",
+            age=28,
         )
 
         assert isinstance(result, SQLResult)
@@ -187,7 +207,7 @@ def test_result_metadata(spanner_config: SpannerSyncConfig, test_users_table: st
 
     with spanner_config.provide_session() as session:
         select_result = session.execute(
-            f"SELECT id, name, email, age FROM {test_users_table} WHERE id = @id", {"id": user_id}
+            f"SELECT id, name, email, age FROM {test_users_table} WHERE id = @id", id=user_id
         )
 
         assert isinstance(select_result, SQLResult)
@@ -198,4 +218,4 @@ def test_result_metadata(spanner_config: SpannerSyncConfig, test_users_table: st
         assert "name" in select_result.column_names
 
     with spanner_config.provide_write_session() as session:
-        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=user_id)

--- a/tests/integration/adapters/spanner/spanner/test_driver.py
+++ b/tests/integration/adapters/spanner/spanner/test_driver.py
@@ -36,7 +36,7 @@ def test_driver_select_value(spanner_session: "SpannerSyncDriver") -> None:
 
 def test_driver_select_value_with_params(spanner_session: "SpannerSyncDriver") -> None:
     """Test select_value() with parameters."""
-    result = spanner_session.select_value("SELECT @val", {"val": 100})
+    result = spanner_session.select_value("SELECT @val", val=100)
     assert result == 100
 
 
@@ -53,11 +53,14 @@ def test_driver_select_one(spanner_config: "SpannerSyncConfig", test_users_table
     with spanner_config.provide_write_session() as session:
         session.execute(
             f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-            {"id": user_id, "name": "Select One", "email": "selectone@example.com", "age": 25},
+            id=user_id,
+            name="Select One",
+            email="selectone@example.com",
+            age=25,
         )
 
     with spanner_config.provide_session() as session:
-        row = session.select_one(f"SELECT id, name, email, age FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        row = session.select_one(f"SELECT id, name, email, age FROM {test_users_table} WHERE id = @id", id=user_id)
         assert row is not None
         assert str(row["id"]) == user_id
         assert row["name"] == "Select One"
@@ -65,7 +68,7 @@ def test_driver_select_one(spanner_config: "SpannerSyncConfig", test_users_table
         assert row["age"] == 25
 
     with spanner_config.provide_write_session() as session:
-        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=user_id)
 
 
 def test_driver_select_one_or_none_found(spanner_config: "SpannerSyncConfig", test_users_table: str) -> None:
@@ -75,22 +78,25 @@ def test_driver_select_one_or_none_found(spanner_config: "SpannerSyncConfig", te
     with spanner_config.provide_write_session() as session:
         session.execute(
             f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-            {"id": user_id, "name": "Found User", "email": "found@example.com", "age": 30},
+            id=user_id,
+            name="Found User",
+            email="found@example.com",
+            age=30,
         )
 
     with spanner_config.provide_session() as session:
-        row = session.select_one_or_none(f"SELECT id, name FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        row = session.select_one_or_none(f"SELECT id, name FROM {test_users_table} WHERE id = @id", id=user_id)
         assert row is not None
         assert row["name"] == "Found User"
 
     with spanner_config.provide_write_session() as session:
-        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=user_id)
 
 
 def test_driver_select_one_or_none_not_found(spanner_config: "SpannerSyncConfig", test_users_table: str) -> None:
     """Test select_one_or_none() returns None when not found."""
     with spanner_config.provide_session() as session:
-        row = session.select_one_or_none(f"SELECT id FROM {test_users_table} WHERE id = @id", {"id": "nonexistent-id"})
+        row = session.select_one_or_none(f"SELECT id FROM {test_users_table} WHERE id = @id", id="nonexistent-id")
         assert row is None
 
 
@@ -102,12 +108,15 @@ def test_driver_select_returns_list(spanner_config: "SpannerSyncConfig", test_us
         for i, uid in enumerate(user_ids):
             session.execute(
                 f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-                {"id": uid, "name": f"User {i}", "email": f"user{i}@example.com", "age": 20 + i},
+                id=uid,
+                name=f"User {i}",
+                email=f"user{i}@example.com",
+                age=20 + i,
             )
 
     with spanner_config.provide_session() as session:
         rows = session.select(
-            f"SELECT id, name, age FROM {test_users_table} WHERE age >= @min_age ORDER BY age", {"min_age": 20}
+            f"SELECT id, name, age FROM {test_users_table} WHERE age >= @min_age ORDER BY age", min_age=20
         )
         assert len(rows) >= 3
         names = [r["name"] for r in rows if r["name"].startswith("User ")]
@@ -117,7 +126,7 @@ def test_driver_select_returns_list(spanner_config: "SpannerSyncConfig", test_us
 
     with spanner_config.provide_write_session() as session:
         for uid in user_ids:
-            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": uid})
+            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=uid)
 
 
 def test_driver_execute_returns_sql_result(spanner_config: "SpannerSyncConfig", test_users_table: str) -> None:
@@ -127,7 +136,10 @@ def test_driver_execute_returns_sql_result(spanner_config: "SpannerSyncConfig", 
     with spanner_config.provide_write_session() as session:
         result = session.execute(
             f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-            {"id": user_id, "name": "Result Test", "email": "result@example.com", "age": 35},
+            id=user_id,
+            name="Result Test",
+            email="result@example.com",
+            age=35,
         )
 
         assert isinstance(result, SQLResult)
@@ -135,7 +147,7 @@ def test_driver_execute_returns_sql_result(spanner_config: "SpannerSyncConfig", 
         assert result.statement is not None
 
     with spanner_config.provide_write_session() as session:
-        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=user_id)
 
 
 def test_driver_execute_select_returns_data(spanner_config: "SpannerSyncConfig", test_users_table: str) -> None:
@@ -145,11 +157,14 @@ def test_driver_execute_select_returns_data(spanner_config: "SpannerSyncConfig",
     with spanner_config.provide_write_session() as session:
         session.execute(
             f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-            {"id": user_id, "name": "Data Test", "email": "data@example.com", "age": 40},
+            id=user_id,
+            name="Data Test",
+            email="data@example.com",
+            age=40,
         )
 
     with spanner_config.provide_session() as session:
-        result = session.execute(f"SELECT id, name, email, age FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        result = session.execute(f"SELECT id, name, email, age FROM {test_users_table} WHERE id = @id", id=user_id)
 
         assert isinstance(result, SQLResult)
         assert result.data is not None
@@ -159,7 +174,7 @@ def test_driver_execute_select_returns_data(spanner_config: "SpannerSyncConfig",
         assert "name" in result.column_names
 
     with spanner_config.provide_write_session() as session:
-        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=user_id)
 
 
 def test_driver_parameter_style_named_at(spanner_config: "SpannerSyncConfig", test_users_table: str) -> None:
@@ -170,50 +185,53 @@ def test_driver_parameter_style_named_at(spanner_config: "SpannerSyncConfig", te
         result = session.execute(
             f"INSERT INTO {test_users_table} (id, name, email, age) "
             f"VALUES (@user_id, @user_name, @user_email, @user_age)",
-            {"user_id": user_id, "user_name": "Param Test", "user_email": "param@example.com", "user_age": 45},
+            user_id=user_id,
+            user_name="Param Test",
+            user_email="param@example.com",
+            user_age=45,
         )
         assert result.rows_affected == 1
 
     with spanner_config.provide_session() as session:
         row = session.select_one(
-            f"SELECT name, age FROM {test_users_table} WHERE id = @id AND age = @age", {"id": user_id, "age": 45}
+            f"SELECT name, age FROM {test_users_table} WHERE id = @id AND age = @age", id=user_id, age=45
         )
         assert row["name"] == "Param Test"
         assert row["age"] == 45
 
     with spanner_config.provide_write_session() as session:
-        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=user_id)
 
 
 def test_driver_data_type_int64(spanner_session: "SpannerSyncDriver") -> None:
     """Test INT64 data type handling."""
-    result = spanner_session.select_value("SELECT @val", {"val": 9223372036854775807})
+    result = spanner_session.select_value("SELECT @val", val=9223372036854775807)
     assert result == 9223372036854775807
 
 
 def test_driver_data_type_float64(spanner_session: "SpannerSyncDriver") -> None:
     """Test FLOAT64 data type handling."""
-    result = spanner_session.select_value("SELECT @val", {"val": 3.14159265359})
+    result = spanner_session.select_value("SELECT @val", val=3.14159265359)
     assert abs(result - 3.14159265359) < 1e-10
 
 
 def test_driver_data_type_string(spanner_session: "SpannerSyncDriver") -> None:
     """Test STRING data type handling."""
     test_str = "Hello, Spanner! 日本語"
-    result = spanner_session.select_value("SELECT @val", {"val": test_str})
+    result = spanner_session.select_value("SELECT @val", val=test_str)
     assert result == test_str
 
 
 def test_driver_data_type_bool(spanner_session: "SpannerSyncDriver") -> None:
     """Test BOOL data type handling."""
-    assert spanner_session.select_value("SELECT @val", {"val": True}) is True
-    assert spanner_session.select_value("SELECT @val", {"val": False}) is False
+    assert spanner_session.select_value("SELECT @val", val=True) is True
+    assert spanner_session.select_value("SELECT @val", val=False) is False
 
 
 def test_driver_data_type_timestamp(spanner_session: "SpannerSyncDriver") -> None:
     """Test TIMESTAMP data type handling."""
     ts = datetime(2024, 1, 15, 12, 30, 45, tzinfo=timezone.utc)
-    result = spanner_session.select_value("SELECT @val", {"val": ts})
+    result = spanner_session.select_value("SELECT @val", val=ts)
     assert result.year == 2024
     assert result.month == 1
     assert result.day == 15
@@ -221,7 +239,7 @@ def test_driver_data_type_timestamp(spanner_session: "SpannerSyncDriver") -> Non
 
 def test_driver_data_type_null(spanner_session: "SpannerSyncDriver") -> None:
     """Test NULL handling."""
-    result = spanner_session.select_value("SELECT @val", {"val": None})
+    result = spanner_session.select_value("SELECT @val", val=None)
     assert result is None
 
 
@@ -232,35 +250,41 @@ def test_driver_multiple_operations_same_session(spanner_config: "SpannerSyncCon
     with spanner_config.provide_write_session() as session:
         result1 = session.execute(
             f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-            {"id": user_ids[0], "name": "User A", "email": "a@example.com", "age": 25},
+            id=user_ids[0],
+            name="User A",
+            email="a@example.com",
+            age=25,
         )
         result2 = session.execute(
             f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-            {"id": user_ids[1], "name": "User B", "email": "b@example.com", "age": 30},
+            id=user_ids[1],
+            name="User B",
+            email="b@example.com",
+            age=30,
         )
 
         assert result1.rows_affected == 1
         assert result2.rows_affected == 1
 
     with spanner_config.provide_session() as session:
-        rows = session.select(f"SELECT id, name FROM {test_users_table} WHERE id IN UNNEST(@ids)", {"ids": user_ids})
+        rows = session.select(f"SELECT id, name FROM {test_users_table} WHERE id IN UNNEST(@ids)", ids=user_ids)
         assert len(rows) == 2
 
     with spanner_config.provide_write_session() as session:
         for uid in user_ids:
-            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": uid})
+            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=uid)
 
 
 def test_driver_array_parameter(spanner_session: "SpannerSyncDriver") -> None:
     """Test array parameter expansion."""
-    result = spanner_session.select_value("SELECT ARRAY_LENGTH(@arr)", {"arr": [1, 2, 3, 4, 5]})
+    result = spanner_session.select_value("SELECT ARRAY_LENGTH(@arr)", arr=[1, 2, 3, 4, 5])
     assert result == 5
 
 
 def test_driver_empty_result_set(spanner_config: "SpannerSyncConfig", test_users_table: str) -> None:
     """Test handling empty result sets."""
     with spanner_config.provide_session() as session:
-        rows = session.select(f"SELECT id FROM {test_users_table} WHERE id = @id", {"id": "definitely-does-not-exist"})
+        rows = session.select(f"SELECT id FROM {test_users_table} WHERE id = @id", id="definitely-does-not-exist")
         assert rows == []
 
 
@@ -272,16 +296,19 @@ def test_driver_large_string(spanner_config: "SpannerSyncConfig", test_users_tab
     with spanner_config.provide_write_session() as session:
         result = session.execute(
             f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-            {"id": user_id, "name": large_name, "email": "large@example.com", "age": 50},
+            id=user_id,
+            name=large_name,
+            email="large@example.com",
+            age=50,
         )
         assert result.rows_affected == 1
 
     with spanner_config.provide_session() as session:
-        row = session.select_one(f"SELECT name FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        row = session.select_one(f"SELECT name FROM {test_users_table} WHERE id = @id", id=user_id)
         assert row["name"] == large_name
 
     with spanner_config.provide_write_session() as session:
-        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=user_id)
 
 
 def test_driver_update_multiple_columns(spanner_config: "SpannerSyncConfig", test_users_table: str) -> None:
@@ -291,24 +318,30 @@ def test_driver_update_multiple_columns(spanner_config: "SpannerSyncConfig", tes
     with spanner_config.provide_write_session() as session:
         session.execute(
             f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-            {"id": user_id, "name": "Original", "email": "original@example.com", "age": 20},
+            id=user_id,
+            name="Original",
+            email="original@example.com",
+            age=20,
         )
 
     with spanner_config.provide_write_session() as session:
         result = session.execute(
             f"UPDATE {test_users_table} SET name = @name, email = @email, age = @age WHERE id = @id",
-            {"id": user_id, "name": "Updated", "email": "updated@example.com", "age": 21},
+            id=user_id,
+            name="Updated",
+            email="updated@example.com",
+            age=21,
         )
         assert result.rows_affected == 1
 
     with spanner_config.provide_session() as session:
-        row = session.select_one(f"SELECT name, email, age FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        row = session.select_one(f"SELECT name, email, age FROM {test_users_table} WHERE id = @id", id=user_id)
         assert row["name"] == "Updated"
         assert row["email"] == "updated@example.com"
         assert row["age"] == 21
 
     with spanner_config.provide_write_session() as session:
-        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=user_id)
 
 
 def test_driver_delete_with_condition(spanner_config: "SpannerSyncConfig", test_users_table: str) -> None:
@@ -319,20 +352,23 @@ def test_driver_delete_with_condition(spanner_config: "SpannerSyncConfig", test_
         for i, uid in enumerate(user_ids):
             session.execute(
                 f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-                {"id": uid, "name": f"Delete Test {i}", "email": f"delete{i}@example.com", "age": 10 + i},
+                id=uid,
+                name=f"Delete Test {i}",
+                email=f"delete{i}@example.com",
+                age=10 + i,
             )
 
     with spanner_config.provide_write_session() as session:
-        result = session.execute(f"DELETE FROM {test_users_table} WHERE age < @max_age", {"max_age": 12})
+        result = session.execute(f"DELETE FROM {test_users_table} WHERE age < @max_age", max_age=12)
         assert result.rows_affected == 2
 
     with spanner_config.provide_session() as session:
-        rows = session.select(f"SELECT id FROM {test_users_table} WHERE id IN UNNEST(@ids)", {"ids": user_ids})
+        rows = session.select(f"SELECT id FROM {test_users_table} WHERE id IN UNNEST(@ids)", ids=user_ids)
         assert len(rows) == 1
 
     with spanner_config.provide_write_session() as session:
         for uid in user_ids:
-            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": uid})
+            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=uid)
 
 
 def test_driver_column_order_preserved(spanner_config: "SpannerSyncConfig", test_users_table: str) -> None:
@@ -342,12 +378,15 @@ def test_driver_column_order_preserved(spanner_config: "SpannerSyncConfig", test
     with spanner_config.provide_write_session() as session:
         session.execute(
             f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-            {"id": user_id, "name": "Column Order", "email": "order@example.com", "age": 55},
+            id=user_id,
+            name="Column Order",
+            email="order@example.com",
+            age=55,
         )
 
     with spanner_config.provide_session() as session:
-        result = session.execute(f"SELECT age, name, id FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        result = session.execute(f"SELECT age, name, id FROM {test_users_table} WHERE id = @id", id=user_id)
         assert result.column_names == ["age", "name", "id"]
 
     with spanner_config.provide_write_session() as session:
-        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=user_id)

--- a/tests/integration/adapters/spanner/spanner/test_exceptions.py
+++ b/tests/integration/adapters/spanner/spanner/test_exceptions.py
@@ -51,25 +51,31 @@ def test_unique_violation_duplicate_key(spanner_config: SpannerSyncConfig, test_
     with spanner_config.provide_write_session() as session:
         session.execute(
             f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-            {"id": user_id, "name": "First", "email": "first@example.com", "age": 25},
+            id=user_id,
+            name="First",
+            email="first@example.com",
+            age=25,
         )
 
     with spanner_config.provide_write_session() as session:
         with pytest.raises(UniqueViolationError):
             session.execute(
                 f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-                {"id": user_id, "name": "Duplicate", "email": "dup@example.com", "age": 30},
+                id=user_id,
+                name="Duplicate",
+                email="dup@example.com",
+                age=30,
             )
 
     with spanner_config.provide_write_session() as session:
-        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=user_id)
 
 
 def test_invalid_parameter_type(spanner_config: SpannerSyncConfig) -> None:
     """Test that invalid parameter type raises SQLParsingError."""
     with spanner_config.provide_session() as session:
         with pytest.raises(SQLParsingError):
-            session.select_value("SELECT @num + 1", {"num": "not_a_number"})
+            session.select_value("SELECT @num + 1", num="not_a_number")
 
 
 def test_execute_many_in_read_only_session(spanner_config: SpannerSyncConfig, test_users_table: str) -> None:
@@ -91,7 +97,7 @@ def test_select_one_no_results(spanner_config: SpannerSyncConfig, test_users_tab
 
     with spanner_config.provide_session() as session:
         with pytest.raises(SQLSpecNotFoundError):
-            session.select_one(f"SELECT * FROM {test_users_table} WHERE id = @id", {"id": "definitely-does-not-exist"})
+            session.select_one(f"SELECT * FROM {test_users_table} WHERE id = @id", id="definitely-does-not-exist")
 
 
 def test_invalid_column_name(spanner_config: SpannerSyncConfig, test_users_table: str) -> None:
@@ -105,8 +111,7 @@ def test_update_nonexistent_row_no_error(spanner_config: SpannerSyncConfig, test
     """Test that UPDATE on non-existent row succeeds with 0 rows affected."""
     with spanner_config.provide_write_session() as session:
         result = session.execute(
-            f"UPDATE {test_users_table} SET name = @name WHERE id = @id",
-            {"id": "nonexistent-id", "name": "Should Not Exist"},
+            f"UPDATE {test_users_table} SET name = @name WHERE id = @id", id="nonexistent-id", name="Should Not Exist"
         )
         assert result.rows_affected == 0
 
@@ -114,5 +119,5 @@ def test_update_nonexistent_row_no_error(spanner_config: SpannerSyncConfig, test
 def test_delete_nonexistent_row_no_error(spanner_config: SpannerSyncConfig, test_users_table: str) -> None:
     """Test that DELETE on non-existent row succeeds with 0 rows affected."""
     with spanner_config.provide_write_session() as session:
-        result = session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": "nonexistent-id"})
+        result = session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id="nonexistent-id")
         assert result.rows_affected == 0

--- a/tests/integration/adapters/spanner/spanner/test_execute_many.py
+++ b/tests/integration/adapters/spanner/spanner/test_execute_many.py
@@ -33,7 +33,7 @@ def test_execute_many_basic_insert(spanner_config: SpannerSyncConfig, test_users
 
     with spanner_config.provide_session() as session:
         rows = session.select(
-            f"SELECT id, name FROM {test_users_table} WHERE id IN UNNEST(@ids) ORDER BY name", {"ids": user_ids}
+            f"SELECT id, name FROM {test_users_table} WHERE id IN UNNEST(@ids) ORDER BY name", ids=user_ids
         )
         assert len(rows) == 5
         names = [r["name"] for r in rows]
@@ -42,7 +42,7 @@ def test_execute_many_basic_insert(spanner_config: SpannerSyncConfig, test_users
 
     with spanner_config.provide_write_session() as session:
         for uid in user_ids:
-            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": uid})
+            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=uid)
 
 
 def test_execute_many_update(spanner_config: SpannerSyncConfig, test_users_table: str) -> None:
@@ -53,7 +53,10 @@ def test_execute_many_update(spanner_config: SpannerSyncConfig, test_users_table
         for i, uid in enumerate(user_ids):
             session.execute(
                 f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-                {"id": uid, "name": f"Original {i}", "email": f"orig{i}@example.com", "age": 30 + i},
+                id=uid,
+                name=f"Original {i}",
+                email=f"orig{i}@example.com",
+                age=30 + i,
             )
 
     update_params = [{"id": uid, "name": f"Updated {i}", "age": 40 + i} for i, uid in enumerate(user_ids)]
@@ -66,7 +69,7 @@ def test_execute_many_update(spanner_config: SpannerSyncConfig, test_users_table
 
     with spanner_config.provide_session() as session:
         rows = session.select(
-            f"SELECT id, name, age FROM {test_users_table} WHERE id IN UNNEST(@ids) ORDER BY age", {"ids": user_ids}
+            f"SELECT id, name, age FROM {test_users_table} WHERE id IN UNNEST(@ids) ORDER BY age", ids=user_ids
         )
         assert len(rows) == 3
         assert rows[0]["name"] == "Updated 0"
@@ -76,7 +79,7 @@ def test_execute_many_update(spanner_config: SpannerSyncConfig, test_users_table
 
     with spanner_config.provide_write_session() as session:
         for uid in user_ids:
-            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": uid})
+            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=uid)
 
 
 def test_execute_many_delete(spanner_config: SpannerSyncConfig, test_users_table: str) -> None:
@@ -87,7 +90,10 @@ def test_execute_many_delete(spanner_config: SpannerSyncConfig, test_users_table
         for i, uid in enumerate(user_ids):
             session.execute(
                 f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-                {"id": uid, "name": f"ToDelete {i}", "email": f"del{i}@example.com", "age": 25 + i},
+                id=uid,
+                name=f"ToDelete {i}",
+                email=f"del{i}@example.com",
+                age=25 + i,
             )
 
     delete_params = [{"id": uid} for uid in user_ids[:2]]
@@ -97,12 +103,12 @@ def test_execute_many_delete(spanner_config: SpannerSyncConfig, test_users_table
         assert result.rows_affected == 2
 
     with spanner_config.provide_session() as session:
-        rows = session.select(f"SELECT id FROM {test_users_table} WHERE id IN UNNEST(@ids)", {"ids": user_ids})
+        rows = session.select(f"SELECT id FROM {test_users_table} WHERE id IN UNNEST(@ids)", ids=user_ids)
         assert len(rows) == 2
 
     with spanner_config.provide_write_session() as session:
         for uid in user_ids[2:]:
-            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": uid})
+            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=uid)
 
 
 def test_execute_many_large_batch(spanner_config: SpannerSyncConfig, test_users_table: str) -> None:
@@ -143,11 +149,11 @@ def test_execute_many_single_item(spanner_config: SpannerSyncConfig, test_users_
         assert result.rows_affected == 1
 
     with spanner_config.provide_session() as session:
-        row = session.select_one(f"SELECT name FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        row = session.select_one(f"SELECT name FROM {test_users_table} WHERE id = @id", id=user_id)
         assert row["name"] == "Single"
 
     with spanner_config.provide_write_session() as session:
-        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=user_id)
 
 
 def test_execute_many_requires_write_session(spanner_config: SpannerSyncConfig, test_users_table: str) -> None:
@@ -177,16 +183,14 @@ def test_execute_many_mixed_values(spanner_config: SpannerSyncConfig, test_users
         assert result.rows_affected == 3
 
     with spanner_config.provide_session() as session:
-        rows = session.select(
-            f"SELECT id, name, age FROM {test_users_table} WHERE id IN UNNEST(@ids)", {"ids": user_ids}
-        )
+        rows = session.select(f"SELECT id, name, age FROM {test_users_table} WHERE id IN UNNEST(@ids)", ids=user_ids)
         assert len(rows) == 3
         ages = sorted([r["age"] for r in rows])
         assert ages == [18, 45, 99]
 
     with spanner_config.provide_write_session() as session:
         for uid in user_ids:
-            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": uid})
+            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=uid)
 
 
 def test_execute_many_consecutive_batches(spanner_config: SpannerSyncConfig, test_users_table: str) -> None:
@@ -216,10 +220,10 @@ def test_execute_many_consecutive_batches(spanner_config: SpannerSyncConfig, tes
 
     with spanner_config.provide_session() as session:
         all_ids = batch1_ids + batch2_ids
-        rows = session.select(f"SELECT id FROM {test_users_table} WHERE id IN UNNEST(@ids)", {"ids": all_ids})
+        rows = session.select(f"SELECT id FROM {test_users_table} WHERE id IN UNNEST(@ids)", ids=all_ids)
         assert len(rows) == 6
 
     with spanner_config.provide_write_session() as session:
         all_ids = batch1_ids + batch2_ids
         for uid in all_ids:
-            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": uid})
+            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=uid)

--- a/tests/integration/adapters/spanner/spanner/test_load_from_arrow_mutations.py
+++ b/tests/integration/adapters/spanner/spanner/test_load_from_arrow_mutations.py
@@ -28,7 +28,7 @@ def test_load_from_arrow_inserts_via_mutations(spanner_config: SpannerSyncConfig
         assert job.telemetry["rows_processed"] == 10
 
     with spanner_config.provide_session() as session:
-        rows = session.select(f"SELECT id FROM {test_users_table} WHERE id IN UNNEST(@ids)", {"ids": user_ids})
+        rows = session.select(f"SELECT id FROM {test_users_table} WHERE id IN UNNEST(@ids)", ids=user_ids)
         assert len(rows) == 10
 
 
@@ -48,5 +48,5 @@ def test_load_from_arrow_rerun_upserts_idempotently(spanner_config: SpannerSyncC
         session.load_from_arrow(test_users_table, arrow_table)
 
     with spanner_config.provide_session() as session:
-        rows = session.select(f"SELECT id FROM {test_users_table} WHERE id IN UNNEST(@ids)", {"ids": user_ids})
+        rows = session.select(f"SELECT id FROM {test_users_table} WHERE id IN UNNEST(@ids)", ids=user_ids)
         assert len(rows) == 5

--- a/tests/integration/adapters/spanner/spanner/test_parameter_variants.py
+++ b/tests/integration/adapters/spanner/spanner/test_parameter_variants.py
@@ -48,7 +48,7 @@ def test_spanner_native_types_round_trip_through_read_session(spanner_session: S
 
 def test_spanner_date_parameter_allows_emulator_datetime_return(spanner_session: SpannerSyncDriver) -> None:
     """Spanner emulator may return DATE parameters as datetime-like objects."""
-    result = spanner_session.select_value("SELECT @value", {"value": date(2024, 12, 25)})
+    result = spanner_session.select_value("SELECT @value", value=date(2024, 12, 25))
 
     assert result.year == 2024
     assert result.month == 12
@@ -64,18 +64,21 @@ def test_spanner_null_parameters_round_trip_through_write_and_read_sessions(
     with spanner_config.provide_write_session() as session:
         result = session.execute(
             f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-            {"id": user_id, "name": "Null Test", "email": None, "age": None},
+            id=user_id,
+            name="Null Test",
+            email=None,
+            age=None,
         )
         assert result.rows_affected == 1
 
     with spanner_config.provide_read_session() as session:
-        row = session.select_one(f"SELECT name, email, age FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        row = session.select_one(f"SELECT name, email, age FROM {test_users_table} WHERE id = @id", id=user_id)
         assert row["name"] == "Null Test"
         assert row["email"] is None
         assert row["age"] is None
 
     with spanner_config.provide_write_session() as session:
-        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": user_id})
+        session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=user_id)
 
 
 def test_spanner_array_parameter_with_unnest_uses_read_and_write_sessions(
@@ -88,19 +91,22 @@ def test_spanner_array_parameter_with_unnest_uses_read_and_write_sessions(
         for index, user_id in enumerate(user_ids):
             session.execute(
                 f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-                {"id": user_id, "name": f"Array Test {index}", "email": f"arr{index}@example.com", "age": 20},
+                id=user_id,
+                name=f"Array Test {index}",
+                email=f"arr{index}@example.com",
+                age=20,
             )
 
     with spanner_config.provide_read_session() as session:
         rows = session.select(
-            f"SELECT id, name FROM {test_users_table} WHERE id IN UNNEST(@ids) ORDER BY name", {"ids": user_ids}
+            f"SELECT id, name FROM {test_users_table} WHERE id IN UNNEST(@ids) ORDER BY name", ids=user_ids
         )
 
     assert [row["name"] for row in rows] == ["Array Test 0", "Array Test 1", "Array Test 2"]
 
     with spanner_config.provide_write_session() as session:
         for user_id in user_ids:
-            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": user_id})
+            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=user_id)
 
 
 def test_spanner_parameterized_limit_uses_native_parameter_syntax(
@@ -113,17 +119,20 @@ def test_spanner_parameterized_limit_uses_native_parameter_syntax(
         for index, user_id in enumerate(user_ids):
             session.execute(
                 f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-                {"id": user_id, "name": f"Limit Test {index}", "email": f"limit{index}@example.com", "age": index},
+                id=user_id,
+                name=f"Limit Test {index}",
+                email=f"limit{index}@example.com",
+                age=index,
             )
 
     with spanner_config.provide_read_session() as session:
         rows = session.select(
             f"SELECT name FROM {test_users_table} WHERE name LIKE 'Limit Test%' ORDER BY age LIMIT @row_limit",
-            {"row_limit": 3},
+            row_limit=3,
         )
 
     assert [row["name"] for row in rows] == ["Limit Test 0", "Limit Test 1", "Limit Test 2"]
 
     with spanner_config.provide_write_session() as session:
         for user_id in user_ids:
-            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", {"id": user_id})
+            session.execute(f"DELETE FROM {test_users_table} WHERE id = @id", id=user_id)

--- a/tests/integration/adapters/spanner/spanner/test_session_defaults.py
+++ b/tests/integration/adapters/spanner/spanner/test_session_defaults.py
@@ -31,9 +31,12 @@ def test_default_provide_session_runs_dml(spanner_config: "SpannerSyncConfig", t
     with spanner_config.provide_session() as driver:
         driver.execute(
             f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-            {"id": "u1", "name": "Alice", "email": "alice@example.com", "age": 30},
+            id="u1",
+            name="Alice",
+            email="alice@example.com",
+            age=30,
         )
-        row = driver.execute(f"SELECT name FROM {test_users_table} WHERE id = @id", {"id": "u1"}).one()
+        row = driver.execute(f"SELECT name FROM {test_users_table} WHERE id = @id", id="u1").one()
         assert row["name"] == "Alice"
 
 
@@ -43,5 +46,8 @@ def test_provide_read_session_blocks_writes(spanner_config: "SpannerSyncConfig",
         with pytest.raises(SQLConversionError, match="provide_read_session"):
             driver.execute(
                 f"INSERT INTO {test_users_table} (id, name, email, age) VALUES (@id, @name, @email, @age)",
-                {"id": "u2", "name": "Bob", "email": "bob@example.com", "age": 25},
+                id="u2",
+                name="Bob",
+                email="bob@example.com",
+                age=25,
             )

--- a/tests/integration/extensions/fastapi/test_integration.py
+++ b/tests/integration/extensions/fastapi/test_integration.py
@@ -89,7 +89,7 @@ def test_fastapi_manual_commit() -> None:
             conn: Annotated[AiosqliteConnection, Depends(db_ext.provide_connection(config))],
         ) -> dict[str, Any]:
             await db.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)")
-            await db.execute("INSERT INTO test (name) VALUES (:name)", {"name": "FastAPI"})
+            await db.execute("INSERT INTO test (name) VALUES (:name)", name="FastAPI")
             await conn.commit()
             return {"created": True}
 
@@ -127,7 +127,7 @@ def test_fastapi_autocommit_mode() -> None:
             db: Annotated[AiosqliteDriver, Depends(db_ext.provide_session(config))],
         ) -> dict[str, Any]:
             await db.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)")
-            await db.execute("INSERT INTO test (name) VALUES (:name)", {"name": "AutoCommit"})
+            await db.execute("INSERT INTO test (name) VALUES (:name)", name="AutoCommit")
             return {"created": True}
 
         @app.get("/data")
@@ -238,15 +238,11 @@ def test_fastapi_complex_route_with_multiple_queries() -> None:
             await db.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
             await db.execute("CREATE TABLE posts (id INTEGER PRIMARY KEY, user_id INTEGER, title TEXT)")
 
-            await db.execute("INSERT INTO users (name) VALUES (:name)", {"name": "Alice"})
-            await db.execute("INSERT INTO users (name) VALUES (:name)", {"name": "Bob"})
+            await db.execute("INSERT INTO users (name) VALUES (:name)", name="Alice")
+            await db.execute("INSERT INTO users (name) VALUES (:name)", name="Bob")
 
-            await db.execute(
-                "INSERT INTO posts (user_id, title) VALUES (:user_id, :title)", {"user_id": 1, "title": "Post 1"}
-            )
-            await db.execute(
-                "INSERT INTO posts (user_id, title) VALUES (:user_id, :title)", {"user_id": 1, "title": "Post 2"}
-            )
+            await db.execute("INSERT INTO posts (user_id, title) VALUES (:user_id, :title)", user_id=1, title="Post 1")
+            await db.execute("INSERT INTO posts (user_id, title) VALUES (:user_id, :title)", user_id=1, title="Post 2")
 
             await conn.commit()
             return {"setup": True}

--- a/tests/integration/extensions/sanic/test_integration.py
+++ b/tests/integration/extensions/sanic/test_integration.py
@@ -66,13 +66,13 @@ def test_sanic_autocommit_commits_success_and_rolls_back_error_status() -> None:
         async def setup(request: Request):
             db = plugin.get_session(request, "db")
             await db.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)")
-            await db.execute("INSERT INTO test (name) VALUES (:name)", {"name": "committed"})
+            await db.execute("INSERT INTO test (name) VALUES (:name)", name="committed")
             return response.json({"created": True})
 
         @app.post("/insert-error")
         async def insert_error(request: Request):
             db = plugin.get_session(request, "db")
-            await db.execute("INSERT INTO test (name) VALUES (:name)", {"name": "rolled-back"})
+            await db.execute("INSERT INTO test (name) VALUES (:name)", name="rolled-back")
             return response.json({"error": "failed"}, status=500)
 
         @app.get("/data")
@@ -110,13 +110,13 @@ def test_sanic_autocommit_rolls_back_on_exception_response() -> None:
         async def setup(request: Request):
             db = plugin.get_session(request, "db")
             await db.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)")
-            await db.execute("INSERT INTO test (name) VALUES (:name)", {"name": "committed"})
+            await db.execute("INSERT INTO test (name) VALUES (:name)", name="committed")
             return response.json({"created": True})
 
         @app.post("/explode")
         async def explode(request: Request):
             db = plugin.get_session(request, "db")
-            await db.execute("INSERT INTO test (name) VALUES (:name)", {"name": "rolled-back"})
+            await db.execute("INSERT INTO test (name) VALUES (:name)", name="rolled-back")
             msg = "request failed"
             raise RuntimeError(msg)
 
@@ -225,8 +225,8 @@ def test_sanic_multi_database_sessions() -> None:
             products_db = plugin.get_session(request, "products_db")
             await users_db.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
             await products_db.execute("CREATE TABLE products (id INTEGER PRIMARY KEY, name TEXT)")
-            await users_db.execute("INSERT INTO users (name) VALUES (:name)", {"name": "Alice"})
-            await products_db.execute("INSERT INTO products (name) VALUES (:name)", {"name": "Widget"})
+            await users_db.execute("INSERT INTO users (name) VALUES (:name)", name="Alice")
+            await products_db.execute("INSERT INTO products (name) VALUES (:name)", name="Widget")
             return response.json({"created": True})
 
         @app.get("/counts")

--- a/tests/integration/extensions/starlette/test_integration.py
+++ b/tests/integration/extensions/starlette/test_integration.py
@@ -57,7 +57,7 @@ def test_starlette_manual_commit_mode() -> None:
         async def create_table(request: Request) -> Response:
             session = db_ext.get_session(request)
             await session.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)")
-            await session.execute("INSERT INTO test (name) VALUES (:name)", {"name": "Alice"})
+            await session.execute("INSERT INTO test (name) VALUES (:name)", name="Alice")
             connection = db_ext.get_connection(request)
             await connection.commit()
             return JSONResponse({"created": True})
@@ -94,7 +94,7 @@ def test_starlette_autocommit_mode() -> None:
         async def create_table(request: Request) -> Response:
             session = db_ext.get_session(request)
             await session.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)")
-            await session.execute("INSERT INTO test (name) VALUES (:name)", {"name": "Bob"})
+            await session.execute("INSERT INTO test (name) VALUES (:name)", name="Bob")
             return JSONResponse({"created": True})
 
         async def get_data(request: Request) -> Response:
@@ -129,7 +129,7 @@ def test_starlette_autocommit_rolls_back_on_error() -> None:
         async def create_table(request: Request) -> Response:
             session = db_ext.get_session(request)
             await session.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)")
-            await session.execute("INSERT INTO test (name) VALUES (:name)", {"name": "Charlie"})
+            await session.execute("INSERT INTO test (name) VALUES (:name)", name="Charlie")
             return JSONResponse({"error": "Failed"}, status_code=500)
 
         async def get_data(request: Request) -> Response:

--- a/tests/unit/adapters/test_oracledb/test_vector_handlers.py
+++ b/tests/unit/adapters/test_oracledb/test_vector_handlers.py
@@ -367,9 +367,7 @@ def test_pack_sequence_converter_is_module_level_named_function() -> None:
     """The vector inconverter must be a named module-level function."""
     import inspect
 
-    from sqlspec.adapters.oracledb._vector_handlers import (
-        _pack_sequence_converter,  # pyright: ignore[reportPrivateUsage]
-    )
+    from sqlspec.adapters.oracledb._vector_handlers import _pack_sequence_converter  # pyright: ignore[reportPrivateUsage]
 
     assert inspect.isfunction(_pack_sequence_converter)
     assert _pack_sequence_converter.__name__ == "_pack_sequence_converter"
@@ -378,9 +376,7 @@ def test_pack_sequence_converter_is_module_level_named_function() -> None:
 
 def test_pack_sequence_converter_float_list() -> None:
     """_pack_sequence_converter packs float lists as float32."""
-    from sqlspec.adapters.oracledb._vector_handlers import (
-        _pack_sequence_converter,  # pyright: ignore[reportPrivateUsage]
-    )
+    from sqlspec.adapters.oracledb._vector_handlers import _pack_sequence_converter  # pyright: ignore[reportPrivateUsage]
 
     result = _pack_sequence_converter([1.5, 2.5, 3.5])
 
@@ -391,9 +387,7 @@ def test_pack_sequence_converter_float_list() -> None:
 
 def test_pack_sequence_converter_int8_range() -> None:
     """_pack_sequence_converter packs small int lists as int8."""
-    from sqlspec.adapters.oracledb._vector_handlers import (
-        _pack_sequence_converter,  # pyright: ignore[reportPrivateUsage]
-    )
+    from sqlspec.adapters.oracledb._vector_handlers import _pack_sequence_converter  # pyright: ignore[reportPrivateUsage]
 
     result = _pack_sequence_converter([-128, 0, 127])
 

--- a/tests/unit/core/test_single_compilation.py
+++ b/tests/unit/core/test_single_compilation.py
@@ -107,7 +107,7 @@ def test_single_compilation_compile_called_once_with_named_parameters(sqlite_spe
 
     with spec.provide_session(config) as session:
         with patch.object(SQL, "compile", counting_compile):
-            session.execute("SELECT :value", {"value": 42})
+            session.execute("SELECT :value", value=42)
     assert call_count == 1, f"compile() called {call_count} times, expected 1"
 
 

--- a/tests/unit/extensions/test_events/test_channel.py
+++ b/tests/unit/extensions/test_events/test_channel.py
@@ -57,7 +57,7 @@ def test_event_channel_publish_and_ack_sync(tmp_path) -> None:
     assert message.payload["action"] == "refresh"
     channel.ack(message.event_id)
     with config.provide_session() as driver:
-        row = driver.select_one("SELECT status FROM app_events WHERE event_id = :event_id", {"event_id": event_id})
+        row = driver.select_one("SELECT status FROM app_events WHERE event_id = :event_id", event_id=event_id)
     assert row["status"] == "acked"
     snapshot = spec.telemetry_snapshot()
     assert snapshot.get("SqliteConfig.events.publish") == pytest.approx(1.0)

--- a/uv.lock
+++ b/uv.lock
@@ -3,16 +3,16 @@ revision = 3
 requires-python = ">=3.10, <4.0"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -405,16 +405,16 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.14.2"
+version = "4.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/d2/f4d173e22df740bc37b1db102b386ba719b66e95b0f0d751f556b387e6d2/anyio-4.15.1.tar.gz", hash = "sha256:9f28306018cbd6d329e64a36d58256edff76dd996fe423bc957326e578b82a94", size = 276966, upload-time = "2026-09-05T10:42:39.44Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+    { url = "https://files.pythonhosted.org/packages/12/b8/4bd346e22b28902df4d651910f5242c28d84e4a5c2435ca5c3f797ed7e2e/anyio-4.15.1-py3-none-any.whl", hash = "sha256:6152fdbbf9a77fdec97731721bebf7c4c44f7c29b424b0065826173efc7ed101", size = 132079, upload-time = "2026-09-05T10:42:37.923Z" },
 ]
 
 [[package]]
@@ -1138,7 +1138,7 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "9.0.0"
+version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boltons" },
@@ -1151,9 +1151,9 @@ dependencies = [
     { name = "wcmatch" },
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/ad/12875fcb2e444171679078e4adb1101809a416d85a6afda7c801cd7fbb58/click_extra-9.0.0.tar.gz", hash = "sha256:8668a7eac4da065e5a15edfe042b8e1c7b90b7c807fddf75b2e457e8c82fa0de", size = 1537734, upload-time = "2026-08-29T06:16:24.802Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/b9/40f42f760ed0d4ce0e445cec909d252c88f8a165993551aa2eec7699b030/click_extra-9.1.0.tar.gz", hash = "sha256:68e7dbf80500deb369794ab1ef44ae1713d0bb64698072b0ba6f28fbdea98084", size = 1608251, upload-time = "2026-09-03T09:16:23.328Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/9e/23cb15beddee01f7ae92b54e9bf223a71e7dec722ec2c1394b3d86fb9785/click_extra-9.0.0-py3-none-any.whl", hash = "sha256:a8e06bb8d62dabdf092f4338405cf941b0438f99abe884e036a00ce9ce6abfaf", size = 584429, upload-time = "2026-08-29T06:16:22.993Z" },
+    { url = "https://files.pythonhosted.org/packages/73/8d/663be1cb83ef91f97b49529f6a91e2b2cedcfe2d2c874d61dee6f6406585/click_extra-9.1.0-py3-none-any.whl", hash = "sha256:b385b0d5d9eb05fd1a7795642bb577a1cd557b6a793351b7869ca1ed57ae30b5", size = 610197, upload-time = "2026-09-03T09:16:21.606Z" },
 ]
 
 [package.optional-dependencies]
@@ -1536,16 +1536,16 @@ version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -1644,11 +1644,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "13.7.0"
+version = "13.7.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3d/e1/01785853e8f1b1029b7417f4ca057ff1c58690e7e8bd97f2e79c101287ab/extra_platforms-13.7.0.tar.gz", hash = "sha256:888437802eb1734de914c1dce062371c1c942acdddbfa0b94dd04be99eec0240", size = 474310, upload-time = "2026-08-28T11:30:28.538Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/7d/507e27b623cbc3a1d81b2a5ee9f1d94cd4151c605986396b41b97f20d804/extra_platforms-13.7.1.tar.gz", hash = "sha256:9c0056a60c89097e531745b3925a717aa4719cd3d8acd48f7edb8f9de7969079", size = 478006, upload-time = "2026-09-03T15:34:43.288Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/c8/10044a206661cedf4596171efc53c8588bfa2bf77888c734e9410cfbf46a/extra_platforms-13.7.0-py3-none-any.whl", hash = "sha256:6af50473ee325e40eda3c5fafa782fbcf7484ed5c63c76b52ce21d3474987b3d", size = 102922, upload-time = "2026-08-28T11:30:26.997Z" },
+    { url = "https://files.pythonhosted.org/packages/78/95/4cb5e2e3c3c28ffeeeda086129047eabb7d5aac992db7cffb07e52c98a27/extra_platforms-13.7.1-py3-none-any.whl", hash = "sha256:e5255107fa18eb2fe63e88c267c0ef361cb4ff051182431cc35bc2f7b9d19962", size = 103240, upload-time = "2026-09-03T15:34:41.81Z" },
 ]
 
 [[package]]
@@ -2001,15 +2001,15 @@ grpc = [
 
 [[package]]
 name = "google-auth"
-version = "2.57.0"
+version = "2.57.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/64/55f316b729f92a552d26e00aa3b1542b2e149d0a5efe2842afff0cac7af7/google_auth-2.57.0.tar.gz", hash = "sha256:9b4f96d6a1feb5f7201231f47cfb3de08d8f176f8a61f9e461555116e95a8789", size = 370794, upload-time = "2026-08-25T19:18:26.419Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/3a/d3982b28d267880b5641f9a32c55d8062a9d2bad2d28d0274285391c89c2/google_auth-2.57.1.tar.gz", hash = "sha256:eb47b230fc6707eed4aee1c9cef55ec05bc1785eecba74ff8b572d531e921b1e", size = 372426, upload-time = "2026-09-04T00:50:27.593Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/f3/8508a702c094af5f6e89773f4dfdeee74913df0f41a02c21b5e7dc3d75cd/google_auth-2.57.0-py3-none-any.whl", hash = "sha256:180dafe015cfb62193bea26b677500fab5b9fd51a1e825ebf3ad9b182047ae59", size = 259728, upload-time = "2026-08-24T21:55:08.449Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/27/0f7247b8002a1404fdb5412aeb15fb0fe70288eb8f88a5873d1c0d8262cf/google_auth-2.57.1-py3-none-any.whl", hash = "sha256:ab439dee60a6856412bc058f13a68eb6a59c5b81526bb89cfdcf89ce9c0a48c9", size = 259974, upload-time = "2026-09-04T00:50:21.693Z" },
 ]
 
 [package.optional-dependencies]
@@ -2057,7 +2057,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-bigquery"
-version = "3.44.0"
+version = "3.45.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -2068,9 +2068,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/fb/86d5bfdfbd9d810f6a49eb3e9cc591a2b46d33262338acc244cc79d032c1/google_cloud_bigquery-3.44.0.tar.gz", hash = "sha256:30651ae469b419f450b9c96581fd4942e2e060490df1ac0314bf379f16883215", size = 527575, upload-time = "2026-08-25T19:18:36.317Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/a5/64ba829eb6c8acf5c0a80b4c9b217c286a2cd592f661121660de9cdba329/google_cloud_bigquery-3.45.0.tar.gz", hash = "sha256:5a799856825f47743ce561802cbd01b4d5c70062b36a942cfef5146017ecf0a4", size = 528642, upload-time = "2026-09-03T22:30:57.289Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/84/af193ca97ce72b56fd05f8ad15776bf7446d99cb0ba1cd2f4880dbc52543/google_cloud_bigquery-3.44.0-py3-none-any.whl", hash = "sha256:ac2f0a6ab61a3c742ba4674dc220fb98461c13e1def96fe7a980ef7d5e0c0285", size = 267691, upload-time = "2026-08-24T21:55:19.249Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/af/f1c877f3d47a616f19003ba958cec5efe6e8d43d3576c5827bf53ae94ad2/google_cloud_bigquery-3.45.0-py3-none-any.whl", hash = "sha256:30637314d67526cbaefebfb9106c5a41c5f30a137ace404531148f09a6b487a6", size = 267964, upload-time = "2026-09-03T22:30:15.283Z" },
 ]
 
 [[package]]
@@ -2120,7 +2120,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-spanner"
-version = "3.70.0"
+version = "3.71.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core", extra = ["grpc"] },
@@ -2139,9 +2139,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "sqlparse" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/94/8f1512f4423b6f468e98e59956a9503f9fe37bc69d0a309193c6b873982f/google_cloud_spanner-3.70.0.tar.gz", hash = "sha256:34eb9bd16c2b66adb534244bd9c2596fefb93905b7f1e739516f9b25fb6df0a8", size = 920505, upload-time = "2026-08-25T19:19:04.345Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/ed/b02289c6b4035a1dd04c6377883b5e5310e79e3eb4ce9a687aaea78da23d/google_cloud_spanner-3.71.0.tar.gz", hash = "sha256:976280a8338cd10dcbe5673788eb4b54a55c4f271b31d251c18ab4d9e1c001d3", size = 921825, upload-time = "2026-09-03T22:31:16.358Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/61/e32bbbd87f40cc98a5f14286fc7a1ea17cf01047e7b9472f702aee8e35a0/google_cloud_spanner-3.70.0-py3-none-any.whl", hash = "sha256:9c22c29dff352e323fe658c59ed0b98a9264fb5fc05b710060c0a050dde77845", size = 624929, upload-time = "2026-08-24T21:55:53.276Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/f15b3a0fa188a550b0a7c2dde7c7ce88d792ef813c74042eec55dea036b1/google_cloud_spanner-3.71.0-py3-none-any.whl", hash = "sha256:658443c774c3967a3a5773f40f42aebf7b93cf1b63d5a8cb556926ff9fc53f9d", size = 626703, upload-time = "2026-09-03T22:30:37.359Z" },
 ]
 
 [[package]]
@@ -2198,7 +2198,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "2.21.0"
+version = "2.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2212,9 +2212,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/a7/a45f64f22ab9302b55fcbeb32acb6f313690a7748629b01e451aad1817a3/google_genai-2.21.0.tar.gz", hash = "sha256:0ecc11c6a5b9f5e3cc58e77ae5fead00c6719f8a1b2b654b803f514a9a6b64c0", size = 677301, upload-time = "2026-08-31T21:49:14.508Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/f1/f2f31b2a6bd826bc2cb73068df880954a026474c03a4315637d20cc13965/google_genai-2.22.0.tar.gz", hash = "sha256:9fa3b5d9ddb635005d8ab2d6206fb2b3d7204b66965bbce7de13ecd1a866ebcd", size = 684719, upload-time = "2026-09-02T18:06:02.906Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/d7/c2419dd5fedd5803ce09810e4e39561a0a13a960b3f48d2581c12e42af3e/google_genai-2.21.0-py3-none-any.whl", hash = "sha256:36b575034be46a03acd603a852e22a6359f2cdd6b26bb1d65d9b7e0cc7ab3648", size = 1080223, upload-time = "2026-08-31T21:49:12.699Z" },
+    { url = "https://files.pythonhosted.org/packages/de/96/0120d214958cb54f2b9c48da9f564a0e6eae269e9dd702415fb1d0551cc7/google_genai-2.22.0-py3-none-any.whl", hash = "sha256:c514001c45470cc0a942440ae1b8215445d12bfb6c373aac94637127e1f74ec6", size = 1088792, upload-time = "2026-09-02T18:06:00.629Z" },
 ]
 
 [[package]]
@@ -2231,14 +2231,14 @@ wheels = [
 
 [[package]]
 name = "googleapis-common-protos"
-version = "1.75.2"
+version = "1.75.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/90/fb8f1c84537fbf210c1f53a53ae473a805f6599c5a40b93c1bbadd211f7a/googleapis_common_protos-1.75.2.tar.gz", hash = "sha256:8829a3d1e4508c5b7b9a6b9525f7fccff611f8531644579a76466c29295d4bb2", size = 154083, upload-time = "2026-08-25T19:19:13.028Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/c5/4353a188e2c335aee33269e8b654af228278cca8e5f0b4b5f11e5d0e9adb/googleapis_common_protos-1.75.3.tar.gz", hash = "sha256:57c435ac2c68b108999b6db075d9053e4d7a936ba57b4a3d45667b1346f1738a", size = 153905, upload-time = "2026-09-03T22:31:21.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/5b/1c9e55363c3b1890a98cae813de5b4ea327845756cd8fb7ee690140c7eac/googleapis_common_protos-1.75.2-py3-none-any.whl", hash = "sha256:6b83302f554ea93a0f48409c7fc2050f954bcbcddb7e3a9c76d4a823cb22920e", size = 307002, upload-time = "2026-08-25T19:18:08.927Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7a/7d79170c6ce6f12e109df2b3879d6b934010cf4f99aea8de8b7e5408c174/googleapis_common_protos-1.75.3-py3-none-any.whl", hash = "sha256:a018d2bf098ca9fb6faa08d5bb780e2a2c2f73c566f069761331386c9596d3f2", size = 306984, upload-time = "2026-09-03T22:30:45.133Z" },
 ]
 
 [package.optional-dependencies]
@@ -2701,16 +2701,16 @@ version = "9.17.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -3098,16 +3098,16 @@ version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -3827,16 +3827,16 @@ version = "5.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -4104,16 +4104,16 @@ version = "2.5.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/80/db0b4559e57ec36362bedbb05530a87fafbcb6067708c946967a41d449e7/numpy-2.5.2.tar.gz", hash = "sha256:d482d171c406ae88c5b19cad3b6a1c4c5209f886ab74bc44c2c865c23f52d860", size = 20773161, upload-time = "2026-08-09T13:48:27.962Z" }
@@ -4532,16 +4532,16 @@ version = "3.0.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -4722,18 +4722,18 @@ wheels = [
 
 [[package]]
 name = "prek"
-version = "0.5.1"
+version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/5e/76262cecced2c8d8d20474f8fc7cf4b7059d01a0b1ae2ffb9e375815c5a4/prek-0.5.1.tar.gz", hash = "sha256:581af5dc6462cfc60b58cadcf8e6bf5b9819d75493074f435dfa14d660a33218", size = 549170, upload-time = "2026-09-01T04:19:59.228Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/05/4402641f168dd862d27592cbd4c5fb171d119c15611e5dbef3df857e8932/prek-0.5.2.tar.gz", hash = "sha256:a90ea4eeba35c6081bad29775f6a49fcc33fb80372424fce64c7a9c5774e8204", size = 549442, upload-time = "2026-09-02T17:49:27.241Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/13/ab44b9a4aba8b8f1f4204bc754648cb89959ae4b0a81114c850ed8888bb6/prek-0.5.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:821fe17617fe0b26385ce6ce324a4201810ff50349b8bb75176da72f0b858cc6", size = 5981894, upload-time = "2026-09-01T04:19:46.92Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/b4/3b2f9bc42bdbf17b182508a32f1f382d84502b7be1091b4c8ef21d043124/prek-0.5.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:afa9f5567c559e3045688bace59fa6c8336a6950f0bba063b57e57c476fb63d1", size = 5526575, upload-time = "2026-09-01T04:19:48.695Z" },
-    { url = "https://files.pythonhosted.org/packages/df/26/a9e43ddc34fa3fe3199c7d5fc09d4d77045ac330d504c62a8b87983f0ebf/prek-0.5.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:25d2c63fadcc0b2eae434cea4ddc4164792add0abfb20e1bf6bbefd33610f2a9", size = 5824937, upload-time = "2026-09-01T04:19:50.184Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/e6/c67e1d0661a97aa88ce8a3dca4b67ca5d26a1dc759c9df37430cb8f4aea9/prek-0.5.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:231cc325d31e9d92db51da08b4d9a2e061f084d459307b5920ccea95e86b5c9f", size = 6202110, upload-time = "2026-09-01T04:19:51.747Z" },
-    { url = "https://files.pythonhosted.org/packages/55/1c/8d46f27b6be800ecda86f15b3d476d80f290d6d4a39a6cf992b170148ce6/prek-0.5.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:39d92d26a1d210d3fad63e316d9379ad4fbedb4545af42c82cb73ebc20ffc64d", size = 5829515, upload-time = "2026-09-01T04:19:53.473Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/de/0d5c1c20e26bfc866885aed4ca68222c1fb8d7ddd8639a789ba0be8ba57e/prek-0.5.1-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:c6481f5effbb1a83a578bf769a527e1192d0faf4f2e481733917e1fff2007253", size = 6317963, upload-time = "2026-09-01T04:19:55.051Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/21/56b31d445ac84607919679841b47288d42687925cdf9a31207db277d753d/prek-0.5.1-py3-none-win_amd64.whl", hash = "sha256:74609c3cd3f1c14d35d081905f58b266133b9532df53a75648a280e6a80febb3", size = 5726528, upload-time = "2026-09-01T04:19:56.482Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/95/ada15ee42ef72b7d422ae3e3fbc4753d4bc6634ba23de1b7cec84b407df7/prek-0.5.1-py3-none-win_arm64.whl", hash = "sha256:f408364fc7f10996f396a14542d8a3e35494a4fde2b1cb873d996715d1876322", size = 5490020, upload-time = "2026-09-01T04:19:57.841Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/25/cf9c6064fea82ba6f4801dc3be650cc86eae3d9951e2a6fb28b21cbfa156/prek-0.5.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:40d488a48de3f47f48bd4911ee5dec25e615f992b4cde821e9b50d40c615b39e", size = 5982622, upload-time = "2026-09-02T17:49:10.111Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/d9/9772fd4d4023c34780d957f407d9437e2a16d6bef77e3da9fa4374cd75bb/prek-0.5.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0eb3b812fc13bc5c05cfc1a8b469f9665a02f845753c3759ad7aca50af707afb", size = 5525662, upload-time = "2026-09-02T17:49:12.336Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/19/be25a56ab243f2e5c9333c38bad33bddffec92ea8a25e34248eba6e00ac8/prek-0.5.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:c0219d1e694a962e3b3ae98f42f53065d2e2856719caee88578d24b35ea74cad", size = 5826109, upload-time = "2026-09-02T17:49:13.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/bd/a4a5a3022915b8e1768df9b2d8744f3e7c4b3bb7cdbe697612cc96054169/prek-0.5.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0e22f11c1fb5df89acf5cbde78f6139edf2c30a205bea5a5d4a094366dcdbda", size = 6201473, upload-time = "2026-09-02T17:49:16.156Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fb/2e5f8adbee718f15333a113872104c4b3d25ecce423dd7117cfcd28a25fe/prek-0.5.2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:1d52de8428d5eef7c8c0fd64efd7d31210d13924fd36a02975d462675715aeb7", size = 5829166, upload-time = "2026-09-02T17:49:17.997Z" },
+    { url = "https://files.pythonhosted.org/packages/44/71/c798d54741cc8f345b211e453dda9599546fb213c3593eb711cb6c710bbf/prek-0.5.2-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:86aebcd8ab831036fc3ac9b15275412403e21041da031e6c9f1547888843e5c6", size = 6318980, upload-time = "2026-09-02T17:49:21.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/f8/4aefbf76dae091078655fbaf065c34fa900d43b39c2b88e80cbaa71b5efb/prek-0.5.2-py3-none-win_amd64.whl", hash = "sha256:b6c0e4f272f9410f8218d1db0cc7ea10cd8f62db19f820b9ace9f6c2b33bd8dd", size = 5727075, upload-time = "2026-09-02T17:49:23.656Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7c/409ced8866197da50e9bcb2c9bf101e3e9a35b98a851c0ccd2a44509eaa5/prek-0.5.2-py3-none-win_arm64.whl", hash = "sha256:0ebea4ef39f6446f6c414a5a506cde8942b17b5899f74cf90e352628085d4005", size = 5489643, upload-time = "2026-09-02T17:49:25.778Z" },
 ]
 
 [[package]]
@@ -5875,7 +5875,7 @@ wheels = [
 
 [[package]]
 name = "rich-click"
-version = "1.9.8"
+version = "1.9.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -5883,9 +5883,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/ea/21e4867ea0ef881ffd4c0550fc21a061435e50d6324bcd034396633cbc18/rich_click-1.9.8.tar.gz", hash = "sha256:4008f921da88b5d91646c134ec881c1500e5a6b3f093e90e8f29400e09608371", size = 75363, upload-time = "2026-05-28T19:54:59.144Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/3e/5688fdd83aea416de336582a274f2bc8236b5c261b04c11e17bc262786ad/rich_click-1.9.9.tar.gz", hash = "sha256:324cba7513cd4187ee92b2eef21f071714e45be062458c8b157bd7e0c81103e3", size = 75866, upload-time = "2026-09-05T19:20:14.799Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/97/a87901aef6b7e7e4a34c6dd6cc17dca8594a592ef9d9dd765fca2b7facf7/rich_click-1.9.8-py3-none-any.whl", hash = "sha256:12873865396e6927835d4eabb1cc3996edcd65b7ac9b2391a29eca4f335a2f93", size = 72189, upload-time = "2026-05-28T19:54:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/51/b2b91aec091e86bc961e5164f00207d89f133cc82b5ddad541d2132ea819/rich_click-1.9.9-py3-none-any.whl", hash = "sha256:365e7a9d0adb42e41ea832a0a12e02c44c079a26536dee688125eb9814f97274", size = 71910, upload-time = "2026-09-05T19:20:13.587Z" },
 ]
 
 [[package]]
@@ -6028,16 +6028,16 @@ version = "2026.6.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -6164,27 +6164,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.16.5"
+version = "0.16.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/85/c8e12473c93018f92d19dd988a294202e1c27426c47ec4de53ffb847b8d8/ruff-0.16.5.tar.gz", hash = "sha256:1b88500f9ffbcab3dedb0082c9f9492e91ec3d618aac1236a3e0189938f7040b", size = 4912003, upload-time = "2026-08-27T16:34:18.258Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/7c/6adb35d70e7c027e308274557901c7e00fb3407750faf3620c184ae058cb/ruff-0.16.6.tar.gz", hash = "sha256:dcf8a73d2ff77e99dde91244b4da16feba7f14e6beeb4015dee7c5a909e99050", size = 4921251, upload-time = "2026-09-03T16:57:29.037Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/b6/77c90a970fe2dae17a723acbd011043ea97c98d7deacccefdc4ba74ec512/ruff-0.16.5-py3-none-linux_armv6l.whl", hash = "sha256:12e5f673e774c35fbb62f288809c7653b73445f8ecec6b6063fd6ea3521aa14b", size = 10011941, upload-time = "2026-08-27T16:33:41.287Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/46/6cf67cf6411885a1d6f7f6d801682f155536a85176d10b605e2ceffed8bd/ruff-0.16.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:eda58a5802de40e7ed5b32b64e0b32539338cc6fcd2c78f61e3ad6a0d79f51c3", size = 10204049, upload-time = "2026-08-27T16:33:44.056Z" },
-    { url = "https://files.pythonhosted.org/packages/46/fd/c8720ca7a090abf0c2fef4abe8a5ef6e5127ed15196d8886ff75a2b370e2/ruff-0.16.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5ae9a7b9a8875131f40f8fe967cc86abf899779efd663cb7ce3d572d01da7eb", size = 9809037, upload-time = "2026-08-27T16:33:46.257Z" },
-    { url = "https://files.pythonhosted.org/packages/43/45/a684caacdedaca180f52bacccc40bf0789d2c5a7c75f25324853e9eaedb5/ruff-0.16.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b719b0a1f4d59710d283ab2965f621684a108a9e41da622e3b23f0326cd0025", size = 9964129, upload-time = "2026-08-27T16:33:48.352Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/f2/5d2bcdaca6b5b93d1b4dfc166cd2aebf7680143a1b38a28759df13a94d31/ruff-0.16.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2298f2780ed1be0c5cb1361e32ab7b1467f3cce7dabe101d2210a314f2fe42e9", size = 9821518, upload-time = "2026-08-27T16:33:50.57Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/ff/011cce29accf9257d5974145b733fc653a37985ed6825413a3987cefbfe0/ruff-0.16.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:258f29035a2dd021e7861e631b227a5b3f14e50c1184c9a6a122c5f4576154d7", size = 10534835, upload-time = "2026-08-27T16:33:52.522Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/5a/f0cf109bada9bba0e96c90c21c9f9251803f57225c32d293327a03c710d6/ruff-0.16.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9a4f0432966834019c74d1b7e5c51224305d7713f3d7faf3e7451f1a3be3cde", size = 11252550, upload-time = "2026-08-27T16:33:54.521Z" },
-    { url = "https://files.pythonhosted.org/packages/63/4d/1d481aaea2046c6a7ed7c291f9004c669cce3c087b6b376ed5b08271e3fe/ruff-0.16.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b5eb3a8c3d0ade9cea42b591fd530368e8798380e30e0a308b85a5cf718f09ea", size = 10777949, upload-time = "2026-08-27T16:33:56.88Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/34/ee245ca55f64443233034b3d02b03236b19242004281247c079390b7facd/ruff-0.16.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef0f69e191a13a3c9816f63163c88790cb12cd157bbbb384e9c44745702ab105", size = 10311656, upload-time = "2026-08-27T16:33:59.12Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/4d/c33a333e341c0a2b96c715b52d89a606f5a34cd4ac493cd9b8d0187186b8/ruff-0.16.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0eeab41fbea2c42f98dfb9822cdccda9d24ba38d49f6dc945b5c236d48f0ef29", size = 10532125, upload-time = "2026-08-27T16:34:01.166Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e1/a64cef78b40192497bb98a27a8aa8f2c98ee9ee15bc97f7712d94ef32937/ruff-0.16.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f0768e9df4300713fff30733c87575f68b6f1d8de41184e505b7fdd9c0c95eaf", size = 10097648, upload-time = "2026-08-27T16:34:03.16Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/4e/4cdc9ed3c3e109d2f71e62572a37457298d7bc7501ec3138babb7ed32bbd/ruff-0.16.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:95cc70cdc7aa80c338de356279d2adbeb2de0f520b9ecd8aba75b94e95e02f91", size = 9829344, upload-time = "2026-08-27T16:34:05.134Z" },
-    { url = "https://files.pythonhosted.org/packages/39/4a/31ed35ce31729955fc583ee0d176d6e784c1290cb0b0a75cb2134c1ab72a/ruff-0.16.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d185c8398ded1bfd91c0c2cb258346307571eccc473a8490af8c3977399c384a", size = 10277117, upload-time = "2026-08-27T16:34:07.425Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/a0/60356d86687b4b666d593df213f4dc3041750d024cb7bf2cfa81cfd65c2e/ruff-0.16.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fb8e3a3c4c6a784150a7ced53b015f4b253fc2bf97a610886419ead64b4756ef", size = 10711653, upload-time = "2026-08-27T16:34:09.712Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/20/656d67f5b25ca9bda4e02b1de25867b2954e1d19e03648060f167ad0f4cc/ruff-0.16.5-py3-none-win32.whl", hash = "sha256:288b0a5f080492fe5635db849f9e2e84aa3cce7b7f0e955997d416c507c76a26", size = 10034250, upload-time = "2026-08-27T16:34:11.8Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/42/ee8e68a207b9127fcde6c3d7e197def432f346cb1af159e1fa14ca0d1cdc/ruff-0.16.5-py3-none-win_amd64.whl", hash = "sha256:ddc6385fb2137f616357ca03d6c74f4be987f80fed4008566b754f6032b8546f", size = 10516714, upload-time = "2026-08-27T16:34:13.963Z" },
-    { url = "https://files.pythonhosted.org/packages/73/e3/7df5a396e445b9ba49ce9a9437439a4d80042c61c0ade199abf8d16de1ac/ruff-0.16.5-py3-none-win_arm64.whl", hash = "sha256:a64abe90968719b851bb7cedffaa8753fbdbdadab483089682db623f3edc587e", size = 10391564, upload-time = "2026-08-27T16:34:16.064Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/9cc1b79639e284ec103f43c88c644db4eb58cbd0ea1ca11f1193435369ac/ruff-0.16.6-py3-none-linux_armv6l.whl", hash = "sha256:61c368c26bf8e973e5ab14a2772de587bc068ea3f9a277f673380749b4898fb8", size = 10015638, upload-time = "2026-09-03T16:56:40.986Z" },
+    { url = "https://files.pythonhosted.org/packages/71/11/627d342ef727ea7794edf74fe23d60a074b02c3acc2e9436684e782286ca/ruff-0.16.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ecf4f068e2e123e43a26e9db4e19524cc56563912404e83bbfca375757e45a32", size = 10220762, upload-time = "2026-09-03T16:56:44.681Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d9/b75668ce41e4c8d073d18d6d08672ba6906ce45d5c06ea4fdb2e84ce3853/ruff-0.16.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:99b62ea33baf130f50368798d841f0d95527b6d817bf31817b65dd058f1d314c", size = 9835082, upload-time = "2026-09-03T16:56:47.142Z" },
+    { url = "https://files.pythonhosted.org/packages/99/97/123ab10b05cde889c107c20f5a9774955104b5552796a2a8584b089ae8eb/ruff-0.16.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7fbf89013f2bb3f6835a6038ff658dc8a1b38c98dc8e724b964168ad4e881876", size = 9949304, upload-time = "2026-09-03T16:56:49.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/58/a4a2c59dd2e5b85929c912d9cac3056eb9ee8c7e75e9b9fe3e109174966b/ruff-0.16.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56a67065e22efa6bc4d498299d3bb06c0c90aace8fac2068b5a12f9dc4d8d51d", size = 9840612, upload-time = "2026-09-03T16:56:52.368Z" },
+    { url = "https://files.pythonhosted.org/packages/61/6a/ff8c8626a786c4f49d48ced4a752dadbca65f5263005f9c2416578194694/ruff-0.16.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e25cc89174874b176a157e4428d66761c2c0c006654419bf384f967f361ff1b1", size = 10543465, upload-time = "2026-09-03T16:56:55.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/bb/c47535923365f337b82e28192e4e9eef2176511007cfd99a62fc22df5dad/ruff-0.16.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0700580ed5303723cb3c11c2f1d2a8913ce77b7ea86646dddb887f5417a9ba70", size = 11267576, upload-time = "2026-09-03T16:56:57.791Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/50/e5119a5212b5cd63b51e1f4b25e7bd636a6668fc069a3160b108ad7e3c16/ruff-0.16.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:15f1d0b6e165a6e56567befb6629f8209271311d990bae0f37e6d065035ef5f3", size = 10781993, upload-time = "2026-09-03T16:57:00.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/98/083d8b4ef3c51a0d19db84367791cbe9f44e4b53343d19dfa83556e1cd9a/ruff-0.16.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d72c591a96986ee4268860e2b7235082129ca5e4cb9cbba653a4b57c11893757", size = 10317748, upload-time = "2026-09-03T16:57:03.428Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/29/68f7ff2c5ad95f19f00627ac2de95644e25fe47371ea60b2db1fd952315e/ruff-0.16.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:65a006baa18f33324325814c864daef03541d51564b98c517610ea756ab7003e", size = 10540096, upload-time = "2026-09-03T16:57:06.182Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f9/79a8f6de85968641d68a7863aeec577551924ef066a990a48ff93167beab/ruff-0.16.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:cd02a7bf1a21a8735228a3e8c95a9dc5cf86bd2a52194f4aaae2a5755b4de0f4", size = 10100494, upload-time = "2026-09-03T16:57:09.194Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e8/b81a22d9b90c00b892ccf2fa2ac36fa95de4c13ab85aea3e73795cfe4651/ruff-0.16.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:31b36f1e5ad85e0737f09d2be4e512e2e283583c14015da3b9dc07359ac0fc88", size = 9843663, upload-time = "2026-09-03T16:57:12.168Z" },
+    { url = "https://files.pythonhosted.org/packages/39/aa/54f516ec5e5a11c4afdceb1c454ebb054ffb96e4f4a1705580b4346abd35/ruff-0.16.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:61029b4ab4aa723fd3064fab96b1d814492596bf0c792679fffcbde1e1679953", size = 10282461, upload-time = "2026-09-03T16:57:15.077Z" },
+    { url = "https://files.pythonhosted.org/packages/52/0b/38d0aa8aa32372b96dc44f97b22e576c4147808271aab7b2cb1e353d4445/ruff-0.16.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9ac8998457832c2061709d900856b7ad271dace0cb41f346588d540162bfa718", size = 10728808, upload-time = "2026-09-03T16:57:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e5/9e274e24eeb027640ffc7442f21239f16d17f47acec15ae34f32e03a5c79/ruff-0.16.6-py3-none-win32.whl", hash = "sha256:0b87d9d16fcb63e8018423ca1d50b7260f15cb2da33e30db4baad4183a948c25", size = 10049212, upload-time = "2026-09-03T16:57:20.55Z" },
+    { url = "https://files.pythonhosted.org/packages/22/31/72472449414223ed1a2da236b992adbb1a2ae59e34794574810f60ce068e/ruff-0.16.6-py3-none-win_amd64.whl", hash = "sha256:10d21c51c3495d8eaea7b703a16592117ea6eb1d649e36335aa965ff1173eb39", size = 10556402, upload-time = "2026-09-03T16:57:23.501Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/07/d781f8f8e1ac24bef9f3269cf62ffb1407ca24c3a8f12e5e22874f90528c/ruff-0.16.6-py3-none-win_arm64.whl", hash = "sha256:7a976c79b958f94e50a022a19f0f8c87387448020935ec14fc74331bd0a7f2c5", size = 10412850, upload-time = "2026-09-03T16:57:26.416Z" },
 ]
 
 [[package]]
@@ -6386,16 +6386,16 @@ version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
@@ -6448,16 +6448,16 @@ version = "2025.8.25"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -6515,16 +6515,16 @@ version = "3.13.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
@@ -6603,16 +6603,16 @@ version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -6883,7 +6883,7 @@ wheels = [
 
 [[package]]
 name = "sqlspec"
-version = "0.62.2"
+version = "0.63.0"
 source = { editable = "." }
 dependencies = [
     { name = "mypy-extensions" },
@@ -7735,82 +7735,102 @@ wheels = [
 
 [[package]]
 name = "ujson"
-version = "5.13.0"
+version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/89/7a/c8bb37c8f6f3623d60c33d15d18cd6d6655d0f9c3eb31a9969f76361b199/ujson-5.13.0.tar.gz", hash = "sha256:d62e3d7625384c08082abad81a077af587fdef2761bb14c3822f4234b8d07d75", size = 7166784, upload-time = "2026-06-14T22:36:50.209Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/7c/e1fa3fb70b53192436d751b5cb671f0ee960baa188b8351a7fec735223d3/ujson-6.0.0.tar.gz", hash = "sha256:80e23393feb707582e0ad495c397a4477b646d08094d2df64f7316f9fafd8aae", size = 7169158, upload-time = "2026-09-04T03:55:42.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/a4/ff15f528d386f47b1972859f25587da017d5be84c75076b380fedde318fe/ujson-5.13.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:770643b4752266c5a466149848b78c3874940926a4ecef304f518b2b6cdb432f", size = 56497, upload-time = "2026-06-14T22:34:58.806Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/d2/92e83af35cd65d3b7c47fb0e24927aa2b478897af8b0dd0ee19abcd50c03/ujson-5.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a8e8c1203cb1a27720debc334f840a9170da741503522f86999710cb4738fbe3", size = 54301, upload-time = "2026-06-14T22:35:00.301Z" },
-    { url = "https://files.pythonhosted.org/packages/96/9c/3eb2d21778dbd0a9f1adae7ce73e4f6c981efa7fab534eb28afde31fd25e/ujson-5.13.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:65c1813fdd742fe3c249d9c417fa490e5b54e8a91bf343a88486ec50d175c444", size = 59968, upload-time = "2026-06-14T22:35:01.612Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/52/f5b72747349c66552396166a13424a717df70e76a18ac5bbedc84c244407/ujson-5.13.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5aa9bf16f0131812720dd4ae70bc1a0cf68f79e93c07c66100d328e75944b567", size = 53434, upload-time = "2026-06-14T22:35:02.644Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/73/103c2c6df7bfe57e01fb6006551188b4dc9f873cb5f72146bd5b177b75f9/ujson-5.13.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:82c17b904c03c2b9629486ec91a8fa46a15f10d03504284f54ed7257a917d9f1", size = 54976, upload-time = "2026-06-14T22:35:03.759Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/ba/44fcf17cc93be7c6647fef2e556d703791659280e6409623dea854e6db7d/ujson-5.13.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0b5f6983b2469db00e540b68fa8297b7a0ccd0d5173c60cc3e84f336b09395f", size = 58239, upload-time = "2026-06-14T22:35:04.842Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/60/10f6c92b549cff72e555a900ee7128b992ebf510bad0eebd946e72b68ecb/ujson-5.13.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b877fe7926107d25d54b655c5b8dd94b294b22c157233163ad29fdb54ac10cf4", size = 57876, upload-time = "2026-06-14T22:35:05.998Z" },
-    { url = "https://files.pythonhosted.org/packages/71/5e/b8b2806996c75d4c34cf92ec04c5fff58a645a32632f27836886a718cb87/ujson-5.13.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f3cae1c811e787b9500e2830af8632dcb32a78dea5baf15aac51d681c59a59dd", size = 1037734, upload-time = "2026-06-14T22:35:07.081Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/02/baaf3ad0bb4b2c3bec3d9ff8a59768d39d20201146742e8581f8a0f87e77/ujson-5.13.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:820b78a6a183ab6591b2ea888020032ef0fe328d852af9a5c8d8084ababb2218", size = 1197048, upload-time = "2026-06-14T22:35:08.319Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/aa/a945aeba9d463e335169b3c0ee60adc147e22e80bb636fe0f185bed1247f/ujson-5.13.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b1209c985d1f4c2ae085ced7325509650cdb3533bb7294558dd1f26d48377942", size = 1090118, upload-time = "2026-06-14T22:35:10.014Z" },
-    { url = "https://files.pythonhosted.org/packages/58/dc/2fcf821896803248122835c800e74f4582de9d6092efb37152acd7f79bdc/ujson-5.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4b7badefa73f96bad9e295ea22bd06967b851c8aad68c74196437e3584f25de5", size = 56496, upload-time = "2026-06-14T22:35:14.362Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/c6/83db69f96dc12509c9510084c0389c4aff4dcf427f9b613d1a23abd446ce/ujson-5.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:09effd42924a80df20a63b31a1ede905e66b0ce24aafe7a4cbedb05c783f8bb3", size = 54300, upload-time = "2026-06-14T22:35:15.522Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/6c/6d87206988172015781b9ff842c0a7eca897c026b2e7a95e11d86d46ddf5/ujson-5.13.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:89d0bfc986d02b4ce76b00e0f560bc8d30dfe8c05a1bfd8529e085eb6c1a77d9", size = 59976, upload-time = "2026-06-14T22:35:16.636Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/43/d28ca5e6c3d8c467a4c6296404067f4eee9d67dfeeebeb3c5fb0bd6cb958/ujson-5.13.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cdd9618e07b3b142a02f0ab8227fd52453688b8e8e60ac0511f13a25fa8009db", size = 53476, upload-time = "2026-06-14T22:35:17.664Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/99/d6bb0e18188954326b38499ae61b04ce8ead6425b8844384e537a491267b/ujson-5.13.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0806683e8171ec06817e6af22f14ba0cd2f16def8a2ffb22a28a10615249355d", size = 54962, upload-time = "2026-06-14T22:35:18.693Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/5f/8f1ce659a59ef9510fa47b95773442049a383c533a645b2da8beeeec90f1/ujson-5.13.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1cf46c79498c81f088cad4165b1669a78bba7bfbeb778c7cc1aff316e062b0d", size = 58265, upload-time = "2026-06-14T22:35:19.775Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/8e/9d11af9d1d19ea239b0d289cf62a611cb4f2da9ec0d46b826767f4ab1768/ujson-5.13.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2282039eb26f08ed1a1381360395f8a310f39a45ef7314cb0f258a7d2917ea3", size = 57874, upload-time = "2026-06-14T22:35:20.896Z" },
-    { url = "https://files.pythonhosted.org/packages/25/e2/7891c4a1c954307ab6a575686897a4963aad36c284742216f52dc40cba4a/ujson-5.13.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2c75eb7fac0fe92925b959cf2fa18f88d9fb76b10781fd2a6ccb895d5fb89171", size = 1037746, upload-time = "2026-06-14T22:35:21.964Z" },
-    { url = "https://files.pythonhosted.org/packages/89/4e/8a4ce87d3eaaee398f4238f74f128c6eb34269f041659995b2c09710ae7c/ujson-5.13.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:12078e81def2790140583abefc1b979f3c77be15d53c524bf0e232f669822052", size = 1197022, upload-time = "2026-06-14T22:35:23.183Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/fb/a1d0a6a83a13adee3a13cad308dcd3251ac53c4bd781f737242ad2f10d19/ujson-5.13.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e12192a37c6c0e476554b62647acdf6139a47b6f13d8bad8dd2316763c4cee12", size = 1090116, upload-time = "2026-06-14T22:35:24.421Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/ae/b66deca15da1f7faf6952d8eddf55978482bcbfd294ed2afe2c526ea325f/ujson-5.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bf81570ac056cb058f9117b52ca5dd800bfe9381d0076d0bb30a08a54591d654", size = 56743, upload-time = "2026-06-14T22:35:28.863Z" },
-    { url = "https://files.pythonhosted.org/packages/88/4f/b03bcc9eaf4621ac9008dec90918d8fb4839d611666cb99eb255696c67fe/ujson-5.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7edf16359c52ed53406e216565d83e6b98c23c3cb9a0a01673f2493f8fb15edf", size = 54390, upload-time = "2026-06-14T22:35:29.857Z" },
-    { url = "https://files.pythonhosted.org/packages/77/79/f98c6c1a4ed9d92d39d5d2d133f2b6fce5da11ea50c341117aedde8011c4/ujson-5.13.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:24539618fb3243cfdf27dab9a850acab80798a01501e9586b61fb9ecd016a891", size = 60047, upload-time = "2026-06-14T22:35:30.857Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/1d/f68e14cf476d149945211142f4c20782c1f232c489e8edcc4f4b58ce4997/ujson-5.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fdde6341d213b29f413b5fa9fad1392d5408074c75f0900ed949e97e546fa5df", size = 53437, upload-time = "2026-06-14T22:35:31.835Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/1a/5718237cf4141e5be46ff371387e90b01f27774cb6f0f79ff4803a2430ca/ujson-5.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:229faf041ef249ee3fd57bac1cedb123d2718ab63f6ccd50eca95ea902eb0dca", size = 55057, upload-time = "2026-06-14T22:35:32.897Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/6f/7f55c1e9e0be87beebaed553fa186ad5f6d5d639cbaa9d49f78f2f91c3a9/ujson-5.13.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d02f31c2f59cc6a1c2c3633b377701fc2d8e876cc01950735d7a01132ccc233", size = 58186, upload-time = "2026-06-14T22:35:34.055Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/c4/9a34ade542426f56a0bc042f774073d1c247ae7575363c27587788cb2b2f/ujson-5.13.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea7204e9fa7538bfbb1396e1ee8c2bbcd3818b3633ef5bb14d4fdea52994d14d", size = 57935, upload-time = "2026-06-14T22:35:35.05Z" },
-    { url = "https://files.pythonhosted.org/packages/36/06/407633f0709e168107f56368bd5a0fa8fe07acd7f1d3000710bc0bb07470/ujson-5.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7c5a2478a3a1fa4421f7e035b87194eea0cf44c7971a3f32ad1b42a0dfd63c03", size = 1037685, upload-time = "2026-06-14T22:35:36.022Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/df/eb5bd92dc1b23254fea5b2022007baff5491a7478bfcf7e9260d3a10f1ac/ujson-5.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:b535e0970c96957e999cfe5ec89361f0e8d0bb987fb5d5144f6f495cb3ed9e19", size = 1197141, upload-time = "2026-06-14T22:35:37.38Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/1c/65f2ce1a0411ec9a87339db01f0d5d554a49c4248ec68ab52a1b7e14e9c4/ujson-5.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3d0ad1207694988498fca7e0bb28eba7564fa33261d2f9fdf66a3aaab376b803", size = 1090225, upload-time = "2026-06-14T22:35:38.95Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/f1/fe8a467d8ff5821e076b96f398d3acfe3cd568d900e6ccb41b215592b152/ujson-5.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:46998fc8d11aec34a20e2010905e7059732a3d192d9a3c3fe4f9ffd146c87ec8", size = 56746, upload-time = "2026-06-14T22:35:43.398Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/c0/c7ab82d6471dfa7e4fd68ae6ff2c6a50d077c05d6ecdea0cec8af635b2c4/ujson-5.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ee03ce288ba25b05cf0de87203165642277a25caa4f00a437e13152e5214e310", size = 54388, upload-time = "2026-06-14T22:35:44.586Z" },
-    { url = "https://files.pythonhosted.org/packages/10/e6/4e9e998d991ff88bbc93b21daa63bba2baa61c6f952dbcec937cf7304ebe/ujson-5.13.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:cdf33b588a81b05d0b585c66f83050c49cb670623424d10e4d1ad37ba2f7eed9", size = 60051, upload-time = "2026-06-14T22:35:45.567Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/11/876dff43f05417a01c6119f0fa10e01f1226631c5927ef08f56876b2bb67/ujson-5.13.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4cabd73c114ce93c21d7db2e2d8e16217fd8a5b2b3ec754629eebef5c262d47f", size = 53438, upload-time = "2026-06-14T22:35:46.623Z" },
-    { url = "https://files.pythonhosted.org/packages/09/02/f9dbf6c3e46d700eb1d9ed637567221a06eeb1ec289633be992ef54d7a34/ujson-5.13.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ffc61fc756a64f4d169a78cc638d769e3c324f45fc51997626abf4e5e5dd6460", size = 55060, upload-time = "2026-06-14T22:35:47.647Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/3d/7e49a70265a1e5ed1b5e8edd5f54d57ae41e2134faeae9b16f6f5a0eae20/ujson-5.13.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c00323c13a35822c9a67a26c0b2a0787510bf1ef490922b58009b362d1a3e21", size = 58189, upload-time = "2026-06-14T22:35:48.617Z" },
-    { url = "https://files.pythonhosted.org/packages/66/34/b64278f67e19052f09810576c7e50b3da8d4f5218b226046324d4d5c24b4/ujson-5.13.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:496e662a6b46d5f936d77fb68259cece19213bb2301ddd520dbd75ac7c90c5f4", size = 57941, upload-time = "2026-06-14T22:35:49.674Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/8c/51513357a5c75bf3e5bae46accfdb3e6e6f5caeb72ca8b253ec45ba853fb/ujson-5.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7fd41b86444df14f8b4b7afaaa9f27bacfbf8c18380872317aeab6cd125dcede", size = 1037688, upload-time = "2026-06-14T22:35:50.699Z" },
-    { url = "https://files.pythonhosted.org/packages/54/5a/dc6afe071d6b977390d2dc41e15800a2716f317988dd03187cffe7b4d624/ujson-5.13.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bf3c2c4ea55d4187903fcdc689a9bf5b0fc72d8c0eaff39db18c1f337c8832c1", size = 1197141, upload-time = "2026-06-14T22:35:52.052Z" },
-    { url = "https://files.pythonhosted.org/packages/50/23/b473d101412c68527cb502a8728f96ab307aa7bfa75d6ea2037e2c7f74e8/ujson-5.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b6eca7751d61045a9b1e7f9a8c97ac24b164f085b60bef1c4668654bb2338011", size = 1090235, upload-time = "2026-06-14T22:35:53.589Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/9a/b5139d696f5328f3cab70b9ec046f15e3f49497a4de6280974640602f539/ujson-5.13.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:cc9dfd41fed397ab03bb9d9fe1cbd83301211c772a17536033ce7d68877ac82b", size = 56897, upload-time = "2026-06-14T22:35:57.974Z" },
-    { url = "https://files.pythonhosted.org/packages/53/55/477183aeddfdf0f88ae039ffee0ed866cfb993da0c0c9aa915807554aef8/ujson-5.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca7ef2fa6c408a7c0f558e4d33d93b32ddc35ed6d3cfc505747931a64b7465d5", size = 54451, upload-time = "2026-06-14T22:35:58.932Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/63/55e5f23e156b4c8bca095d828b4cd3180c0b42aa3501ef88836d79606fea/ujson-5.13.0-cp314-cp314-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:a554b2e5bee85030369514cef8b0b913cebe1a4c2c0c13541966d50bcba22b1a", size = 60053, upload-time = "2026-06-14T22:35:59.969Z" },
-    { url = "https://files.pythonhosted.org/packages/26/b6/08c6cf5548bd6f4bb557c9fa7e8edf87324bb04c17249d1966028d61dde0/ujson-5.13.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ea939ff629ab03ae970d03eca6d1febd8ed55ba38ca44aec64ce997537cd3fa0", size = 53481, upload-time = "2026-06-14T22:36:01.007Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/b3/0ac9a03551467784067f505df1bb875c639ba32f1da79ce467ab15911ada/ujson-5.13.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b98bf2faa5e37ecfe752226ea08290031e375a0c43d425a0b955fb3e702a2a71", size = 55058, upload-time = "2026-06-14T22:36:02.297Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/be/ec91029aec067174473d022fa0f6c3c1431a173f888d7599739f05c668eb/ujson-5.13.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9a4b92344b16e414aeb609e57f62c466500e53c94f1698f5b149dc0b7223ec3e", size = 58225, upload-time = "2026-06-14T22:36:03.321Z" },
-    { url = "https://files.pythonhosted.org/packages/29/33/a948f329252ece3f9c93d177243de6e677927ebc6ac44256742dbbef3c39/ujson-5.13.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7df805aad707507a1fa165fb716218ca3a89f142125dc4b23c9fcc08fa402d97", size = 57930, upload-time = "2026-06-14T22:36:04.385Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/0c/c33655218b8e0a8adbf066de0b999cae5c324061f3eaa4dda17423145d9e/ujson-5.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7576bdbef327c3528f011002a2d74486f6fe4e33289bdb7a042b7f1a6e9d8285", size = 1037728, upload-time = "2026-06-14T22:36:05.467Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/bd/d286947525ea7ce3f2d8dc55c15b9ffbe425bc455c96af7b8f8a402599a9/ujson-5.13.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:6eee5d7cce3f32a468905f9ff61807a60287a90258d849460f6fa826e810870d", size = 1197146, upload-time = "2026-06-14T22:36:06.839Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/3c/9eb916377050b0785f048a34588c1c390ddd41ae00b78db68ee1ad022356/ujson-5.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:144e9d8a454cfa727e0f755e1863738ed68068583bda5463052cb446835bd56c", size = 1090223, upload-time = "2026-06-14T22:36:08.329Z" },
-    { url = "https://files.pythonhosted.org/packages/12/e9/1c543837c6a3c6672361882a0fa269bd02daf9cc4c0ca88a9dccd9df98d9/ujson-5.13.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:69b4e36bb7d5f413ba8c00c8006b2ec627cc5ace97301462f6aadb66ec9d2979", size = 57402, upload-time = "2026-06-14T22:36:13.238Z" },
-    { url = "https://files.pythonhosted.org/packages/99/e4/39862f0f7174ff07cfd1e2d0c9065ded34aeebdb7db8daf2f0e5bf89b46f/ujson-5.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8b644d50f66de5490c1823c7176618cead5e8e8a88cba9f40a6308ca52e79267", size = 54973, upload-time = "2026-06-14T22:36:14.432Z" },
-    { url = "https://files.pythonhosted.org/packages/02/66/f53d3b32c3f177f846ca6b624e832f29000d8a213a2d8768e254bd470ced/ujson-5.13.0-cp314-cp314t-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:15107aaa4f559d55201165ec32abb35c283a861be1fa67229578cb7d93fcd93a", size = 60683, upload-time = "2026-06-14T22:36:15.806Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/d4/dddc4646d2633c85c938c2ded7d5a9711cdad5be1e13b31b7dad76f61c83/ujson-5.13.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6e343c5f0c058523f1edbf6ae4eceb4e0d934205a53bbdd8d9a945c83324662a", size = 54167, upload-time = "2026-06-14T22:36:16.952Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/c0/d8608c3f4d3f05e6441364b63fde1d279700135c1a6577a773662c07fbcc/ujson-5.13.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:02200035bc80e830f076ffc1b329a94c295aee6d9de8c9043647cb9a7bd4f76f", size = 55568, upload-time = "2026-06-14T22:36:17.975Z" },
-    { url = "https://files.pythonhosted.org/packages/22/8e/dd12b735aaba0806c3d70c18184d50e1f9712e0757c7c0a4f376450cfe28/ujson-5.13.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7f19b81b73ff28f5c5022ee794f94122bfcda07a76423078e349465d71223a1", size = 59086, upload-time = "2026-06-14T22:36:19.071Z" },
-    { url = "https://files.pythonhosted.org/packages/48/43/ad41e8752d5ec3a590a5e7b426a54e36b7aab911d9b5a4f7384dc62507ab/ujson-5.13.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:82e1393e6dbe3c95fdfc95c6c528890e191351a1f024ef51126cf1f22543af52", size = 58667, upload-time = "2026-06-14T22:36:20.171Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/8e/b44a6afb77b94118655c029081b7932d64bb4c5b1c8ba2b7f5808b5d0bc2/ujson-5.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:38afcf994b28ed85ea2420e2a8d79a37d0a77348b3daf53850c16edda66f942d", size = 1038553, upload-time = "2026-06-14T22:36:21.245Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/93/fab1d786174c8780eb3e386c73f1925a435e97fbf77c957fea4fca83994d/ujson-5.13.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:1bdf2518971586f2b413156c49d9dd8b56cc990a8647081e1bd00af60564d469", size = 1197938, upload-time = "2026-06-14T22:36:22.585Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/bc/2f073bb708f9d128f5d1cb39063a5f6421b1ce94c61be8661c55a189f407/ujson-5.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:751ad01042472f1c7c02f5c597c7aee79834e82a6cc384ca302173bbc8e8deb8", size = 1090938, upload-time = "2026-06-14T22:36:23.947Z" },
-    { url = "https://files.pythonhosted.org/packages/30/70/dbdd277d64bd3a149532567ceb082fe26f4ead58c39e0a97566ccbdf14a3/ujson-5.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3e074a1f7778d58aa3b3056bab7b6251aabb3f381808018ca2b7fb8dbdeef7ab", size = 58393, upload-time = "2026-06-14T22:36:28.702Z" },
-    { url = "https://files.pythonhosted.org/packages/71/48/592c70af94a67cafacd9c840ae2980f27d511dde2732a4c0dfac8f176ae8/ujson-5.13.0-graalpy312-graalpy250_312_native-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8bb53ef95d35875262b8d0aa28506ca612ddd07058bee2a90f609938e69dc801", size = 54447, upload-time = "2026-06-14T22:36:29.802Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/9d/2bb91e1e25a8584cb3b63544b9bd26f621173535c77ac6cae13bad8e7904/ujson-5.13.0-graalpy312-graalpy250_312_native-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fb296a0aa480ab88d895ddaa90372604c08ccc72323f02590612c775426ab413", size = 56066, upload-time = "2026-06-14T22:36:30.806Z" },
-    { url = "https://files.pythonhosted.org/packages/76/ec/8e3802fc4a4e31e817b972bbb0e704a484d8c75ec349b3feb45fa9fb54c4/ujson-5.13.0-graalpy312-graalpy250_312_native-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2862f81af44b3a7e74c5d80caa118d736be1991ce6f1d5c723716fa403060cc6", size = 54938, upload-time = "2026-06-14T22:36:32.051Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/48/d0e3e511039b86fd1ecfe2bf761c800552d273ef8f19e71de93bf38a909e/ujson-5.13.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c16e07581172f08585b409246f4535dab13ee85af0e3d3cfa8684b653ca44fa8", size = 56115, upload-time = "2026-06-14T22:36:33.349Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/7f/276f830bef4d530d50ff4d8f8c568002e7ebed9f64c06747b1d1c4325f02/ujson-5.13.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:96e7e019b097b4b25fccddadb369d13f412c13695fcf0680b6bf906376156151", size = 52479, upload-time = "2026-06-14T22:36:35.627Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/50/99b05555ef42a2ab2e26aa369c46bde6a64f8aeeb687628102e98cc78bed/ujson-5.13.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:7892ea6dd85ede6d30fbbd22af1239b9d81dabdf9b7a8f10ca6d4464d4d9b8ab", size = 49953, upload-time = "2026-06-14T22:36:36.72Z" },
-    { url = "https://files.pythonhosted.org/packages/78/15/399766e8ba002bd8e5e2e45828e0e12a5dbeb4145d6a604ba3787db5eec2/ujson-5.13.0-pp311-pypy311_pp73-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:e1842e10adc8f0db0d3e8aa3a1f8b05ce0456b39e180c8553d7f36dd0bf24b6b", size = 55716, upload-time = "2026-06-14T22:36:37.833Z" },
-    { url = "https://files.pythonhosted.org/packages/61/a6/825d92bce42cd442b57d89b4c20afc1737246321d3433c6194e5c35c6a11/ujson-5.13.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c8bbb1f5ab810954fb307b6c5e68af58210c31da8569f9e6498a3958c1859e72", size = 48648, upload-time = "2026-06-14T22:36:38.878Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/d6/7ea7a32f35457560806375193dbc4f0d8ffd8c8adae42f86686392a76c41/ujson-5.13.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3f6d55c68985654a84a9b47ac51f2655adac4fd264e4189f832960c2270dcf70", size = 49947, upload-time = "2026-06-14T22:36:40.022Z" },
-    { url = "https://files.pythonhosted.org/packages/af/b4/0bd6449ae35b6026d94f4d1a32dbc9f40c969ed1d6e36a7e26ccf56371be/ujson-5.13.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b266f182d4bce74a6a9e1f86988485e8cd422efdcc7c3f537e00cc956f52678", size = 51149, upload-time = "2026-06-14T22:36:41.129Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/2d/39da479a8461d1d78d533940a8426a84e23708a6a7a426f2178e04443252/ujson-5.13.0-pp311-pypy311_pp73-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfaa8302eb9bb7f5e231f256caf83040760585e32751d19155c0f0c0225f8de1", size = 52456, upload-time = "2026-06-14T22:36:42.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0e/37251c324a2b8799a22b5354b8edd4b867b91f0e68fb74423772c377bd7f/ujson-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cca83e86a300db6c72847bc7acc259bf86481063aea408b07c8a96d649797b7f", size = 54947, upload-time = "2026-09-04T03:53:06.967Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e6/988d06bf5e46c992397d93123012bdd1e84bd829afe8181d8334a98ba7e0/ujson-6.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dc8510c8b5b8373e0789ca05ebffc0aaab6e8a8f86d67956c91bc37f43d4f989", size = 54239, upload-time = "2026-09-04T03:53:08.176Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/78/ac325bada531de2fa2623e7dca1f690ae2314f9fb790ebad64dd41571298/ujson-6.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:1080587042cb19f9cfb08f289498d866ac5f93393b21006321dea331dbf62375", size = 58298, upload-time = "2026-09-04T03:53:09.41Z" },
+    { url = "https://files.pythonhosted.org/packages/76/67/0e6a2ee29000cdde7a8fb931bf2fdd941a8c0deef18451e3e9c936dbfece/ujson-6.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b8d019e935e4f8d6493690036161e62fae033891b71f20d238342ae266fec852", size = 52397, upload-time = "2026-09-04T03:53:10.631Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9a/cce4d9f023bc3213a17ceab844c597399f1e65c6654ba3ba178aff28683e/ujson-6.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:83194e213d9df2f2aed1edb821689f99c0f7789bdee173125fda510282f61070", size = 53487, upload-time = "2026-09-04T03:53:11.648Z" },
+    { url = "https://files.pythonhosted.org/packages/15/bd/d1652f9e1ff16b1324c0715d97c8c295d845aba2766d69dab8a2cd90de9c/ujson-6.0.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:108a9f3a635913d38a856e05007afc9b243929938939cd11576a3f5484925145", size = 57182, upload-time = "2026-09-04T03:53:12.731Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ec/ed610aff77e0f060d0abb6e1d5ad8f07b2b6e4a0c5e765225ccc5f229ef4/ujson-6.0.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e94f0b95459caa6cb5e333baf6763bf1e7a96ea5e4f1ea7fbb0ad88e81a88ab", size = 56232, upload-time = "2026-09-04T03:53:13.848Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/bb/4e37fb0c4593870684f848ba0e3f06f17695596df3311fd4ccf0185db2de/ujson-6.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:bde35c0d6b5a204990f43e4ab43b6e3e4d5a1de773246e11d518945e3ba789ed", size = 1037432, upload-time = "2026-09-04T03:53:15.084Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/40/7db01714718c4324d3641061b12cce285ef906f750c09157f65dfc5c16fa/ujson-6.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:666a91606eeb47c997927ff294f3a9f8f930a02d0d2293ec7b19da5ed688f7ec", size = 1196188, upload-time = "2026-09-04T03:53:16.611Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2b/a445456fdca0a4bd6c691861d66a7c226f015a543d9f6b2f5537e1b734cc/ujson-6.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:03a385e523f67dec6d4dad0970f20a080cad045b56d9a3564d07807090a9c106", size = 1088475, upload-time = "2026-09-04T03:53:17.848Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/c3/170109078742892cf5ca19b0c8df517e5945f5b7141782235c2cb6124518/ujson-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4a69419253e9367281db03355eb55b5231eef5ff338bb816eb5926ee788faf48", size = 54948, upload-time = "2026-09-04T03:53:23.106Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f8/4b927dc315819479058551d9b18307460a5e1a07ff0e7470a82aedf63c1a/ujson-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ff3b33d8c8dbbe32936d2056296324371a07ed0b29177e2eb8ec46569436817f", size = 54233, upload-time = "2026-09-04T03:53:24.334Z" },
+    { url = "https://files.pythonhosted.org/packages/84/52/bf7a055ae58f13933500906a937b58b7e9052ea881c1159c1ad5bfdb17d3/ujson-6.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:d4a731cc7cd513bf4c4016a24a060fb1aa8475e8682e1f8b1bfb836f8d3f50f0", size = 58323, upload-time = "2026-09-04T03:53:25.357Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/42/878078293fcb394f3da724e6cfee089d57202365846a3b2e3ace2f112405/ujson-6.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:20eff4f1ea3b970b998bf111036404eb18e976d4919783f793e539370b8627cb", size = 52433, upload-time = "2026-09-04T03:53:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/35/de/fba3d2c547622e66dfa0aca869a61a457df64d6a29867b9a5c7279336902/ujson-6.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7e747c535d4ca9afdde31e034484a1020717fb18fa8a8faa789171abeb2ad1ff", size = 53503, upload-time = "2026-09-04T03:53:27.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/23ed92a4f03d44598775709fcbf7930021353ed17d98a992c62ad6a29b29/ujson-6.0.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2f3c0a77235d7ffcce5c54b872fa25de4f14e6ffc159c62ad93b0a9ca98a1d20", size = 57189, upload-time = "2026-09-04T03:53:28.738Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b5/68e1eeee2c35f79a0d720ac066236f0ddfb9a29864cec5dbe9ec006a0f74/ujson-6.0.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd26d4b182b7138fc948cda55fe2e91b70d987731e169e628f42ba22cc6e3cce", size = 56248, upload-time = "2026-09-04T03:53:30.171Z" },
+    { url = "https://files.pythonhosted.org/packages/db/66/e5edd446495ede37491da219779b762d1877c9a3d69f87aadbddafe0cdb2/ujson-6.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0a4edbeb091b195031a0e96fab005150340e383c095cac6b5c2b7dc8f55040b5", size = 1037453, upload-time = "2026-09-04T03:53:31.421Z" },
+    { url = "https://files.pythonhosted.org/packages/40/11/6335f73db7f59e54f574adf226e94b7c148c1b492cf4fbfd95d853504d4f/ujson-6.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:d2e29a0dd1d33e49623d4c69bfa7e6d3d5c7530cf42bebe612cff965acffd1a9", size = 1196209, upload-time = "2026-09-04T03:53:32.737Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/03/76c7213a59dd0f21a984f3422e14f7955e97a67e159890b29f3a2c5c0e30/ujson-6.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5919fe3109a08f8bd682a2ad1cec5cdeff7c1f563b812aba26e86b8b0ab05558", size = 1088502, upload-time = "2026-09-04T03:53:34.125Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d1/6a5526d896ead68746997a95f0ae9077e5a438c1574ecb6ea031e72cb75b/ujson-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:02148bd4706f42b063bb95f6cc309e16554fb4c250db4683688c0a3eb83048ad", size = 55112, upload-time = "2026-09-04T03:53:39.569Z" },
+    { url = "https://files.pythonhosted.org/packages/84/b0/454f4a6aea48fd580eaaceb9d692cfa219b41e197c6bbfd534ee8945dad9/ujson-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b305657e2ddc29a50b333053e7c7f431a8c24c92b7dcbbf7a420f2330152b486", size = 54240, upload-time = "2026-09-04T03:53:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/39/4536f25a8c47fb78a12b5253929ce4b41a121fcd4e1b34d02634b6939e4d/ujson-6.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:a054959ec07f2fd63b6e8a63019a6879262c4f1983a100545c5a0206eefe993e", size = 58494, upload-time = "2026-09-04T03:53:41.561Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e7/870f261071662573c6e0d74f28ed3e6d4ed8c604ced85df3a1e404c679d8/ujson-6.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c51915961a51e37403fd94114e293d580dd916ddd1961b229217a87193d2454e", size = 52376, upload-time = "2026-09-04T03:53:42.67Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/7d/cd5139cbdab193562713851e751249e2981c90c275c57584403351d7d70c/ujson-6.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aa03ac78c7806c6a391c037e0a63552e11532210b719bc062cddc00671a7577f", size = 53714, upload-time = "2026-09-04T03:53:43.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3d/066537298a91738f2f598ebea58baf0a612a65fad92a522ddac31d8191fd/ujson-6.0.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0aa247eb50a52bb2190871ca8c2e0a96f8190bfdb1ebd68c70d1bf422f640b73", size = 57184, upload-time = "2026-09-04T03:53:44.999Z" },
+    { url = "https://files.pythonhosted.org/packages/09/be/4ddd61b3d4beb21eced10d0d100a4dca26f13303d4952e48fb5e89167869/ujson-6.0.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e9359bfd0efd12593f0db40ccb2d1497284401da207f1d6a1783718313201b21", size = 56411, upload-time = "2026-09-04T03:53:46.079Z" },
+    { url = "https://files.pythonhosted.org/packages/21/18/8835fce508f89f20409b1ba336ffe5cde18e4ef66889aeafaf3e9a73ce4d/ujson-6.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:921408c159b01d39d70e90252b8ab17f16594fc91f229e6f881642fb0ed24ae7", size = 1037444, upload-time = "2026-09-04T03:53:47.21Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b1/58a77bf3939317a679474d9e0cca62ce87f0c299689aadf2940ba6a5acc5/ujson-6.0.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8141cade37dabc5f090eb5e6a267eabb6b193078becdc82aaf10433196715c33", size = 1196452, upload-time = "2026-09-04T03:53:48.631Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8d/39cd22f388524daa0155e78ab64232711e7331fe31ae3074f9e6593b7685/ujson-6.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dd55ca435d6c3c7e4cb6d8a0a98a133d4fd1b67d9abf90449442d9f5a728a9ff", size = 1088719, upload-time = "2026-09-04T03:53:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/32/c67df85215ba0ebcdca8f8b1b3a856fd2434da87f84f9757e275ef99bd40/ujson-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fb37ec7d7542e2f23fd7ca8fd034c8db7221c5e86d6a6a3a170711f993eecf15", size = 55113, upload-time = "2026-09-04T03:53:55.285Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/a0/e5c7ae933fab41be06f0ff7976e3483519cbbf9e2492a217a5550af95c18/ujson-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ad11c9153c775087d261634410da7cfaac2743d79bc9ab573177d9e3398f00c6", size = 54247, upload-time = "2026-09-04T03:53:56.383Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/10/0993497a08f9fcff34cbcdcd6da46491f415e711a459c5d81f594e89769c/ujson-6.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:2dbe0b6d417b458164ccf1f59e081d6bd65c1fb2f626e0daeb6fb88c436f9643", size = 58497, upload-time = "2026-09-04T03:53:57.791Z" },
+    { url = "https://files.pythonhosted.org/packages/70/55/06a578dd00551b10bc94d68889387e5de11977ee92cc53921eb02713146f/ujson-6.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:455e6ae6c925eca6358110e665a31e5bbcf0a93dfe9822a26b954c9351de2c3f", size = 52377, upload-time = "2026-09-04T03:53:58.859Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9a/cc0d306e93d1a8f1d48d54f52cb2cae39b56a4c990e2cd8cf328697bbc80/ujson-6.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5376a8c14d0eaf80789bdb10e21ae12582cdf526eb921a47f57053ef08c63f8c", size = 53718, upload-time = "2026-09-04T03:53:59.962Z" },
+    { url = "https://files.pythonhosted.org/packages/15/48/0462149003b03afe83450f6bdad3ebff9ac9aee315690eb0670bf2a6e342/ujson-6.0.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8bd6743ad58fe6067ea1677d5df4674bd7de143b038bcd4129c3a6ced483ae8", size = 57191, upload-time = "2026-09-04T03:54:01.005Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ad/26f40cdffaebd1158b1083d6c89efd9e056badd706022386a0e9567ae499/ujson-6.0.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3967550c8952bc516c79c40726a54313aceeb3162a8d5cc655362ab83d0957c", size = 56413, upload-time = "2026-09-04T03:54:02.019Z" },
+    { url = "https://files.pythonhosted.org/packages/62/60/7f0d5da6198fcad7037dafc68e6c76aebb6536b323c07a2d1f82bf692099/ujson-6.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:619b2152aa77c57a535e3e7eaf88ec8e25beac6d380378b2ade10362cce50f75", size = 1037442, upload-time = "2026-09-04T03:54:03.104Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bf/21cd9110b8b33ff1530d854f38b7bd2b8d2be41af67590fccffb418fb29f/ujson-6.0.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2e36269e715c8deea036d263557042e2598e79d52110233c1a623ed9e7c1cf0a", size = 1196458, upload-time = "2026-09-04T03:54:04.39Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/51/2e3b3a19b36862f72300a306051fb7a265ba0f5a72d6e2eebd30f2722b44/ujson-6.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c626f68524a19f50d9a9babc17f9c379d1b2a9f2a3da5ac3c40a205cc736259f", size = 1088718, upload-time = "2026-09-04T03:54:05.787Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/40/c22e49f786f5a0a71bae6323d0e6fa9a4a47b7b68c9f00631fdd78f147f7/ujson-6.0.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:63eefaa34abbe14167493710619b840d3fc167ba86e5fbe0c4a5eb01686aa3a0", size = 55208, upload-time = "2026-09-04T03:54:11.403Z" },
+    { url = "https://files.pythonhosted.org/packages/86/40/90a47580ae4246134a080b0f76637e038476271461d7ab227c1c4431822d/ujson-6.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:af85ae40c71d422fad944aa8666d59374e4fa92f77899fce34b984037db41420", size = 54303, upload-time = "2026-09-04T03:54:12.467Z" },
+    { url = "https://files.pythonhosted.org/packages/62/63/a275e218f7c5f49c0e31b446e9eb581267b7d3393d4dfbc25f397967e51b/ujson-6.0.0-cp314-cp314-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:2145005321a4b175486dd890946b036bb8730e4e8e17744f5abce23ea014e024", size = 58509, upload-time = "2026-09-04T03:54:13.472Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/3b/11fc8994c579a325c5c2075f03c70c967849d2c63cf97197507f31aaa739/ujson-6.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2c670cd7aaad2a3bff450addb32b26aa831f82a8b6c2c875ec19bb282a6c45d", size = 52422, upload-time = "2026-09-04T03:54:14.475Z" },
+    { url = "https://files.pythonhosted.org/packages/37/73/a7ecfa39bb08cfe57d35064b4be21712fe671bae47574a4c9901a9a1ad2a/ujson-6.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:63b56e3fcccc339e2c1332e75adc779bd145964e1a47a39a229fa01b2e25618a", size = 53707, upload-time = "2026-09-04T03:54:15.657Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c3/e6d76ff353d179dd0dca2e5df6afdd170874031eb73284acb9a327dd7f52/ujson-6.0.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab7b316bba31be494635dcc5db87e429f2478073d15d2c54925c32fd9e1947f4", size = 57234, upload-time = "2026-09-04T03:54:16.793Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/b4/c52aa5b797b76a2ca10da513010120809d70bb12acdfc27ad7875a652fee/ujson-6.0.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f9d26982045b28db1937ac60682a9940fdb72f9cab3421a5d56c03f2207c99e9", size = 56411, upload-time = "2026-09-04T03:54:17.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ad/5e2dd3fbbadee85811279e57dee23f346d8cc099809c14f7bb01d1a5a879/ujson-6.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fc115cca04dbdfd98a67ec89ba5ffd8a87f3201171af54980cfd550997611c41", size = 1037485, upload-time = "2026-09-04T03:54:19.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/61/73d5ef4020716e08de4992519d090785908bf229a3d464abf0a067f06c21/ujson-6.0.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:90f766c5f8e55de2fe65e4241e3e2e46ed7528e7931255a7ed0dfcb5ce622b15", size = 1196525, upload-time = "2026-09-04T03:54:20.759Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/4d/d63aafdf83ecb52a76ab46b0450e5431462b713e0b2576539a1b80ed6afb/ujson-6.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dfceda99f3105e9e6fce8dfd157f80894ad20247dc9ffce368c8b7883e7a2aac", size = 1088718, upload-time = "2026-09-04T03:54:22.056Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/53/cdc879e035a9b67e50fa34aa13d2d9160a826801a5fcf2993f48b9768944/ujson-6.0.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:222389a616f6407eb40e1efa80a35c1ba468903e50a305faf425c26e3c32bdb9", size = 55660, upload-time = "2026-09-04T03:54:26.996Z" },
+    { url = "https://files.pythonhosted.org/packages/51/29/33891cfee86cc13e00a1de6fa326378a637dad786078aaf56ab6336c60cf/ujson-6.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:593acfa0f36ada24e89c07147441fe364081fa1631db73ee55f40893c196e0b9", size = 54730, upload-time = "2026-09-04T03:54:28.106Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f6/2d4bd6fb364f8ded5840854bdda58032c8cd11614d70ce0c125a52dfb7a9/ujson-6.0.0-cp314-cp314t-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5b3afbe992e2d1b8c1e4e7a0da2c77da23f29545e5ba695a4a9241702234f20e", size = 59301, upload-time = "2026-09-04T03:54:29.215Z" },
+    { url = "https://files.pythonhosted.org/packages/61/fd/7baf38f591fd964558891a1798e9b49078558346a24020b7c27945389130/ujson-6.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:65e0e0c21ead4d0087c9c65a82eb2446c4bd51d36388d41035ce773517e7a3bf", size = 53364, upload-time = "2026-09-04T03:54:30.327Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c0/640ed28e4443c81e3ed9cbec2b216f4c3943388f4f45b703e8e0993c4f8f/ujson-6.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0f3eff1f93d9d1f0bd5eee35883b9c71ad9befcfcd0ddc7cd5862c69fba21cf6", size = 54447, upload-time = "2026-09-04T03:54:31.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f7/3688adc11a3e22e4b26563256404c6557682efe62510f988bf7dfc09d8b1/ujson-6.0.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4579b8c96824f65888d4a615463c2dc2b7db6c6f0c7f83ece2a58714fd1a8123", size = 58263, upload-time = "2026-09-04T03:54:32.587Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c9/9ab8d5ab9ca362381d0fcc8c6e6a831e96385a908792b2378db6282a374e/ujson-6.0.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8af54166141d5c8ebeebc044c3569ef10edfcdf6fd8ecb487a2bf33c776ebc8f", size = 57154, upload-time = "2026-09-04T03:54:33.698Z" },
+    { url = "https://files.pythonhosted.org/packages/23/01/82ed9b5594d770f6490334ce78af22c754b91b8de12efd3ddfaa1d23da9a/ujson-6.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ad8bdad17cfc64aefb049e53687ff8730a72e2c3d99edcb36001683122597846", size = 1038449, upload-time = "2026-09-04T03:54:34.784Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/dc/3cea633a17cb79d8b642e06b6c07f21ac31072a4b3043cc41df74db54fa5/ujson-6.0.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0dd8981828f6b515ba5e9f2473f433aa59bebe4784182b48695b71af52033b4f", size = 1197332, upload-time = "2026-09-04T03:54:36.441Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1d/3fcc1ae871d8cd6ee40ec7e92556d9641fdf248875656780c4feea33c793/ujson-6.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:97caee7e4c3e20dff9e6adca0b7443c3cf9d7546ed5d0750954c5bb5456bad86", size = 1089519, upload-time = "2026-09-04T03:54:38.866Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/2b/020feca4cc502b274029cd1514d428908e334a17386761d157da32447fa6/ujson-6.0.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:b2ab962524adb39dbad565fd259e15a1c26b8944fa978c24ed6dea5ab1eeefd0", size = 55210, upload-time = "2026-09-04T03:54:44.1Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/0e/1cd913419d17260f6d4c9869ab1208132b1281f4db00d3f07b664712ffdf/ujson-6.0.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:dae3765f731779faa947715485f6794bc5984802be4584478a3e9e5143dd62e1", size = 54370, upload-time = "2026-09-04T03:54:45.249Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0e/876719d6f04bb48560806bb508a038550f6a8184558f0a7274bc3015e1fa/ujson-6.0.0-cp315-cp315-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:34c0403b485d8ddd86bd29d879cc9f72223579b57188b0a2bc07a8b06f8cfbdf", size = 55682, upload-time = "2026-09-04T03:54:46.34Z" },
+    { url = "https://files.pythonhosted.org/packages/99/92/b59b4827a9c6ba0d12939b0d6e790b8629946873b7a655ff5a06735bd173/ujson-6.0.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8d56340493496d50ccc41b460610c1ce6a197aac710733b5f36910e8c9f3ba6d", size = 52648, upload-time = "2026-09-04T03:54:47.641Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/49/3d702afd9beb434f5140b12ffdf88198c144c1de5bd17a2a3a6fd7872b22/ujson-6.0.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a38a21efd05384fb82d35bed81fac0ff6056ea39c3dee3c293885ce910879dd0", size = 54007, upload-time = "2026-09-04T03:54:48.714Z" },
+    { url = "https://files.pythonhosted.org/packages/52/fb/4dd3f307f62f0b22f33b9d760efbfa7c7890a76591e6867c72bd27070966/ujson-6.0.0-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee87d8c4a4ebbef1c7cb2cf251a1d77726ef06a1597ed04d3dce92709b8fe0f1", size = 57412, upload-time = "2026-09-04T03:54:49.753Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/12/03ef04cde2e056f9ec699046f78bf2e8c1339ebfe0f29486098bf965e9ca/ujson-6.0.0-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:928d83b72808dc73a5df530b7fc27101052be1baf013a5dd75a1535de6cf107e", size = 56439, upload-time = "2026-09-04T03:54:50.795Z" },
+    { url = "https://files.pythonhosted.org/packages/26/d6/5cd07dc0732de702101e2360b07f2841ba50a77d2d758b0042623caae049/ujson-6.0.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:cd835565b660ca125f5895105981d691c708c15367b88a69fa4d92ddbe24504a", size = 1037774, upload-time = "2026-09-04T03:54:52.087Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/a3/59bcf91336ceebeb6a54716987c7069f9ddf99579488e513252300beb6ba/ujson-6.0.0-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:e6926204905e1a2f278bacf92ff2fe31343bcc7fb9ff08fdd42be66b3a217ef0", size = 1193839, upload-time = "2026-09-04T03:54:53.548Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1c/fb168acf568b8d1312cfb3b079ae4a91ff95130219551ce2a3fd5edf71a4/ujson-6.0.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:7a1472649bc9ef3b9ce3ab279e9e812368bfac25210b7ec96bd544767c019577", size = 1088955, upload-time = "2026-09-04T03:54:55.287Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/60/5c91a9e9e7f0b433dd782c57c388f7e764f162a1de433545f30fe93f48c6/ujson-6.0.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:7168df25a051fd2a60f8d123b2123b60ead7c1f22cdd467ab7c2bba0fad0aec1", size = 55668, upload-time = "2026-09-04T03:55:01.139Z" },
+    { url = "https://files.pythonhosted.org/packages/09/dd/1dddba1b0f74092f433e6a26ce4cb0f419a7a93575b54fcbb0c6d64e616d/ujson-6.0.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:987e191700873419cc23d94d4212e57a85df24eebbe9a33785907b0c99a5a57a", size = 54828, upload-time = "2026-09-04T03:55:02.353Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2d/6e65a3a336717d65cd8035ff870ad507b5a6375b8bc992718e744d620891/ujson-6.0.0-cp315-cp315t-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:0eeef12ef46e129278b50ca4c66c6b35c318f2fd09346bacddf218ed378cc0bb", size = 56651, upload-time = "2026-09-04T03:55:03.39Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a4/89d2bfc97fd073a3fe44c90beea19eb402c48101f83d46626d4b4d32c9d4/ujson-6.0.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68d623416ad997666bd8ea899b15554462b6250e803f4ce084c7dfd06a775314", size = 53687, upload-time = "2026-09-04T03:55:04.587Z" },
+    { url = "https://files.pythonhosted.org/packages/02/5b/ff1227377dbd1b1bb5834d59e3410ff27ef9c1eac1125fbb610e220f0e47/ujson-6.0.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7253ae5cac107d2940226a113165738630a98c19cdeaec1e6d6d6c3a7c307b95", size = 54873, upload-time = "2026-09-04T03:55:05.828Z" },
+    { url = "https://files.pythonhosted.org/packages/55/49/f80678f440126a3bd20253b91cf5bb200f1233bc5822f90024c7c94cfcd0/ujson-6.0.0-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b6494d29f7103a97d930cbd25f23fdc4d77e145a931e743660d697a200fd831", size = 58581, upload-time = "2026-09-04T03:55:07.009Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/2d/742897add5ea6b4ac9262208fba4bcb463e3f1b60606b6d79f05c7f27f17/ujson-6.0.0-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d56d408ccfb9b0e5c2b4ea687396df30ca42ebe2aedac88362069620ce65402", size = 57408, upload-time = "2026-09-04T03:55:08.105Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/b1/8747b3acf29d6219b042e8983f840fd4866dd9c65e5da9457311d4fb4fa1/ujson-6.0.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:add6b3827cbd6ce068ad70b1b890d44271801386a726e2bafe5bced784466642", size = 1038904, upload-time = "2026-09-04T03:55:09.313Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/21/deab9b41b6a8737210cd2460054e915f10b878bfda824e2dccc3e5f0db5f/ujson-6.0.0-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:1cda9f81e58120675dbaba7b254849ee59698e5dee83c4383a3c1a96ca92a679", size = 1194845, upload-time = "2026-09-04T03:55:10.988Z" },
+    { url = "https://files.pythonhosted.org/packages/31/40/b25a5f2b7bb6a5940692dc9d10bd89dad0c1e7d5af64c473d7391ec94513/ujson-6.0.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:d7945560fc6ce687ea83aa0bc375aa8a1101d9eee1fcbd085c5e0a5b6c6ac8ad", size = 1089861, upload-time = "2026-09-04T03:55:12.564Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/04/46d0146a9b4185aaee6b8b5d4fb58df59ec62e9557d6f59b0fdcd7c84b9a/ujson-6.0.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:28ac884b58c62eacdb6ac67284475b3f19b8160dbacb723956e67a0c11e45014", size = 58103, upload-time = "2026-09-04T03:55:18.697Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ea/2175d546216366acddc5f677d8a2eb27fb1a24b53871c8e31f5109237ec8/ujson-6.0.0-graalpy312-graalpy250_312_native-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e0652b2110fc374c766cdfca4fad61f9d13a0ad60c5b335ef3fed509374557bc", size = 53902, upload-time = "2026-09-04T03:55:19.806Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ca/caa8d28fc2507443fd4c32fb7e415f6d8fc70aa332160de36e253d8b083c/ujson-6.0.0-graalpy312-graalpy250_312_native-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8604968307105c3229ce0170e70bf3f172cf96f73c978b1afbc3d0ec8bdfcf86", size = 55419, upload-time = "2026-09-04T03:55:21.046Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a9/7fcaed6aa33a50a9dfb2c2e3259a2fe9075b66bba44bef77bc597c05a263/ujson-6.0.0-graalpy312-graalpy250_312_native-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:15aa57f6d0dafccd20f282f46f6a8d721d46c73fd9474f5ba996e9adc48d3177", size = 54396, upload-time = "2026-09-04T03:55:22.274Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/59/7b0b75c19cc394436fe8143a3f88a39a9c2015469e540e236c6046773e42/ujson-6.0.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:868856ea75794d952c773c506bb638e2a692bc5a8095cefebdcd98f43c79e772", size = 55497, upload-time = "2026-09-04T03:55:24.238Z" },
+    { url = "https://files.pythonhosted.org/packages/59/84/cdb0286e5fb188b0fec4448fbc48be6be6c029fdfda7bff949f789997386/ujson-6.0.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:fbae9b1a4d70e2283d71a0b66db2a91eb1a2cefaf370e47eff3a79f8ece7148d", size = 50935, upload-time = "2026-09-04T03:55:26.755Z" },
+    { url = "https://files.pythonhosted.org/packages/38/e4/95346e93cea1e0af9d987ee1e8dc9a22867baa59f2cd60bbe1f3d77d78ef/ujson-6.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:970f9ff27d12e089fa342379f52ea3f4aff6fbe8690aca9a1645c14aee5d08fb", size = 49254, upload-time = "2026-09-04T03:55:28.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ab/a0f4f171b4244a9d61be0c7be767791cd51d01cf805db534a2a2bde59eba/ujson-6.0.0-pp311-pypy311_pp73-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:65bbea52c251b568268b61f9377bee867addc81c9b4c24da277b051ce16f6151", size = 54327, upload-time = "2026-09-04T03:55:29.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/0d/a93e8d790a36262b662187dad04ab84b0204a9ad58c4ab5d87004b18b2f3/ujson-6.0.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7de7692f330c1ceaf6335ad8039d2fe9344d30ecb415e86ee719e9d5585b2077", size = 47526, upload-time = "2026-09-04T03:55:30.521Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8f/a4c91917c51f64ecc846bd2bc7f0a4397d4339cd1e91d2965cb85a484cee/ujson-6.0.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6759d1a9f8aa45dbe2fb3e49ef181e8e6dacca89c595c5ec007ab2b839235117", size = 48631, upload-time = "2026-09-04T03:55:31.733Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a7/8c2e2121ef48616dfa2357d1f982d54e2d44586a557f9720ee84bb4f0021/ujson-6.0.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:89b1962c30dc29ba99e522c4f2e39173961b6098328cfbcdad3f9f1c308dae89", size = 49878, upload-time = "2026-09-04T03:55:32.887Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/da/cae247036886535a5e43945f3ffd414b9fab92f54706ad40d7304c7630c1/ujson-6.0.0-pp311-pypy311_pp73-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d13a4ccf3fc9a00fb4e8cae818ad7ecf33f210d8098fecbfc087ff43573544", size = 50739, upload-time = "2026-09-04T03:55:34.213Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

This PR enforces keyword argument parameter passing across documentation, examples, and tests, audits all documentation chapters against live code, reconciles documentation for recently merged PRs (#752, #753, #755, #757, #759, #761, #764, #767, #768), and rewrites the v0.63.0 changelog.

### Key Changes
1. **Execution Parameter Passing Refactor**:
   - Enforced keyword argument parameter passing (`execute(sql, a=1, b=2)` or `execute(sql, **params)`) instead of positional dictionary literals across documentation, code examples, test suites, and internal extensions to take advantage of driver fast-path parameter dispatch.
2. **Documentation Audit & Expansion**:
   - Added reference pages for OpenTelemetry (`docs/reference/extensions/otel.rst`) and Prometheus (`docs/reference/extensions/prometheus.rst`).
   - Audited Sphinx autodoc directives, adapter guides, and usage pages against live code.
   - Documented driver `transaction()` context managers, savepoint semantics, unsupported adapter handling, and nested service transactions (#767).
   - Documented table fixture loading and exporting utilities (`load_table_fixtures_*`, `export_table_fixtures_*`), conflict resolution, sequence resync, and generated column omission (#768).
   - Documented SQL file fragments, includes, and fill-in slots (#764).
   - Documented DuckDB and CockroachDB native object storage transfers and DuckDB secret reuse/replacement options (#752, #753, #755).
   - Documented Litestar extension updates: Litestar 2.23+ requirement, default HTTP 409 `IntegrityError` handling, correlation middleware deduplication, and lifespan management (#757, #759, #761).
3. **Changelog**:
   - Structured and expanded `docs/changelog.rst` for release `v0.63.0`.
